### PR TITLE
M-005: Agent passthrough model discovery

### DIFF
--- a/zig/build.zig
+++ b/zig/build.zig
@@ -510,6 +510,7 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
         .imports = &.{
             .{ .name = "protocol_types", .module = protocol_types_mod },
+            .{ .name = "model_catalog_types", .module = protocol_model_catalog_types_mod },
             .{ .name = "owned_slice", .module = owned_slice_mod },
         },
     });
@@ -521,6 +522,7 @@ pub fn build(b: *std.Build) void {
         .imports = &.{
             .{ .name = "agent_types", .module = protocol_agent_types_mod },
             .{ .name = "json_writer", .module = json_writer_mod },
+            .{ .name = "model_catalog_types", .module = protocol_model_catalog_types_mod },
             .{ .name = "owned_slice", .module = owned_slice_mod },
         },
     });

--- a/zig/src/protocol/agent/envelope.zig
+++ b/zig/src/protocol/agent/envelope.zig
@@ -359,6 +359,13 @@ fn deserializePayload(type_str: []const u8, payload: std.json.ObjectMap, allocat
     if (std.mem.eql(u8, type_str, "nack")) {
         const rejected_id = try parseUuidRequired(payload.get("rejected_id").?.string);
         const reason = OwnedSlice(u8).initOwned(try allocator.dupe(u8, payload.get("reason").?.string));
+        // forward-compat: unknown error codes degrade to null rather than
+        // failing deserialization. This is intentional asymmetry from the
+        // other enum parsers in this file (which fail with InvalidEnumValue):
+        // a newer peer may emit a code our build doesn't know about, and we
+        // would rather still surface the human-readable `reason` than reject
+        // the whole nack envelope. Callers MUST treat `null` as "unrecognised
+        // code" and fall back to `reason` for diagnostics.
         const error_code = if (payload.get("error_code")) |v|
             std.meta.stringToEnum(agent_types.ErrorCode, v.string)
         else
@@ -539,6 +546,12 @@ fn deserializeModelDescriptor(
     };
 }
 
+// `.unknown` is a forward-compatibility sentinel — auth states added in
+// future protocol versions degrade gracefully to `.unknown` rather than
+// failing deserialization (intentionally asymmetric with `parseModelLifecycle`
+// / `parseModelCapability` / `parseModelSource` / `parseReasoningLevel`,
+// which all fail hard on unknown strings because those enums have no
+// "unknown" sentinel and a missing variant indicates a real protocol bug).
 fn parseAuthStatus(str: []const u8) model_catalog_types.AuthStatus {
     if (std.mem.eql(u8, str, "authenticated")) return .authenticated;
     if (std.mem.eql(u8, str, "login_required")) return .login_required;

--- a/zig/src/protocol/agent/envelope.zig
+++ b/zig/src/protocol/agent/envelope.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const agent_types = @import("agent_types");
 const json_writer = @import("json_writer");
+const model_catalog_types = @import("model_catalog_types");
 const OwnedSlice = @import("owned_slice").OwnedSlice;
 
 pub const protocol_types = agent_types;
@@ -134,6 +135,83 @@ fn serializePayload(w: *json_writer.JsonWriter, payload: agent_types.Payload, al
         .goodbye => |p| {
             if (p.getReason()) |reason| try w.writeStringField("reason", reason);
         },
+        .ack => |p| {
+            const ack_id = try agent_types.uuidToString(p.acknowledged_id, allocator);
+            defer allocator.free(ack_id);
+            try w.writeStringField("acknowledged_id", ack_id);
+        },
+        .nack => |p| {
+            const rejected_id = try agent_types.uuidToString(p.rejected_id, allocator);
+            defer allocator.free(rejected_id);
+            try w.writeStringField("rejected_id", rejected_id);
+            try w.writeStringField("reason", p.reason.slice());
+            if (p.error_code) |code| {
+                try w.writeStringField("error_code", @tagName(code));
+            }
+        },
+        .models_request => |p| {
+            if (p.getProviderId()) |provider_id| try w.writeStringField("provider_id", provider_id);
+            if (p.getApi()) |api| try w.writeStringField("api", api);
+            if (p.getModelId()) |model_id| try w.writeStringField("model_id", model_id);
+            try w.writeBoolField("include_deprecated", p.include_deprecated);
+            try w.writeBoolField("include_login_required", p.include_login_required);
+        },
+        .models_response => |p| {
+            try w.writeIntField("fetched_at_ms", p.fetched_at_ms);
+            try w.writeIntField("cache_max_age_ms", p.cache_max_age_ms);
+            try w.writeKey("models");
+            try w.beginArray();
+            for (p.models.slice()) |descriptor| {
+                try serializeModelDescriptor(w, descriptor);
+            }
+            try w.endArray();
+        },
+    }
+
+    try w.endObject();
+}
+
+fn serializeModelDescriptor(
+    w: *json_writer.JsonWriter,
+    model: model_catalog_types.ModelDescriptor,
+) !void {
+    try w.beginObject();
+
+    try w.writeStringField("model_ref", model.model_ref.slice());
+    try w.writeStringField("model_id", model.model_id.slice());
+    try w.writeStringField("display_name", model.display_name.slice());
+    try w.writeStringField("provider_id", model.provider_id.slice());
+    try w.writeStringField("api", model.api.slice());
+    if (model.base_url.slice().len > 0) {
+        try w.writeStringField("base_url", model.base_url.slice());
+    }
+    try w.writeStringField("auth_status", @tagName(model.auth_status));
+    try w.writeStringField("lifecycle", @tagName(model.lifecycle));
+    try w.writeStringField("source", @tagName(model.source));
+
+    try w.writeKey("capabilities");
+    try w.beginArray();
+    for (model.capabilities.slice()) |capability| {
+        try w.writeString(@tagName(capability));
+    }
+    try w.endArray();
+
+    if (model.context_window) |value| {
+        try w.writeIntField("context_window", value);
+    }
+    if (model.max_output_tokens) |value| {
+        try w.writeIntField("max_output_tokens", value);
+    }
+    if (model.reasoning_default) |value| {
+        try w.writeStringField("reasoning_default", @tagName(value));
+    }
+    if (model.metadata) |entries| {
+        try w.writeKey("metadata");
+        try w.beginObject();
+        for (entries.slice()) |entry| {
+            try w.writeStringField(entry.key.slice(), entry.value.slice());
+        }
+        try w.endObject();
     }
 
     try w.endObject();
@@ -275,8 +353,235 @@ fn deserializePayload(type_str: []const u8, payload: std.json.ObjectMap, allocat
         if (payload.get("reason")) |v| g.reason = OwnedSlice(u8).initOwned(try allocator.dupe(u8, v.string));
         return .{ .goodbye = g };
     }
+    if (std.mem.eql(u8, type_str, "ack")) {
+        return .{ .ack = .{ .acknowledged_id = try parseUuidRequired(payload.get("acknowledged_id").?.string) } };
+    }
+    if (std.mem.eql(u8, type_str, "nack")) {
+        const rejected_id = try parseUuidRequired(payload.get("rejected_id").?.string);
+        const reason = OwnedSlice(u8).initOwned(try allocator.dupe(u8, payload.get("reason").?.string));
+        const error_code = if (payload.get("error_code")) |v|
+            std.meta.stringToEnum(agent_types.ErrorCode, v.string)
+        else
+            null;
+        return .{ .nack = .{
+            .rejected_id = rejected_id,
+            .reason = reason,
+            .error_code = error_code,
+        } };
+    }
+    if (std.mem.eql(u8, type_str, "models_request")) {
+        return .{ .models_request = try deserializeModelsRequest(payload, allocator) };
+    }
+    if (std.mem.eql(u8, type_str, "models_response")) {
+        return .{ .models_response = try deserializeModelsResponse(payload, allocator) };
+    }
 
     return error.InvalidPayloadType;
+}
+
+fn deserializeModelsRequest(
+    obj: std.json.ObjectMap,
+    allocator: std.mem.Allocator,
+) !agent_types.ModelsRequest {
+    const provider_id = if (obj.get("provider_id")) |value|
+        OwnedSlice(u8).initOwned(try allocator.dupe(u8, value.string))
+    else
+        OwnedSlice(u8).initBorrowed("");
+    errdefer {
+        var mutable = provider_id;
+        mutable.deinit(allocator);
+    }
+
+    const api = if (obj.get("api")) |value|
+        OwnedSlice(u8).initOwned(try allocator.dupe(u8, value.string))
+    else
+        OwnedSlice(u8).initBorrowed("");
+    errdefer {
+        var mutable = api;
+        mutable.deinit(allocator);
+    }
+
+    const model_id = if (obj.get("model_id")) |value|
+        OwnedSlice(u8).initOwned(try allocator.dupe(u8, value.string))
+    else
+        OwnedSlice(u8).initBorrowed("");
+    errdefer {
+        var mutable = model_id;
+        mutable.deinit(allocator);
+    }
+
+    const include_deprecated = if (obj.get("include_deprecated")) |value| value.bool else false;
+    const include_login_required = if (obj.get("include_login_required")) |value| value.bool else true;
+
+    return .{
+        .provider_id = provider_id,
+        .api = api,
+        .model_id = model_id,
+        .include_deprecated = include_deprecated,
+        .include_login_required = include_login_required,
+    };
+}
+
+fn deserializeModelsResponse(
+    obj: std.json.ObjectMap,
+    allocator: std.mem.Allocator,
+) !agent_types.ModelsResponse {
+    const fetched_at_ms = obj.get("fetched_at_ms").?.integer;
+    const cache_max_age_ms: u64 = @intCast(obj.get("cache_max_age_ms").?.integer);
+    const models_array = obj.get("models").?.array;
+
+    const descriptors = try allocator.alloc(model_catalog_types.ModelDescriptor, models_array.items.len);
+    var allocated_count: usize = 0;
+    errdefer {
+        for (descriptors[0..allocated_count]) |*descriptor| descriptor.deinit(allocator);
+        allocator.free(descriptors);
+    }
+
+    for (models_array.items, 0..) |item, idx| {
+        descriptors[idx] = try deserializeModelDescriptor(item.object, allocator);
+        allocated_count += 1;
+    }
+
+    return .{
+        .models = OwnedSlice(model_catalog_types.ModelDescriptor).initOwned(descriptors),
+        .fetched_at_ms = fetched_at_ms,
+        .cache_max_age_ms = cache_max_age_ms,
+    };
+}
+
+fn deserializeModelDescriptor(
+    obj: std.json.ObjectMap,
+    allocator: std.mem.Allocator,
+) !model_catalog_types.ModelDescriptor {
+    const model_ref = OwnedSlice(u8).initOwned(try allocator.dupe(u8, obj.get("model_ref").?.string));
+    errdefer {
+        var mutable = model_ref;
+        mutable.deinit(allocator);
+    }
+
+    const model_id = OwnedSlice(u8).initOwned(try allocator.dupe(u8, obj.get("model_id").?.string));
+    errdefer {
+        var mutable = model_id;
+        mutable.deinit(allocator);
+    }
+
+    const display_name = OwnedSlice(u8).initOwned(try allocator.dupe(u8, obj.get("display_name").?.string));
+    errdefer {
+        var mutable = display_name;
+        mutable.deinit(allocator);
+    }
+
+    const provider_id = OwnedSlice(u8).initOwned(try allocator.dupe(u8, obj.get("provider_id").?.string));
+    errdefer {
+        var mutable = provider_id;
+        mutable.deinit(allocator);
+    }
+
+    const api = OwnedSlice(u8).initOwned(try allocator.dupe(u8, obj.get("api").?.string));
+    errdefer {
+        var mutable = api;
+        mutable.deinit(allocator);
+    }
+
+    const base_url = if (obj.get("base_url")) |value|
+        OwnedSlice(u8).initOwned(try allocator.dupe(u8, value.string))
+    else
+        OwnedSlice(u8).initBorrowed("");
+    errdefer {
+        var mutable = base_url;
+        mutable.deinit(allocator);
+    }
+
+    const capabilities_array = obj.get("capabilities").?.array;
+    const capabilities = try allocator.alloc(model_catalog_types.ModelCapability, capabilities_array.items.len);
+    errdefer allocator.free(capabilities);
+    for (capabilities_array.items, 0..) |item, idx| {
+        capabilities[idx] = try parseModelCapability(item.string);
+    }
+
+    var metadata: ?OwnedSlice(model_catalog_types.MetadataEntry) = null;
+    if (obj.get("metadata")) |metadata_value| {
+        const metadata_obj = metadata_value.object;
+        const metadata_items = try allocator.alloc(model_catalog_types.MetadataEntry, metadata_obj.count());
+        var metadata_count: usize = 0;
+        errdefer {
+            for (metadata_items[0..metadata_count]) |*entry| entry.deinit(allocator);
+            allocator.free(metadata_items);
+        }
+
+        var iter = metadata_obj.iterator();
+        while (iter.next()) |entry| {
+            metadata_items[metadata_count] = .{
+                .key = OwnedSlice(u8).initOwned(try allocator.dupe(u8, entry.key_ptr.*)),
+                .value = OwnedSlice(u8).initOwned(try allocator.dupe(u8, entry.value_ptr.string)),
+            };
+            metadata_count += 1;
+        }
+
+        metadata = OwnedSlice(model_catalog_types.MetadataEntry).initOwned(metadata_items);
+    }
+
+    return .{
+        .model_ref = model_ref,
+        .model_id = model_id,
+        .display_name = display_name,
+        .provider_id = provider_id,
+        .api = api,
+        .base_url = base_url,
+        .auth_status = parseAuthStatus(obj.get("auth_status").?.string),
+        .lifecycle = try parseModelLifecycle(obj.get("lifecycle").?.string),
+        .capabilities = OwnedSlice(model_catalog_types.ModelCapability).initOwned(capabilities),
+        .source = try parseModelSource(obj.get("source").?.string),
+        .context_window = if (obj.get("context_window")) |value| @intCast(value.integer) else null,
+        .max_output_tokens = if (obj.get("max_output_tokens")) |value| @intCast(value.integer) else null,
+        .reasoning_default = if (obj.get("reasoning_default")) |value| try parseReasoningLevel(value.string) else null,
+        .metadata = metadata,
+    };
+}
+
+fn parseAuthStatus(str: []const u8) model_catalog_types.AuthStatus {
+    if (std.mem.eql(u8, str, "authenticated")) return .authenticated;
+    if (std.mem.eql(u8, str, "login_required")) return .login_required;
+    if (std.mem.eql(u8, str, "expired")) return .expired;
+    if (std.mem.eql(u8, str, "refreshing")) return .refreshing;
+    if (std.mem.eql(u8, str, "login_in_progress")) return .login_in_progress;
+    if (std.mem.eql(u8, str, "failed")) return .failed;
+    return .unknown;
+}
+
+fn parseModelLifecycle(str: []const u8) error{InvalidEnumValue}!model_catalog_types.ModelLifecycle {
+    if (std.mem.eql(u8, str, "stable")) return .stable;
+    if (std.mem.eql(u8, str, "preview")) return .preview;
+    if (std.mem.eql(u8, str, "deprecated")) return .deprecated;
+    return error.InvalidEnumValue;
+}
+
+fn parseModelCapability(str: []const u8) error{InvalidEnumValue}!model_catalog_types.ModelCapability {
+    if (std.mem.eql(u8, str, "chat")) return .chat;
+    if (std.mem.eql(u8, str, "streaming")) return .streaming;
+    if (std.mem.eql(u8, str, "tools")) return .tools;
+    if (std.mem.eql(u8, str, "vision")) return .vision;
+    if (std.mem.eql(u8, str, "reasoning")) return .reasoning;
+    if (std.mem.eql(u8, str, "prompt_cache")) return .prompt_cache;
+    if (std.mem.eql(u8, str, "audio_input")) return .audio_input;
+    if (std.mem.eql(u8, str, "audio_output")) return .audio_output;
+    return error.InvalidEnumValue;
+}
+
+fn parseModelSource(str: []const u8) error{InvalidEnumValue}!model_catalog_types.ModelSource {
+    if (std.mem.eql(u8, str, "dynamic")) return .dynamic;
+    if (std.mem.eql(u8, str, "static_fallback")) return .static_fallback;
+    return error.InvalidEnumValue;
+}
+
+fn parseReasoningLevel(str: []const u8) error{InvalidEnumValue}!model_catalog_types.ReasoningLevel {
+    if (std.mem.eql(u8, str, "off")) return .off;
+    if (std.mem.eql(u8, str, "minimal")) return .minimal;
+    if (std.mem.eql(u8, str, "low")) return .low;
+    if (std.mem.eql(u8, str, "medium")) return .medium;
+    if (std.mem.eql(u8, str, "high")) return .high;
+    if (std.mem.eql(u8, str, "xhigh")) return .xhigh;
+    return error.InvalidEnumValue;
 }
 
 test "deserializeEnvelope rejects invalid uuid" {
@@ -323,4 +628,158 @@ test "agent envelope roundtrip" {
 
     try std.testing.expect(parsed.payload == .agent_message);
     try std.testing.expectEqualStrings("{\"role\":\"user\"}", parsed.payload.agent_message.message_json);
+}
+
+test "agent envelope roundtrip for models_request" {
+    const allocator = std.testing.allocator;
+
+    var env = agent_types.Envelope{
+        .session_id = agent_types.generateUuid(),
+        .message_id = agent_types.generateUuid(),
+        .sequence = 1,
+        .timestamp = std.time.milliTimestamp(),
+        .payload = .{ .models_request = .{
+            .provider_id = OwnedSlice(u8).initOwned(try allocator.dupe(u8, "anthropic")),
+            .api = OwnedSlice(u8).initOwned(try allocator.dupe(u8, "anthropic-messages")),
+            .model_id = OwnedSlice(u8).initOwned(try allocator.dupe(u8, "claude-sonnet-4-5")),
+            .include_deprecated = false,
+            .include_login_required = true,
+        } },
+    };
+    defer env.deinit(allocator);
+
+    const json = try serializeEnvelope(env, allocator);
+    defer allocator.free(json);
+
+    var parsed = try deserializeEnvelope(json, allocator);
+    defer parsed.deinit(allocator);
+
+    try std.testing.expect(parsed.payload == .models_request);
+    try std.testing.expectEqualStrings("anthropic", parsed.payload.models_request.getProviderId().?);
+    try std.testing.expectEqualStrings("anthropic-messages", parsed.payload.models_request.getApi().?);
+    try std.testing.expectEqualStrings("claude-sonnet-4-5", parsed.payload.models_request.getModelId().?);
+    try std.testing.expect(!parsed.payload.models_request.include_deprecated);
+    try std.testing.expect(parsed.payload.models_request.include_login_required);
+}
+
+test "agent envelope roundtrip for models_response preserves shape" {
+    const allocator = std.testing.allocator;
+
+    const capabilities = try allocator.alloc(agent_types.ModelCapability, 3);
+    capabilities[0] = .chat;
+    capabilities[1] = .streaming;
+    capabilities[2] = .reasoning;
+
+    const metadata = try allocator.alloc(agent_types.MetadataEntry, 1);
+    metadata[0] = .{
+        .key = OwnedSlice(u8).initOwned(try allocator.dupe(u8, "tier")),
+        .value = OwnedSlice(u8).initOwned(try allocator.dupe(u8, "standard")),
+    };
+
+    const descriptors = try allocator.alloc(agent_types.ModelDescriptor, 1);
+    descriptors[0] = .{
+        .model_ref = OwnedSlice(u8).initOwned(try allocator.dupe(u8, "anthropic/anthropic-messages@claude-sonnet-4-5")),
+        .model_id = OwnedSlice(u8).initOwned(try allocator.dupe(u8, "claude-sonnet-4-5")),
+        .display_name = OwnedSlice(u8).initOwned(try allocator.dupe(u8, "Claude Sonnet 4.5")),
+        .provider_id = OwnedSlice(u8).initOwned(try allocator.dupe(u8, "anthropic")),
+        .api = OwnedSlice(u8).initOwned(try allocator.dupe(u8, "anthropic-messages")),
+        .base_url = OwnedSlice(u8).initOwned(try allocator.dupe(u8, "https://api.anthropic.com")),
+        .auth_status = .authenticated,
+        .lifecycle = .stable,
+        .capabilities = OwnedSlice(agent_types.ModelCapability).initOwned(capabilities),
+        .source = .dynamic,
+        .context_window = 200_000,
+        .max_output_tokens = 8_192,
+        .reasoning_default = .medium,
+        .metadata = OwnedSlice(agent_types.MetadataEntry).initOwned(metadata),
+    };
+
+    var env = agent_types.Envelope{
+        .session_id = agent_types.generateUuid(),
+        .message_id = agent_types.generateUuid(),
+        .sequence = 2,
+        .timestamp = std.time.milliTimestamp(),
+        .payload = .{ .models_response = .{
+            .models = OwnedSlice(agent_types.ModelDescriptor).initOwned(descriptors),
+            .fetched_at_ms = 1_700_000_000_000,
+            .cache_max_age_ms = 300_000,
+        } },
+    };
+    defer env.deinit(allocator);
+
+    const json = try serializeEnvelope(env, allocator);
+    defer allocator.free(json);
+
+    var parsed = try deserializeEnvelope(json, allocator);
+    defer parsed.deinit(allocator);
+
+    try std.testing.expect(parsed.payload == .models_response);
+    try std.testing.expectEqual(@as(i64, 1_700_000_000_000), parsed.payload.models_response.fetched_at_ms);
+    try std.testing.expectEqual(@as(u64, 300_000), parsed.payload.models_response.cache_max_age_ms);
+
+    const parsed_models = parsed.payload.models_response.models.slice();
+    try std.testing.expectEqual(@as(usize, 1), parsed_models.len);
+    try std.testing.expectEqualStrings("claude-sonnet-4-5", parsed_models[0].model_id.slice());
+    try std.testing.expectEqualStrings("anthropic", parsed_models[0].provider_id.slice());
+    try std.testing.expectEqualStrings("anthropic-messages", parsed_models[0].api.slice());
+    try std.testing.expectEqual(agent_types.ModelSource.dynamic, parsed_models[0].source);
+    try std.testing.expectEqual(@as(u32, 200_000), parsed_models[0].context_window.?);
+    try std.testing.expectEqual(@as(u32, 8_192), parsed_models[0].max_output_tokens.?);
+    try std.testing.expectEqual(agent_types.ReasoningLevel.medium, parsed_models[0].reasoning_default.?);
+    try std.testing.expectEqual(@as(usize, 3), parsed_models[0].capabilities.slice().len);
+    try std.testing.expectEqual(agent_types.ModelCapability.chat, parsed_models[0].capabilities.slice()[0]);
+    try std.testing.expectEqual(agent_types.ModelCapability.reasoning, parsed_models[0].capabilities.slice()[2]);
+    try std.testing.expectEqualStrings("tier", parsed_models[0].metadata.?.slice()[0].key.slice());
+    try std.testing.expectEqualStrings("standard", parsed_models[0].metadata.?.slice()[0].value.slice());
+}
+
+test "agent envelope roundtrip for ack and nack" {
+    const allocator = std.testing.allocator;
+
+    const acked_id = agent_types.generateUuid();
+    var ack_env = agent_types.Envelope{
+        .session_id = agent_types.generateUuid(),
+        .message_id = agent_types.generateUuid(),
+        .sequence = 1,
+        .timestamp = std.time.milliTimestamp(),
+        .payload = .{ .ack = .{ .acknowledged_id = acked_id } },
+    };
+    defer ack_env.deinit(allocator);
+
+    const ack_json = try serializeEnvelope(ack_env, allocator);
+    defer allocator.free(ack_json);
+
+    var parsed_ack = try deserializeEnvelope(ack_json, allocator);
+    defer parsed_ack.deinit(allocator);
+
+    try std.testing.expect(parsed_ack.payload == .ack);
+    try std.testing.expectEqualSlices(u8, &acked_id, &parsed_ack.payload.ack.acknowledged_id);
+
+    const rejected_id = agent_types.generateUuid();
+    var nack_env = agent_types.Envelope{
+        .session_id = agent_types.generateUuid(),
+        .message_id = agent_types.generateUuid(),
+        .sequence = 1,
+        .timestamp = std.time.milliTimestamp(),
+        .payload = .{ .nack = .{
+            .rejected_id = rejected_id,
+            .reason = OwnedSlice(u8).initOwned(try allocator.dupe(u8, "models catalog is not implemented for this runtime")),
+            .error_code = .not_implemented,
+        } },
+    };
+    defer nack_env.deinit(allocator);
+
+    const nack_json = try serializeEnvelope(nack_env, allocator);
+    defer allocator.free(nack_json);
+
+    var parsed_nack = try deserializeEnvelope(nack_json, allocator);
+    defer parsed_nack.deinit(allocator);
+
+    try std.testing.expect(parsed_nack.payload == .nack);
+    try std.testing.expectEqualSlices(u8, &rejected_id, &parsed_nack.payload.nack.rejected_id);
+    try std.testing.expectEqualStrings(
+        "models catalog is not implemented for this runtime",
+        parsed_nack.payload.nack.reason.slice(),
+    );
+    try std.testing.expectEqual(agent_types.ErrorCode.not_implemented, parsed_nack.payload.nack.error_code.?);
 }

--- a/zig/src/protocol/agent/server.zig
+++ b/zig/src/protocol/agent/server.zig
@@ -11,22 +11,48 @@ pub const SessionState = struct {
     updated_at: i64,
 };
 
+/// Delegate that resolves a passthrough `models_request` by calling into the
+/// canonical provider protocol. Implementations must return a fully-owned
+/// `ModelsResponse` (the agent server takes ownership and frees it).
+pub const ProviderModelsDelegateFn = *const fn (
+    ctx: ?*anyopaque,
+    allocator: std.mem.Allocator,
+    request: agent_types.ModelsRequest,
+) anyerror!agent_types.ModelsResponse;
+
+pub const Options = struct {
+    /// When false, `models_request` always returns a `not_implemented` nack
+    /// regardless of whether a delegate is configured.
+    supports_model_catalog: bool = true,
+    /// Provider-protocol passthrough for model discovery. When null, the agent
+    /// server replies with `not_implemented` to advertise capability absence.
+    provider_models_delegate: ?ProviderModelsDelegateFn = null,
+    /// Opaque context passed to `provider_models_delegate`.
+    provider_models_ctx: ?*anyopaque = null,
+};
+
 pub const AgentProtocolServer = struct {
     allocator: std.mem.Allocator,
     sessions: std.AutoHashMap(agent_types.Uuid, SessionState),
     expected_sequences: std.AutoHashMap(agent_types.Uuid, u64),
     outgoing_sequences: std.AutoHashMap(agent_types.Uuid, u64),
     outbox: std.ArrayList(agent_types.Envelope),
+    options: Options,
 
     const Self = @This();
 
     pub fn init(allocator: std.mem.Allocator) Self {
+        return initWithOptions(allocator, .{});
+    }
+
+    pub fn initWithOptions(allocator: std.mem.Allocator, options: Options) Self {
         return .{
             .allocator = allocator,
             .sessions = std.AutoHashMap(agent_types.Uuid, SessionState).init(allocator),
             .expected_sequences = std.AutoHashMap(agent_types.Uuid, u64).init(allocator),
             .outgoing_sequences = std.AutoHashMap(agent_types.Uuid, u64).init(allocator),
             .outbox = std.ArrayList(agent_types.Envelope){},
+            .options = options,
         };
     }
 
@@ -55,6 +81,7 @@ pub const AgentProtocolServer = struct {
             .agent_message => |req| return try self.handleMessage(req, env),
             .agent_stop => |req| return try self.handleStop(req, env),
             .agent_status => |req| return try self.handleStatus(req, env),
+            .models_request => |req| return try self.handleModelsRequest(req, env),
             .tool_list => |_| {
                 return .{
                     .session_id = env.session_id,
@@ -177,6 +204,103 @@ pub const AgentProtocolServer = struct {
         };
     }
 
+    /// Passthrough model discovery: forwards `models_request` to the provider
+    /// protocol via the configured delegate and emits the same typed
+    /// `ModelsResponse` shape on the wire (no raw JSON blob passthrough).
+    /// See `docs/v1-sdk-agent-provider-spec.md §6`.
+    ///
+    /// On success: returns an `ack` envelope synchronously and queues the
+    /// `models_response` envelope on the outbox. On capability absence or
+    /// delegate failure: returns a `nack` envelope with a typed `error_code`.
+    fn handleModelsRequest(
+        self: *Self,
+        request: agent_types.ModelsRequest,
+        env: agent_types.Envelope,
+    ) !?agent_types.Envelope {
+        if (!self.options.supports_model_catalog or self.options.provider_models_delegate == null) {
+            return try self.makeModelsNack(
+                env.session_id,
+                env.message_id,
+                .not_implemented,
+                "models catalog is not implemented for this runtime",
+            );
+        }
+
+        const delegate = self.options.provider_models_delegate.?;
+        var response = delegate(self.options.provider_models_ctx, self.allocator, request) catch |err| switch (err) {
+            error.NotImplemented => return try self.makeModelsNack(
+                env.session_id,
+                env.message_id,
+                .not_implemented,
+                "models catalog is not implemented for this runtime",
+            ),
+            error.ModelNotFound => return try self.makeModelsNack(
+                env.session_id,
+                env.message_id,
+                .invalid_request,
+                "model not found",
+            ),
+            error.AmbiguousModelId => return try self.makeModelsNack(
+                env.session_id,
+                env.message_id,
+                .invalid_request,
+                "model_id matches multiple APIs; specify api",
+            ),
+            error.OutOfMemory => return error.OutOfMemory,
+            else => return try self.makeModelsNack(
+                env.session_id,
+                env.message_id,
+                .provider_error,
+                "failed to build model catalog response",
+            ),
+        };
+        errdefer response.deinit(self.allocator);
+
+        const ack_seq = self.nextOutgoingSequence(env.session_id);
+        const ack_envelope = agent_types.Envelope{
+            .session_id = env.session_id,
+            .message_id = agent_types.generateUuid(),
+            .sequence = ack_seq,
+            .in_reply_to = env.message_id,
+            .timestamp = std.time.milliTimestamp(),
+            .payload = .{ .ack = .{ .acknowledged_id = env.message_id } },
+        };
+
+        const response_seq = self.nextOutgoingSequence(env.session_id);
+        try self.outbox.append(self.allocator, .{
+            .session_id = env.session_id,
+            .message_id = agent_types.generateUuid(),
+            .sequence = response_seq,
+            .in_reply_to = env.message_id,
+            .timestamp = std.time.milliTimestamp(),
+            .payload = .{ .models_response = response },
+        });
+
+        return ack_envelope;
+    }
+
+    fn makeModelsNack(
+        self: *Self,
+        session_id: agent_types.Uuid,
+        in_reply_to: agent_types.Uuid,
+        code: agent_types.ErrorCode,
+        msg: []const u8,
+    ) !agent_types.Envelope {
+        const reason = try self.allocator.dupe(u8, msg);
+        return .{
+            .session_id = session_id,
+            .message_id = agent_types.generateUuid(),
+            .sequence = self.nextOutgoingSequence(session_id),
+            .in_reply_to = in_reply_to,
+            .timestamp = std.time.milliTimestamp(),
+            .payload = .{ .nack = .{
+                .rejected_id = in_reply_to,
+                .reason = OwnedSlice(u8).initOwned(reason),
+                .error_code = code,
+            } },
+        };
+    }
+
     fn makeError(self: *Self, session_id: agent_types.Uuid, in_reply_to: agent_types.Uuid, code: agent_types.AgentErrorCode, msg: []const u8) !agent_types.Envelope {
         return .{
             .session_id = session_id,
@@ -270,6 +394,230 @@ test "AgentProtocolServer rejects unknown session message" {
 
     try std.testing.expect(resp.payload == .agent_error);
     try std.testing.expectEqual(agent_types.AgentErrorCode.agent_not_found, resp.payload.agent_error.code);
+}
+
+// ============================================================================
+// Models passthrough test fixtures (M-005)
+// ============================================================================
+
+const ModelsTestCtx = struct {
+    response_models: []const struct {
+        model_ref: []const u8,
+        model_id: []const u8,
+        display_name: []const u8,
+        provider_id: []const u8,
+        api: []const u8,
+        source: agent_types.ModelSource,
+    },
+    fetched_at_ms: i64,
+    cache_max_age_ms: u64,
+    saw_provider_id: ?[]const u8 = null,
+    error_to_return: ?anyerror = null,
+    call_count: usize = 0,
+};
+
+fn modelsTestDelegate(
+    ctx: ?*anyopaque,
+    allocator: std.mem.Allocator,
+    request: agent_types.ModelsRequest,
+) anyerror!agent_types.ModelsResponse {
+    const test_ctx = @as(*ModelsTestCtx, @ptrCast(@alignCast(ctx.?)));
+    test_ctx.call_count += 1;
+    test_ctx.saw_provider_id = request.getProviderId();
+
+    if (test_ctx.error_to_return) |err| {
+        return err;
+    }
+
+    const descriptors = try allocator.alloc(agent_types.ModelDescriptor, test_ctx.response_models.len);
+    var allocated_count: usize = 0;
+    errdefer {
+        for (descriptors[0..allocated_count]) |*d| d.deinit(allocator);
+        allocator.free(descriptors);
+    }
+
+    for (test_ctx.response_models, 0..) |model, idx| {
+        const capabilities = try allocator.alloc(agent_types.ModelCapability, 1);
+        capabilities[0] = .chat;
+
+        descriptors[idx] = .{
+            .model_ref = OwnedSlice(u8).initOwned(try allocator.dupe(u8, model.model_ref)),
+            .model_id = OwnedSlice(u8).initOwned(try allocator.dupe(u8, model.model_id)),
+            .display_name = OwnedSlice(u8).initOwned(try allocator.dupe(u8, model.display_name)),
+            .provider_id = OwnedSlice(u8).initOwned(try allocator.dupe(u8, model.provider_id)),
+            .api = OwnedSlice(u8).initOwned(try allocator.dupe(u8, model.api)),
+            .auth_status = .authenticated,
+            .lifecycle = .stable,
+            .capabilities = OwnedSlice(agent_types.ModelCapability).initOwned(capabilities),
+            .source = model.source,
+        };
+        allocated_count += 1;
+    }
+
+    return .{
+        .models = OwnedSlice(agent_types.ModelDescriptor).initOwned(descriptors),
+        .fetched_at_ms = test_ctx.fetched_at_ms,
+        .cache_max_age_ms = test_ctx.cache_max_age_ms,
+    };
+}
+
+test "handleModelsRequest emits ack then models_response with same shape as provider protocol" {
+    const allocator = std.testing.allocator;
+
+    var ctx = ModelsTestCtx{
+        .response_models = &.{
+            .{
+                .model_ref = "anthropic/anthropic-messages@claude-sonnet-4-5",
+                .model_id = "claude-sonnet-4-5",
+                .display_name = "Claude Sonnet 4.5",
+                .provider_id = "anthropic",
+                .api = "anthropic-messages",
+                .source = .dynamic,
+            },
+        },
+        .fetched_at_ms = 1_700_000_000_000,
+        .cache_max_age_ms = 300_000,
+    };
+
+    var server = AgentProtocolServer.initWithOptions(allocator, .{
+        .supports_model_catalog = true,
+        .provider_models_delegate = modelsTestDelegate,
+        .provider_models_ctx = @ptrCast(&ctx),
+    });
+    defer server.deinit();
+
+    var request = agent_types.Envelope{
+        .session_id = agent_types.generateUuid(),
+        .message_id = agent_types.generateUuid(),
+        .sequence = 1,
+        .timestamp = std.time.milliTimestamp(),
+        .payload = .{ .models_request = .{
+            .provider_id = OwnedSlice(u8).initBorrowed("anthropic"),
+        } },
+    };
+    defer request.deinit(allocator);
+
+    const maybe_ack = try server.handleEnvelope(request);
+    try std.testing.expect(maybe_ack != null);
+    var ack = maybe_ack.?;
+    defer ack.deinit(allocator);
+
+    try std.testing.expect(ack.payload == .ack);
+    try std.testing.expectEqual(@as(u64, 1), ack.sequence);
+    try std.testing.expectEqualSlices(u8, &request.message_id, &ack.payload.ack.acknowledged_id);
+    try std.testing.expectEqualSlices(u8, &request.message_id, &ack.in_reply_to.?);
+
+    const maybe_response = server.popOutbound();
+    try std.testing.expect(maybe_response != null);
+    var response = maybe_response.?;
+    defer response.deinit(allocator);
+
+    try std.testing.expect(response.payload == .models_response);
+    try std.testing.expectEqual(@as(u64, 2), response.sequence);
+    try std.testing.expectEqualSlices(u8, &request.message_id, &response.in_reply_to.?);
+    try std.testing.expectEqual(@as(i64, 1_700_000_000_000), response.payload.models_response.fetched_at_ms);
+    try std.testing.expectEqual(@as(u64, 300_000), response.payload.models_response.cache_max_age_ms);
+
+    const models = response.payload.models_response.models.slice();
+    try std.testing.expectEqual(@as(usize, 1), models.len);
+    try std.testing.expectEqualStrings("claude-sonnet-4-5", models[0].model_id.slice());
+    try std.testing.expectEqualStrings("anthropic", models[0].provider_id.slice());
+    try std.testing.expectEqualStrings("anthropic-messages", models[0].api.slice());
+    try std.testing.expectEqual(agent_types.ModelSource.dynamic, models[0].source);
+
+    try std.testing.expectEqual(@as(usize, 1), ctx.call_count);
+    try std.testing.expectEqualStrings("anthropic", ctx.saw_provider_id.?);
+
+    // Outbox should now be empty
+    try std.testing.expect(server.popOutbound() == null);
+}
+
+test "handleModelsRequest returns not_implemented nack when unsupported" {
+    const allocator = std.testing.allocator;
+
+    var server = AgentProtocolServer.initWithOptions(allocator, .{
+        .supports_model_catalog = false,
+    });
+    defer server.deinit();
+
+    var request = agent_types.Envelope{
+        .session_id = agent_types.generateUuid(),
+        .message_id = agent_types.generateUuid(),
+        .sequence = 1,
+        .timestamp = std.time.milliTimestamp(),
+        .payload = .{ .models_request = .{} },
+    };
+    defer request.deinit(allocator);
+
+    const maybe_response = try server.handleEnvelope(request);
+    try std.testing.expect(maybe_response != null);
+    var response = maybe_response.?;
+    defer response.deinit(allocator);
+
+    try std.testing.expect(response.payload == .nack);
+    try std.testing.expectEqual(agent_types.ErrorCode.not_implemented, response.payload.nack.error_code.?);
+    try std.testing.expectEqualSlices(u8, &request.message_id, &response.payload.nack.rejected_id);
+    try std.testing.expect(server.popOutbound() == null);
+}
+
+test "handleModelsRequest returns not_implemented nack when delegate is missing" {
+    const allocator = std.testing.allocator;
+
+    // supports_model_catalog defaults to true, but no delegate is configured
+    var server = AgentProtocolServer.init(allocator);
+    defer server.deinit();
+
+    var request = agent_types.Envelope{
+        .session_id = agent_types.generateUuid(),
+        .message_id = agent_types.generateUuid(),
+        .sequence = 1,
+        .timestamp = std.time.milliTimestamp(),
+        .payload = .{ .models_request = .{} },
+    };
+    defer request.deinit(allocator);
+
+    const maybe_response = try server.handleEnvelope(request);
+    try std.testing.expect(maybe_response != null);
+    var response = maybe_response.?;
+    defer response.deinit(allocator);
+
+    try std.testing.expect(response.payload == .nack);
+    try std.testing.expectEqual(agent_types.ErrorCode.not_implemented, response.payload.nack.error_code.?);
+    try std.testing.expect(server.popOutbound() == null);
+}
+
+test "handleModelsRequest maps delegate NotImplemented error to not_implemented nack" {
+    const allocator = std.testing.allocator;
+
+    var ctx = ModelsTestCtx{
+        .response_models = &.{},
+        .fetched_at_ms = 0,
+        .cache_max_age_ms = 0,
+        .error_to_return = error.NotImplemented,
+    };
+
+    var server = AgentProtocolServer.initWithOptions(allocator, .{
+        .provider_models_delegate = modelsTestDelegate,
+        .provider_models_ctx = @ptrCast(&ctx),
+    });
+    defer server.deinit();
+
+    var request = agent_types.Envelope{
+        .session_id = agent_types.generateUuid(),
+        .message_id = agent_types.generateUuid(),
+        .sequence = 1,
+        .timestamp = std.time.milliTimestamp(),
+        .payload = .{ .models_request = .{} },
+    };
+    defer request.deinit(allocator);
+
+    const maybe_response = try server.handleEnvelope(request);
+    var response = maybe_response.?;
+    defer response.deinit(allocator);
+
+    try std.testing.expect(response.payload == .nack);
+    try std.testing.expectEqual(agent_types.ErrorCode.not_implemented, response.payload.nack.error_code.?);
+    try std.testing.expect(server.popOutbound() == null);
 }
 
 test "AgentProtocolServer start message status stop" {

--- a/zig/src/protocol/agent/server.zig
+++ b/zig/src/protocol/agent/server.zig
@@ -21,8 +21,21 @@ pub const ProviderModelsDelegateFn = *const fn (
 ) anyerror!agent_types.ModelsResponse;
 
 pub const Options = struct {
-    /// When false, `models_request` always returns a `not_implemented` nack
-    /// regardless of whether a delegate is configured.
+    /// Explicit kill-switch for the model catalog feature. When `false`,
+    /// `models_request` always returns a `not_implemented` nack regardless of
+    /// whether a delegate is configured.
+    ///
+    /// NOTE: this flag alone does not advertise the capability. A
+    /// `models_request` is only answered with a `models_response` when BOTH
+    /// `supports_model_catalog == true` AND `provider_models_delegate != null`.
+    /// All four combinations resolve as follows:
+    ///   * supports=true,  delegate=set  -> delegate is invoked.
+    ///   * supports=true,  delegate=null -> `not_implemented` nack (default).
+    ///   * supports=false, delegate=set  -> `not_implemented` nack (kill-switch).
+    ///   * supports=false, delegate=null -> `not_implemented` nack.
+    /// In other words, the default-constructed server is a NO-OP responder
+    /// until a delegate is wired; flipping this flag is only meaningful when
+    /// callers want to disable an otherwise-configured delegate at runtime.
     supports_model_catalog: bool = true,
     /// Provider-protocol passthrough for model discovery. When null, the agent
     /// server replies with `not_implemented` to advertise capability absence.
@@ -234,6 +247,11 @@ pub const AgentProtocolServer = struct {
                 .not_implemented,
                 "models catalog is not implemented for this runtime",
             ),
+            // Spec §6 step 7: when no models match the request filters the
+            // protocol mandates `error_code = invalid_request` (NOT
+            // `model_not_found`). The `ErrorCode.model_not_found` variant is
+            // reserved for future/SDK-internal use — do not "fix" this to use
+            // it without first updating the spec.
             error.ModelNotFound => return try self.makeModelsNack(
                 env.session_id,
                 env.message_id,
@@ -612,6 +630,7 @@ test "handleModelsRequest maps delegate NotImplemented error to not_implemented 
     defer request.deinit(allocator);
 
     const maybe_response = try server.handleEnvelope(request);
+    try std.testing.expect(maybe_response != null);
     var response = maybe_response.?;
     defer response.deinit(allocator);
 

--- a/zig/src/protocol/agent/types.zig
+++ b/zig/src/protocol/agent/types.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const provider_types = @import("protocol_types");
+const model_catalog_types = @import("model_catalog_types");
 const OwnedSlice = @import("owned_slice").OwnedSlice;
 
 /// Re-export Uuid from provider types for convenience
@@ -7,6 +8,28 @@ pub const Uuid = provider_types.Uuid;
 pub const generateUuid = provider_types.generateUuid;
 pub const uuidToString = provider_types.uuidToString;
 pub const parseUuid = provider_types.parseUuid;
+
+/// Re-export provider ack/nack/error-code envelope types so that the agent
+/// passthrough emits the same shape as the provider protocol.
+pub const Ack = provider_types.Ack;
+pub const Nack = provider_types.Nack;
+pub const ErrorCode = provider_types.ErrorCode;
+
+/// Re-export shared model catalog types — the agent passthrough must return
+/// the same typed shape as the provider protocol (no raw JSON blob passthrough).
+/// See `docs/v1-sdk-agent-provider-spec.md §6`.
+pub const ModelDescriptor = model_catalog_types.ModelDescriptor;
+pub const ModelCapability = model_catalog_types.ModelCapability;
+pub const ModelLifecycle = model_catalog_types.ModelLifecycle;
+pub const ModelSource = model_catalog_types.ModelSource;
+pub const ReasoningLevel = model_catalog_types.ReasoningLevel;
+pub const AuthStatus = model_catalog_types.AuthStatus;
+pub const MetadataEntry = model_catalog_types.MetadataEntry;
+pub const ModelsResponse = model_catalog_types.ModelsResponse;
+
+/// Reuse provider's `ModelsRequest` shape verbatim so the agent passthrough is
+/// indistinguishable from the canonical provider protocol on the wire.
+pub const ModelsRequest = provider_types.ModelsRequest;
 
 // ============================================================================
 // Agent Protocol Types
@@ -193,6 +216,9 @@ pub const Payload = union(enum) {
     agent_stop: AgentStopRequest,
     agent_status: struct { session_id: Uuid },
     tool_list: ToolListRequest,
+    /// Passthrough model discovery request — delegates to the provider protocol
+    /// and returns the same `ModelsResponse` shape. See spec §6.
+    models_request: ModelsRequest,
 
     // Agent Server -> Client
     agent_started: struct { session_id: Uuid },
@@ -202,6 +228,13 @@ pub const Payload = union(enum) {
     agent_error: struct { code: AgentErrorCode, message: []const u8 },
     session_info: AgentSessionInfo,
     tool_list_response: ToolListResponse,
+    /// Acknowledgment for two-step request/response flows (e.g. models_request).
+    ack: Ack,
+    /// Negative acknowledgment used to surface typed protocol errors such as
+    /// `not_implemented` for capability probes.
+    nack: Nack,
+    /// Passthrough models response — same typed shape as provider protocol.
+    models_response: ModelsResponse,
 
     // Agent -> Tool Server
     tool_execute: ToolExecuteRequest,
@@ -263,7 +296,10 @@ pub const Payload = union(enum) {
                 allocator.free(t.partial_json);
             },
             .session_info => |*s| allocator.free(s.model),
-            .agent_started, .agent_status, .ping => {},
+            .models_request => |*req| req.deinit(allocator),
+            .models_response => |*res| res.deinit(allocator),
+            .nack => |*n| n.deinit(allocator),
+            .ack, .agent_started, .agent_status, .ping => {},
         }
     }
 };
@@ -314,4 +350,64 @@ test "Payload deinit for agent_start" {
 
     payload.deinit(allocator);
     // Should not leak
+}
+
+test "Payload deinit for models_request frees owned filters" {
+    const allocator = std.testing.allocator;
+
+    var payload = Payload{
+        .models_request = .{
+            .provider_id = OwnedSlice(u8).initOwned(try allocator.dupe(u8, "anthropic")),
+            .api = OwnedSlice(u8).initOwned(try allocator.dupe(u8, "anthropic-messages")),
+            .model_id = OwnedSlice(u8).initOwned(try allocator.dupe(u8, "claude-sonnet-4-5")),
+            .include_deprecated = false,
+            .include_login_required = true,
+        },
+    };
+
+    payload.deinit(allocator);
+}
+
+test "Payload deinit for models_response frees descriptors" {
+    const allocator = std.testing.allocator;
+
+    const capabilities = try allocator.alloc(ModelCapability, 1);
+    capabilities[0] = .chat;
+
+    const descriptors = try allocator.alloc(ModelDescriptor, 1);
+    descriptors[0] = .{
+        .model_ref = OwnedSlice(u8).initOwned(try allocator.dupe(u8, "anthropic/anthropic-messages@claude-sonnet-4-5")),
+        .model_id = OwnedSlice(u8).initOwned(try allocator.dupe(u8, "claude-sonnet-4-5")),
+        .display_name = OwnedSlice(u8).initOwned(try allocator.dupe(u8, "Claude Sonnet 4.5")),
+        .provider_id = OwnedSlice(u8).initOwned(try allocator.dupe(u8, "anthropic")),
+        .api = OwnedSlice(u8).initOwned(try allocator.dupe(u8, "anthropic-messages")),
+        .auth_status = .authenticated,
+        .lifecycle = .stable,
+        .capabilities = OwnedSlice(ModelCapability).initOwned(capabilities),
+        .source = .dynamic,
+    };
+
+    var payload = Payload{
+        .models_response = .{
+            .models = OwnedSlice(ModelDescriptor).initOwned(descriptors),
+            .fetched_at_ms = 0,
+            .cache_max_age_ms = 0,
+        },
+    };
+
+    payload.deinit(allocator);
+}
+
+test "Payload deinit for nack frees reason" {
+    const allocator = std.testing.allocator;
+
+    var payload = Payload{
+        .nack = .{
+            .rejected_id = generateUuid(),
+            .reason = OwnedSlice(u8).initOwned(try allocator.dupe(u8, "not implemented")),
+            .error_code = .not_implemented,
+        },
+    };
+
+    payload.deinit(allocator);
 }


### PR DESCRIPTION
## Summary

Implements agent passthrough for model discovery so clients connected only to an agent endpoint can list models with the same typed shape as the provider protocol (no raw JSON blob passthrough).

- Adds `models_request` / `models_response` payload variants to `protocol/agent`, reusing shared types from `protocol/model_catalog_types.zig`.
- Adds `ack` / `nack` envelope variants and a typed `ErrorCode` re-export so the passthrough emits the exact same wire shape as provider.
- Agent server delegates to the provider protocol via a `provider_models_delegate` callback in `Options`; falls back to `not_implemented` nack when unsupported or unconfigured.
- On success, server emits `ack` synchronously and queues `models_response` on the outbox (two-step flow that mirrors the provider protocol).

Implements **M-005** per:
- `docs/v1-sdk-agent-provider-spec.md §6`
- `docs/ts-sdk-chat-integration-plan.md` Phase 1.5

## Test plan

- [x] `handleModelsRequest` emits `ack` then `models_response` with the same shape as provider protocol (sequences 1 and 2, `in_reply_to` set, all fields preserved including `source`, `fetched_at_ms`, `cache_max_age_ms`).
- [x] `handleModelsRequest` returns `not_implemented` nack when `supports_model_catalog = false`.
- [x] `handleModelsRequest` returns `not_implemented` nack when no delegate is configured.
- [x] Delegate-side `error.NotImplemented` is mapped to a typed nack.
- [x] Roundtrip serialize/deserialize tests for agent `models_request`, `models_response`, `ack`, and `nack` envelopes (including all `ModelDescriptor` fields, capabilities, metadata, optional ints, reasoning_default).
- [x] `zig build test-unit-protocol` — passes
- [x] `zig build test-unit-makai-cli` — passes
- [x] `zig build test` — full suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)