### PR TITLE
Add image to AssistantContent and ping event support

### DIFF
--- a/zig/src/utils/pre_transform.zig
+++ b/zig/src/utils/pre_transform.zig
@@ -141,6 +141,10 @@ pub const TransformResult = struct {
                         if (tc.arguments_json.len > 0) self.allocator.free(tc.arguments_json);
                         if (tc.thought_signature) |s| self.allocator.free(s);
                     },
+                    .image => |img| {
+                        self.allocator.free(img.data);
+                        self.allocator.free(img.mime_type);
+                    },
                 }
             }
             self.allocator.free(content);
@@ -331,6 +335,12 @@ pub fn preTransform(
 
                             // Track pending tool calls
                             try pending_tool_calls.append(allocator, .{ .id = normalized_id, .name = normalized_name });
+                        },
+                        .image => |img| {
+                            try new_content.append(allocator, .{ .image = .{
+                                .data = try allocator.dupe(u8, img.data),
+                                .mime_type = try allocator.dupe(u8, img.mime_type),
+                            } });
                         },
                     }
                 }


### PR DESCRIPTION
## Summary
- Add `image` variant to `AssistantContent` union for handling image data in assistant messages, with proper memory management in deinit and clone functions
- Add `ping` event to `AssistantMessageEvent` for streaming keepalive support
- Add `ping_interval_ms` option to `StreamOptions` for configurable keepalive intervals
- Implement ping event emission in all provider streaming loops (Anthropic, OpenAI, Azure, Google, Ollama)

## Test plan
- All Zig unit tests pass: `zig build test` (139 tests)
- Image variant properly handled in:
  - `AssistantMessage.deinit()` - frees image data and mime_type
  - `cloneAssistantMessage()` - deep copies image content
  - `preTransform` - clones image content during message transformation
- Ping events emitted at configured intervals during streaming