### PR TITLE
M-009c: add TS execution client APIs

### DIFF
--- a/typescript/src/execution_client.ts
+++ b/typescript/src/execution_client.ts
@@ -1,0 +1,448 @@
+import { randomUUID } from "node:crypto";
+import { MakaiAuthClient, type MakaiAuthApi } from "./auth_protocol";
+import { createMakaiModelsApi } from "./models_client";
+import type { MakaiModelsApi } from "./models_types";
+import { type CreateMakaiStdioClientOptions, createMakaiStdioClient, MakaiStdioClient, type StdioFrame } from "./stdio_client";
+import {
+  MakaiStreamError,
+  type AgentRunRequest,
+  type AgentRunResponse,
+  type AgentStreamEvent,
+  type ChatMessage,
+  type CompletionResponse,
+  type ContentPart,
+  type MakaiAgentApi,
+  type MakaiClientOptions,
+  type MakaiProviderApi,
+  type ProviderCompleteRequest,
+  type ProviderCompleteResponse,
+  type ProviderStreamEvent,
+  type RunOptions,
+  type ToolDefinition,
+  type UsageSummary,
+} from "./execution_types";
+
+const ENVELOPE_VERSION = 1;
+const DEFAULT_RESPONSE_TIMEOUT_MS = 30_000;
+
+type ExecutionOptions = {
+  responseTimeoutMs?: number;
+};
+
+export interface MakaiClient {
+  auth: MakaiAuthApi;
+  models: MakaiModelsApi;
+  agent: MakaiAgentApi;
+  provider: MakaiProviderApi;
+  close(): Promise<void>;
+}
+
+export type CreateMakaiClientOptions = CreateMakaiStdioClientOptions & MakaiClientOptions;
+
+export function createMakaiProviderApi(
+  transport: MakaiStdioClient,
+  options: ExecutionOptions = {},
+): MakaiProviderApi {
+  return new StdioProviderApi(transport, options);
+}
+
+export function createMakaiAgentApi(
+  transport: MakaiStdioClient,
+  options: ExecutionOptions = {},
+): MakaiAgentApi {
+  return new StdioAgentApi(transport, options);
+}
+
+class StdioProviderApi implements MakaiProviderApi {
+  private readonly responseTimeoutMs: number;
+
+  constructor(private readonly transport: MakaiStdioClient, options: ExecutionOptions) {
+    this.responseTimeoutMs = options.responseTimeoutMs ?? DEFAULT_RESPONSE_TIMEOUT_MS;
+  }
+
+  async complete(request: ProviderCompleteRequest): Promise<ProviderCompleteResponse> {
+    const streamId = randomUUID();
+    this.transport.send(buildEnvelope("complete_request", streamId, buildExecutionPayload(request)));
+    while (true) {
+      const frame = await nextFrame(this.transport, streamId, this.responseTimeoutMs);
+      if (frame.type === "ack") continue;
+      if (frame.type === "nack") throw nackToStreamError(frame);
+      if (frame.type === "stream_error") throw streamErrorFrameToError(frame);
+      if (frame.type === "result" || frame.type === "complete_response") {
+        return parseCompletionResponse(frame.payload ?? frame);
+      }
+      throw new MakaiStreamError(`unexpected frame type while awaiting provider result: ${String(frame.type)}`, { kind: "transport_error" });
+    }
+  }
+
+  async *stream(request: ProviderCompleteRequest): AsyncIterable<ProviderStreamEvent> {
+    const streamId = randomUUID();
+    this.transport.send(buildEnvelope("stream_request", streamId, buildExecutionPayload(request, true)));
+    let terminal = false;
+    const toolBuffers = new Map<number, { id?: string; name?: string; args: string }>();
+    try {
+      while (!terminal) {
+        const frame = await nextFrame(this.transport, streamId, this.responseTimeoutMs);
+        if (frame.type === "ack") continue;
+        if (frame.type === "nack") throw nackToStreamError(frame);
+        const event = normalizeProviderFrame(frame, toolBuffers);
+        if (!event) continue;
+        if (event.type === "error") {
+          terminal = true;
+          throw new MakaiStreamError(event.message, { kind: "provider_error", code: event.code });
+        }
+        if (event.type === "message_end") terminal = true;
+        yield event;
+      }
+    } catch (error) {
+      if (error instanceof MakaiStreamError) throw error;
+      throw new MakaiStreamError(error instanceof Error ? error.message : String(error), { kind: "transport_error" });
+    }
+  }
+}
+
+class StdioAgentApi implements MakaiAgentApi {
+  private readonly responseTimeoutMs: number;
+
+  constructor(private readonly transport: MakaiStdioClient, options: ExecutionOptions) {
+    this.responseTimeoutMs = options.responseTimeoutMs ?? DEFAULT_RESPONSE_TIMEOUT_MS;
+  }
+
+  async run(request: AgentRunRequest): Promise<AgentRunResponse> {
+    const events: AgentStreamEvent[] = [];
+    for await (const event of this.stream(request)) events.push(event);
+    const terminal = [...events].reverse().find((event: AgentStreamEvent) => event.type === "message_end" || event.type === "agent_end");
+    const messageEnd = [...events].reverse().find((event: AgentStreamEvent) => event.type === "message_end");
+    const text = events.filter((event) => event.type === "text_delta").map((event) => event.delta).join("");
+    const start = events.find((event) => event.type === "message_start") as Extract<ProviderStreamEvent, { type: "message_start" }> | undefined;
+    return {
+      message: { role: "assistant", content: text },
+      usage: (terminal && "usage" in terminal ? terminal.usage : undefined) ?? messageEnd?.usage,
+      provider_id: start?.provider_id ?? "",
+      api: start?.api ?? "",
+      model_id: start?.model_id ?? "",
+      stop_reason: terminal && "stop_reason" in terminal ? terminal.stop_reason : undefined,
+    };
+  }
+
+  async *stream(request: AgentRunRequest): AsyncIterable<AgentStreamEvent> {
+    const streamId = randomUUID();
+    this.transport.send(buildEnvelope("agent_run_request", streamId, buildExecutionPayload(request)));
+    let terminal = false;
+    const toolBuffers = new Map<number, { id?: string; name?: string; args: string }>();
+    try {
+      while (!terminal) {
+        const frame = await nextFrame(this.transport, streamId, this.responseTimeoutMs);
+        if (frame.type === "ack") continue;
+        if (frame.type === "nack") throw nackToStreamError(frame);
+        const events = normalizeAgentFrame(frame, toolBuffers);
+        for (const event of events) {
+          if (event.type === "error") {
+            terminal = true;
+            throw new MakaiStreamError(event.message, { kind: "provider_error", code: event.code });
+          }
+          if (event.type === "agent_end") terminal = true;
+          yield event;
+        }
+      }
+    } catch (error) {
+      if (error instanceof MakaiStreamError) throw error;
+      throw new MakaiStreamError(error instanceof Error ? error.message : String(error), { kind: "transport_error" });
+    }
+  }
+}
+
+function buildEnvelope(type: string, streamId: string, payload: Record<string, unknown>): StdioFrame {
+  return {
+    type,
+    stream_id: streamId,
+    message_id: streamId,
+    sequence: 1,
+    timestamp: Date.now(),
+    version: ENVELOPE_VERSION,
+    payload,
+  };
+}
+
+function buildExecutionPayload(
+  request: ProviderCompleteRequest | AgentRunRequest,
+  includePartial = false,
+): Record<string, unknown> {
+  if (!request || typeof request.model_ref !== "string" || request.model_ref.length === 0) {
+    throw new MakaiStreamError("request requires opaque model_ref", { kind: "transport_error", code: "invalid_request" });
+  }
+  if (!Array.isArray(request.messages)) {
+    throw new MakaiStreamError("request requires messages array", { kind: "transport_error", code: "invalid_request" });
+  }
+  const payload: Record<string, unknown> = {
+    model_ref: request.model_ref,
+    messages: request.messages.map(serializeChatMessage),
+  };
+  if (request.tools) payload.tools = request.tools.map(serializeTool);
+  if (request.options) payload.options = serializeOptions(request.options);
+  if (includePartial) payload.include_partial = false;
+  return payload;
+}
+
+function serializeChatMessage(message: ChatMessage): Record<string, unknown> {
+  const out: Record<string, unknown> = { role: message.role, content: message.content };
+  if (message.name) out.name = message.name;
+  if (message.tool_call_id) out.tool_call_id = message.tool_call_id;
+  return out;
+}
+
+function serializeTool(tool: ToolDefinition): Record<string, unknown> {
+  return {
+    name: tool.name,
+    description: tool.description,
+    parameters_schema_json: tool.parameters_schema_json,
+  };
+}
+
+function serializeOptions(options: RunOptions): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const key of ["temperature", "max_tokens", "reasoning_effort", "auth_retry_policy", "session_id", "metadata"] as const) {
+    if (options[key] !== undefined) out[key] = options[key];
+  }
+  return out;
+}
+
+async function nextFrame(transport: MakaiStdioClient, streamId: string, timeoutMs: number): Promise<StdioFrame> {
+  try {
+    return await transport.nextFrameForStream(streamId, timeoutMs);
+  } catch (error) {
+    throw new MakaiStreamError(error instanceof Error ? error.message : String(error), { kind: "transport_error" });
+  }
+}
+
+function normalizeProviderFrame(
+  frame: StdioFrame,
+  toolBuffers: Map<number, { id?: string; name?: string; args: string }>,
+): ProviderStreamEvent | undefined {
+  if (frame.type === "event") return normalizeProviderEvent(readPayloadOrFrame(frame), toolBuffers);
+  if (frame.type === "stream_error") return { type: "error", message: stringValue(readPayloadOrFrame(frame).message, "stream error") };
+  if (frame.type === "message_start") return messageStartFrom(readPayloadOrFrame(frame));
+  if (frame.type === "text_delta") return { type: "text_delta", delta: stringValue(readPayloadOrFrame(frame).delta) };
+  if (frame.type === "thinking_delta" || frame.type === "reasoning_delta" || frame.type === "reasoning") {
+    return { type: "thinking_delta", delta: stringValue(readPayloadOrFrame(frame).delta ?? readPayloadOrFrame(frame).reasoning) };
+  }
+  if (frame.type === "tool_call") return parseToolCall(readPayloadOrFrame(frame));
+  if (frame.type === "message_end" || frame.type === "done" || frame.type === "result") return messageEndFrom(readPayloadOrFrame(frame));
+  if (frame.type === "error") return parseError(readPayloadOrFrame(frame));
+  return undefined;
+}
+
+function normalizeProviderEvent(
+  payload: Record<string, unknown>,
+  toolBuffers: Map<number, { id?: string; name?: string; args: string }>,
+): ProviderStreamEvent | undefined {
+  const type = stringValue(payload.type ?? payload.event_type);
+  if (type === "start") return messageStartFrom(payload.message && isObject(payload.message) ? payload.message : payload);
+  if (type === "text_delta") return { type: "text_delta", delta: stringValue(payload.delta) };
+  if (type === "thinking_delta" || type === "reasoning_delta" || type === "reasoning") {
+    return { type: "thinking_delta", delta: stringValue(payload.delta ?? payload.reasoning) };
+  }
+  if (type === "toolcall_start") {
+    const index = numericValue(payload.content_index, toolBuffers.size);
+    toolBuffers.set(index, { id: optionalString(payload.id), name: optionalString(payload.name), args: "" });
+    return undefined;
+  }
+  if (type === "toolcall_delta") {
+    const index = numericValue(payload.content_index, 0);
+    const existing = toolBuffers.get(index) ?? { args: "" };
+    existing.args += stringValue(payload.delta);
+    toolBuffers.set(index, existing);
+    return undefined;
+  }
+  if (type === "toolcall_end") return parseBufferedToolCall(payload, toolBuffers);
+  if (type === "tool_call") return parseToolCall(payload);
+  if (type === "done") return messageEndFrom(payload);
+  if (type === "error") return parseError(payload);
+  return undefined;
+}
+
+function normalizeAgentFrame(
+  frame: StdioFrame,
+  toolBuffers: Map<number, { id?: string; name?: string; args: string }>,
+): AgentStreamEvent[] {
+  if (frame.type === "agent_result") return [agentEndFrom(readJsonStringPayload(frame, "result_json"))];
+  if (frame.type === "agent_error") return [parseError(readPayloadOrFrame(frame))];
+  if (frame.type === "agent_event") return normalizeAgentEvent(readJsonStringPayload(frame, "event_json"), toolBuffers);
+  const providerEvent = normalizeProviderFrame(frame, toolBuffers);
+  return providerEvent ? [providerEvent] : [];
+}
+
+function normalizeAgentEvent(
+  event: Record<string, unknown>,
+  toolBuffers: Map<number, { id?: string; name?: string; args: string }>,
+): AgentStreamEvent[] {
+  const type = stringValue(event.type ?? firstKey(event));
+  const data = event.type ? event : (event[type] && isObject(event[type]) ? event[type] as Record<string, unknown> : event);
+  switch (type) {
+    case "agent_start":
+      return [{ type: "agent_start", ...(optionalString(data.session_id) ? { session_id: optionalString(data.session_id) } : {}) }];
+    case "turn_start":
+      return [{ type: "turn_start" }];
+    case "turn_end":
+      return [{ type: "turn_end", ...(optionalString(data.stop_reason) ? { stop_reason: optionalString(data.stop_reason) } : {}) }];
+    case "tool_execution_start":
+      return [{ type: "tool_execution_start", tool_call_id: stringValue(data.tool_call_id), tool_name: stringValue(data.tool_name) }];
+    case "tool_execution_end":
+      return [{ type: "tool_execution_end", tool_call_id: stringValue(data.tool_call_id), ...(typeof data.is_error === "boolean" ? { is_error: data.is_error } : {}) }];
+    case "agent_end":
+      return [agentEndFrom(data)];
+    case "message_start":
+      return [messageStartFrom(data.message && isObject(data.message) ? data.message : data)];
+    case "message_update": {
+      const inner = data.event && isObject(data.event) ? data.event as Record<string, unknown> : data;
+      const providerEvent = normalizeProviderEvent(inner, toolBuffers);
+      return providerEvent ? [providerEvent] : [];
+    }
+    case "text_delta":
+    case "thinking_delta":
+    case "reasoning_delta":
+    case "reasoning":
+    case "toolcall_start":
+    case "toolcall_delta":
+    case "toolcall_end":
+    case "tool_call": {
+      const providerEvent = normalizeProviderEvent(event, toolBuffers);
+      return providerEvent ? [providerEvent] : [];
+    }
+    case "message_end":
+      return [messageEndFrom(data.message && isObject(data.message) ? data.message : data)];
+    case "error":
+      return [parseError(data)];
+    default:
+      return [];
+  }
+}
+
+function parseCompletionResponse(raw: unknown): CompletionResponse {
+  const data = isObject(raw) ? raw : {};
+  const message = data.message && isObject(data.message) ? data.message : data;
+  const content = parseContent(message.content);
+  return {
+    message: { role: "assistant", content },
+    usage: parseUsage(message.usage ?? data.usage ?? data),
+    provider_id: stringValue(message.provider_id ?? message.provider ?? data.provider_id ?? data.provider),
+    api: stringValue(message.api ?? data.api),
+    model_id: stringValue(message.model_id ?? message.model ?? data.model_id ?? data.model),
+    stop_reason: optionalString(message.stop_reason ?? data.stop_reason ?? data.reason),
+  };
+}
+
+function parseContent(raw: unknown): string | ContentPart[] {
+  if (typeof raw === "string") return raw;
+  if (!Array.isArray(raw)) return "";
+  return raw.map((part) => {
+    if (!isObject(part)) return { type: "text", text: String(part) } as ContentPart;
+    if (part.type === "tool_call") return { type: "tool_call", tool_call_id: stringValue(part.tool_call_id ?? part.id), name: stringValue(part.name), arguments_json: stringValue(part.arguments_json) };
+    return part as ContentPart;
+  });
+}
+
+function messageStartFrom(data: Record<string, unknown>): ProviderStreamEvent {
+  return {
+    type: "message_start",
+    ...(optionalString(data.provider_id ?? data.provider) ? { provider_id: optionalString(data.provider_id ?? data.provider) } : {}),
+    ...(optionalString(data.api) ? { api: optionalString(data.api) } : {}),
+    ...(optionalString(data.model_id ?? data.model) ? { model_id: optionalString(data.model_id ?? data.model) } : {}),
+  };
+}
+
+function messageEndFrom(data: Record<string, unknown>): ProviderStreamEvent {
+  const message = data.message && isObject(data.message) ? data.message as Record<string, unknown> : data;
+  return { type: "message_end", usage: parseUsage(message.usage ?? data.usage ?? message), stop_reason: optionalString(data.stop_reason ?? data.reason ?? message.stop_reason) };
+}
+
+function agentEndFrom(data: Record<string, unknown>): AgentStreamEvent {
+  return { type: "agent_end", usage: parseUsage(data.usage ?? data), stop_reason: optionalString(data.stop_reason ?? data.reason) };
+}
+
+function parseToolCall(data: Record<string, unknown>): ProviderStreamEvent {
+  return { type: "tool_call", tool_call_id: stringValue(data.tool_call_id ?? data.id), name: stringValue(data.name), arguments_json: stringValue(data.arguments_json) };
+}
+
+function parseBufferedToolCall(
+  data: Record<string, unknown>,
+  toolBuffers: Map<number, { id?: string; name?: string; args: string }>,
+): ProviderStreamEvent {
+  const index = numericValue(data.content_index, 0);
+  const buffered = toolBuffers.get(index);
+  toolBuffers.delete(index);
+  return { type: "tool_call", tool_call_id: stringValue(data.tool_call_id ?? data.id ?? buffered?.id), name: stringValue(data.name ?? buffered?.name), arguments_json: stringValue(data.arguments_json ?? buffered?.args) };
+}
+
+function parseError(data: Record<string, unknown>): ProviderStreamEvent {
+  return { type: "error", message: stringValue(data.message ?? data.error_message ?? data.reason, "stream error"), code: optionalString(data.code ?? data.error_code ?? data.reason) };
+}
+
+function parseUsage(raw: unknown): UsageSummary | undefined {
+  if (!isObject(raw)) return undefined;
+  const input = raw.input ?? raw.input_tokens;
+  const output = raw.output ?? raw.output_tokens;
+  if (typeof input !== "number" || typeof output !== "number") return undefined;
+  const usage: UsageSummary = { input, output };
+  if (typeof raw.cache_read === "number") usage.cache_read = raw.cache_read;
+  if (typeof raw.cache_write === "number") usage.cache_write = raw.cache_write;
+  return usage;
+}
+
+function nackToStreamError(frame: StdioFrame): MakaiStreamError {
+  const payload = readPayloadOrFrame(frame);
+  return new MakaiStreamError(stringValue(payload.reason, "request rejected"), { kind: "provider_error", code: optionalString(payload.error_code) });
+}
+
+function streamErrorFrameToError(frame: StdioFrame): MakaiStreamError {
+  const payload = readPayloadOrFrame(frame);
+  return new MakaiStreamError(stringValue(payload.message ?? payload.reason, "stream error"), { kind: "provider_error", code: optionalString(payload.code ?? payload.error_code) });
+}
+
+function readPayloadOrFrame(frame: StdioFrame): Record<string, unknown> {
+  return frame.payload && isObject(frame.payload) ? frame.payload : frame;
+}
+
+function readJsonStringPayload(frame: StdioFrame, key: string): Record<string, unknown> {
+  const payload = readPayloadOrFrame(frame);
+  const json = payload[key] ?? payload.event_json ?? payload.result_json;
+  if (typeof json === "string") {
+    const parsed = JSON.parse(json) as unknown;
+    return isObject(parsed) ? parsed : {};
+  }
+  return payload;
+}
+
+function stringValue(value: unknown, fallback = ""): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function numericValue(value: unknown, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+function firstKey(value: Record<string, unknown>): string {
+  return Object.keys(value)[0] ?? "";
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export async function createMakaiClient(options: CreateMakaiClientOptions = {}): Promise<MakaiClient> {
+  const { auth: authOptions, responseTimeoutMs, frameTimeoutMs, ...transportOptions } = options;
+  const transport = await createMakaiStdioClient(transportOptions);
+  await transport.connect();
+  const executionOptions = { responseTimeoutMs: responseTimeoutMs ?? frameTimeoutMs };
+  return {
+    auth: new MakaiAuthClient(transport, { handlers: authOptions?.handlers, frameTimeoutMs }),
+    models: createMakaiModelsApi(transport, { responseTimeoutMs: responseTimeoutMs ?? frameTimeoutMs }),
+    agent: createMakaiAgentApi(transport, executionOptions),
+    provider: createMakaiProviderApi(transport, executionOptions),
+    close: () => transport.close(),
+  };
+}

--- a/typescript/src/execution_types.ts
+++ b/typescript/src/execution_types.ts
@@ -1,0 +1,162 @@
+import type { ApiId, ProviderId } from "./models_types";
+import type { AuthFlowHandlers } from "./auth_protocol";
+
+export type AuthRetryPolicy = "manual" | "auto_once";
+
+export type StopReason =
+  | "end_turn"
+  | "max_tokens"
+  | "tool_use"
+  | "stop_sequence"
+  | "max_turns"
+  | string;
+
+export type TextContentPart = {
+  type: "text";
+  text: string;
+  text_signature?: string;
+};
+
+export type ThinkingContentPart = {
+  type: "thinking";
+  thinking: string;
+  thinking_signature?: string;
+};
+
+export type ImageContentPart = {
+  type: "image";
+  data: string;
+  mime_type: string;
+};
+
+export type ToolCallContentPart = {
+  type: "tool_call";
+  tool_call_id: string;
+  name: string;
+  arguments_json: string;
+};
+
+export type ToolResultContentPart = {
+  type: "tool_result";
+  tool_call_id: string;
+  tool_name: string;
+  content: string | TextContentPart[];
+  is_error?: boolean;
+  details_json?: string;
+};
+
+export type ContentPart =
+  | TextContentPart
+  | ThinkingContentPart
+  | ImageContentPart
+  | ToolCallContentPart
+  | ToolResultContentPart;
+
+export interface ChatMessage {
+  role: "system" | "developer" | "user" | "assistant" | "tool";
+  content: string | ContentPart[];
+  name?: string;
+  tool_call_id?: string;
+}
+
+export interface ToolDefinition {
+  name: string;
+  description: string;
+  parameters_schema_json: string;
+}
+
+export interface RunOptions {
+  temperature?: number;
+  max_tokens?: number;
+  reasoning_effort?: "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
+  auth_retry_policy?: AuthRetryPolicy;
+  session_id?: string;
+  metadata?: Record<string, string>;
+}
+
+export interface UsageSummary {
+  input: number;
+  output: number;
+  cache_read?: number;
+  cache_write?: number;
+}
+
+export interface AgentRunRequest {
+  model_ref: string;
+  messages: ChatMessage[];
+  tools?: ToolDefinition[];
+  options?: RunOptions;
+}
+
+export interface CompletionResponse {
+  message: {
+    role: "assistant";
+    content: string | ContentPart[];
+  };
+  usage?: UsageSummary;
+  provider_id: ProviderId;
+  api: ApiId;
+  model_id: string;
+  stop_reason?: StopReason;
+}
+
+export type AgentRunResponse = CompletionResponse;
+
+export type ProviderStreamEvent =
+  | { type: "message_start"; provider_id?: ProviderId; api?: ApiId; model_id?: string }
+  | { type: "text_delta"; delta: string }
+  | { type: "thinking_delta"; delta: string }
+  | { type: "tool_call"; name: string; arguments_json: string; tool_call_id: string }
+  | { type: "message_end"; usage?: UsageSummary; stop_reason?: StopReason }
+  | { type: "error"; message: string; code?: string };
+
+export type AgentStreamEvent =
+  | ProviderStreamEvent
+  | { type: "agent_start"; session_id?: string }
+  | { type: "agent_end"; stop_reason?: StopReason; usage?: UsageSummary }
+  | { type: "turn_start" }
+  | { type: "turn_end"; stop_reason?: StopReason }
+  | { type: "tool_execution_start"; tool_call_id: string; tool_name: string }
+  | { type: "tool_execution_end"; tool_call_id: string; is_error?: boolean };
+
+export interface ProviderCompleteRequest {
+  model_ref: string;
+  messages: ChatMessage[];
+  tools?: ToolDefinition[];
+  options?: RunOptions;
+}
+
+export type ProviderCompleteResponse = CompletionResponse;
+
+export interface MakaiAgentApi {
+  run(request: AgentRunRequest): Promise<AgentRunResponse>;
+  stream(request: AgentRunRequest): AsyncIterable<AgentStreamEvent>;
+}
+
+export interface MakaiProviderApi {
+  complete(request: ProviderCompleteRequest): Promise<ProviderCompleteResponse>;
+  stream(request: ProviderCompleteRequest): AsyncIterable<ProviderStreamEvent>;
+}
+
+export type MakaiStreamErrorKind = "provider_error" | "transport_error" | "aborted" | "unknown";
+
+export class MakaiStreamError extends Error {
+  public readonly kind: MakaiStreamErrorKind;
+  public readonly code?: string;
+
+  constructor(message: string, options: { kind?: MakaiStreamErrorKind; code?: string } = {}) {
+    super(message);
+    this.name = "MakaiStreamError";
+    this.kind = options.kind ?? "unknown";
+    this.code = options.code;
+  }
+}
+
+export interface MakaiClientOptions {
+  auth?: {
+    auth_retry_policy?: AuthRetryPolicy;
+    handlers?: AuthFlowHandlers;
+  };
+  responseTimeoutMs?: number;
+  frameTimeoutMs?: number;
+}

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -5,9 +5,10 @@ export {
   type CreateMakaiStdioClientOptions,
   type MakaiStdioClientOptions,
   type StdioFrame,
-  // Deprecated aliases retained for backward compatibility with older imports.
-  type CreateMakaiClientOptions,
-  type MakaiClientOptions,
+  // Deprecated aliases retained under transport-specific names to avoid
+  // colliding with the unified high-level client factory options.
+  type CreateMakaiClientOptions as DeprecatedCreateMakaiStdioClientOptions,
+  type MakaiClientOptions as DeprecatedMakaiStdioClientOptions,
 } from "./stdio_client";
 
 export { resolveMakaiBinary, type BinaryResolverOptions } from "./binary_resolver";
@@ -33,6 +34,41 @@ export {
   createMakaiModelsApi,
   type ModelsApiOptions,
 } from "./models_client";
+
+export {
+  createMakaiAgentApi,
+  createMakaiClient,
+  createMakaiProviderApi,
+  type CreateMakaiClientOptions,
+  type MakaiClient,
+} from "./execution_client";
+
+export {
+  MakaiStreamError,
+  type AgentRunRequest,
+  type AgentRunResponse,
+  type AgentStreamEvent,
+  type AuthRetryPolicy,
+  type ChatMessage,
+  type CompletionResponse,
+  type ContentPart,
+  type ImageContentPart,
+  type MakaiAgentApi,
+  type MakaiClientOptions,
+  type MakaiProviderApi,
+  type MakaiStreamErrorKind,
+  type ProviderCompleteRequest,
+  type ProviderCompleteResponse,
+  type ProviderStreamEvent,
+  type RunOptions,
+  type StopReason,
+  type TextContentPart,
+  type ThinkingContentPart,
+  type ToolCallContentPart,
+  type ToolDefinition,
+  type ToolResultContentPart,
+  type UsageSummary,
+} from "./execution_types";
 export {
   MakaiProtocolError,
   // Note: `AuthStatus` and `ProviderId` are re-exported from `./auth_protocol`

--- a/typescript/test/execution_client.test.ts
+++ b/typescript/test/execution_client.test.ts
@@ -1,0 +1,179 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+  createMakaiAgentApi,
+  createMakaiClient,
+  createMakaiProviderApi,
+  MakaiStdioClient,
+  MakaiStreamError,
+  type AgentStreamEvent,
+  type ProviderStreamEvent,
+} from "../src";
+
+const sourceFixturesDir = path.resolve(__dirname, "../../typescript/test/fixtures");
+const fixtureScript = path.join(sourceFixturesDir, "execution-server.js");
+
+type Harness = {
+  client: MakaiStdioClient;
+  tmpDir: string;
+  logPath: string;
+  cleanup(): Promise<void>;
+};
+
+async function setupHarness(envOverrides: NodeJS.ProcessEnv = {}): Promise<Harness> {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "makai-exec-test-"));
+  const logPath = path.join(tmpDir, "request.log");
+  const client = new MakaiStdioClient({
+    command: process.execPath,
+    args: [fixtureScript],
+    env: { ...process.env, MAKAI_TEST_REQUEST_LOG: logPath, ...envOverrides },
+    handshakeTimeoutMs: 5000,
+  });
+  await client.connect();
+  return {
+    client,
+    tmpDir,
+    logPath,
+    cleanup: async () => {
+      await client.close();
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    },
+  };
+}
+
+function request() {
+  return {
+    model_ref: "opaque-model-ref-with:colon",
+    messages: [{ role: "user" as const, content: "hello" }],
+    options: { temperature: 0.2, session_id: "session-1" },
+  };
+}
+
+function readLoggedRequests(logPath: string): Array<Record<string, unknown>> {
+  if (!fs.existsSync(logPath)) return [];
+  return fs.readFileSync(logPath, "utf8").trim().split(/\r?\n/).filter(Boolean).map((line) => JSON.parse(line));
+}
+
+async function collect<T>(iterable: AsyncIterable<T>): Promise<T[]> {
+  const out: T[] = [];
+  for await (const item of iterable) out.push(item);
+  return out;
+}
+
+test("client.provider.complete resolves with correct CompletionResponse shape", async () => {
+  const harness = await setupHarness();
+  try {
+    const provider = createMakaiProviderApi(harness.client);
+    const result = await provider.complete(request());
+
+    assert.equal(result.message.role, "assistant");
+    assert.deepEqual(result.message.content, [{ type: "text", text: "hello" }]);
+    assert.deepEqual(result.usage, { input: 3, output: 5, cache_read: 1, cache_write: 0 });
+    assert.equal(result.provider_id, "anthropic");
+    assert.equal(result.api, "anthropic-messages");
+    assert.equal(result.model_id, "claude-sonnet-4-5");
+    assert.equal(result.stop_reason, "end_turn");
+
+    const logged = readLoggedRequests(harness.logPath);
+    assert.equal(logged[0]?.type, "complete_request");
+    assert.equal((logged[0]?.payload as Record<string, unknown>).model_ref, "opaque-model-ref-with:colon");
+  } finally {
+    await harness.cleanup();
+  }
+});
+
+test("client.provider.stream yields ProviderStreamEvent sequence including message_end", async () => {
+  const harness = await setupHarness();
+  try {
+    const provider = createMakaiProviderApi(harness.client);
+    const events = await collect(provider.stream(request()));
+    assert.deepEqual(events, [
+      { type: "message_start", provider_id: "anthropic", api: "anthropic-messages", model_id: "claude-sonnet-4-5" },
+      { type: "text_delta", delta: "hel" },
+      { type: "thinking_delta", delta: "thinking" },
+      { type: "text_delta", delta: "lo" },
+      { type: "message_end", usage: { input: 3, output: 5 }, stop_reason: "end_turn" },
+    ] satisfies ProviderStreamEvent[]);
+  } finally {
+    await harness.cleanup();
+  }
+});
+
+test("client.agent.run resolves with correct AgentRunResponse", async () => {
+  const harness = await setupHarness();
+  try {
+    const agent = createMakaiAgentApi(harness.client);
+    const result = await agent.run(request());
+    assert.equal(result.message.content, "agent");
+    assert.deepEqual(result.usage, { input: 7, output: 9 });
+    assert.equal(result.provider_id, "anthropic");
+    assert.equal(result.api, "anthropic-messages");
+    assert.equal(result.model_id, "claude-sonnet-4-5");
+    assert.equal(result.stop_reason, "end_turn");
+  } finally {
+    await harness.cleanup();
+  }
+});
+
+test("client.agent.stream yields agent lifecycle events in order", async () => {
+  const harness = await setupHarness();
+  try {
+    const agent = createMakaiAgentApi(harness.client);
+    const events = await collect(agent.stream(request()));
+    assert.deepEqual(events.map((event) => event.type), [
+      "agent_start",
+      "turn_start",
+      "message_start",
+      "text_delta",
+      "tool_execution_start",
+      "tool_execution_end",
+      "turn_end",
+      "agent_end",
+    ]);
+    assert.deepEqual(events[0], { type: "agent_start", session_id: "session-1" } satisfies AgentStreamEvent);
+    assert.deepEqual(events.at(-1), { type: "agent_end", usage: { input: 7, output: 9 }, stop_reason: "end_turn" } satisfies AgentStreamEvent);
+  } finally {
+    await harness.cleanup();
+  }
+});
+
+test("stream error paths throw MakaiStreamError", async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "makai-exec-error-test-"));
+  const eventsPath = path.join(tmpDir, "events.json");
+  fs.writeFileSync(eventsPath, JSON.stringify([{ type: "message_start" }, { type: "error", message: "boom", code: "provider_error" }]));
+  const harness = await setupHarness({ MAKAI_TEST_PROVIDER_EVENTS_PATH: eventsPath });
+  try {
+    const provider = createMakaiProviderApi(harness.client);
+    await assert.rejects(
+      async () => collect(provider.stream(request())),
+      (err: unknown) => err instanceof MakaiStreamError && err.message === "boom" && err.code === "provider_error",
+    );
+  } finally {
+    await harness.cleanup();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("createMakaiClient wires all namespaces correctly", async () => {
+  const handle = await createMakaiClient({
+    command: process.execPath,
+    args: [fixtureScript],
+    handshakeTimeoutMs: 5000,
+    responseTimeoutMs: 5000,
+  });
+  try {
+    assert.equal(typeof handle.auth.listProviders, "function");
+    assert.equal(typeof handle.models.list, "function");
+    assert.equal(typeof handle.provider.complete, "function");
+    assert.equal(typeof handle.provider.stream, "function");
+    assert.equal(typeof handle.agent.run, "function");
+    assert.equal(typeof handle.agent.stream, "function");
+    assert.deepEqual(await handle.auth.listProviders(), []);
+    assert.deepEqual((await handle.models.list()).models, []);
+  } finally {
+    await handle.close();
+  }
+});

--- a/typescript/test/fixtures/execution-server.js
+++ b/typescript/test/fixtures/execution-server.js
@@ -1,0 +1,115 @@
+const fs = require("node:fs");
+const readline = require("node:readline");
+
+function emit(frame) {
+  process.stdout.write(JSON.stringify(frame) + "\n");
+}
+
+function loadJson(path, fallback) {
+  if (!path) return fallback;
+  return JSON.parse(fs.readFileSync(path, "utf8"));
+}
+
+function appendLog(path, line) {
+  if (!path) return;
+  fs.appendFileSync(path, line + "\n");
+}
+
+function ack(env) {
+  return {
+    type: "ack",
+    stream_id: env.stream_id,
+    message_id: `${env.stream_id}-ack`,
+    sequence: 2,
+    timestamp: Date.now(),
+    version: 1,
+    in_reply_to: env.message_id,
+    payload: { acknowledged_id: env.message_id },
+  };
+}
+
+function frame(env, type, payload, sequence) {
+  return {
+    type,
+    stream_id: env.stream_id,
+    message_id: `${env.stream_id}-${sequence}`,
+    sequence,
+    timestamp: Date.now(),
+    version: 1,
+    in_reply_to: env.message_id,
+    payload,
+  };
+}
+
+const defaultProviderResult = {
+  role: "assistant",
+  content: [{ type: "text", text: "hello" }],
+  usage: { input: 3, output: 5, cache_read: 1, cache_write: 0 },
+  provider_id: "anthropic",
+  api: "anthropic-messages",
+  model_id: "claude-sonnet-4-5",
+  stop_reason: "end_turn",
+};
+
+const defaultProviderEvents = [
+  { type: "message_start", provider_id: "anthropic", api: "anthropic-messages", model_id: "claude-sonnet-4-5" },
+  { type: "text_delta", delta: "hel" },
+  { type: "reasoning", delta: "thinking" },
+  { type: "text_delta", delta: "lo" },
+  { type: "message_end", usage: { input: 3, output: 5 }, stop_reason: "end_turn" },
+];
+
+const defaultAgentEvents = [
+  { type: "agent_start", session_id: "session-1" },
+  { type: "turn_start" },
+  { type: "message_start", provider_id: "anthropic", api: "anthropic-messages", model_id: "claude-sonnet-4-5" },
+  { type: "text_delta", delta: "agent" },
+  { type: "tool_execution_start", tool_call_id: "tool-1", tool_name: "lookup" },
+  { type: "tool_execution_end", tool_call_id: "tool-1", is_error: false },
+  { type: "turn_end", stop_reason: "end_turn" },
+  { type: "agent_end", usage: { input: 7, output: 9 }, stop_reason: "end_turn" },
+];
+
+emit({ type: "ready", protocol_version: "1" });
+
+const requestLog = process.env.MAKAI_TEST_REQUEST_LOG || "";
+const providerResult = loadJson(process.env.MAKAI_TEST_PROVIDER_RESULT_PATH, defaultProviderResult);
+const providerEvents = loadJson(process.env.MAKAI_TEST_PROVIDER_EVENTS_PATH, defaultProviderEvents);
+const agentEvents = loadJson(process.env.MAKAI_TEST_AGENT_EVENTS_PATH, defaultAgentEvents);
+const modelsResponse = loadJson(process.env.MAKAI_TEST_MODELS_RESPONSE_PATH, {
+  models: [],
+  fetched_at_ms: 1,
+  cache_max_age_ms: 300000,
+});
+
+const rl = readline.createInterface({ input: process.stdin, crlfDelay: Infinity });
+
+rl.on("line", (line) => {
+  let env;
+  try {
+    env = JSON.parse(line);
+  } catch {
+    return;
+  }
+  appendLog(requestLog, JSON.stringify(env));
+  emit(ack(env));
+
+  if (env.type === "complete_request") {
+    emit(frame(env, "result", providerResult, 3));
+  } else if (env.type === "stream_request") {
+    for (let i = 0; i < providerEvents.length; i += 1) {
+      const event = providerEvents[i];
+      emit(frame(env, event.type, event, i + 3));
+    }
+  } else if (env.type === "agent_run_request") {
+    for (let i = 0; i < agentEvents.length; i += 1) {
+      emit(frame(env, "agent_event", { event_json: JSON.stringify(agentEvents[i]) }, i + 3));
+    }
+  } else if (env.type === "auth_providers_request") {
+    emit(frame(env, "auth_providers_response", { providers: [] }, 3));
+  } else if (env.type === "models_request") {
+    emit(frame(env, "models_response", modelsResponse, 3));
+  }
+});
+
+rl.on("close", () => process.exit(0));


### PR DESCRIPTION
## Summary
- Add high-level `client.provider.*` and `client.agent.*` APIs over the stdio protocol transport.
- Normalize provider stream events, including reasoning to `thinking_delta` and buffered tool call emission.
- Add unified `createMakaiClient()` wiring auth, models, provider, and agent namespaces.

## Test plan
- [x] `npm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)