### PR TITLE
feat(agent): add async support and align with pi-mono TypeScript implementation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,8 +21,7 @@ There is no single-test command. Tests are inline in each `.zig` file using Zig'
 ## Dependencies
 
 Managed via `zig/build.zig.zon` with automatic fetching and hash verification:
-- **zio** (v0.7.0): Fiber-based async runtime for structured concurrency
-- **libxev**: Cross-platform event loop (epoll/kqueue/IOCP)
+- **libxev**: Cross-platform event loop (epoll/kqueue/IOCP) for async I/O
 
 ## Architecture
 


### PR DESCRIPTION
## Summary
- Add `promptAsync()`/`waitForIdle()` using threading for non-blocking execution
- Add thread-safe queue operations with mutex protection for `steer()`, `followUp()`, and queue clearing methods
- Add message cloning for thread ownership when spawning background threads
- Add `args_json` to `ToolExecutionUpdatePayload` to match TypeScript implementation
- Move `turn_start` emission to correct location in runLoop (before streaming assistant response)
- Add `message_start`/`message_end` events for tool result messages
- Add `validateToolArguments()` placeholder function for future JSON schema validation
- Add `AgentMessage` type for separating LLM messages from custom app messages
- Fix CLAUDE.md to reference libxev (not incorrect "zio")

## Test plan
- [x] All existing unit tests pass (`zig build test`)
- [x] New async functionality tested inline (`test "Agent isIdle and waitForIdle"`, `test "Agent cloneMessage"`)