### PR TITLE
fix(event_stream): add owns_events flag to prevent double-free panics

### DIFF
--- a/zig/src/protocol/client.zig
+++ b/zig/src/protocol/client.zig
@@ -65,6 +65,9 @@ pub const ProtocolClient = struct {
     pub fn init(allocator: std.mem.Allocator, options: Options) Self {
         const es = allocator.create(event_stream.AssistantMessageEventStream) catch unreachable;
         es.* = event_stream.AssistantMessageEventStream.init(allocator);
+        // ProtocolClient deep-copies events via cloneAssistantMessageEvent() before pushing,
+        // so the stream owns its events and must free them in deinit()
+        es.owns_events = true;
         return .{
             .allocator = allocator,
             .reconstructor = partial_reconstructor.PartialReconstructor.init(allocator),


### PR DESCRIPTION
## Summary
- Adds `owns_events: bool` flag to `EventStream` to track whether events own their string memory
- Default behavior (`owns_events=false`): Events contain borrowed strings from provider buffers - stream does NOT free them
- `ProtocolClient` sets `owns_events=true` since it deep-copies events via `cloneAssistantMessageEvent()`
- Adds documentation at multiple levels to prevent future regressions

## Root Cause
CI was failing with "Invalid free" panics in E2E tests. Events pushed by providers contain borrowed string slices (delta, content, id, name, etc.) that point into provider-managed temporary buffers (SSE parser, JSON buffers). The stream's `deinit()` was incorrectly calling `deinitAssistantMessageEvent()` to free these borrowed strings, causing double-free panics.

## Test Plan
- [x] `zig build test` - unit tests pass, no leaks
- [x] `zig build test-e2e-protocol` - mock e2e tests pass
- [ ] CI E2E tests should pass after merge