### PR TITLE
M-009c: add TS execution client APIs

### DIFF
--- a/typescript/src/execution_client.ts
+++ b/typescript/src/execution_client.ts
@@ -252,12 +252,26 @@ function validateExecutionRequest(request: ProviderCompleteRequest | AgentRunReq
 }
 
 function modelFromRef(modelRef: string): Record<string, unknown> {
-  const parsed = parseModelRef(modelRef);
+  try {
+    const parsed = parseModelRef(modelRef);
+    return {
+      id: parsed.modelId,
+      name: parsed.modelId,
+      api: parsed.api,
+      provider: parsed.providerId,
+      base_url: "",
+    };
+  } catch {
+    return opaqueModel(modelRef);
+  }
+}
+
+function opaqueModel(modelRef: string): Record<string, unknown> {
   return {
-    id: parsed.modelId,
-    name: parsed.modelId,
-    api: parsed.api,
-    provider: parsed.providerId,
+    id: modelRef,
+    name: modelRef,
+    api: "",
+    provider: "",
     base_url: "",
   };
 }
@@ -377,6 +391,9 @@ function normalizeProviderFrame(
     return { type: "thinking_delta", delta: stringValue(readPayloadOrFrame(frame).delta ?? readPayloadOrFrame(frame).reasoning) };
   }
   if (frame.type === "tool_call") return parseToolCall(readPayloadOrFrame(frame));
+  if (frame.type === "toolcall_start" || frame.type === "toolcall_delta" || frame.type === "toolcall_end") {
+    return normalizeProviderEvent(readPayloadOrFrame(frame), toolBuffers);
+  }
   if (frame.type === "message_end" || frame.type === "done" || frame.type === "result") return messageEndFrom(readPayloadOrFrame(frame));
   if (frame.type === "error") return parseError(readPayloadOrFrame(frame));
   return undefined;

--- a/typescript/src/execution_client.ts
+++ b/typescript/src/execution_client.ts
@@ -289,7 +289,7 @@ function agentSessionId(request: AgentRunRequest): string {
 }
 
 function isUuid(value: string): boolean {
-  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value);
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value);
 }
 
 function serializeChatMessage(message: ChatMessage): Record<string, unknown> {

--- a/typescript/src/execution_client.ts
+++ b/typescript/src/execution_client.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { MakaiAuthClient, type MakaiAuthApi } from "./auth_protocol";
+import { parseModelRef } from "./diagnostics/model_ref";
 import { createMakaiModelsApi } from "./models_client";
 import type { MakaiModelsApi } from "./models_types";
 import { type CreateMakaiStdioClientOptions, createMakaiStdioClient, MakaiStdioClient, type StdioFrame } from "./stdio_client";
@@ -212,6 +213,7 @@ function buildExecutionPayload(
   const payload: Record<string, unknown> = {
     model,
     context: executionContext(request),
+    model_ref: request.model_ref,
   };
   const serializedOptions = serializeOptionsWithDefaults(request.options, options.authRetryPolicy);
   if (Object.keys(serializedOptions).length > 0) payload.options = serializedOptions;
@@ -250,11 +252,12 @@ function validateExecutionRequest(request: ProviderCompleteRequest | AgentRunReq
 }
 
 function modelFromRef(modelRef: string): Record<string, unknown> {
+  const parsed = parseModelRef(modelRef);
   return {
-    id: modelRef,
-    name: modelRef,
-    api: "",
-    provider: "",
+    id: parsed.modelId,
+    name: parsed.modelId,
+    api: parsed.api,
+    provider: parsed.providerId,
     base_url: "",
   };
 }

--- a/typescript/src/execution_client.ts
+++ b/typescript/src/execution_client.ts
@@ -179,9 +179,21 @@ class StdioAgentApi implements MakaiAgentApi {
 
   async run(request: AgentRunRequest): Promise<AgentRunResponse> {
     const effectivePolicy = request.options?.auth_retry_policy ?? this.authRetryPolicy;
+    let retryRequest = request;
     return withAuthRetry(
-      () => this.runOnce(request, effectivePolicy),
-      { auth: this.auth, authHandlers: this.authHandlers, authRetryPolicy: effectivePolicy, fallbackProviderId: providerIdFromRequest(request) },
+      () => this.runOnce(retryRequest, effectivePolicy),
+      {
+        auth: this.auth,
+        authHandlers: this.authHandlers,
+        authRetryPolicy: effectivePolicy,
+        fallbackProviderId: providerIdFromRequest(request),
+        beforeRetry: () => {
+          retryRequest = {
+            ...request,
+            options: { ...request.options, session_id: generateNanoId() },
+          };
+        },
+      },
     );
   }
 
@@ -221,7 +233,8 @@ class StdioAgentApi implements MakaiAgentApi {
   async *stream(request: AgentRunRequest): AsyncIterable<AgentStreamEvent> {
     const effectivePolicy = request.options?.auth_retry_policy ?? this.authRetryPolicy;
     const fallbackProviderId = providerIdFromRequest(request);
-    let attempt = this.streamAttempt(request, effectivePolicy);
+    let streamRequest = request;
+    let attempt = this.streamAttempt(streamRequest, effectivePolicy);
     let iterator = attempt[Symbol.asyncIterator]();
     let yielded = false;
     let retried = false;
@@ -240,7 +253,11 @@ class StdioAgentApi implements MakaiAgentApi {
               throw error;
             }
             retried = true;
-            attempt = this.streamAttempt(request, effectivePolicy);
+            streamRequest = {
+              ...request,
+              options: { ...request.options, session_id: generateNanoId() },
+            };
+            attempt = this.streamAttempt(streamRequest, effectivePolicy);
             iterator = attempt[Symbol.asyncIterator]();
             continue;
           }
@@ -832,6 +849,7 @@ async function withAuthRetry<T>(
     authHandlers?: AuthFlowHandlers;
     authRetryPolicy?: RunOptions["auth_retry_policy"];
     fallbackProviderId?: string;
+    beforeRetry?: () => void;
   },
 ): Promise<T> {
   try {
@@ -845,6 +863,7 @@ async function withAuthRetry<T>(
       } catch {
         throw error;
       }
+      options.beforeRetry?.();
       return await operation();
     }
     throw error;

--- a/typescript/src/execution_client.ts
+++ b/typescript/src/execution_client.ts
@@ -74,7 +74,7 @@ class StdioProviderApi implements MakaiProviderApi {
     const effectivePolicy = request.options?.auth_retry_policy ?? this.authRetryPolicy;
     return withAuthRetry(
       () => this.completeOnce(request, effectivePolicy),
-      { auth: this.auth, authHandlers: this.authHandlers, authRetryPolicy: effectivePolicy },
+      { auth: this.auth, authHandlers: this.authHandlers, authRetryPolicy: effectivePolicy, fallbackProviderId: providerIdFromRequest(request) },
     );
   }
 
@@ -95,6 +95,7 @@ class StdioProviderApi implements MakaiProviderApi {
 
   async *stream(request: ProviderCompleteRequest): AsyncIterable<ProviderStreamEvent> {
     const effectivePolicy = request.options?.auth_retry_policy ?? this.authRetryPolicy;
+    const fallbackProviderId = providerIdFromRequest(request);
     let attempt = this.streamAttempt(request, effectivePolicy);
     let iterator = attempt[Symbol.asyncIterator]();
     let yielded = false;
@@ -104,15 +105,18 @@ class StdioProviderApi implements MakaiProviderApi {
       try {
         result = await iterator.next();
       } catch (error) {
-        if (!yielded && isRetryableAuthError(error) && effectivePolicy === "auto_once" && this.auth && error.provider_id) {
-          try {
-            await this.auth.login(error.provider_id, this.authHandlers);
-          } catch {
-            throw error;
+        if (!yielded && isRetryableAuthError(error) && effectivePolicy === "auto_once" && this.auth) {
+          const providerId = error.provider_id ?? fallbackProviderId;
+          if (providerId) {
+            try {
+              await this.auth.login(providerId, this.authHandlers);
+            } catch {
+              throw error;
+            }
+            attempt = this.streamAttempt(request, effectivePolicy);
+            iterator = attempt[Symbol.asyncIterator]();
+            continue;
           }
-          attempt = this.streamAttempt(request, effectivePolicy);
-          iterator = attempt[Symbol.asyncIterator]();
-          continue;
         }
         throw error;
       }
@@ -165,7 +169,7 @@ class StdioAgentApi implements MakaiAgentApi {
     const effectivePolicy = request.options?.auth_retry_policy ?? this.authRetryPolicy;
     return withAuthRetry(
       () => this.runOnce(request, effectivePolicy),
-      { auth: this.auth, authHandlers: this.authHandlers, authRetryPolicy: effectivePolicy },
+      { auth: this.auth, authHandlers: this.authHandlers, authRetryPolicy: effectivePolicy, fallbackProviderId: providerIdFromRequest(request) },
     );
   }
 
@@ -204,6 +208,7 @@ class StdioAgentApi implements MakaiAgentApi {
 
   async *stream(request: AgentRunRequest): AsyncIterable<AgentStreamEvent> {
     const effectivePolicy = request.options?.auth_retry_policy ?? this.authRetryPolicy;
+    const fallbackProviderId = providerIdFromRequest(request);
     let attempt = this.streamAttempt(request, effectivePolicy);
     let iterator = attempt[Symbol.asyncIterator]();
     let yielded = false;
@@ -213,15 +218,18 @@ class StdioAgentApi implements MakaiAgentApi {
       try {
         result = await iterator.next();
       } catch (error) {
-        if (!yielded && isRetryableAuthError(error) && effectivePolicy === "auto_once" && this.auth && error.provider_id) {
-          try {
-            await this.auth.login(error.provider_id, this.authHandlers);
-          } catch {
-            throw error;
+        if (!yielded && isRetryableAuthError(error) && effectivePolicy === "auto_once" && this.auth) {
+          const providerId = error.provider_id ?? fallbackProviderId;
+          if (providerId) {
+            try {
+              await this.auth.login(providerId, this.authHandlers);
+            } catch {
+              throw error;
+            }
+            attempt = this.streamAttempt(request, effectivePolicy);
+            iterator = attempt[Symbol.asyncIterator]();
+            continue;
           }
-          attempt = this.streamAttempt(request, effectivePolicy);
-          iterator = attempt[Symbol.asyncIterator]();
-          continue;
         }
         throw error;
       }
@@ -787,20 +795,35 @@ function isRetryableAuthError(error: unknown): error is MakaiStreamError {
   return error instanceof MakaiStreamError && error.code === "auth_required";
 }
 
+function providerIdFromRequest(request: ProviderCompleteRequest | AgentRunRequest): string | undefined {
+  // model_ref is opaque per spec, but canonical refs carry provider info.
+  // We derive a fallback provider_id for auth retry only when the runtime
+  // error frame does not include one.
+  try {
+    const parsed = parseModelRef(request.model_ref);
+    return parsed.providerId;
+  } catch {
+    return undefined;
+  }
+}
+
 async function withAuthRetry<T>(
   operation: () => Promise<T>,
   options: {
     auth?: MakaiAuthApi;
     authHandlers?: AuthFlowHandlers;
     authRetryPolicy?: RunOptions["auth_retry_policy"];
+    fallbackProviderId?: string;
   },
 ): Promise<T> {
   try {
     return await operation();
   } catch (error) {
-    if (isRetryableAuthError(error) && options.authRetryPolicy === "auto_once" && options.auth && error.provider_id) {
+    if (isRetryableAuthError(error) && options.authRetryPolicy === "auto_once" && options.auth) {
+      const providerId = error.provider_id ?? options.fallbackProviderId;
+      if (!providerId) throw error;
       try {
-        await options.auth.login(error.provider_id, options.authHandlers);
+        await options.auth.login(providerId, options.authHandlers);
       } catch {
         throw error;
       }

--- a/typescript/src/execution_client.ts
+++ b/typescript/src/execution_client.ts
@@ -71,15 +71,16 @@ class StdioProviderApi implements MakaiProviderApi {
   }
 
   async complete(request: ProviderCompleteRequest): Promise<ProviderCompleteResponse> {
+    const effectivePolicy = request.options?.auth_retry_policy ?? this.authRetryPolicy;
     return withAuthRetry(
-      () => this.completeOnce(request),
-      { auth: this.auth, authHandlers: this.authHandlers, authRetryPolicy: this.authRetryPolicy },
+      () => this.completeOnce(request, effectivePolicy),
+      { auth: this.auth, authHandlers: this.authHandlers, authRetryPolicy: effectivePolicy },
     );
   }
 
-  private async completeOnce(request: ProviderCompleteRequest): Promise<ProviderCompleteResponse> {
+  private async completeOnce(request: ProviderCompleteRequest, effectivePolicy: RunOptions["auth_retry_policy"] | undefined): Promise<ProviderCompleteResponse> {
     const streamId = randomUUID();
-    this.transport.send(buildEnvelope("complete_request", streamId, buildExecutionPayload(request, { authRetryPolicy: this.authRetryPolicy })));
+    this.transport.send(buildEnvelope("complete_request", streamId, buildExecutionPayload(request, { authRetryPolicy: effectivePolicy })));
     while (true) {
       const frame = await nextFrame(this.transport, streamId, this.responseTimeoutMs);
       if (frame.type === "ack") continue;
@@ -93,7 +94,8 @@ class StdioProviderApi implements MakaiProviderApi {
   }
 
   async *stream(request: ProviderCompleteRequest): AsyncIterable<ProviderStreamEvent> {
-    let attempt = this.streamAttempt(request);
+    const effectivePolicy = request.options?.auth_retry_policy ?? this.authRetryPolicy;
+    let attempt = this.streamAttempt(request, effectivePolicy);
     let iterator = attempt[Symbol.asyncIterator]();
     let yielded = false;
 
@@ -102,13 +104,13 @@ class StdioProviderApi implements MakaiProviderApi {
       try {
         result = await iterator.next();
       } catch (error) {
-        if (!yielded && isRetryableAuthError(error) && this.authRetryPolicy === "auto_once" && this.auth && error.provider_id) {
+        if (!yielded && isRetryableAuthError(error) && effectivePolicy === "auto_once" && this.auth && error.provider_id) {
           try {
             await this.auth.login(error.provider_id, this.authHandlers);
           } catch {
             throw error;
           }
-          attempt = this.streamAttempt(request);
+          attempt = this.streamAttempt(request, effectivePolicy);
           iterator = attempt[Symbol.asyncIterator]();
           continue;
         }
@@ -120,9 +122,9 @@ class StdioProviderApi implements MakaiProviderApi {
     }
   }
 
-  private async *streamAttempt(request: ProviderCompleteRequest): AsyncIterable<ProviderStreamEvent> {
+  private async *streamAttempt(request: ProviderCompleteRequest, effectivePolicy: RunOptions["auth_retry_policy"] | undefined): AsyncIterable<ProviderStreamEvent> {
     const streamId = randomUUID();
-    this.transport.send(buildEnvelope("stream_request", streamId, buildExecutionPayload(request, { suppressPartial: true, authRetryPolicy: this.authRetryPolicy })));
+    this.transport.send(buildEnvelope("stream_request", streamId, buildExecutionPayload(request, { suppressPartial: true, authRetryPolicy: effectivePolicy })));
     let terminal = false;
     const toolBuffers = new Map<number, { id?: string; name?: string; args: string }>();
     try {
@@ -160,15 +162,16 @@ class StdioAgentApi implements MakaiAgentApi {
   }
 
   async run(request: AgentRunRequest): Promise<AgentRunResponse> {
+    const effectivePolicy = request.options?.auth_retry_policy ?? this.authRetryPolicy;
     return withAuthRetry(
-      () => this.runOnce(request),
-      { auth: this.auth, authHandlers: this.authHandlers, authRetryPolicy: this.authRetryPolicy },
+      () => this.runOnce(request, effectivePolicy),
+      { auth: this.auth, authHandlers: this.authHandlers, authRetryPolicy: effectivePolicy },
     );
   }
 
-  private async runOnce(request: AgentRunRequest): Promise<AgentRunResponse> {
+  private async runOnce(request: AgentRunRequest, effectivePolicy: RunOptions["auth_retry_policy"] | undefined): Promise<AgentRunResponse> {
     const sessionId = agentSessionId(request);
-    this.transport.send(buildAgentEnvelope("agent_start", sessionId, 1, buildAgentStartPayload(request)));
+    this.transport.send(buildAgentEnvelope("agent_start", sessionId, 1, buildAgentStartPayload(request, sessionId)));
     const events: AgentStreamEvent[] = [];
     const toolBuffers = new Map<number, { id?: string; name?: string; args: string }>();
     let messageSent = false;
@@ -179,7 +182,7 @@ class StdioAgentApi implements MakaiAgentApi {
       if (frame.type === "agent_error") throw streamErrorFrameToError(frame);
       if (frame.type === "agent_started") {
         if (!messageSent) {
-          this.transport.send(buildAgentEnvelope("agent_message", sessionId, 2, buildAgentMessagePayload(request, sessionId, this.authRetryPolicy)));
+          this.transport.send(buildAgentEnvelope("agent_message", sessionId, 2, buildAgentMessagePayload(request, sessionId, effectivePolicy)));
           messageSent = true;
         }
         continue;
@@ -200,7 +203,8 @@ class StdioAgentApi implements MakaiAgentApi {
   }
 
   async *stream(request: AgentRunRequest): AsyncIterable<AgentStreamEvent> {
-    let attempt = this.streamAttempt(request);
+    const effectivePolicy = request.options?.auth_retry_policy ?? this.authRetryPolicy;
+    let attempt = this.streamAttempt(request, effectivePolicy);
     let iterator = attempt[Symbol.asyncIterator]();
     let yielded = false;
 
@@ -209,13 +213,13 @@ class StdioAgentApi implements MakaiAgentApi {
       try {
         result = await iterator.next();
       } catch (error) {
-        if (!yielded && isRetryableAuthError(error) && this.authRetryPolicy === "auto_once" && this.auth && error.provider_id) {
+        if (!yielded && isRetryableAuthError(error) && effectivePolicy === "auto_once" && this.auth && error.provider_id) {
           try {
             await this.auth.login(error.provider_id, this.authHandlers);
           } catch {
             throw error;
           }
-          attempt = this.streamAttempt(request);
+          attempt = this.streamAttempt(request, effectivePolicy);
           iterator = attempt[Symbol.asyncIterator]();
           continue;
         }
@@ -227,9 +231,9 @@ class StdioAgentApi implements MakaiAgentApi {
     }
   }
 
-  private async *streamAttempt(request: AgentRunRequest): AsyncIterable<AgentStreamEvent> {
+  private async *streamAttempt(request: AgentRunRequest, effectivePolicy: RunOptions["auth_retry_policy"] | undefined): AsyncIterable<AgentStreamEvent> {
     const sessionId = agentSessionId(request);
-    this.transport.send(buildAgentEnvelope("agent_start", sessionId, 1, buildAgentStartPayload(request)));
+    this.transport.send(buildAgentEnvelope("agent_start", sessionId, 1, buildAgentStartPayload(request, sessionId)));
     let terminal = false;
     let messageSent = false;
     const toolBuffers = new Map<number, { id?: string; name?: string; args: string }>();
@@ -239,7 +243,7 @@ class StdioAgentApi implements MakaiAgentApi {
         if (frame.type === "ack") continue;
         if (frame.type === "nack") throw nackToStreamError(frame);
         if (frame.type === "agent_started" && !messageSent) {
-          this.transport.send(buildAgentEnvelope("agent_message", sessionId, 2, buildAgentMessagePayload(request, sessionId, this.authRetryPolicy)));
+          this.transport.send(buildAgentEnvelope("agent_message", sessionId, 2, buildAgentMessagePayload(request, sessionId, effectivePolicy)));
           messageSent = true;
           continue;
         }
@@ -303,9 +307,12 @@ function buildExecutionPayload(
   return payload;
 }
 
-function buildAgentStartPayload(request: AgentRunRequest): Record<string, unknown> {
+function buildAgentStartPayload(request: AgentRunRequest, sessionId: string): Record<string, unknown> {
   validateExecutionRequest(request);
-  return { config_json: JSON.stringify({ model_ref: request.model_ref, tools: request.tools ?? [] }) };
+  return {
+    resume_session_id: sessionId,
+    config_json: JSON.stringify({ model_ref: request.model_ref, tools: request.tools ?? [] }),
+  };
 }
 
 function buildAgentMessagePayload(

--- a/typescript/src/execution_client.ts
+++ b/typescript/src/execution_client.ts
@@ -277,7 +277,16 @@ function executionContext(request: ProviderCompleteRequest | AgentRunRequest): R
 }
 
 function agentSessionId(request: AgentRunRequest): string {
-  return request.options?.session_id ?? randomUUID();
+  const sessionId = request.options?.session_id;
+  if (sessionId === undefined) return randomUUID();
+  if (!isUuid(sessionId)) {
+    throw new TypeError("request.options.session_id must be a UUID for agent transport");
+  }
+  return sessionId;
+}
+
+function isUuid(value: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value);
 }
 
 function serializeChatMessage(message: ChatMessage): Record<string, unknown> {

--- a/typescript/src/execution_client.ts
+++ b/typescript/src/execution_client.ts
@@ -1,7 +1,5 @@
+import { randomInt } from "node:crypto";
 import { ulid } from "ulid";
-// nanoid is ESM-only; ts-ignore lets us require it in a CJS build.
-// @ts-ignore
-import { customAlphabet } from "nanoid";
 import { MakaiAuthClient, type AuthFlowHandlers, type MakaiAuthApi } from "./auth_protocol";
 import { parseModelRef } from "./diagnostics/model_ref";
 import { createMakaiModelsApi } from "./models_client";
@@ -29,7 +27,14 @@ import {
 const ENVELOPE_VERSION = 1;
 const DEFAULT_RESPONSE_TIMEOUT_MS = 30_000;
 const NANO_ID_ALPHABET = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
-const nanoid = customAlphabet(NANO_ID_ALPHABET, 21);
+
+function generateNanoId(): string {
+  let id = "";
+  for (let i = 0; i < 21; i++) {
+    id += NANO_ID_ALPHABET[randomInt(NANO_ID_ALPHABET.length)];
+  }
+  return id;
+}
 
 type ExecutionOptions = {
   responseTimeoutMs?: number;
@@ -395,7 +400,7 @@ function executionContext(request: ProviderCompleteRequest | AgentRunRequest): R
 
 function agentSessionId(request: AgentRunRequest): string {
   const sessionId = request.options?.session_id;
-  if (sessionId === undefined) return nanoid();
+  if (sessionId === undefined) return generateNanoId();
   if (!isNanoId(sessionId)) {
     throw new TypeError("request.options.session_id must be a 21-character alphanumeric NanoID for agent transport");
   }

--- a/typescript/src/execution_client.ts
+++ b/typescript/src/execution_client.ts
@@ -388,6 +388,24 @@ function modelFromRef(modelRef: string): Record<string, unknown> {
       base_url: "",
     };
   } catch {
+    // Best-effort: extract provider/api even when model_id is non-canonical
+    // so the runtime has routing metadata for opaque server-issued handles.
+    const slashIndex = modelRef.indexOf("/");
+    const atIndex = modelRef.indexOf("@");
+    if (slashIndex !== -1 && atIndex !== -1 && slashIndex < atIndex) {
+      const provider = modelRef.slice(0, slashIndex);
+      const api = modelRef.slice(slashIndex + 1, atIndex);
+      const id = modelRef.slice(atIndex + 1);
+      if (provider.length > 0 && api.length > 0) {
+        return {
+          id,
+          name: id,
+          api,
+          provider,
+          base_url: "",
+        };
+      }
+    }
     return opaqueModel(modelRef);
   }
 }

--- a/typescript/src/execution_client.ts
+++ b/typescript/src/execution_client.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { MakaiAuthClient, type MakaiAuthApi } from "./auth_protocol";
+import { MakaiAuthClient, type AuthFlowHandlers, type MakaiAuthApi } from "./auth_protocol";
 import { parseModelRef } from "./diagnostics/model_ref";
 import { createMakaiModelsApi } from "./models_client";
 import type { MakaiModelsApi } from "./models_types";
@@ -29,6 +29,8 @@ const DEFAULT_RESPONSE_TIMEOUT_MS = 30_000;
 type ExecutionOptions = {
   responseTimeoutMs?: number;
   authRetryPolicy?: RunOptions["auth_retry_policy"];
+  auth?: MakaiAuthApi;
+  authHandlers?: AuthFlowHandlers;
 };
 
 export interface MakaiClient {
@@ -58,13 +60,24 @@ export function createMakaiAgentApi(
 class StdioProviderApi implements MakaiProviderApi {
   private readonly responseTimeoutMs: number;
   private readonly authRetryPolicy?: RunOptions["auth_retry_policy"];
+  private readonly auth?: MakaiAuthApi;
+  private readonly authHandlers?: AuthFlowHandlers;
 
   constructor(private readonly transport: MakaiStdioClient, options: ExecutionOptions) {
     this.responseTimeoutMs = options.responseTimeoutMs ?? DEFAULT_RESPONSE_TIMEOUT_MS;
     this.authRetryPolicy = options.authRetryPolicy;
+    this.auth = options.auth;
+    this.authHandlers = options.authHandlers;
   }
 
   async complete(request: ProviderCompleteRequest): Promise<ProviderCompleteResponse> {
+    return withAuthRetry(
+      () => this.completeOnce(request),
+      { auth: this.auth, authHandlers: this.authHandlers, authRetryPolicy: this.authRetryPolicy },
+    );
+  }
+
+  private async completeOnce(request: ProviderCompleteRequest): Promise<ProviderCompleteResponse> {
     const streamId = randomUUID();
     this.transport.send(buildEnvelope("complete_request", streamId, buildExecutionPayload(request, { authRetryPolicy: this.authRetryPolicy })));
     while (true) {
@@ -80,6 +93,34 @@ class StdioProviderApi implements MakaiProviderApi {
   }
 
   async *stream(request: ProviderCompleteRequest): AsyncIterable<ProviderStreamEvent> {
+    let attempt = this.streamAttempt(request);
+    let iterator = attempt[Symbol.asyncIterator]();
+    let yielded = false;
+
+    while (true) {
+      let result;
+      try {
+        result = await iterator.next();
+      } catch (error) {
+        if (!yielded && isRetryableAuthError(error) && this.authRetryPolicy === "auto_once" && this.auth && error.provider_id) {
+          try {
+            await this.auth.login(error.provider_id, this.authHandlers);
+          } catch {
+            throw error;
+          }
+          attempt = this.streamAttempt(request);
+          iterator = attempt[Symbol.asyncIterator]();
+          continue;
+        }
+        throw error;
+      }
+      if (result.done) return;
+      yielded = true;
+      yield result.value;
+    }
+  }
+
+  private async *streamAttempt(request: ProviderCompleteRequest): AsyncIterable<ProviderStreamEvent> {
     const streamId = randomUUID();
     this.transport.send(buildEnvelope("stream_request", streamId, buildExecutionPayload(request, { suppressPartial: true, authRetryPolicy: this.authRetryPolicy })));
     let terminal = false;
@@ -93,7 +134,7 @@ class StdioProviderApi implements MakaiProviderApi {
         if (!event) continue;
         if (event.type === "error") {
           terminal = true;
-          throw new MakaiStreamError(event.message, { kind: "provider_error", code: event.code });
+          throw new MakaiStreamError(event.message, { kind: "provider_error", code: event.code, provider_id: event.provider_id });
         }
         if (event.type === "message_end") terminal = true;
         yield event;
@@ -108,13 +149,24 @@ class StdioProviderApi implements MakaiProviderApi {
 class StdioAgentApi implements MakaiAgentApi {
   private readonly responseTimeoutMs: number;
   private readonly authRetryPolicy?: RunOptions["auth_retry_policy"];
+  private readonly auth?: MakaiAuthApi;
+  private readonly authHandlers?: AuthFlowHandlers;
 
   constructor(private readonly transport: MakaiStdioClient, options: ExecutionOptions) {
     this.responseTimeoutMs = options.responseTimeoutMs ?? DEFAULT_RESPONSE_TIMEOUT_MS;
     this.authRetryPolicy = options.authRetryPolicy;
+    this.auth = options.auth;
+    this.authHandlers = options.authHandlers;
   }
 
   async run(request: AgentRunRequest): Promise<AgentRunResponse> {
+    return withAuthRetry(
+      () => this.runOnce(request),
+      { auth: this.auth, authHandlers: this.authHandlers, authRetryPolicy: this.authRetryPolicy },
+    );
+  }
+
+  private async runOnce(request: AgentRunRequest): Promise<AgentRunResponse> {
     const sessionId = agentSessionId(request);
     this.transport.send(buildAgentEnvelope("agent_start", sessionId, 1, buildAgentStartPayload(request)));
     const events: AgentStreamEvent[] = [];
@@ -140,7 +192,7 @@ class StdioAgentApi implements MakaiAgentApi {
         throw new MakaiStreamError(`unexpected frame type while awaiting agent result: ${String(frame.type)}`, { kind: "transport_error" });
       }
       for (const event of normalized) {
-        if (event.type === "error") throw new MakaiStreamError(event.message, { kind: "provider_error", code: event.code });
+        if (event.type === "error") throw new MakaiStreamError(event.message, { kind: "provider_error", code: event.code, provider_id: event.provider_id });
         events.push(event);
         if (event.type === "agent_end") return buildAgentRunResponseFromEvents(events);
       }
@@ -148,6 +200,34 @@ class StdioAgentApi implements MakaiAgentApi {
   }
 
   async *stream(request: AgentRunRequest): AsyncIterable<AgentStreamEvent> {
+    let attempt = this.streamAttempt(request);
+    let iterator = attempt[Symbol.asyncIterator]();
+    let yielded = false;
+
+    while (true) {
+      let result;
+      try {
+        result = await iterator.next();
+      } catch (error) {
+        if (!yielded && isRetryableAuthError(error) && this.authRetryPolicy === "auto_once" && this.auth && error.provider_id) {
+          try {
+            await this.auth.login(error.provider_id, this.authHandlers);
+          } catch {
+            throw error;
+          }
+          attempt = this.streamAttempt(request);
+          iterator = attempt[Symbol.asyncIterator]();
+          continue;
+        }
+        throw error;
+      }
+      if (result.done) return;
+      yielded = true;
+      yield result.value;
+    }
+  }
+
+  private async *streamAttempt(request: AgentRunRequest): AsyncIterable<AgentStreamEvent> {
     const sessionId = agentSessionId(request);
     this.transport.send(buildAgentEnvelope("agent_start", sessionId, 1, buildAgentStartPayload(request)));
     let terminal = false;
@@ -167,7 +247,7 @@ class StdioAgentApi implements MakaiAgentApi {
         for (const event of events) {
           if (event.type === "error") {
             terminal = true;
-            throw new MakaiStreamError(event.message, { kind: "provider_error", code: event.code });
+            throw new MakaiStreamError(event.message, { kind: "provider_error", code: event.code, provider_id: event.provider_id });
           }
           if (event.type === "agent_end") terminal = true;
           yield event;
@@ -385,7 +465,7 @@ function normalizeProviderFrame(
     );
   }
   if (frame.type === "stream_error") return parseError(readPayloadOrFrame(frame));
-  if (frame.type === "message_start") return messageStartFrom(readPayloadOrFrame(frame));
+  if (frame.type === "start" || frame.type === "message_start") return messageStartFrom(readPayloadOrFrame(frame));
   if (frame.type === "text_delta") return { type: "text_delta", delta: stringValue(readPayloadOrFrame(frame).delta) };
   if (frame.type === "thinking_delta" || frame.type === "reasoning_delta" || frame.type === "reasoning") {
     return { type: "thinking_delta", delta: stringValue(readPayloadOrFrame(frame).delta ?? readPayloadOrFrame(frame).reasoning) };
@@ -625,7 +705,12 @@ function parseBufferedToolCall(
 }
 
 function parseError(data: Record<string, unknown>): ProviderStreamEvent {
-  return { type: "error", message: stringValue(data.message ?? data.error_message ?? data.reason, "stream error"), code: optionalString(data.code ?? data.error_code) };
+  return {
+    type: "error",
+    message: stringValue(data.message ?? data.error_message ?? data.reason, "stream error"),
+    code: optionalString(data.code ?? data.error_code),
+    ...(optionalString(data.provider_id) ? { provider_id: optionalString(data.provider_id) } : {}),
+  };
 }
 
 function parseUsage(raw: unknown): UsageSummary | undefined {
@@ -641,12 +726,20 @@ function parseUsage(raw: unknown): UsageSummary | undefined {
 
 function nackToStreamError(frame: StdioFrame): MakaiStreamError {
   const payload = readPayloadOrFrame(frame);
-  return new MakaiStreamError(stringValue(payload.reason, "request rejected"), { kind: "provider_error", code: optionalString(payload.error_code) });
+  return new MakaiStreamError(stringValue(payload.reason, "request rejected"), {
+    kind: "provider_error",
+    code: optionalString(payload.error_code),
+    provider_id: optionalString(payload.provider_id),
+  });
 }
 
 function streamErrorFrameToError(frame: StdioFrame): MakaiStreamError {
   const payload = readPayloadOrFrame(frame);
-  return new MakaiStreamError(stringValue(payload.message ?? payload.reason, "stream error"), { kind: "provider_error", code: optionalString(payload.code ?? payload.error_code) });
+  return new MakaiStreamError(stringValue(payload.message ?? payload.reason, "stream error"), {
+    kind: "provider_error",
+    code: optionalString(payload.code ?? payload.error_code),
+    provider_id: optionalString(payload.provider_id),
+  });
 }
 
 function readPayloadOrFrame(frame: StdioFrame): Record<string, unknown> {
@@ -683,16 +776,46 @@ function isObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+function isRetryableAuthError(error: unknown): error is MakaiStreamError {
+  return error instanceof MakaiStreamError && error.code === "auth_required";
+}
+
+async function withAuthRetry<T>(
+  operation: () => Promise<T>,
+  options: {
+    auth?: MakaiAuthApi;
+    authHandlers?: AuthFlowHandlers;
+    authRetryPolicy?: RunOptions["auth_retry_policy"];
+  },
+): Promise<T> {
+  try {
+    return await operation();
+  } catch (error) {
+    if (isRetryableAuthError(error) && options.authRetryPolicy === "auto_once" && options.auth && error.provider_id) {
+      try {
+        await options.auth.login(error.provider_id, options.authHandlers);
+      } catch {
+        throw error;
+      }
+      return await operation();
+    }
+    throw error;
+  }
+}
+
 export async function createMakaiClient(options: CreateMakaiClientOptions = {}): Promise<MakaiClient> {
   const { auth: authOptions, responseTimeoutMs, frameTimeoutMs, ...transportOptions } = options;
   const transport = await createMakaiStdioClient(transportOptions);
   await transport.connect();
+  const authClient = new MakaiAuthClient(transport, { handlers: authOptions?.handlers, frameTimeoutMs });
   const executionOptions = {
     responseTimeoutMs: responseTimeoutMs ?? frameTimeoutMs,
     authRetryPolicy: authOptions?.auth_retry_policy,
+    auth: authClient,
+    authHandlers: authOptions?.handlers,
   };
   return {
-    auth: new MakaiAuthClient(transport, { handlers: authOptions?.handlers, frameTimeoutMs }),
+    auth: authClient,
     models: createMakaiModelsApi(transport, { responseTimeoutMs: responseTimeoutMs ?? frameTimeoutMs }),
     agent: createMakaiAgentApi(transport, executionOptions),
     provider: createMakaiProviderApi(transport, executionOptions),

--- a/typescript/src/execution_client.ts
+++ b/typescript/src/execution_client.ts
@@ -260,7 +260,18 @@ function modelFromRef(modelRef: string): Record<string, unknown> {
 }
 
 function executionContext(request: ProviderCompleteRequest | AgentRunRequest): Record<string, unknown> {
-  const context: Record<string, unknown> = { messages: request.messages.map(serializeChatMessage) };
+  const messages: Record<string, unknown>[] = [];
+  const systemPrompts: string[] = [];
+  for (const message of request.messages) {
+    if (message.role === "system" || message.role === "developer") {
+      systemPrompts.push(contentAsPromptText(message.content));
+    } else {
+      messages.push(serializeChatMessage(message));
+    }
+  }
+
+  const context: Record<string, unknown> = { messages };
+  if (systemPrompts.length > 0) context.system_prompt = systemPrompts.join("\n\n");
   if (request.tools) context.tools = request.tools.map(serializeTool);
   return context;
 }
@@ -270,10 +281,33 @@ function agentSessionId(request: AgentRunRequest): string {
 }
 
 function serializeChatMessage(message: ChatMessage): Record<string, unknown> {
-  const out: Record<string, unknown> = { role: message.role, content: message.content };
+  const out: Record<string, unknown> = { role: message.role, content: serializeMessageContent(message) };
   if (message.name) out.name = message.name;
+  if (message.role === "tool") out.tool_name = message.name ?? "";
   if (message.tool_call_id) out.tool_call_id = message.tool_call_id;
   return out;
+}
+
+function serializeMessageContent(message: ChatMessage): string | ContentPart[] {
+  if (message.role === "tool") return contentAsUserParts(message.content);
+  return message.content;
+}
+
+function contentAsPromptText(content: ChatMessage["content"]): string {
+  if (typeof content === "string") return content;
+  return content.map(contentPartText).filter((part) => part.length > 0).join("\n");
+}
+
+function contentPartText(part: ContentPart): string {
+  if (part.type === "text") return part.text;
+  if (part.type === "thinking") return part.thinking;
+  if (part.type === "tool_result") return typeof part.content === "string" ? part.content : contentAsPromptText(part.content);
+  return "";
+}
+
+function contentAsUserParts(content: ChatMessage["content"]): ContentPart[] {
+  if (typeof content === "string") return [{ type: "text", text: content }];
+  return content;
 }
 
 function serializeTool(tool: ToolDefinition): Record<string, unknown> {

--- a/typescript/src/execution_client.ts
+++ b/typescript/src/execution_client.ts
@@ -1,0 +1,448 @@
+import { randomUUID } from "node:crypto";
+import { MakaiAuthClient, type MakaiAuthApi } from "./auth_protocol";
+import { createMakaiModelsApi } from "./models_client";
+import type { MakaiModelsApi } from "./models_types";
+import { type CreateMakaiStdioClientOptions, createMakaiStdioClient, MakaiStdioClient, type StdioFrame } from "./stdio_client";
+import {
+  MakaiStreamError,
+  type AgentRunRequest,
+  type AgentRunResponse,
+  type AgentStreamEvent,
+  type ChatMessage,
+  type CompletionResponse,
+  type ContentPart,
+  type MakaiAgentApi,
+  type MakaiClientOptions,
+  type MakaiProviderApi,
+  type ProviderCompleteRequest,
+  type ProviderCompleteResponse,
+  type ProviderStreamEvent,
+  type RunOptions,
+  type ToolDefinition,
+  type UsageSummary,
+} from "./execution_types";
+
+const ENVELOPE_VERSION = 1;
+const DEFAULT_RESPONSE_TIMEOUT_MS = 30_000;
+
+type ExecutionOptions = {
+  responseTimeoutMs?: number;
+};
+
+export interface MakaiClient {
+  auth: MakaiAuthApi;
+  models: MakaiModelsApi;
+  agent: MakaiAgentApi;
+  provider: MakaiProviderApi;
+  close(): Promise<void>;
+}
+
+export type CreateMakaiClientOptions = CreateMakaiStdioClientOptions & MakaiClientOptions;
+
+export function createMakaiProviderApi(
+  transport: MakaiStdioClient,
+  options: ExecutionOptions = {},
+): MakaiProviderApi {
+  return new StdioProviderApi(transport, options);
+}
+
+export function createMakaiAgentApi(
+  transport: MakaiStdioClient,
+  options: ExecutionOptions = {},
+): MakaiAgentApi {
+  return new StdioAgentApi(transport, options);
+}
+
+class StdioProviderApi implements MakaiProviderApi {
+  private readonly responseTimeoutMs: number;
+
+  constructor(private readonly transport: MakaiStdioClient, options: ExecutionOptions) {
+    this.responseTimeoutMs = options.responseTimeoutMs ?? DEFAULT_RESPONSE_TIMEOUT_MS;
+  }
+
+  async complete(request: ProviderCompleteRequest): Promise<ProviderCompleteResponse> {
+    const streamId = randomUUID();
+    this.transport.send(buildEnvelope("complete_request", streamId, buildExecutionPayload(request)));
+    while (true) {
+      const frame = await nextFrame(this.transport, streamId, this.responseTimeoutMs);
+      if (frame.type === "ack") continue;
+      if (frame.type === "nack") throw nackToStreamError(frame);
+      if (frame.type === "stream_error") throw streamErrorFrameToError(frame);
+      if (frame.type === "result" || frame.type === "complete_response") {
+        return parseCompletionResponse(frame.payload ?? frame);
+      }
+      throw new MakaiStreamError(`unexpected frame type while awaiting provider result: ${String(frame.type)}`, { kind: "transport_error" });
+    }
+  }
+
+  async *stream(request: ProviderCompleteRequest): AsyncIterable<ProviderStreamEvent> {
+    const streamId = randomUUID();
+    this.transport.send(buildEnvelope("stream_request", streamId, buildExecutionPayload(request, true)));
+    let terminal = false;
+    const toolBuffers = new Map<number, { id?: string; name?: string; args: string }>();
+    try {
+      while (!terminal) {
+        const frame = await nextFrame(this.transport, streamId, this.responseTimeoutMs);
+        if (frame.type === "ack") continue;
+        if (frame.type === "nack") throw nackToStreamError(frame);
+        const event = normalizeProviderFrame(frame, toolBuffers);
+        if (!event) continue;
+        if (event.type === "error") {
+          terminal = true;
+          throw new MakaiStreamError(event.message, { kind: "provider_error", code: event.code });
+        }
+        if (event.type === "message_end") terminal = true;
+        yield event;
+      }
+    } catch (error) {
+      if (error instanceof MakaiStreamError) throw error;
+      throw new MakaiStreamError(error instanceof Error ? error.message : String(error), { kind: "transport_error" });
+    }
+  }
+}
+
+class StdioAgentApi implements MakaiAgentApi {
+  private readonly responseTimeoutMs: number;
+
+  constructor(private readonly transport: MakaiStdioClient, options: ExecutionOptions) {
+    this.responseTimeoutMs = options.responseTimeoutMs ?? DEFAULT_RESPONSE_TIMEOUT_MS;
+  }
+
+  async run(request: AgentRunRequest): Promise<AgentRunResponse> {
+    const events: AgentStreamEvent[] = [];
+    for await (const event of this.stream(request)) events.push(event);
+    const terminal = [...events].reverse().find((event: AgentStreamEvent) => event.type === "message_end" || event.type === "agent_end");
+    const messageEnd = [...events].reverse().find((event: AgentStreamEvent) => event.type === "message_end");
+    const text = events.filter((event) => event.type === "text_delta").map((event) => event.delta).join("");
+    const start = events.find((event) => event.type === "message_start") as Extract<ProviderStreamEvent, { type: "message_start" }> | undefined;
+    return {
+      message: { role: "assistant", content: text },
+      usage: (terminal && "usage" in terminal ? terminal.usage : undefined) ?? messageEnd?.usage,
+      provider_id: start?.provider_id ?? "",
+      api: start?.api ?? "",
+      model_id: start?.model_id ?? "",
+      stop_reason: terminal && "stop_reason" in terminal ? terminal.stop_reason : undefined,
+    };
+  }
+
+  async *stream(request: AgentRunRequest): AsyncIterable<AgentStreamEvent> {
+    const streamId = randomUUID();
+    this.transport.send(buildEnvelope("agent_run_request", streamId, buildExecutionPayload(request)));
+    let terminal = false;
+    const toolBuffers = new Map<number, { id?: string; name?: string; args: string }>();
+    try {
+      while (!terminal) {
+        const frame = await nextFrame(this.transport, streamId, this.responseTimeoutMs);
+        if (frame.type === "ack") continue;
+        if (frame.type === "nack") throw nackToStreamError(frame);
+        const events = normalizeAgentFrame(frame, toolBuffers);
+        for (const event of events) {
+          if (event.type === "error") {
+            terminal = true;
+            throw new MakaiStreamError(event.message, { kind: "provider_error", code: event.code });
+          }
+          if (event.type === "agent_end") terminal = true;
+          yield event;
+        }
+      }
+    } catch (error) {
+      if (error instanceof MakaiStreamError) throw error;
+      throw new MakaiStreamError(error instanceof Error ? error.message : String(error), { kind: "transport_error" });
+    }
+  }
+}
+
+function buildEnvelope(type: string, streamId: string, payload: Record<string, unknown>): StdioFrame {
+  return {
+    type,
+    stream_id: streamId,
+    message_id: streamId,
+    sequence: 1,
+    timestamp: Date.now(),
+    version: ENVELOPE_VERSION,
+    payload,
+  };
+}
+
+function buildExecutionPayload(
+  request: ProviderCompleteRequest | AgentRunRequest,
+  includePartial = false,
+): Record<string, unknown> {
+  if (!request || typeof request.model_ref !== "string" || request.model_ref.length === 0) {
+    throw new MakaiStreamError("request requires opaque model_ref", { kind: "transport_error", code: "invalid_request" });
+  }
+  if (!Array.isArray(request.messages)) {
+    throw new MakaiStreamError("request requires messages array", { kind: "transport_error", code: "invalid_request" });
+  }
+  const payload: Record<string, unknown> = {
+    model_ref: request.model_ref,
+    messages: request.messages.map(serializeChatMessage),
+  };
+  if (request.tools) payload.tools = request.tools.map(serializeTool);
+  if (request.options) payload.options = serializeOptions(request.options);
+  if (includePartial) payload.include_partial = false;
+  return payload;
+}
+
+function serializeChatMessage(message: ChatMessage): Record<string, unknown> {
+  const out: Record<string, unknown> = { role: message.role, content: message.content };
+  if (message.name) out.name = message.name;
+  if (message.tool_call_id) out.tool_call_id = message.tool_call_id;
+  return out;
+}
+
+function serializeTool(tool: ToolDefinition): Record<string, unknown> {
+  return {
+    name: tool.name,
+    description: tool.description,
+    parameters_schema_json: tool.parameters_schema_json,
+  };
+}
+
+function serializeOptions(options: RunOptions): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const key of ["temperature", "max_tokens", "reasoning_effort", "auth_retry_policy", "session_id", "metadata"] as const) {
+    if (options[key] !== undefined) out[key] = options[key];
+  }
+  return out;
+}
+
+async function nextFrame(transport: MakaiStdioClient, streamId: string, timeoutMs: number): Promise<StdioFrame> {
+  try {
+    return await transport.nextFrameForStream(streamId, timeoutMs);
+  } catch (error) {
+    throw new MakaiStreamError(error instanceof Error ? error.message : String(error), { kind: "transport_error" });
+  }
+}
+
+function normalizeProviderFrame(
+  frame: StdioFrame,
+  toolBuffers: Map<number, { id?: string; name?: string; args: string }>,
+): ProviderStreamEvent | undefined {
+  if (frame.type === "event") return normalizeProviderEvent(readPayloadOrFrame(frame), toolBuffers);
+  if (frame.type === "stream_error") return { type: "error", message: stringValue(readPayloadOrFrame(frame).message, "stream error") };
+  if (frame.type === "message_start") return messageStartFrom(readPayloadOrFrame(frame));
+  if (frame.type === "text_delta") return { type: "text_delta", delta: stringValue(readPayloadOrFrame(frame).delta) };
+  if (frame.type === "thinking_delta" || frame.type === "reasoning_delta" || frame.type === "reasoning") {
+    return { type: "thinking_delta", delta: stringValue(readPayloadOrFrame(frame).delta ?? readPayloadOrFrame(frame).reasoning) };
+  }
+  if (frame.type === "tool_call") return parseToolCall(readPayloadOrFrame(frame));
+  if (frame.type === "message_end" || frame.type === "done" || frame.type === "result") return messageEndFrom(readPayloadOrFrame(frame));
+  if (frame.type === "error") return parseError(readPayloadOrFrame(frame));
+  return undefined;
+}
+
+function normalizeProviderEvent(
+  payload: Record<string, unknown>,
+  toolBuffers: Map<number, { id?: string; name?: string; args: string }>,
+): ProviderStreamEvent | undefined {
+  const type = stringValue(payload.type ?? payload.event_type);
+  if (type === "start") return messageStartFrom(payload.message && isObject(payload.message) ? payload.message : payload);
+  if (type === "text_delta") return { type: "text_delta", delta: stringValue(payload.delta) };
+  if (type === "thinking_delta" || type === "reasoning_delta" || type === "reasoning") {
+    return { type: "thinking_delta", delta: stringValue(payload.delta ?? payload.reasoning) };
+  }
+  if (type === "toolcall_start") {
+    const index = numericValue(payload.content_index, toolBuffers.size);
+    toolBuffers.set(index, { id: optionalString(payload.id), name: optionalString(payload.name), args: "" });
+    return undefined;
+  }
+  if (type === "toolcall_delta") {
+    const index = numericValue(payload.content_index, 0);
+    const existing = toolBuffers.get(index) ?? { args: "" };
+    existing.args += stringValue(payload.delta);
+    toolBuffers.set(index, existing);
+    return undefined;
+  }
+  if (type === "toolcall_end") return parseBufferedToolCall(payload, toolBuffers);
+  if (type === "tool_call") return parseToolCall(payload);
+  if (type === "done") return messageEndFrom(payload);
+  if (type === "error") return parseError(payload);
+  return undefined;
+}
+
+function normalizeAgentFrame(
+  frame: StdioFrame,
+  toolBuffers: Map<number, { id?: string; name?: string; args: string }>,
+): AgentStreamEvent[] {
+  if (frame.type === "agent_result") return [agentEndFrom(readJsonStringPayload(frame, "result_json"))];
+  if (frame.type === "agent_error") return [parseError(readPayloadOrFrame(frame))];
+  if (frame.type === "agent_event") return normalizeAgentEvent(readJsonStringPayload(frame, "event_json"), toolBuffers);
+  const providerEvent = normalizeProviderFrame(frame, toolBuffers);
+  return providerEvent ? [providerEvent] : [];
+}
+
+function normalizeAgentEvent(
+  event: Record<string, unknown>,
+  toolBuffers: Map<number, { id?: string; name?: string; args: string }>,
+): AgentStreamEvent[] {
+  const type = stringValue(event.type ?? firstKey(event));
+  const data = event.type ? event : (event[type] && isObject(event[type]) ? event[type] as Record<string, unknown> : event);
+  switch (type) {
+    case "agent_start":
+      return [{ type: "agent_start", ...(optionalString(data.session_id) ? { session_id: optionalString(data.session_id) } : {}) }];
+    case "turn_start":
+      return [{ type: "turn_start" }];
+    case "turn_end":
+      return [{ type: "turn_end", ...(optionalString(data.stop_reason) ? { stop_reason: optionalString(data.stop_reason) } : {}) }];
+    case "tool_execution_start":
+      return [{ type: "tool_execution_start", tool_call_id: stringValue(data.tool_call_id), tool_name: stringValue(data.tool_name) }];
+    case "tool_execution_end":
+      return [{ type: "tool_execution_end", tool_call_id: stringValue(data.tool_call_id), ...(typeof data.is_error === "boolean" ? { is_error: data.is_error } : {}) }];
+    case "agent_end":
+      return [agentEndFrom(data)];
+    case "message_start":
+      return [messageStartFrom(data.message && isObject(data.message) ? data.message : data)];
+    case "message_update": {
+      const inner = data.event && isObject(data.event) ? data.event as Record<string, unknown> : data;
+      const providerEvent = normalizeProviderEvent(inner, toolBuffers);
+      return providerEvent ? [providerEvent] : [];
+    }
+    case "text_delta":
+    case "thinking_delta":
+    case "reasoning_delta":
+    case "reasoning":
+    case "toolcall_start":
+    case "toolcall_delta":
+    case "toolcall_end":
+    case "tool_call": {
+      const providerEvent = normalizeProviderEvent(event, toolBuffers);
+      return providerEvent ? [providerEvent] : [];
+    }
+    case "message_end":
+      return [messageEndFrom(data.message && isObject(data.message) ? data.message : data)];
+    case "error":
+      return [parseError(data)];
+    default:
+      return [];
+  }
+}
+
+function parseCompletionResponse(raw: unknown): CompletionResponse {
+  const data = isObject(raw) ? raw : {};
+  const message = data.message && isObject(data.message) ? data.message : data;
+  const content = parseContent(message.content);
+  return {
+    message: { role: "assistant", content },
+    usage: parseUsage(message.usage ?? data.usage ?? data),
+    provider_id: stringValue(message.provider_id ?? message.provider ?? data.provider_id ?? data.provider),
+    api: stringValue(message.api ?? data.api),
+    model_id: stringValue(message.model_id ?? message.model ?? data.model_id ?? data.model),
+    stop_reason: optionalString(message.stop_reason ?? data.stop_reason ?? data.reason),
+  };
+}
+
+function parseContent(raw: unknown): string | ContentPart[] {
+  if (typeof raw === "string") return raw;
+  if (!Array.isArray(raw)) return "";
+  return raw.map((part) => {
+    if (!isObject(part)) return { type: "text", text: String(part) } as ContentPart;
+    if (part.type === "tool_call") return { type: "tool_call", tool_call_id: stringValue(part.tool_call_id ?? part.id), name: stringValue(part.name), arguments_json: stringValue(part.arguments_json) };
+    return part as ContentPart;
+  });
+}
+
+function messageStartFrom(data: Record<string, unknown>): ProviderStreamEvent {
+  return {
+    type: "message_start",
+    ...(optionalString(data.provider_id ?? data.provider) ? { provider_id: optionalString(data.provider_id ?? data.provider) } : {}),
+    ...(optionalString(data.api) ? { api: optionalString(data.api) } : {}),
+    ...(optionalString(data.model_id ?? data.model) ? { model_id: optionalString(data.model_id ?? data.model) } : {}),
+  };
+}
+
+function messageEndFrom(data: Record<string, unknown>): ProviderStreamEvent {
+  const message = data.message && isObject(data.message) ? data.message as Record<string, unknown> : data;
+  return { type: "message_end", usage: parseUsage(message.usage ?? data.usage ?? message), stop_reason: optionalString(data.stop_reason ?? data.reason ?? message.stop_reason) };
+}
+
+function agentEndFrom(data: Record<string, unknown>): AgentStreamEvent {
+  return { type: "agent_end", usage: parseUsage(data.usage ?? data), stop_reason: optionalString(data.stop_reason ?? data.reason) };
+}
+
+function parseToolCall(data: Record<string, unknown>): ProviderStreamEvent {
+  return { type: "tool_call", tool_call_id: stringValue(data.tool_call_id ?? data.id), name: stringValue(data.name), arguments_json: stringValue(data.arguments_json) };
+}
+
+function parseBufferedToolCall(
+  data: Record<string, unknown>,
+  toolBuffers: Map<number, { id?: string; name?: string; args: string }>,
+): ProviderStreamEvent {
+  const index = numericValue(data.content_index, 0);
+  const buffered = toolBuffers.get(index);
+  toolBuffers.delete(index);
+  return { type: "tool_call", tool_call_id: stringValue(data.tool_call_id ?? data.id ?? buffered?.id), name: stringValue(data.name ?? buffered?.name), arguments_json: stringValue(data.arguments_json ?? buffered?.args) };
+}
+
+function parseError(data: Record<string, unknown>): ProviderStreamEvent {
+  return { type: "error", message: stringValue(data.message ?? data.error_message ?? data.reason, "stream error"), code: optionalString(data.code ?? data.error_code ?? data.reason) };
+}
+
+function parseUsage(raw: unknown): UsageSummary | undefined {
+  if (!isObject(raw)) return undefined;
+  const input = raw.input ?? raw.input_tokens;
+  const output = raw.output ?? raw.output_tokens;
+  if (typeof input !== "number" || typeof output !== "number") return undefined;
+  const usage: UsageSummary = { input, output };
+  if (typeof raw.cache_read === "number") usage.cache_read = raw.cache_read;
+  if (typeof raw.cache_write === "number") usage.cache_write = raw.cache_write;
+  return usage;
+}
+
+function nackToStreamError(frame: StdioFrame): MakaiStreamError {
+  const payload = readPayloadOrFrame(frame);
+  return new MakaiStreamError(stringValue(payload.reason, "request rejected"), { kind: "provider_error", code: optionalString(payload.error_code) });
+}
+
+function streamErrorFrameToError(frame: StdioFrame): MakaiStreamError {
+  const payload = readPayloadOrFrame(frame);
+  return new MakaiStreamError(stringValue(payload.message ?? payload.reason, "stream error"), { kind: "provider_error", code: optionalString(payload.code ?? payload.error_code) });
+}
+
+function readPayloadOrFrame(frame: StdioFrame): Record<string, unknown> {
+  return frame.payload && isObject(frame.payload) ? frame.payload : frame;
+}
+
+function readJsonStringPayload(frame: StdioFrame, key: string): Record<string, unknown> {
+  const payload = readPayloadOrFrame(frame);
+  const json = payload[key] ?? payload.event_json ?? payload.result_json;
+  if (typeof json === "string") {
+    const parsed = JSON.parse(json) as unknown;
+    return isObject(parsed) ? parsed : {};
+  }
+  return payload;
+}
+
+function stringValue(value: unknown, fallback = ""): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function numericValue(value: unknown, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+function firstKey(value: Record<string, unknown>): string {
+  return Object.keys(value)[0] ?? "";
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export async function createMakaiClient(options: CreateMakaiClientOptions = {}): Promise<MakaiClient> {
+  const { auth: authOptions, responseTimeoutMs, frameTimeoutMs, ...transportOptions } = options;
+  const transport = await createMakaiStdioClient(transportOptions);
+  await transport.connect();
+  const executionOptions = { responseTimeoutMs: responseTimeoutMs ?? frameTimeoutMs };
+  return {
+    auth: new MakaiAuthClient(transport, { handlers: authOptions?.handlers, frameTimeoutMs }),
+    models: createMakaiModelsApi(transport, { responseTimeoutMs: responseTimeoutMs ?? frameTimeoutMs }),
+    agent: createMakaiAgentApi(transport, executionOptions),
+    provider: createMakaiProviderApi(transport, executionOptions),
+    close: () => transport.close(),
+  };
+}

--- a/typescript/src/execution_client.ts
+++ b/typescript/src/execution_client.ts
@@ -90,11 +90,12 @@ class StdioProviderApi implements MakaiProviderApi {
 
   private async completeOnce(request: ProviderCompleteRequest, effectivePolicy: RunOptions["auth_retry_policy"] | undefined): Promise<ProviderCompleteResponse> {
     const streamId = ulid();
+    const fallbackProviderId = providerIdFromRequest(request);
     this.transport.send(buildEnvelope("complete_request", streamId, buildExecutionPayload(request, { authRetryPolicy: effectivePolicy })));
     while (true) {
       const frame = await nextFrame(this.transport, streamId, this.responseTimeoutMs);
       if (frame.type === "ack") continue;
-      if (frame.type === "nack") throw nackToStreamError(frame);
+      if (frame.type === "nack") throw nackToStreamError(frame, fallbackProviderId);
       if (frame.type === "stream_error") throw streamErrorFrameToError(frame);
       if (frame.type === "result" || frame.type === "complete_response") {
         return parseCompletionResponse(frame.payload ?? frame);
@@ -140,6 +141,7 @@ class StdioProviderApi implements MakaiProviderApi {
 
   private async *streamAttempt(request: ProviderCompleteRequest, effectivePolicy: RunOptions["auth_retry_policy"] | undefined): AsyncIterable<ProviderStreamEvent> {
     const streamId = ulid();
+    const fallbackProviderId = providerIdFromRequest(request);
     this.transport.send(buildEnvelope("stream_request", streamId, buildExecutionPayload(request, { suppressPartial: true, authRetryPolicy: effectivePolicy })));
     let terminal = false;
     const toolBuffers = new Map<number, { id?: string; name?: string; args: string }>();
@@ -147,7 +149,7 @@ class StdioProviderApi implements MakaiProviderApi {
       while (!terminal) {
         const frame = await nextFrame(this.transport, streamId, this.responseTimeoutMs);
         if (frame.type === "ack") continue;
-        if (frame.type === "nack") throw nackToStreamError(frame);
+        if (frame.type === "nack") throw nackToStreamError(frame, fallbackProviderId);
         const event = normalizeProviderFrame(frame, toolBuffers);
         if (!event) continue;
         if (event.type === "error") {
@@ -199,6 +201,7 @@ class StdioAgentApi implements MakaiAgentApi {
 
   private async runOnce(request: AgentRunRequest, effectivePolicy: RunOptions["auth_retry_policy"] | undefined): Promise<AgentRunResponse> {
     const sessionId = agentSessionId(request);
+    const fallbackProviderId = providerIdFromRequest(request);
     this.transport.send(buildAgentEnvelope("agent_start", sessionId, 1, buildAgentStartPayload(request, sessionId)));
     const events: AgentStreamEvent[] = [];
     const toolBuffers = new Map<number, { id?: string; name?: string; args: string }>();
@@ -206,7 +209,7 @@ class StdioAgentApi implements MakaiAgentApi {
     while (true) {
       const frame = await nextAgentFrame(this.transport, sessionId, this.responseTimeoutMs);
       if (frame.type === "ack") continue;
-      if (frame.type === "nack") throw nackToStreamError(frame);
+      if (frame.type === "nack") throw nackToStreamError(frame, fallbackProviderId);
       if (frame.type === "agent_error") throw streamErrorFrameToError(frame);
       if (frame.type === "agent_started") {
         if (!messageSent) {
@@ -272,6 +275,7 @@ class StdioAgentApi implements MakaiAgentApi {
 
   private async *streamAttempt(request: AgentRunRequest, effectivePolicy: RunOptions["auth_retry_policy"] | undefined): AsyncIterable<AgentStreamEvent> {
     const sessionId = agentSessionId(request);
+    const fallbackProviderId = providerIdFromRequest(request);
     this.transport.send(buildAgentEnvelope("agent_start", sessionId, 1, buildAgentStartPayload(request, sessionId)));
     let terminal = false;
     let messageSent = false;
@@ -280,7 +284,7 @@ class StdioAgentApi implements MakaiAgentApi {
       while (!terminal) {
         const frame = await nextAgentFrame(this.transport, sessionId, this.responseTimeoutMs);
         if (frame.type === "ack") continue;
-        if (frame.type === "nack") throw nackToStreamError(frame);
+        if (frame.type === "nack") throw nackToStreamError(frame, fallbackProviderId);
         if (frame.type === "agent_started" && !messageSent) {
           this.transport.send(buildAgentEnvelope("agent_message", sessionId, 2, buildAgentMessagePayload(request, sessionId, effectivePolicy)));
           messageSent = true;
@@ -788,12 +792,17 @@ function parseUsage(raw: unknown): UsageSummary | undefined {
   return usage;
 }
 
-function nackToStreamError(frame: StdioFrame): MakaiStreamError {
+function nackToStreamError(frame: StdioFrame, fallbackProviderId?: string): MakaiStreamError {
   const payload = readPayloadOrFrame(frame);
+  const code = optionalString(payload.error_code);
+  let providerId = optionalString(payload.provider_id);
+  if (!providerId && code === "auth_required") {
+    providerId = fallbackProviderId;
+  }
   return new MakaiStreamError(stringValue(payload.reason, "request rejected"), {
     kind: "provider_error",
-    code: optionalString(payload.error_code),
-    provider_id: optionalString(payload.provider_id),
+    code,
+    provider_id: providerId,
   });
 }
 

--- a/typescript/src/execution_client.ts
+++ b/typescript/src/execution_client.ts
@@ -856,6 +856,14 @@ function providerIdFromRequest(request: ProviderCompleteRequest | AgentRunReques
     const parsed = parseModelRef(request.model_ref);
     return parsed.providerId;
   } catch {
+    // Best-effort: extract provider even when model_id is non-canonical
+    // so auto_once auth retry can still target the right provider.
+    const slashIndex = request.model_ref.indexOf("/");
+    const atIndex = request.model_ref.indexOf("@");
+    if (slashIndex !== -1 && atIndex !== -1 && slashIndex < atIndex) {
+      const provider = request.model_ref.slice(0, slashIndex);
+      if (provider.length > 0) return provider;
+    }
     return undefined;
   }
 }

--- a/typescript/src/execution_client.ts
+++ b/typescript/src/execution_client.ts
@@ -27,6 +27,7 @@ const DEFAULT_RESPONSE_TIMEOUT_MS = 30_000;
 
 type ExecutionOptions = {
   responseTimeoutMs?: number;
+  authRetryPolicy?: RunOptions["auth_retry_policy"];
 };
 
 export interface MakaiClient {
@@ -55,14 +56,16 @@ export function createMakaiAgentApi(
 
 class StdioProviderApi implements MakaiProviderApi {
   private readonly responseTimeoutMs: number;
+  private readonly authRetryPolicy?: RunOptions["auth_retry_policy"];
 
   constructor(private readonly transport: MakaiStdioClient, options: ExecutionOptions) {
     this.responseTimeoutMs = options.responseTimeoutMs ?? DEFAULT_RESPONSE_TIMEOUT_MS;
+    this.authRetryPolicy = options.authRetryPolicy;
   }
 
   async complete(request: ProviderCompleteRequest): Promise<ProviderCompleteResponse> {
     const streamId = randomUUID();
-    this.transport.send(buildEnvelope("complete_request", streamId, buildExecutionPayload(request)));
+    this.transport.send(buildEnvelope("complete_request", streamId, buildExecutionPayload(request, { authRetryPolicy: this.authRetryPolicy })));
     while (true) {
       const frame = await nextFrame(this.transport, streamId, this.responseTimeoutMs);
       if (frame.type === "ack") continue;
@@ -77,7 +80,7 @@ class StdioProviderApi implements MakaiProviderApi {
 
   async *stream(request: ProviderCompleteRequest): AsyncIterable<ProviderStreamEvent> {
     const streamId = randomUUID();
-    this.transport.send(buildEnvelope("stream_request", streamId, buildExecutionPayload(request, true)));
+    this.transport.send(buildEnvelope("stream_request", streamId, buildExecutionPayload(request, { suppressPartial: true, authRetryPolicy: this.authRetryPolicy })));
     let terminal = false;
     const toolBuffers = new Map<number, { id?: string; name?: string; args: string }>();
     try {
@@ -103,31 +106,41 @@ class StdioProviderApi implements MakaiProviderApi {
 
 class StdioAgentApi implements MakaiAgentApi {
   private readonly responseTimeoutMs: number;
+  private readonly authRetryPolicy?: RunOptions["auth_retry_policy"];
 
   constructor(private readonly transport: MakaiStdioClient, options: ExecutionOptions) {
     this.responseTimeoutMs = options.responseTimeoutMs ?? DEFAULT_RESPONSE_TIMEOUT_MS;
+    this.authRetryPolicy = options.authRetryPolicy;
   }
 
   async run(request: AgentRunRequest): Promise<AgentRunResponse> {
+    const streamId = randomUUID();
+    this.transport.send(buildEnvelope("agent_run_request", streamId, buildExecutionPayload(request, { authRetryPolicy: this.authRetryPolicy })));
     const events: AgentStreamEvent[] = [];
-    for await (const event of this.stream(request)) events.push(event);
-    const terminal = [...events].reverse().find((event: AgentStreamEvent) => event.type === "message_end" || event.type === "agent_end");
-    const messageEnd = [...events].reverse().find((event: AgentStreamEvent) => event.type === "message_end");
-    const text = events.filter((event) => event.type === "text_delta").map((event) => event.delta).join("");
-    const start = events.find((event) => event.type === "message_start") as Extract<ProviderStreamEvent, { type: "message_start" }> | undefined;
-    return {
-      message: { role: "assistant", content: text },
-      usage: (terminal && "usage" in terminal ? terminal.usage : undefined) ?? messageEnd?.usage,
-      provider_id: start?.provider_id ?? "",
-      api: start?.api ?? "",
-      model_id: start?.model_id ?? "",
-      stop_reason: terminal && "stop_reason" in terminal ? terminal.stop_reason : undefined,
-    };
+    const toolBuffers = new Map<number, { id?: string; name?: string; args: string }>();
+    while (true) {
+      const frame = await nextFrame(this.transport, streamId, this.responseTimeoutMs);
+      if (frame.type === "ack") continue;
+      if (frame.type === "nack") throw nackToStreamError(frame);
+      if (frame.type === "agent_error") throw streamErrorFrameToError(frame);
+      if (frame.type === "agent_result") return parseAgentRunResponse(readJsonStringPayload(frame, "result_json"));
+      if (frame.type === "result" || frame.type === "complete_response") return parseCompletionResponse(frame.payload ?? frame);
+
+      const normalized = normalizeAgentFrame(frame, toolBuffers);
+      if (normalized.length === 0) {
+        throw new MakaiStreamError(`unexpected frame type while awaiting agent result: ${String(frame.type)}`, { kind: "transport_error" });
+      }
+      for (const event of normalized) {
+        if (event.type === "error") throw new MakaiStreamError(event.message, { kind: "provider_error", code: event.code });
+        events.push(event);
+        if (event.type === "agent_end") return buildAgentRunResponseFromEvents(events);
+      }
+    }
   }
 
   async *stream(request: AgentRunRequest): AsyncIterable<AgentStreamEvent> {
     const streamId = randomUUID();
-    this.transport.send(buildEnvelope("agent_run_request", streamId, buildExecutionPayload(request)));
+    this.transport.send(buildEnvelope("agent_run_request", streamId, buildExecutionPayload(request, { authRetryPolicy: this.authRetryPolicy })));
     let terminal = false;
     const toolBuffers = new Map<number, { id?: string; name?: string; args: string }>();
     try {
@@ -166,21 +179,24 @@ function buildEnvelope(type: string, streamId: string, payload: Record<string, u
 
 function buildExecutionPayload(
   request: ProviderCompleteRequest | AgentRunRequest,
-  includePartial = false,
+  options: { suppressPartial?: boolean; authRetryPolicy?: RunOptions["auth_retry_policy"] } = {},
 ): Record<string, unknown> {
   if (!request || typeof request.model_ref !== "string" || request.model_ref.length === 0) {
-    throw new MakaiStreamError("request requires opaque model_ref", { kind: "transport_error", code: "invalid_request" });
+    throw new TypeError("request requires opaque model_ref");
   }
   if (!Array.isArray(request.messages)) {
-    throw new MakaiStreamError("request requires messages array", { kind: "transport_error", code: "invalid_request" });
+    throw new TypeError("request requires messages array");
   }
   const payload: Record<string, unknown> = {
     model_ref: request.model_ref,
     messages: request.messages.map(serializeChatMessage),
   };
   if (request.tools) payload.tools = request.tools.map(serializeTool);
-  if (request.options) payload.options = serializeOptions(request.options);
-  if (includePartial) payload.include_partial = false;
+  const serializedOptions = serializeOptionsWithDefaults(request.options, options.authRetryPolicy);
+  if (Object.keys(serializedOptions).length > 0) payload.options = serializedOptions;
+  // V1 streams emit fully-buffered tool calls, so ask capable runtimes not to
+  // include heavy partial message snapshots on stream deltas.
+  if (options.suppressPartial) payload.include_partial = false;
   return payload;
 }
 
@@ -199,8 +215,13 @@ function serializeTool(tool: ToolDefinition): Record<string, unknown> {
   };
 }
 
-function serializeOptions(options: RunOptions): Record<string, unknown> {
+function serializeOptionsWithDefaults(
+  options: RunOptions | undefined,
+  authRetryPolicy: RunOptions["auth_retry_policy"] | undefined,
+): Record<string, unknown> {
   const out: Record<string, unknown> = {};
+  if (authRetryPolicy !== undefined) out.auth_retry_policy = authRetryPolicy;
+  if (!options) return out;
   for (const key of ["temperature", "max_tokens", "reasoning_effort", "auth_retry_policy", "session_id", "metadata"] as const) {
     if (options[key] !== undefined) out[key] = options[key];
   }
@@ -219,7 +240,13 @@ function normalizeProviderFrame(
   frame: StdioFrame,
   toolBuffers: Map<number, { id?: string; name?: string; args: string }>,
 ): ProviderStreamEvent | undefined {
-  if (frame.type === "event") return normalizeProviderEvent(readPayloadOrFrame(frame), toolBuffers);
+  if (frame.type === "event") {
+    const payload = readPayloadOrFrame(frame);
+    return normalizeProviderEvent(
+      payload.event && isObject(payload.event) ? payload.event as Record<string, unknown> : payload,
+      toolBuffers,
+    );
+  }
   if (frame.type === "stream_error") return { type: "error", message: stringValue(readPayloadOrFrame(frame).message, "stream error") };
   if (frame.type === "message_start") return messageStartFrom(readPayloadOrFrame(frame));
   if (frame.type === "text_delta") return { type: "text_delta", delta: stringValue(readPayloadOrFrame(frame).delta) };
@@ -236,7 +263,7 @@ function normalizeProviderEvent(
   payload: Record<string, unknown>,
   toolBuffers: Map<number, { id?: string; name?: string; args: string }>,
 ): ProviderStreamEvent | undefined {
-  const type = stringValue(payload.type ?? payload.event_type);
+  const type = stringValue(payload.type === "event" ? payload.event_type : payload.type ?? payload.event_type);
   if (type === "start") return messageStartFrom(payload.message && isObject(payload.message) ? payload.message : payload);
   if (type === "text_delta") return { type: "text_delta", delta: stringValue(payload.delta) };
   if (type === "thinking_delta" || type === "reasoning_delta" || type === "reasoning") {
@@ -332,6 +359,80 @@ function parseCompletionResponse(raw: unknown): CompletionResponse {
   };
 }
 
+function parseAgentRunResponse(raw: unknown): AgentRunResponse {
+  const data = isObject(raw) ? raw : {};
+  if (data.message && isObject(data.message)) return parseCompletionResponse(data);
+
+  const messages = Array.isArray(data.messages) ? data.messages.filter(isObject) : [];
+  const assistantMessage = [...messages].reverse().find((message) => message.role === "assistant") ?? data;
+  const terminal = data.result && isObject(data.result) ? data.result : data;
+  return buildCompletionResponseFromMessage(assistantMessage, terminal);
+}
+
+function buildAgentRunResponseFromEvents(events: AgentStreamEvent[]): AgentRunResponse {
+  const reversed = [...events].reverse();
+  const terminal = reversed.find((event) => event.type === "message_end" || event.type === "agent_end");
+  const messageEnd = reversed.find((event) => event.type === "message_end");
+  const start = events.find((event) => event.type === "message_start") as Extract<ProviderStreamEvent, { type: "message_start" }> | undefined;
+  const content = contentFromEvents(events);
+  return {
+    message: { role: "assistant", content },
+    usage: (terminal && "usage" in terminal ? terminal.usage : undefined) ?? messageEnd?.usage,
+    provider_id: start?.provider_id ?? "",
+    api: start?.api ?? "",
+    model_id: start?.model_id ?? "",
+    stop_reason: terminal && "stop_reason" in terminal ? terminal.stop_reason : undefined,
+  };
+}
+
+function buildCompletionResponseFromMessage(
+  message: Record<string, unknown>,
+  terminal: Record<string, unknown>,
+): CompletionResponse {
+  return {
+    message: { role: "assistant", content: parseContent(message.content) },
+    usage: parseUsage(message.usage ?? terminal.usage ?? terminal),
+    provider_id: stringValue(message.provider_id ?? message.provider ?? terminal.provider_id ?? terminal.provider),
+    api: stringValue(message.api ?? terminal.api),
+    model_id: stringValue(message.model_id ?? message.model ?? terminal.model_id ?? terminal.model),
+    stop_reason: optionalString(message.stop_reason ?? terminal.stop_reason ?? terminal.reason),
+  };
+}
+
+function contentFromEvents(events: AgentStreamEvent[]): string | ContentPart[] {
+  const parts: ContentPart[] = [];
+  let text = "";
+  for (const event of events) {
+    if (event.type === "text_delta") {
+      text += event.delta;
+      continue;
+    }
+    if (event.type === "thinking_delta") {
+      if (text.length > 0) {
+        parts.push({ type: "text", text });
+        text = "";
+      }
+      parts.push({ type: "thinking", thinking: event.delta });
+      continue;
+    }
+    if (event.type === "tool_call") {
+      if (text.length > 0) {
+        parts.push({ type: "text", text });
+        text = "";
+      }
+      parts.push({
+        type: "tool_call",
+        tool_call_id: event.tool_call_id,
+        name: event.name,
+        arguments_json: event.arguments_json,
+      });
+    }
+  }
+  if (parts.length === 0) return text;
+  if (text.length > 0) parts.push({ type: "text", text });
+  return parts;
+}
+
 function parseContent(raw: unknown): string | ContentPart[] {
   if (typeof raw === "string") return raw;
   if (!Array.isArray(raw)) return "";
@@ -375,7 +476,7 @@ function parseBufferedToolCall(
 }
 
 function parseError(data: Record<string, unknown>): ProviderStreamEvent {
-  return { type: "error", message: stringValue(data.message ?? data.error_message ?? data.reason, "stream error"), code: optionalString(data.code ?? data.error_code ?? data.reason) };
+  return { type: "error", message: stringValue(data.message ?? data.error_message ?? data.reason, "stream error"), code: optionalString(data.code ?? data.error_code) };
 }
 
 function parseUsage(raw: unknown): UsageSummary | undefined {
@@ -437,7 +538,10 @@ export async function createMakaiClient(options: CreateMakaiClientOptions = {}):
   const { auth: authOptions, responseTimeoutMs, frameTimeoutMs, ...transportOptions } = options;
   const transport = await createMakaiStdioClient(transportOptions);
   await transport.connect();
-  const executionOptions = { responseTimeoutMs: responseTimeoutMs ?? frameTimeoutMs };
+  const executionOptions = {
+    responseTimeoutMs: responseTimeoutMs ?? frameTimeoutMs,
+    authRetryPolicy: authOptions?.auth_retry_policy,
+  };
   return {
     auth: new MakaiAuthClient(transport, { handlers: authOptions?.handlers, frameTimeoutMs }),
     models: createMakaiModelsApi(transport, { responseTimeoutMs: responseTimeoutMs ?? frameTimeoutMs }),

--- a/typescript/src/execution_client.ts
+++ b/typescript/src/execution_client.ts
@@ -1,6 +1,5 @@
 import { randomUUID } from "node:crypto";
 import { MakaiAuthClient, type MakaiAuthApi } from "./auth_protocol";
-import { parseModelRef } from "./diagnostics/model_ref";
 import { createMakaiModelsApi } from "./models_client";
 import type { MakaiModelsApi } from "./models_types";
 import { type CreateMakaiStdioClientOptions, createMakaiStdioClient, MakaiStdioClient, type StdioFrame } from "./stdio_client";
@@ -251,12 +250,11 @@ function validateExecutionRequest(request: ProviderCompleteRequest | AgentRunReq
 }
 
 function modelFromRef(modelRef: string): Record<string, unknown> {
-  const parsed = parseModelRef(modelRef);
   return {
-    id: parsed.modelId,
-    name: parsed.modelId,
-    api: parsed.api,
-    provider: parsed.providerId,
+    id: modelRef,
+    name: modelRef,
+    api: "",
+    provider: "",
     base_url: "",
   };
 }
@@ -309,13 +307,7 @@ async function nextFrame(transport: MakaiStdioClient, streamId: string, timeoutM
 
 async function nextAgentFrame(transport: MakaiStdioClient, sessionId: string, timeoutMs: number): Promise<StdioFrame> {
   try {
-    const deadline = Date.now() + timeoutMs;
-    while (true) {
-      const remainingMs = deadline - Date.now();
-      if (remainingMs <= 0) throw new Error(`timed out waiting for frame for session ${sessionId} after ${timeoutMs}ms`);
-      const frame = await transport.nextFrame(remainingMs);
-      if (frame.session_id === sessionId) return frame;
-    }
+    return await transport.nextFrameForSession(sessionId, timeoutMs);
   } catch (error) {
     throw new MakaiStreamError(error instanceof Error ? error.message : String(error), { kind: "transport_error" });
   }

--- a/typescript/src/execution_client.ts
+++ b/typescript/src/execution_client.ts
@@ -247,7 +247,7 @@ function normalizeProviderFrame(
       toolBuffers,
     );
   }
-  if (frame.type === "stream_error") return { type: "error", message: stringValue(readPayloadOrFrame(frame).message, "stream error") };
+  if (frame.type === "stream_error") return parseError(readPayloadOrFrame(frame));
   if (frame.type === "message_start") return messageStartFrom(readPayloadOrFrame(frame));
   if (frame.type === "text_delta") return { type: "text_delta", delta: stringValue(readPayloadOrFrame(frame).delta) };
   if (frame.type === "thinking_delta" || frame.type === "reasoning_delta" || frame.type === "reasoning") {

--- a/typescript/src/execution_client.ts
+++ b/typescript/src/execution_client.ts
@@ -770,8 +770,12 @@ function readJsonStringPayload(frame: StdioFrame, key: string): Record<string, u
   const payload = readPayloadOrFrame(frame);
   const json = payload[key] ?? payload.event_json ?? payload.result_json;
   if (typeof json === "string") {
-    const parsed = JSON.parse(json) as unknown;
-    return isObject(parsed) ? parsed : {};
+    try {
+      const parsed = JSON.parse(json) as unknown;
+      return isObject(parsed) ? parsed : {};
+    } catch {
+      throw new MakaiStreamError(`malformed JSON in ${key}`, { kind: "transport_error" });
+    }
   }
   return payload;
 }

--- a/typescript/src/execution_client.ts
+++ b/typescript/src/execution_client.ts
@@ -1,4 +1,7 @@
-import { randomUUID } from "node:crypto";
+import { ulid } from "ulid";
+// nanoid is ESM-only; ts-ignore lets us require it in a CJS build.
+// @ts-ignore
+import { customAlphabet } from "nanoid";
 import { MakaiAuthClient, type AuthFlowHandlers, type MakaiAuthApi } from "./auth_protocol";
 import { parseModelRef } from "./diagnostics/model_ref";
 import { createMakaiModelsApi } from "./models_client";
@@ -25,6 +28,8 @@ import {
 
 const ENVELOPE_VERSION = 1;
 const DEFAULT_RESPONSE_TIMEOUT_MS = 30_000;
+const NANO_ID_ALPHABET = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+const nanoid = customAlphabet(NANO_ID_ALPHABET, 21);
 
 type ExecutionOptions = {
   responseTimeoutMs?: number;
@@ -79,7 +84,7 @@ class StdioProviderApi implements MakaiProviderApi {
   }
 
   private async completeOnce(request: ProviderCompleteRequest, effectivePolicy: RunOptions["auth_retry_policy"] | undefined): Promise<ProviderCompleteResponse> {
-    const streamId = randomUUID();
+    const streamId = ulid();
     this.transport.send(buildEnvelope("complete_request", streamId, buildExecutionPayload(request, { authRetryPolicy: effectivePolicy })));
     while (true) {
       const frame = await nextFrame(this.transport, streamId, this.responseTimeoutMs);
@@ -127,7 +132,7 @@ class StdioProviderApi implements MakaiProviderApi {
   }
 
   private async *streamAttempt(request: ProviderCompleteRequest, effectivePolicy: RunOptions["auth_retry_policy"] | undefined): AsyncIterable<ProviderStreamEvent> {
-    const streamId = randomUUID();
+    const streamId = ulid();
     this.transport.send(buildEnvelope("stream_request", streamId, buildExecutionPayload(request, { suppressPartial: true, authRetryPolicy: effectivePolicy })));
     let terminal = false;
     const toolBuffers = new Map<number, { id?: string; name?: string; args: string }>();
@@ -288,7 +293,7 @@ function buildAgentEnvelope(type: string, sessionId: string, sequence: number, p
   return {
     type,
     session_id: sessionId,
-    message_id: randomUUID(),
+    message_id: ulid(),
     sequence,
     timestamp: Date.now(),
     version: ENVELOPE_VERSION,
@@ -390,15 +395,15 @@ function executionContext(request: ProviderCompleteRequest | AgentRunRequest): R
 
 function agentSessionId(request: AgentRunRequest): string {
   const sessionId = request.options?.session_id;
-  if (sessionId === undefined) return randomUUID();
-  if (!isUuid(sessionId)) {
-    throw new TypeError("request.options.session_id must be a UUID for agent transport");
+  if (sessionId === undefined) return nanoid();
+  if (!isNanoId(sessionId)) {
+    throw new TypeError("request.options.session_id must be a 21-character alphanumeric NanoID for agent transport");
   }
   return sessionId;
 }
 
-function isUuid(value: string): boolean {
-  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value);
+function isNanoId(value: string): boolean {
+  return /^[0-9A-Za-z]{21}$/.test(value);
 }
 
 function serializeChatMessage(message: ChatMessage): Record<string, unknown> {

--- a/typescript/src/execution_client.ts
+++ b/typescript/src/execution_client.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { MakaiAuthClient, type MakaiAuthApi } from "./auth_protocol";
+import { parseModelRef } from "./diagnostics/model_ref";
 import { createMakaiModelsApi } from "./models_client";
 import type { MakaiModelsApi } from "./models_types";
 import { type CreateMakaiStdioClientOptions, createMakaiStdioClient, MakaiStdioClient, type StdioFrame } from "./stdio_client";
@@ -114,15 +115,23 @@ class StdioAgentApi implements MakaiAgentApi {
   }
 
   async run(request: AgentRunRequest): Promise<AgentRunResponse> {
-    const streamId = randomUUID();
-    this.transport.send(buildEnvelope("agent_run_request", streamId, buildExecutionPayload(request, { authRetryPolicy: this.authRetryPolicy })));
+    const sessionId = agentSessionId(request);
+    this.transport.send(buildAgentEnvelope("agent_start", sessionId, 1, buildAgentStartPayload(request)));
     const events: AgentStreamEvent[] = [];
     const toolBuffers = new Map<number, { id?: string; name?: string; args: string }>();
+    let messageSent = false;
     while (true) {
-      const frame = await nextFrame(this.transport, streamId, this.responseTimeoutMs);
+      const frame = await nextAgentFrame(this.transport, sessionId, this.responseTimeoutMs);
       if (frame.type === "ack") continue;
       if (frame.type === "nack") throw nackToStreamError(frame);
       if (frame.type === "agent_error") throw streamErrorFrameToError(frame);
+      if (frame.type === "agent_started") {
+        if (!messageSent) {
+          this.transport.send(buildAgentEnvelope("agent_message", sessionId, 2, buildAgentMessagePayload(request, sessionId, this.authRetryPolicy)));
+          messageSent = true;
+        }
+        continue;
+      }
       if (frame.type === "agent_result") return parseAgentRunResponse(readJsonStringPayload(frame, "result_json"));
       if (frame.type === "result" || frame.type === "complete_response") return parseCompletionResponse(frame.payload ?? frame);
 
@@ -139,15 +148,21 @@ class StdioAgentApi implements MakaiAgentApi {
   }
 
   async *stream(request: AgentRunRequest): AsyncIterable<AgentStreamEvent> {
-    const streamId = randomUUID();
-    this.transport.send(buildEnvelope("agent_run_request", streamId, buildExecutionPayload(request, { authRetryPolicy: this.authRetryPolicy })));
+    const sessionId = agentSessionId(request);
+    this.transport.send(buildAgentEnvelope("agent_start", sessionId, 1, buildAgentStartPayload(request)));
     let terminal = false;
+    let messageSent = false;
     const toolBuffers = new Map<number, { id?: string; name?: string; args: string }>();
     try {
       while (!terminal) {
-        const frame = await nextFrame(this.transport, streamId, this.responseTimeoutMs);
+        const frame = await nextAgentFrame(this.transport, sessionId, this.responseTimeoutMs);
         if (frame.type === "ack") continue;
         if (frame.type === "nack") throw nackToStreamError(frame);
+        if (frame.type === "agent_started" && !messageSent) {
+          this.transport.send(buildAgentEnvelope("agent_message", sessionId, 2, buildAgentMessagePayload(request, sessionId, this.authRetryPolicy)));
+          messageSent = true;
+          continue;
+        }
         const events = normalizeAgentFrame(frame, toolBuffers);
         for (const event of events) {
           if (event.type === "error") {
@@ -177,27 +192,83 @@ function buildEnvelope(type: string, streamId: string, payload: Record<string, u
   };
 }
 
+function buildAgentEnvelope(type: string, sessionId: string, sequence: number, payload: Record<string, unknown>): StdioFrame {
+  return {
+    type,
+    session_id: sessionId,
+    message_id: randomUUID(),
+    sequence,
+    timestamp: Date.now(),
+    version: ENVELOPE_VERSION,
+    payload,
+  };
+}
+
 function buildExecutionPayload(
   request: ProviderCompleteRequest | AgentRunRequest,
   options: { suppressPartial?: boolean; authRetryPolicy?: RunOptions["auth_retry_policy"] } = {},
 ): Record<string, unknown> {
-  if (!request || typeof request.model_ref !== "string" || request.model_ref.length === 0) {
-    throw new TypeError("request requires opaque model_ref");
-  }
-  if (!Array.isArray(request.messages)) {
-    throw new TypeError("request requires messages array");
-  }
+  validateExecutionRequest(request);
+  const model = modelFromRef(request.model_ref);
   const payload: Record<string, unknown> = {
-    model_ref: request.model_ref,
-    messages: request.messages.map(serializeChatMessage),
+    model,
+    context: executionContext(request),
   };
-  if (request.tools) payload.tools = request.tools.map(serializeTool);
   const serializedOptions = serializeOptionsWithDefaults(request.options, options.authRetryPolicy);
   if (Object.keys(serializedOptions).length > 0) payload.options = serializedOptions;
   // V1 streams emit fully-buffered tool calls, so ask capable runtimes not to
   // include heavy partial message snapshots on stream deltas.
   if (options.suppressPartial) payload.include_partial = false;
   return payload;
+}
+
+function buildAgentStartPayload(request: AgentRunRequest): Record<string, unknown> {
+  validateExecutionRequest(request);
+  return { config_json: JSON.stringify({ model_ref: request.model_ref, tools: request.tools ?? [] }) };
+}
+
+function buildAgentMessagePayload(
+  request: AgentRunRequest,
+  sessionId: string,
+  authRetryPolicy: RunOptions["auth_retry_policy"] | undefined,
+): Record<string, unknown> {
+  const payload: Record<string, unknown> = {
+    session_id: sessionId,
+    message_json: JSON.stringify({ model_ref: request.model_ref, messages: request.messages, tools: request.tools ?? [] }),
+  };
+  const serializedOptions = serializeOptionsWithDefaults(request.options, authRetryPolicy);
+  if (Object.keys(serializedOptions).length > 0) payload.options_json = JSON.stringify(serializedOptions);
+  return payload;
+}
+
+function validateExecutionRequest(request: ProviderCompleteRequest | AgentRunRequest): void {
+  if (!request || typeof request.model_ref !== "string" || request.model_ref.length === 0) {
+    throw new TypeError("request requires opaque model_ref");
+  }
+  if (!Array.isArray(request.messages)) {
+    throw new TypeError("request requires messages array");
+  }
+}
+
+function modelFromRef(modelRef: string): Record<string, unknown> {
+  const parsed = parseModelRef(modelRef);
+  return {
+    id: parsed.modelId,
+    name: parsed.modelId,
+    api: parsed.api,
+    provider: parsed.providerId,
+    base_url: "",
+  };
+}
+
+function executionContext(request: ProviderCompleteRequest | AgentRunRequest): Record<string, unknown> {
+  const context: Record<string, unknown> = { messages: request.messages.map(serializeChatMessage) };
+  if (request.tools) context.tools = request.tools.map(serializeTool);
+  return context;
+}
+
+function agentSessionId(request: AgentRunRequest): string {
+  return request.options?.session_id ?? randomUUID();
 }
 
 function serializeChatMessage(message: ChatMessage): Record<string, unknown> {
@@ -231,6 +302,20 @@ function serializeOptionsWithDefaults(
 async function nextFrame(transport: MakaiStdioClient, streamId: string, timeoutMs: number): Promise<StdioFrame> {
   try {
     return await transport.nextFrameForStream(streamId, timeoutMs);
+  } catch (error) {
+    throw new MakaiStreamError(error instanceof Error ? error.message : String(error), { kind: "transport_error" });
+  }
+}
+
+async function nextAgentFrame(transport: MakaiStdioClient, sessionId: string, timeoutMs: number): Promise<StdioFrame> {
+  try {
+    const deadline = Date.now() + timeoutMs;
+    while (true) {
+      const remainingMs = deadline - Date.now();
+      if (remainingMs <= 0) throw new Error(`timed out waiting for frame for session ${sessionId} after ${timeoutMs}ms`);
+      const frame = await transport.nextFrame(remainingMs);
+      if (frame.session_id === sessionId) return frame;
+    }
   } catch (error) {
     throw new MakaiStreamError(error instanceof Error ? error.message : String(error), { kind: "transport_error" });
   }

--- a/typescript/src/execution_client.ts
+++ b/typescript/src/execution_client.ts
@@ -373,8 +373,9 @@ function buildAgentRunResponseFromEvents(events: AgentStreamEvent[]): AgentRunRe
   const reversed = [...events].reverse();
   const terminal = reversed.find((event) => event.type === "message_end" || event.type === "agent_end");
   const messageEnd = reversed.find((event) => event.type === "message_end");
-  const start = events.find((event) => event.type === "message_start") as Extract<ProviderStreamEvent, { type: "message_start" }> | undefined;
-  const content = contentFromEvents(events);
+  const finalMessageEvents = finalAssistantMessageEvents(events);
+  const start = finalMessageEvents.find((event) => event.type === "message_start") as Extract<ProviderStreamEvent, { type: "message_start" }> | undefined;
+  const content = contentFromEvents(finalMessageEvents);
   return {
     message: { role: "assistant", content },
     usage: (terminal && "usage" in terminal ? terminal.usage : undefined) ?? messageEnd?.usage,
@@ -383,6 +384,14 @@ function buildAgentRunResponseFromEvents(events: AgentStreamEvent[]): AgentRunRe
     model_id: start?.model_id ?? "",
     stop_reason: terminal && "stop_reason" in terminal ? terminal.stop_reason : undefined,
   };
+}
+
+function finalAssistantMessageEvents(events: AgentStreamEvent[]): AgentStreamEvent[] {
+  const startIndex = events.map((event) => event.type).lastIndexOf("message_start");
+  if (startIndex < 0) return events;
+  const endOffset = events.slice(startIndex + 1).findIndex((event) => event.type === "message_end");
+  const endIndex = endOffset < 0 ? events.length : startIndex + 1 + endOffset + 1;
+  return events.slice(startIndex, endIndex);
 }
 
 function buildCompletionResponseFromMessage(

--- a/typescript/src/execution_client.ts
+++ b/typescript/src/execution_client.ts
@@ -109,13 +109,14 @@ class StdioProviderApi implements MakaiProviderApi {
     let attempt = this.streamAttempt(request, effectivePolicy);
     let iterator = attempt[Symbol.asyncIterator]();
     let yielded = false;
+    let retried = false;
 
     while (true) {
       let result;
       try {
         result = await iterator.next();
       } catch (error) {
-        if (!yielded && isRetryableAuthError(error) && effectivePolicy === "auto_once" && this.auth) {
+        if (!yielded && !retried && isRetryableAuthError(error) && effectivePolicy === "auto_once" && this.auth) {
           const providerId = error.provider_id ?? fallbackProviderId;
           if (providerId) {
             try {
@@ -123,6 +124,7 @@ class StdioProviderApi implements MakaiProviderApi {
             } catch {
               throw error;
             }
+            retried = true;
             attempt = this.streamAttempt(request, effectivePolicy);
             iterator = attempt[Symbol.asyncIterator]();
             continue;
@@ -222,13 +224,14 @@ class StdioAgentApi implements MakaiAgentApi {
     let attempt = this.streamAttempt(request, effectivePolicy);
     let iterator = attempt[Symbol.asyncIterator]();
     let yielded = false;
+    let retried = false;
 
     while (true) {
       let result;
       try {
         result = await iterator.next();
       } catch (error) {
-        if (!yielded && isRetryableAuthError(error) && effectivePolicy === "auto_once" && this.auth) {
+        if (!yielded && !retried && isRetryableAuthError(error) && effectivePolicy === "auto_once" && this.auth) {
           const providerId = error.provider_id ?? fallbackProviderId;
           if (providerId) {
             try {
@@ -236,6 +239,7 @@ class StdioAgentApi implements MakaiAgentApi {
             } catch {
               throw error;
             }
+            retried = true;
             attempt = this.streamAttempt(request, effectivePolicy);
             iterator = attempt[Symbol.asyncIterator]();
             continue;

--- a/typescript/src/execution_types.ts
+++ b/typescript/src/execution_types.ts
@@ -108,7 +108,7 @@ export type ProviderStreamEvent =
   | { type: "thinking_delta"; delta: string }
   | { type: "tool_call"; name: string; arguments_json: string; tool_call_id: string }
   | { type: "message_end"; usage?: UsageSummary; stop_reason?: StopReason }
-  | { type: "error"; message: string; code?: string };
+  | { type: "error"; message: string; code?: string; provider_id?: string };
 
 export type AgentStreamEvent =
   | ProviderStreamEvent
@@ -143,12 +143,14 @@ export type MakaiStreamErrorKind = "provider_error" | "transport_error" | "abort
 export class MakaiStreamError extends Error {
   public readonly kind: MakaiStreamErrorKind;
   public readonly code?: string;
+  public readonly provider_id?: string;
 
-  constructor(message: string, options: { kind?: MakaiStreamErrorKind; code?: string } = {}) {
+  constructor(message: string, options: { kind?: MakaiStreamErrorKind; code?: string; provider_id?: string } = {}) {
     super(message);
     this.name = "MakaiStreamError";
     this.kind = options.kind ?? "unknown";
     this.code = options.code;
+    this.provider_id = options.provider_id;
   }
 }
 

--- a/typescript/src/execution_types.ts
+++ b/typescript/src/execution_types.ts
@@ -1,0 +1,162 @@
+import type { ApiId, ProviderId } from "./models_types";
+import type { AuthFlowHandlers } from "./auth_protocol";
+
+export type AuthRetryPolicy = "manual" | "auto_once";
+
+export type StopReason =
+  | "end_turn"
+  | "max_tokens"
+  | "tool_use"
+  | "stop_sequence"
+  | "max_turns"
+  | string;
+
+export type TextContentPart = {
+  type: "text";
+  text: string;
+  text_signature?: string;
+};
+
+export type ThinkingContentPart = {
+  type: "thinking";
+  thinking: string;
+  thinking_signature?: string;
+};
+
+export type ImageContentPart = {
+  type: "image";
+  data: string;
+  mime_type: string;
+};
+
+export type ToolCallContentPart = {
+  type: "tool_call";
+  tool_call_id: string;
+  name: string;
+  arguments_json: string;
+};
+
+export type ToolResultContentPart = {
+  type: "tool_result";
+  tool_call_id: string;
+  tool_name: string;
+  content: string | TextContentPart[];
+  is_error?: boolean;
+  details_json?: string;
+};
+
+export type ContentPart =
+  | TextContentPart
+  | ThinkingContentPart
+  | ImageContentPart
+  | ToolCallContentPart
+  | ToolResultContentPart;
+
+export interface ChatMessage {
+  role: "system" | "developer" | "user" | "assistant" | "tool";
+  content: string | ContentPart[];
+  name?: string;
+  tool_call_id?: string;
+}
+
+export interface ToolDefinition {
+  name: string;
+  description: string;
+  parameters_schema_json: string;
+}
+
+export interface RunOptions {
+  temperature?: number;
+  max_tokens?: number;
+  reasoning_effort?: "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
+  auth_retry_policy?: AuthRetryPolicy;
+  session_id?: string;
+  metadata?: Record<string, string>;
+}
+
+export interface UsageSummary {
+  input: number;
+  output: number;
+  cache_read?: number;
+  cache_write?: number;
+}
+
+export interface AgentRunRequest {
+  model_ref: string;
+  messages: ChatMessage[];
+  tools?: ToolDefinition[];
+  options?: RunOptions;
+}
+
+export interface CompletionResponse {
+  message: {
+    role: "assistant";
+    content: string | ContentPart[];
+  };
+  usage?: UsageSummary;
+  provider_id: ProviderId;
+  api: ApiId;
+  model_id: string;
+  stop_reason?: StopReason;
+}
+
+export type AgentRunResponse = CompletionResponse;
+
+export type ProviderStreamEvent =
+  | { type: "message_start"; provider_id?: ProviderId; api?: ApiId; model_id?: string }
+  | { type: "text_delta"; delta: string }
+  | { type: "thinking_delta"; delta: string }
+  | { type: "tool_call"; name: string; arguments_json: string; tool_call_id: string }
+  | { type: "message_end"; usage?: UsageSummary; stop_reason?: StopReason }
+  | { type: "error"; message: string; code?: string };
+
+export type AgentStreamEvent =
+  | ProviderStreamEvent
+  | { type: "agent_start"; session_id?: string }
+  | { type: "agent_end"; stop_reason?: StopReason; usage?: UsageSummary }
+  | { type: "turn_start" }
+  | { type: "turn_end"; stop_reason?: StopReason }
+  | { type: "tool_execution_start"; tool_call_id: string; tool_name: string }
+  | { type: "tool_execution_end"; tool_call_id: string; is_error?: boolean };
+
+export interface ProviderCompleteRequest {
+  model_ref: string;
+  messages: ChatMessage[];
+  tools?: ToolDefinition[];
+  options?: RunOptions;
+}
+
+export type ProviderCompleteResponse = CompletionResponse;
+
+export interface MakaiAgentApi {
+  run(request: AgentRunRequest): Promise<AgentRunResponse>;
+  stream(request: AgentRunRequest): AsyncIterable<AgentStreamEvent>;
+}
+
+export interface MakaiProviderApi {
+  complete(request: ProviderCompleteRequest): Promise<ProviderCompleteResponse>;
+  stream(request: ProviderCompleteRequest): AsyncIterable<ProviderStreamEvent>;
+}
+
+export type MakaiStreamErrorKind = "provider_error" | "transport_error" | "aborted" | "unknown";
+
+export class MakaiStreamError extends Error {
+  public readonly kind: MakaiStreamErrorKind;
+  public readonly code?: string;
+
+  constructor(message: string, options: { kind?: MakaiStreamErrorKind; code?: string } = {}) {
+    super(message);
+    this.name = "MakaiStreamError";
+    this.kind = options.kind ?? "unknown";
+    this.code = options.code;
+  }
+}
+
+export interface MakaiClientOptions {
+  auth?: {
+    auth_retry_policy?: AuthRetryPolicy;
+    handlers?: AuthFlowHandlers;
+  };
+  responseTimeoutMs?: number;
+  frameTimeoutMs?: number;
+}

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -5,9 +5,10 @@ export {
   type CreateMakaiStdioClientOptions,
   type MakaiStdioClientOptions,
   type StdioFrame,
-  // Deprecated aliases retained for backward compatibility with older imports.
-  type CreateMakaiClientOptions,
-  type MakaiClientOptions,
+  // Deprecated aliases retained under transport-specific names to avoid
+  // colliding with the unified high-level client factory options.
+  type CreateMakaiClientOptions as DeprecatedCreateMakaiStdioClientOptions,
+  type MakaiClientOptions as DeprecatedMakaiStdioClientOptions,
 } from "./stdio_client";
 
 export { resolveMakaiBinary, type BinaryResolverOptions } from "./binary_resolver";
@@ -33,6 +34,41 @@ export {
   createMakaiModelsApi,
   type ModelsApiOptions,
 } from "./models_client";
+
+export {
+  createMakaiAgentApi,
+  createMakaiClient,
+  createMakaiProviderApi,
+  type CreateMakaiClientOptions,
+  type MakaiClient,
+} from "./execution_client";
+
+export {
+  MakaiStreamError,
+  type AgentRunRequest,
+  type AgentRunResponse,
+  type AgentStreamEvent,
+  type AuthRetryPolicy,
+  type ChatMessage,
+  type CompletionResponse,
+  type ContentPart,
+  type ImageContentPart,
+  type MakaiAgentApi,
+  type MakaiClientOptions,
+  type MakaiProviderApi,
+  type MakaiStreamErrorKind,
+  type ProviderCompleteRequest,
+  type ProviderCompleteResponse,
+  type ProviderStreamEvent,
+  type RunOptions,
+  type StopReason,
+  type TextContentPart,
+  type ThinkingContentPart,
+  type ToolCallContentPart,
+  type ToolDefinition,
+  type ToolResultContentPart,
+  type UsageSummary,
+} from "./execution_types";
 export {
   MakaiProtocolError,
   // Note: `AuthStatus` and `ProviderId` are re-exported from `./auth_protocol`

--- a/typescript/src/stdio_client.ts
+++ b/typescript/src/stdio_client.ts
@@ -134,8 +134,8 @@ export class MakaiStdioClient {
     const queued = this.dequeueStreamFrame(streamId);
     if (queued) return queued;
 
-    const deadline = Date.now() + timeoutMs;
     return this.withStreamReadLock(async () => {
+      const deadline = Date.now() + timeoutMs;
       while (true) {
         const remainingMs = deadline - Date.now();
         if (remainingMs <= 0) {
@@ -170,8 +170,8 @@ export class MakaiStdioClient {
     const queued = this.dequeueSessionFrame(sessionId);
     if (queued) return queued;
 
-    const deadline = Date.now() + timeoutMs;
     return this.withStreamReadLock(async () => {
+      const deadline = Date.now() + timeoutMs;
       while (true) {
         const remainingMs = deadline - Date.now();
         if (remainingMs <= 0) {

--- a/typescript/src/stdio_client.ts
+++ b/typescript/src/stdio_client.ts
@@ -58,6 +58,7 @@ export class MakaiStdioClient {
   private frameQueue: StdioFrame[] = [];
   private frameWaiters: PendingFrameWaiter[] = [];
   private streamFrameQueues = new Map<string, StreamQueueEntry[]>();
+  private sessionFrameQueues = new Map<string, StreamQueueEntry[]>();
   private streamReadLock: Promise<void> = Promise.resolve();
 
   constructor(options: MakaiStdioClientOptions) {
@@ -155,10 +156,44 @@ export class MakaiStdioClient {
         }
         const frameStreamId = typeof frame.stream_id === "string" ? frame.stream_id : undefined;
         if (frameStreamId === streamId) return frame;
-        if (frameStreamId) {
-          this.enqueueStreamFrame(frameStreamId, frame);
+        this.enqueueRoutableFrame(frame);
+        // Frames without stream_id/session_id cannot be routed to a targeted waiter.
+      }
+    });
+  }
+
+  async nextFrameForSession(sessionId: string, timeoutMs = 1000): Promise<StdioFrame> {
+    if (sessionId.length === 0) {
+      throw new Error("sessionId is required");
+    }
+
+    const queued = this.dequeueSessionFrame(sessionId);
+    if (queued) return queued;
+
+    const deadline = Date.now() + timeoutMs;
+    return this.withStreamReadLock(async () => {
+      while (true) {
+        const remainingMs = deadline - Date.now();
+        if (remainingMs <= 0) {
+          throw new Error(`timed out waiting for frame for session ${sessionId} after ${timeoutMs}ms`);
         }
-        // Frames without stream_id cannot be routed to a stream-specific waiter.
+
+        const queued = this.dequeueSessionFrame(sessionId);
+        if (queued) return queued;
+
+        let frame: StdioFrame;
+        try {
+          frame = await this.nextFrame(remainingMs);
+        } catch (error) {
+          if (deadline - Date.now() <= 0 || isNextFrameTimeout(error, remainingMs)) {
+            throw new Error(`timed out waiting for frame for session ${sessionId} after ${timeoutMs}ms`);
+          }
+          throw error;
+        }
+        const frameSessionId = typeof frame.session_id === "string" ? frame.session_id : undefined;
+        if (frameSessionId === sessionId) return frame;
+        this.enqueueRoutableFrame(frame);
+        // Frames without stream_id/session_id cannot be routed to a targeted waiter.
       }
     });
   }
@@ -186,30 +221,55 @@ export class MakaiStdioClient {
   }
 
   private dequeueStreamFrame(streamId: string): StdioFrame | undefined {
-    this.pruneExpiredStreamFrames();
-    const queued = this.streamFrameQueues.get(streamId);
+    return this.dequeueRoutedFrame(this.streamFrameQueues, streamId);
+  }
+
+  private dequeueSessionFrame(sessionId: string): StdioFrame | undefined {
+    return this.dequeueRoutedFrame(this.sessionFrameQueues, sessionId);
+  }
+
+  private dequeueRoutedFrame(queues: Map<string, StreamQueueEntry[]>, id: string): StdioFrame | undefined {
+    this.pruneExpiredRoutedFrames();
+    const queued = queues.get(id);
     if (!queued || queued.length === 0) return undefined;
     const entry = queued.shift()!;
-    if (queued.length === 0) this.streamFrameQueues.delete(streamId);
+    if (queued.length === 0) queues.delete(id);
     return entry.frame;
   }
 
-  private enqueueStreamFrame(streamId: string, frame: StdioFrame): void {
-    this.pruneExpiredStreamFrames();
-    const queued = this.streamFrameQueues.get(streamId) ?? [];
-    queued.push({ frame, expiresAt: Date.now() + this.options.streamFrameQueueTtlMs });
-    this.streamFrameQueues.set(streamId, queued);
+  private enqueueRoutableFrame(frame: StdioFrame): void {
+    const frameStreamId = typeof frame.stream_id === "string" ? frame.stream_id : undefined;
+    if (frameStreamId) {
+      this.enqueueRoutedFrame(this.streamFrameQueues, frameStreamId, frame);
+      return;
+    }
+    const frameSessionId = typeof frame.session_id === "string" ? frame.session_id : undefined;
+    if (frameSessionId) {
+      this.enqueueRoutedFrame(this.sessionFrameQueues, frameSessionId, frame);
+    }
   }
 
-  private pruneExpiredStreamFrames(now = Date.now()): void {
-    for (const [streamId, queued] of this.streamFrameQueues) {
+  private enqueueRoutedFrame(queues: Map<string, StreamQueueEntry[]>, id: string, frame: StdioFrame): void {
+    this.pruneExpiredRoutedFrames();
+    const queued = queues.get(id) ?? [];
+    queued.push({ frame, expiresAt: Date.now() + this.options.streamFrameQueueTtlMs });
+    queues.set(id, queued);
+  }
+
+  private pruneExpiredRoutedFrames(now = Date.now()): void {
+    this.pruneExpiredQueue(this.streamFrameQueues, now);
+    this.pruneExpiredQueue(this.sessionFrameQueues, now);
+  }
+
+  private pruneExpiredQueue(queues: Map<string, StreamQueueEntry[]>, now: number): void {
+    for (const [id, queued] of queues) {
       const unexpired = queued.filter((entry) => entry.expiresAt > now);
       if (unexpired.length > 0) {
         if (unexpired.length !== queued.length) {
-          this.streamFrameQueues.set(streamId, unexpired);
+          queues.set(id, unexpired);
         }
       } else {
-        this.streamFrameQueues.delete(streamId);
+        queues.delete(id);
       }
     }
   }

--- a/typescript/test/execution_client.test.ts
+++ b/typescript/test/execution_client.test.ts
@@ -93,6 +93,38 @@ test("client.provider.complete resolves with correct CompletionResponse shape", 
   }
 });
 
+test("client.provider.complete maps system prompts and tool messages into provider context", async () => {
+  const harness = await setupHarness();
+  try {
+    const provider = createMakaiProviderApi(harness.client);
+    await provider.complete({
+      model_ref: "opaque-model-ref-with:colon",
+      messages: [
+        { role: "system", content: "You are helpful." },
+        { role: "developer", content: [{ type: "text", text: "Prefer concise answers." }] },
+        { role: "user", content: "hello" },
+        { role: "tool", tool_call_id: "call-1", name: "lookup", content: "tool result" },
+      ],
+    });
+
+    const payload = readLoggedRequests(harness.logPath)[0]?.payload as Record<string, unknown>;
+    const context = payload.context as Record<string, unknown>;
+    assert.equal(context.system_prompt, "You are helpful.\n\nPrefer concise answers.");
+    assert.deepEqual(context.messages, [
+      { role: "user", content: "hello" },
+      {
+        role: "tool",
+        content: [{ type: "text", text: "tool result" }],
+        name: "lookup",
+        tool_name: "lookup",
+        tool_call_id: "call-1",
+      },
+    ]);
+  } finally {
+    await harness.cleanup();
+  }
+});
+
 test("client.provider.stream yields ProviderStreamEvent sequence including message_end", async () => {
   const harness = await setupHarness();
   try {

--- a/typescript/test/execution_client.test.ts
+++ b/typescript/test/execution_client.test.ts
@@ -553,6 +553,31 @@ test("client.provider.stream auto_once retries on auth_required nack and yields 
   }
 });
 
+test("client.provider.stream auto_once retries at most once when auth_required persists", async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "makai-auth-retry-stream-limit-test-"));
+  const logPath = path.join(tmpDir, "request.log");
+  const handle = await createMakaiClient({
+    command: process.execPath,
+    args: [fixtureScript],
+    env: { ...process.env, MAKAI_TEST_REQUEST_LOG: logPath, MAKAI_TEST_AUTH_REQUIRED_ALWAYS: "1" },
+    handshakeTimeoutMs: 5000,
+    responseTimeoutMs: 5000,
+    auth: { auth_retry_policy: "auto_once" },
+  });
+  try {
+    await assert.rejects(
+      async () => collect(handle.provider.stream(request())),
+      (err: unknown) => err instanceof MakaiStreamError && err.code === "auth_required",
+    );
+    const logged = readLoggedRequests(logPath);
+    assert.equal(logged.filter((entry) => entry.type === "stream_request").length, 2);
+    assert.equal(logged.filter((entry) => entry.type === "auth_login_start").length, 1);
+  } finally {
+    await handle.close();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
 test("client.agent.run auto_once retries on auth_required nack and succeeds", async () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "makai-auth-retry-agent-test-"));
   const logPath = path.join(tmpDir, "request.log");
@@ -663,6 +688,31 @@ test("client.agent.stream auto_once retries on auth_required nack and yields eve
     assert.equal(agentStarts.length, 2);
     const loginStarts = logged.filter((entry) => entry.type === "auth_login_start");
     assert.equal(loginStarts.length, 1);
+  } finally {
+    await handle.close();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("client.agent.stream auto_once retries at most once when auth_required persists", async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "makai-auth-retry-agent-stream-limit-test-"));
+  const logPath = path.join(tmpDir, "request.log");
+  const handle = await createMakaiClient({
+    command: process.execPath,
+    args: [fixtureScript],
+    env: { ...process.env, MAKAI_TEST_REQUEST_LOG: logPath, MAKAI_TEST_AUTH_REQUIRED_ALWAYS: "1" },
+    handshakeTimeoutMs: 5000,
+    responseTimeoutMs: 5000,
+    auth: { auth_retry_policy: "auto_once" },
+  });
+  try {
+    await assert.rejects(
+      async () => collect(handle.agent.stream(request())),
+      (err: unknown) => err instanceof MakaiStreamError && err.code === "auth_required",
+    );
+    const logged = readLoggedRequests(logPath);
+    assert.equal(logged.filter((entry) => entry.type === "agent_start").length, 2);
+    assert.equal(logged.filter((entry) => entry.type === "auth_login_start").length, 1);
   } finally {
     await handle.close();
     fs.rmSync(tmpDir, { recursive: true, force: true });

--- a/typescript/test/execution_client.test.ts
+++ b/typescript/test/execution_client.test.ts
@@ -436,3 +436,169 @@ test("createMakaiClient wires all namespaces correctly", async () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }
 });
+
+test("client.provider.stream normalizes top-level start frame to message_start", async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "makai-start-frame-test-"));
+  const eventsPath = path.join(tmpDir, "events.json");
+  fs.writeFileSync(eventsPath, JSON.stringify([
+    { type: "start", provider_id: "anthropic", api: "anthropic-messages", model_id: "claude-sonnet-4-5" },
+    { type: "text_delta", delta: "hello" },
+    { type: "done", usage: { input: 3, output: 5 }, stop_reason: "end_turn" },
+  ]));
+  const harness = await setupHarness({ MAKAI_TEST_PROVIDER_EVENTS_PATH: eventsPath });
+  try {
+    const provider = createMakaiProviderApi(harness.client);
+    const events = await collect(provider.stream(request()));
+    assert.deepEqual(events, [
+      { type: "message_start", provider_id: "anthropic", api: "anthropic-messages", model_id: "claude-sonnet-4-5" },
+      { type: "text_delta", delta: "hello" },
+      { type: "message_end", usage: { input: 3, output: 5 }, stop_reason: "end_turn" },
+    ] satisfies ProviderStreamEvent[]);
+  } finally {
+    await harness.cleanup();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("client.provider.complete auto_once retries on auth_required nack and succeeds", async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "makai-auth-retry-complete-test-"));
+  const logPath = path.join(tmpDir, "request.log");
+  const handle = await createMakaiClient({
+    command: process.execPath,
+    args: [fixtureScript],
+    env: { ...process.env, MAKAI_TEST_REQUEST_LOG: logPath, MAKAI_TEST_AUTH_REQUIRED_ONCE: "1" },
+    handshakeTimeoutMs: 5000,
+    responseTimeoutMs: 5000,
+    auth: { auth_retry_policy: "auto_once" },
+  });
+  try {
+    const result = await handle.provider.complete(request());
+    assert.deepEqual(result.message.content, [{ type: "text", text: "hello" }]);
+    const logged = readLoggedRequests(logPath);
+    const completeRequests = logged.filter((entry) => entry.type === "complete_request");
+    assert.equal(completeRequests.length, 2);
+    assert.equal(completeRequests[0]?.type, "complete_request");
+    assert.equal(completeRequests[1]?.type, "complete_request");
+    const loginStarts = logged.filter((entry) => entry.type === "auth_login_start");
+    assert.equal(loginStarts.length, 1);
+  } finally {
+    await handle.close();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("client.provider.stream auto_once retries on auth_required nack and yields events", async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "makai-auth-retry-stream-test-"));
+  const logPath = path.join(tmpDir, "request.log");
+  const handle = await createMakaiClient({
+    command: process.execPath,
+    args: [fixtureScript],
+    env: { ...process.env, MAKAI_TEST_REQUEST_LOG: logPath, MAKAI_TEST_AUTH_REQUIRED_ONCE: "1" },
+    handshakeTimeoutMs: 5000,
+    responseTimeoutMs: 5000,
+    auth: { auth_retry_policy: "auto_once" },
+  });
+  try {
+    const events = await collect(handle.provider.stream(request()));
+    assert.equal(events[0]?.type, "message_start");
+    const logged = readLoggedRequests(logPath);
+    const streamRequests = logged.filter((entry) => entry.type === "stream_request");
+    assert.equal(streamRequests.length, 2);
+    const loginStarts = logged.filter((entry) => entry.type === "auth_login_start");
+    assert.equal(loginStarts.length, 1);
+  } finally {
+    await handle.close();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("client.agent.run auto_once retries on auth_required nack and succeeds", async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "makai-auth-retry-agent-test-"));
+  const logPath = path.join(tmpDir, "request.log");
+  const resultPath = path.join(tmpDir, "agent-result.json");
+  fs.writeFileSync(resultPath, JSON.stringify({
+    messages: [{
+      role: "assistant",
+      content: "ok",
+      usage: { input: 1, output: 1 },
+      provider: "anthropic",
+      api: "anthropic-messages",
+      model: "claude-sonnet-4-5",
+      stop_reason: "end_turn",
+    }],
+  }));
+  const handle = await createMakaiClient({
+    command: process.execPath,
+    args: [fixtureScript],
+    env: { ...process.env, MAKAI_TEST_REQUEST_LOG: logPath, MAKAI_TEST_AUTH_REQUIRED_ONCE: "1", MAKAI_TEST_AGENT_RESULT_PATH: resultPath },
+    handshakeTimeoutMs: 5000,
+    responseTimeoutMs: 5000,
+    auth: { auth_retry_policy: "auto_once" },
+  });
+  try {
+    const result = await handle.agent.run(request());
+    assert.equal(result.message.content, "ok");
+    const logged = readLoggedRequests(logPath);
+    const agentStarts = logged.filter((entry) => entry.type === "agent_start");
+    assert.equal(agentStarts.length, 2);
+    const loginStarts = logged.filter((entry) => entry.type === "auth_login_start");
+    assert.equal(loginStarts.length, 1);
+  } finally {
+    await handle.close();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("manual auth_retry_policy does not retry on auth_required", async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "makai-auth-manual-test-"));
+  const logPath = path.join(tmpDir, "request.log");
+  const handle = await createMakaiClient({
+    command: process.execPath,
+    args: [fixtureScript],
+    env: { ...process.env, MAKAI_TEST_REQUEST_LOG: logPath, MAKAI_TEST_AUTH_REQUIRED_ONCE: "1" },
+    handshakeTimeoutMs: 5000,
+    responseTimeoutMs: 5000,
+    auth: { auth_retry_policy: "manual" },
+  });
+  try {
+    await assert.rejects(
+      () => handle.provider.complete(request()),
+      (err: unknown) => err instanceof MakaiStreamError && err.code === "auth_required" && err.provider_id === "anthropic",
+    );
+    const logged = readLoggedRequests(logPath);
+    const completeRequests = logged.filter((entry) => entry.type === "complete_request");
+    assert.equal(completeRequests.length, 1);
+    const loginStarts = logged.filter((entry) => entry.type === "auth_login_start");
+    assert.equal(loginStarts.length, 0);
+  } finally {
+    await handle.close();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("auto_once falls back to original auth_required error when login fails", async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "makai-auth-fail-test-"));
+  const logPath = path.join(tmpDir, "request.log");
+  const handle = await createMakaiClient({
+    command: process.execPath,
+    args: [fixtureScript],
+    env: { ...process.env, MAKAI_TEST_REQUEST_LOG: logPath, MAKAI_TEST_AUTH_REQUIRED_ONCE: "1", MAKAI_TEST_AUTH_REQUIRES_PROMPT: "1" },
+    handshakeTimeoutMs: 5000,
+    responseTimeoutMs: 5000,
+    auth: { auth_retry_policy: "auto_once" },
+  });
+  try {
+    await assert.rejects(
+      () => handle.provider.complete(request()),
+      (err: unknown) => err instanceof MakaiStreamError && err.code === "auth_required" && err.provider_id === "anthropic",
+    );
+    const logged = readLoggedRequests(logPath);
+    const completeRequests = logged.filter((entry) => entry.type === "complete_request");
+    assert.equal(completeRequests.length, 1);
+    const loginStarts = logged.filter((entry) => entry.type === "auth_login_start");
+    assert.equal(loginStarts.length, 1);
+  } finally {
+    await handle.close();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});

--- a/typescript/test/execution_client.test.ts
+++ b/typescript/test/execution_client.test.ts
@@ -937,6 +937,130 @@ test("client.agent.stream auto_once retries when error lacks provider_id", async
   }
 });
 
+test("client.provider.complete auto_once retries for non-canonical model_ref when error lacks provider_id", async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "makai-auth-retry-noncanon-complete-test-"));
+  const logPath = path.join(tmpDir, "request.log");
+  const handle = await createMakaiClient({
+    command: process.execPath,
+    args: [fixtureScript],
+    env: { ...process.env, MAKAI_TEST_REQUEST_LOG: logPath, MAKAI_TEST_AUTH_REQUIRED_ONCE: "1", MAKAI_TEST_AUTH_REQUIRED_NO_PROVIDER_ID: "1" },
+    handshakeTimeoutMs: 5000,
+    responseTimeoutMs: 5000,
+    auth: { auth_retry_policy: "auto_once" },
+  });
+  try {
+    const result = await handle.provider.complete({
+      model_ref: "anthropic/anthropic-messages@opaque-model-ref-with:colon",
+      messages: [{ role: "user" as const, content: "hello" }],
+    });
+    assert.deepEqual(result.message.content, [{ type: "text", text: "hello" }]);
+    const logged = readLoggedRequests(logPath);
+    assert.equal(logged.filter((entry) => entry.type === "complete_request").length, 2);
+    assert.equal(logged.filter((entry) => entry.type === "auth_login_start").length, 1);
+    const login = logged.find((entry) => entry.type === "auth_login_start");
+    assert.equal((login?.payload as Record<string, unknown>)?.provider_id, "anthropic");
+  } finally {
+    await handle.close();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("client.provider.stream auto_once retries for non-canonical model_ref when error lacks provider_id", async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "makai-auth-retry-noncanon-stream-test-"));
+  const logPath = path.join(tmpDir, "request.log");
+  const handle = await createMakaiClient({
+    command: process.execPath,
+    args: [fixtureScript],
+    env: { ...process.env, MAKAI_TEST_REQUEST_LOG: logPath, MAKAI_TEST_AUTH_REQUIRED_ONCE: "1", MAKAI_TEST_AUTH_REQUIRED_NO_PROVIDER_ID: "1" },
+    handshakeTimeoutMs: 5000,
+    responseTimeoutMs: 5000,
+    auth: { auth_retry_policy: "auto_once" },
+  });
+  try {
+    const events = await collect(handle.provider.stream({
+      model_ref: "anthropic/anthropic-messages@opaque-model-ref-with:colon",
+      messages: [{ role: "user" as const, content: "hello" }],
+    }));
+    assert.equal(events[0]?.type, "message_start");
+    const logged = readLoggedRequests(logPath);
+    assert.equal(logged.filter((entry) => entry.type === "stream_request").length, 2);
+    assert.equal(logged.filter((entry) => entry.type === "auth_login_start").length, 1);
+    const login = logged.find((entry) => entry.type === "auth_login_start");
+    assert.equal((login?.payload as Record<string, unknown>)?.provider_id, "anthropic");
+  } finally {
+    await handle.close();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("client.agent.run auto_once retries for non-canonical model_ref when error lacks provider_id", async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "makai-auth-retry-noncanon-agent-run-test-"));
+  const logPath = path.join(tmpDir, "request.log");
+  const resultPath = path.join(tmpDir, "agent-result.json");
+  fs.writeFileSync(resultPath, JSON.stringify({
+    messages: [{
+      role: "assistant",
+      content: "ok",
+      usage: { input: 1, output: 1 },
+      provider: "anthropic",
+      api: "anthropic-messages",
+      model: "claude-sonnet-4-5",
+      stop_reason: "end_turn",
+    }],
+  }));
+  const handle = await createMakaiClient({
+    command: process.execPath,
+    args: [fixtureScript],
+    env: { ...process.env, MAKAI_TEST_REQUEST_LOG: logPath, MAKAI_TEST_AUTH_REQUIRED_ONCE: "1", MAKAI_TEST_AUTH_REQUIRED_NO_PROVIDER_ID: "1", MAKAI_TEST_AGENT_RESULT_PATH: resultPath },
+    handshakeTimeoutMs: 5000,
+    responseTimeoutMs: 5000,
+    auth: { auth_retry_policy: "auto_once" },
+  });
+  try {
+    const result = await handle.agent.run({
+      model_ref: "anthropic/anthropic-messages@opaque-model-ref-with:colon",
+      messages: [{ role: "user" as const, content: "hello" }],
+    });
+    assert.equal(result.message.content, "ok");
+    const logged = readLoggedRequests(logPath);
+    assert.equal(logged.filter((entry) => entry.type === "agent_start").length, 2);
+    assert.equal(logged.filter((entry) => entry.type === "auth_login_start").length, 1);
+    const login = logged.find((entry) => entry.type === "auth_login_start");
+    assert.equal((login?.payload as Record<string, unknown>)?.provider_id, "anthropic");
+  } finally {
+    await handle.close();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("client.agent.stream auto_once retries for non-canonical model_ref when error lacks provider_id", async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "makai-auth-retry-noncanon-agent-stream-test-"));
+  const logPath = path.join(tmpDir, "request.log");
+  const handle = await createMakaiClient({
+    command: process.execPath,
+    args: [fixtureScript],
+    env: { ...process.env, MAKAI_TEST_REQUEST_LOG: logPath, MAKAI_TEST_AUTH_REQUIRED_ONCE: "1", MAKAI_TEST_AUTH_REQUIRED_NO_PROVIDER_ID: "1" },
+    handshakeTimeoutMs: 5000,
+    responseTimeoutMs: 5000,
+    auth: { auth_retry_policy: "auto_once" },
+  });
+  try {
+    const events = await collect(handle.agent.stream({
+      model_ref: "anthropic/anthropic-messages@opaque-model-ref-with:colon",
+      messages: [{ role: "user" as const, content: "hello" }],
+    }));
+    assert.equal(events[0]?.type, "agent_start");
+    const logged = readLoggedRequests(logPath);
+    assert.equal(logged.filter((entry) => entry.type === "agent_start").length, 2);
+    assert.equal(logged.filter((entry) => entry.type === "auth_login_start").length, 1);
+    const login = logged.find((entry) => entry.type === "auth_login_start");
+    assert.equal((login?.payload as Record<string, unknown>)?.provider_id, "anthropic");
+  } finally {
+    await handle.close();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
 test("agent_start payload includes resume_session_id", async () => {
   const harness = await setupHarness();
   try {

--- a/typescript/test/execution_client.test.ts
+++ b/typescript/test/execution_client.test.ts
@@ -708,6 +708,142 @@ test("auto_once falls back to original auth_required error when login fails", as
   }
 });
 
+test("manual policy backfills provider_id on auth_required nack missing provider_id", async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "makai-auth-manual-backfill-test-"));
+  const logPath = path.join(tmpDir, "request.log");
+  const handle = await createMakaiClient({
+    command: process.execPath,
+    args: [fixtureScript],
+    env: { ...process.env, MAKAI_TEST_REQUEST_LOG: logPath, MAKAI_TEST_AUTH_REQUIRED_ONCE: "1", MAKAI_TEST_AUTH_REQUIRED_NO_PROVIDER_ID: "1" },
+    handshakeTimeoutMs: 5000,
+    responseTimeoutMs: 5000,
+    auth: { auth_retry_policy: "manual" },
+  });
+  try {
+    await assert.rejects(
+      () => handle.provider.complete(request()),
+      (err: unknown) => err instanceof MakaiStreamError && err.code === "auth_required" && err.provider_id === "anthropic",
+    );
+    const logged = readLoggedRequests(logPath);
+    assert.equal(logged.filter((entry) => entry.type === "complete_request").length, 1);
+    assert.equal(logged.filter((entry) => entry.type === "auth_login_start").length, 0);
+  } finally {
+    await handle.close();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("manual policy backfills provider_id on auth_required stream nack missing provider_id", async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "makai-auth-manual-backfill-stream-test-"));
+  const logPath = path.join(tmpDir, "request.log");
+  const handle = await createMakaiClient({
+    command: process.execPath,
+    args: [fixtureScript],
+    env: { ...process.env, MAKAI_TEST_REQUEST_LOG: logPath, MAKAI_TEST_AUTH_REQUIRED_ONCE: "1", MAKAI_TEST_AUTH_REQUIRED_NO_PROVIDER_ID: "1" },
+    handshakeTimeoutMs: 5000,
+    responseTimeoutMs: 5000,
+    auth: { auth_retry_policy: "manual" },
+  });
+  try {
+    await assert.rejects(
+      async () => {
+        for await (const _event of handle.provider.stream(request())) {
+          // no-op
+        }
+      },
+      (err: unknown) => err instanceof MakaiStreamError && err.code === "auth_required" && err.provider_id === "anthropic",
+    );
+    const logged = readLoggedRequests(logPath);
+    assert.equal(logged.filter((entry) => entry.type === "stream_request").length, 1);
+    assert.equal(logged.filter((entry) => entry.type === "auth_login_start").length, 0);
+  } finally {
+    await handle.close();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("manual policy backfills provider_id on agent run auth_required nack missing provider_id", async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "makai-auth-manual-backfill-agent-run-test-"));
+  const logPath = path.join(tmpDir, "request.log");
+  const handle = await createMakaiClient({
+    command: process.execPath,
+    args: [fixtureScript],
+    env: { ...process.env, MAKAI_TEST_REQUEST_LOG: logPath, MAKAI_TEST_AUTH_REQUIRED_ONCE: "1", MAKAI_TEST_AUTH_REQUIRED_NO_PROVIDER_ID: "1" },
+    handshakeTimeoutMs: 5000,
+    responseTimeoutMs: 5000,
+    auth: { auth_retry_policy: "manual" },
+  });
+  try {
+    await assert.rejects(
+      () => handle.agent.run(request()),
+      (err: unknown) => err instanceof MakaiStreamError && err.code === "auth_required" && err.provider_id === "anthropic",
+    );
+    const logged = readLoggedRequests(logPath);
+    assert.equal(logged.filter((entry) => entry.type === "agent_start").length, 1);
+    assert.equal(logged.filter((entry) => entry.type === "auth_login_start").length, 0);
+  } finally {
+    await handle.close();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("manual policy backfills provider_id on agent stream auth_required nack missing provider_id", async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "makai-auth-manual-backfill-agent-stream-test-"));
+  const logPath = path.join(tmpDir, "request.log");
+  const handle = await createMakaiClient({
+    command: process.execPath,
+    args: [fixtureScript],
+    env: { ...process.env, MAKAI_TEST_REQUEST_LOG: logPath, MAKAI_TEST_AUTH_REQUIRED_ONCE: "1", MAKAI_TEST_AUTH_REQUIRED_NO_PROVIDER_ID: "1" },
+    handshakeTimeoutMs: 5000,
+    responseTimeoutMs: 5000,
+    auth: { auth_retry_policy: "manual" },
+  });
+  try {
+    await assert.rejects(
+      async () => {
+        for await (const _event of handle.agent.stream(request())) {
+          // no-op
+        }
+      },
+      (err: unknown) => err instanceof MakaiStreamError && err.code === "auth_required" && err.provider_id === "anthropic",
+    );
+    const logged = readLoggedRequests(logPath);
+    assert.equal(logged.filter((entry) => entry.type === "agent_start").length, 1);
+    assert.equal(logged.filter((entry) => entry.type === "auth_login_start").length, 0);
+  } finally {
+    await handle.close();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("manual policy backfills provider_id for non-canonical model_ref on auth_required nack", async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "makai-auth-manual-backfill-noncanon-test-"));
+  const logPath = path.join(tmpDir, "request.log");
+  const handle = await createMakaiClient({
+    command: process.execPath,
+    args: [fixtureScript],
+    env: { ...process.env, MAKAI_TEST_REQUEST_LOG: logPath, MAKAI_TEST_AUTH_REQUIRED_ONCE: "1", MAKAI_TEST_AUTH_REQUIRED_NO_PROVIDER_ID: "1" },
+    handshakeTimeoutMs: 5000,
+    responseTimeoutMs: 5000,
+    auth: { auth_retry_policy: "manual" },
+  });
+  try {
+    await assert.rejects(
+      () => handle.provider.complete({
+        model_ref: "anthropic/anthropic-messages@opaque-model-ref-with:colon",
+        messages: [{ role: "user" as const, content: "hello" }],
+      }),
+      (err: unknown) => err instanceof MakaiStreamError && err.code === "auth_required" && err.provider_id === "anthropic",
+    );
+    const logged = readLoggedRequests(logPath);
+    assert.equal(logged.filter((entry) => entry.type === "complete_request").length, 1);
+    assert.equal(logged.filter((entry) => entry.type === "auth_login_start").length, 0);
+  } finally {
+    await handle.close();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
 test("client.agent.stream auto_once retries on auth_required nack and yields events", async () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "makai-auth-retry-agent-stream-test-"));
   const logPath = path.join(tmpDir, "request.log");

--- a/typescript/test/execution_client.test.ts
+++ b/typescript/test/execution_client.test.ts
@@ -615,6 +615,45 @@ test("client.agent.run auto_once retries on auth_required nack and succeeds", as
   }
 });
 
+test("client.agent.run auto_once uses fresh session_id on retry", async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "makai-auth-retry-agent-session-test-"));
+  const logPath = path.join(tmpDir, "request.log");
+  const resultPath = path.join(tmpDir, "agent-result.json");
+  fs.writeFileSync(resultPath, JSON.stringify({
+    messages: [{
+      role: "assistant",
+      content: "ok",
+      usage: { input: 1, output: 1 },
+      provider: "anthropic",
+      api: "anthropic-messages",
+      model: "claude-sonnet-4-5",
+      stop_reason: "end_turn",
+    }],
+  }));
+  const handle = await createMakaiClient({
+    command: process.execPath,
+    args: [fixtureScript],
+    env: { ...process.env, MAKAI_TEST_REQUEST_LOG: logPath, MAKAI_TEST_AUTH_REQUIRED_ONCE: "1", MAKAI_TEST_AGENT_RESULT_PATH: resultPath },
+    handshakeTimeoutMs: 5000,
+    responseTimeoutMs: 5000,
+    auth: { auth_retry_policy: "auto_once" },
+  });
+  try {
+    await handle.agent.run(request());
+    const logged = readLoggedRequests(logPath);
+    const agentStarts = logged.filter((entry) => entry.type === "agent_start");
+    assert.equal(agentStarts.length, 2);
+    const firstSessionId = agentStarts[0]?.session_id;
+    const secondSessionId = agentStarts[1]?.session_id;
+    assert.equal(firstSessionId, "testNanoIdSess1234567");
+    assert.notEqual(secondSessionId, firstSessionId);
+    assert.match(secondSessionId as string, /^[0-9A-Za-z]{21}$/);
+  } finally {
+    await handle.close();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
 test("manual auth_retry_policy does not retry on auth_required", async () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "makai-auth-manual-test-"));
   const logPath = path.join(tmpDir, "request.log");
@@ -688,6 +727,33 @@ test("client.agent.stream auto_once retries on auth_required nack and yields eve
     assert.equal(agentStarts.length, 2);
     const loginStarts = logged.filter((entry) => entry.type === "auth_login_start");
     assert.equal(loginStarts.length, 1);
+  } finally {
+    await handle.close();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("client.agent.stream auto_once uses fresh session_id on retry", async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "makai-auth-retry-agent-stream-session-test-"));
+  const logPath = path.join(tmpDir, "request.log");
+  const handle = await createMakaiClient({
+    command: process.execPath,
+    args: [fixtureScript],
+    env: { ...process.env, MAKAI_TEST_REQUEST_LOG: logPath, MAKAI_TEST_AUTH_REQUIRED_ONCE: "1" },
+    handshakeTimeoutMs: 5000,
+    responseTimeoutMs: 5000,
+    auth: { auth_retry_policy: "auto_once" },
+  });
+  try {
+    await collect(handle.agent.stream(request()));
+    const logged = readLoggedRequests(logPath);
+    const agentStarts = logged.filter((entry) => entry.type === "agent_start");
+    assert.equal(agentStarts.length, 2);
+    const firstSessionId = agentStarts[0]?.session_id;
+    const secondSessionId = agentStarts[1]?.session_id;
+    assert.equal(firstSessionId, "testNanoIdSess1234567");
+    assert.notEqual(secondSessionId, firstSessionId);
+    assert.match(secondSessionId as string, /^[0-9A-Za-z]{21}$/);
   } finally {
     await handle.close();
     fs.rmSync(tmpDir, { recursive: true, force: true });

--- a/typescript/test/execution_client.test.ts
+++ b/typescript/test/execution_client.test.ts
@@ -48,7 +48,7 @@ function request() {
   return {
     model_ref: "opaque-model-ref-with:colon",
     messages: [{ role: "user" as const, content: "hello" }],
-    options: { temperature: 0.2, session_id: "session-1" },
+    options: { temperature: 0.2, session_id: "11111111-1111-4111-8111-111111111111" },
   };
 }
 
@@ -178,6 +178,34 @@ test("client.agent.run resolves with correct AgentRunResponse", async () => {
   }
 });
 
+test("client.agent.run rejects non-UUID session IDs before transport I/O", async () => {
+  const harness = await setupHarness();
+  try {
+    const agent = createMakaiAgentApi(harness.client);
+    await assert.rejects(
+      () => agent.run({ ...request(), options: { ...request().options, session_id: "session-1" } }),
+      (err: unknown) => err instanceof TypeError && err.message === "request.options.session_id must be a UUID for agent transport",
+    );
+    assert.deepEqual(readLoggedRequests(harness.logPath), []);
+  } finally {
+    await harness.cleanup();
+  }
+});
+
+test("client.agent.stream rejects non-UUID session IDs before transport I/O", async () => {
+  const harness = await setupHarness();
+  try {
+    const agent = createMakaiAgentApi(harness.client);
+    await assert.rejects(
+      async () => collect(agent.stream({ ...request(), options: { ...request().options, session_id: "session-1" } })),
+      (err: unknown) => err instanceof TypeError && err.message === "request.options.session_id must be a UUID for agent transport",
+    );
+    assert.deepEqual(readLoggedRequests(harness.logPath), []);
+  } finally {
+    await harness.cleanup();
+  }
+});
+
 test("client.agent.stream yields agent lifecycle events in order", async () => {
   const harness = await setupHarness();
   try {
@@ -193,7 +221,7 @@ test("client.agent.stream yields agent lifecycle events in order", async () => {
       "turn_end",
       "agent_end",
     ]);
-    assert.deepEqual(events[0], { type: "agent_start", session_id: "session-1" } satisfies AgentStreamEvent);
+    assert.deepEqual(events[0], { type: "agent_start", session_id: "11111111-1111-4111-8111-111111111111" } satisfies AgentStreamEvent);
     assert.deepEqual(events.at(-1), { type: "agent_end", usage: { input: 7, output: 9 }, stop_reason: "end_turn" } satisfies AgentStreamEvent);
 
     const logged = readLoggedRequests(harness.logPath);

--- a/typescript/test/execution_client.test.ts
+++ b/typescript/test/execution_client.test.ts
@@ -208,6 +208,23 @@ test("stream error paths throw MakaiStreamError", async () => {
   }
 });
 
+test("provider stream_error frames preserve MakaiStreamError code", async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "makai-stream-error-code-test-"));
+  const eventsPath = path.join(tmpDir, "events.json");
+  fs.writeFileSync(eventsPath, JSON.stringify([{ type: "stream_error", message: "login required", code: "auth_required" }]));
+  const harness = await setupHarness({ MAKAI_TEST_PROVIDER_EVENTS_PATH: eventsPath });
+  try {
+    const provider = createMakaiProviderApi(harness.client);
+    await assert.rejects(
+      async () => collect(provider.stream(request())),
+      (err: unknown) => err instanceof MakaiStreamError && err.message === "login required" && err.code === "auth_required",
+    );
+  } finally {
+    await harness.cleanup();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
 test("agent stream error paths throw MakaiStreamError", async () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "makai-agent-error-test-"));
   const eventsPath = path.join(tmpDir, "events.json");

--- a/typescript/test/execution_client.test.ts
+++ b/typescript/test/execution_client.test.ts
@@ -207,6 +207,31 @@ test("client.agent.stream rejects non-UUID session IDs before transport I/O", as
   }
 });
 
+test("client.agent.run accepts UUID v7 session IDs", async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "makai-agent-v7-session-test-"));
+  const resultPath = path.join(tmpDir, "agent-result.json");
+  fs.writeFileSync(resultPath, JSON.stringify({
+    messages: [{
+      role: "assistant",
+      content: "ok",
+      usage: { input: 1, output: 1 },
+      provider: "anthropic",
+      api: "anthropic-messages",
+      model: "claude-sonnet-4-5",
+      stop_reason: "end_turn",
+    }],
+  }));
+  const harness = await setupHarness({ MAKAI_TEST_AGENT_RESULT_PATH: resultPath });
+  try {
+    const agent = createMakaiAgentApi(harness.client);
+    await agent.run({ ...request(), options: { ...request().options, session_id: "01890f3e-7b62-7cc4-8f68-7a6f6a1b1234" } });
+    assert.equal(readLoggedRequests(harness.logPath)[0]?.session_id, "01890f3e-7b62-7cc4-8f68-7a6f6a1b1234");
+  } finally {
+    await harness.cleanup();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
 test("client.agent.stream yields agent lifecycle events in order", async () => {
   const harness = await setupHarness();
   try {

--- a/typescript/test/execution_client.test.ts
+++ b/typescript/test/execution_client.test.ts
@@ -48,7 +48,7 @@ function request() {
   return {
     model_ref: "anthropic/anthropic-messages@opaque-model-ref-with%3Acolon",
     messages: [{ role: "user" as const, content: "hello" }],
-    options: { temperature: 0.2, session_id: "11111111-1111-4111-8111-111111111111" },
+    options: { temperature: 0.2, session_id: "testNanoIdSess1234567" },
   };
 }
 
@@ -199,13 +199,13 @@ test("client.agent.run resolves with correct AgentRunResponse", async () => {
   }
 });
 
-test("client.agent.run rejects non-UUID session IDs before transport I/O", async () => {
+test("client.agent.run rejects non-NanoID session IDs before transport I/O", async () => {
   const harness = await setupHarness();
   try {
     const agent = createMakaiAgentApi(harness.client);
     await assert.rejects(
       () => agent.run({ ...request(), options: { ...request().options, session_id: "session-1" } }),
-      (err: unknown) => err instanceof TypeError && err.message === "request.options.session_id must be a UUID for agent transport",
+      (err: unknown) => err instanceof TypeError && err.message === "request.options.session_id must be a 21-character alphanumeric NanoID for agent transport",
     );
     assert.deepEqual(readLoggedRequests(harness.logPath), []);
   } finally {
@@ -213,13 +213,13 @@ test("client.agent.run rejects non-UUID session IDs before transport I/O", async
   }
 });
 
-test("client.agent.stream rejects non-UUID session IDs before transport I/O", async () => {
+test("client.agent.stream rejects non-NanoID session IDs before transport I/O", async () => {
   const harness = await setupHarness();
   try {
     const agent = createMakaiAgentApi(harness.client);
     await assert.rejects(
       async () => collect(agent.stream({ ...request(), options: { ...request().options, session_id: "session-1" } })),
-      (err: unknown) => err instanceof TypeError && err.message === "request.options.session_id must be a UUID for agent transport",
+      (err: unknown) => err instanceof TypeError && err.message === "request.options.session_id must be a 21-character alphanumeric NanoID for agent transport",
     );
     assert.deepEqual(readLoggedRequests(harness.logPath), []);
   } finally {
@@ -227,8 +227,22 @@ test("client.agent.stream rejects non-UUID session IDs before transport I/O", as
   }
 });
 
-test("client.agent.run accepts UUID v7 session IDs", async () => {
-  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "makai-agent-v7-session-test-"));
+test("client.agent.run rejects UUID session IDs", async () => {
+  const harness = await setupHarness();
+  try {
+    const agent = createMakaiAgentApi(harness.client);
+    await assert.rejects(
+      () => agent.run({ ...request(), options: { ...request().options, session_id: "01890f3e-7b62-7cc4-8f68-7a6f6a1b1234" } }),
+      (err: unknown) => err instanceof TypeError && err.message === "request.options.session_id must be a 21-character alphanumeric NanoID for agent transport",
+    );
+    assert.deepEqual(readLoggedRequests(harness.logPath), []);
+  } finally {
+    await harness.cleanup();
+  }
+});
+
+test("client.agent.run accepts valid NanoID session IDs", async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "makai-agent-nanoid-session-test-"));
   const resultPath = path.join(tmpDir, "agent-result.json");
   fs.writeFileSync(resultPath, JSON.stringify({
     messages: [{
@@ -244,8 +258,9 @@ test("client.agent.run accepts UUID v7 session IDs", async () => {
   const harness = await setupHarness({ MAKAI_TEST_AGENT_RESULT_PATH: resultPath });
   try {
     const agent = createMakaiAgentApi(harness.client);
-    await agent.run({ ...request(), options: { ...request().options, session_id: "01890f3e-7b62-7cc4-8f68-7a6f6a1b1234" } });
-    assert.equal(readLoggedRequests(harness.logPath)[0]?.session_id, "01890f3e-7b62-7cc4-8f68-7a6f6a1b1234");
+    const nanoId = "abcABC123xyzXYZ789mno";
+    await agent.run({ ...request(), options: { ...request().options, session_id: nanoId } });
+    assert.equal(readLoggedRequests(harness.logPath)[0]?.session_id, nanoId);
   } finally {
     await harness.cleanup();
     fs.rmSync(tmpDir, { recursive: true, force: true });
@@ -267,7 +282,7 @@ test("client.agent.stream yields agent lifecycle events in order", async () => {
       "turn_end",
       "agent_end",
     ]);
-    assert.deepEqual(events[0], { type: "agent_start", session_id: "11111111-1111-4111-8111-111111111111" } satisfies AgentStreamEvent);
+    assert.deepEqual(events[0], { type: "agent_start", session_id: "testNanoIdSess1234567" } satisfies AgentStreamEvent);
     assert.deepEqual(events.at(-1), { type: "agent_end", usage: { input: 7, output: 9 }, stop_reason: "end_turn" } satisfies AgentStreamEvent);
 
     const logged = readLoggedRequests(harness.logPath);
@@ -789,7 +804,7 @@ test("agent_start payload includes resume_session_id", async () => {
     const start = logged.find((entry) => entry.type === "agent_start");
     assert.ok(start);
     const payload = start?.payload as Record<string, unknown>;
-    assert.equal(payload.resume_session_id, "11111111-1111-4111-8111-111111111111");
+    assert.equal(payload.resume_session_id, "testNanoIdSess1234567");
   } finally {
     await harness.cleanup();
   }

--- a/typescript/test/execution_client.test.ts
+++ b/typescript/test/execution_client.test.ts
@@ -103,18 +103,38 @@ test("client.provider.stream yields ProviderStreamEvent sequence including messa
 });
 
 test("client.agent.run resolves with correct AgentRunResponse", async () => {
-  const harness = await setupHarness();
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "makai-agent-result-test-"));
+  const resultPath = path.join(tmpDir, "agent-result.json");
+  fs.writeFileSync(resultPath, JSON.stringify({
+    messages: [{
+      role: "assistant",
+      content: [
+        { type: "text", text: "Use this tool" },
+        { type: "tool_call", id: "call-1", name: "lookup", arguments_json: "{\"q\":\"makai\"}" },
+      ],
+      usage: { input: 7, output: 9 },
+      provider: "anthropic",
+      api: "anthropic-messages",
+      model: "claude-sonnet-4-5",
+      stop_reason: "tool_use",
+    }],
+  }));
+  const harness = await setupHarness({ MAKAI_TEST_AGENT_RESULT_PATH: resultPath });
   try {
     const agent = createMakaiAgentApi(harness.client);
     const result = await agent.run(request());
-    assert.equal(result.message.content, "agent");
+    assert.deepEqual(result.message.content, [
+      { type: "text", text: "Use this tool" },
+      { type: "tool_call", tool_call_id: "call-1", name: "lookup", arguments_json: "{\"q\":\"makai\"}" },
+    ]);
     assert.deepEqual(result.usage, { input: 7, output: 9 });
     assert.equal(result.provider_id, "anthropic");
     assert.equal(result.api, "anthropic-messages");
     assert.equal(result.model_id, "claude-sonnet-4-5");
-    assert.equal(result.stop_reason, "end_turn");
+    assert.equal(result.stop_reason, "tool_use");
   } finally {
     await harness.cleanup();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
   }
 });
 
@@ -140,6 +160,37 @@ test("client.agent.stream yields agent lifecycle events in order", async () => {
   }
 });
 
+test("client.provider.stream buffers incremental tool calls into one tool_call event", async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "makai-tool-buffer-test-"));
+  const eventsPath = path.join(tmpDir, "events.json");
+  fs.writeFileSync(eventsPath, JSON.stringify([
+    { type: "message_start", provider_id: "anthropic", api: "anthropic-messages", model_id: "claude-sonnet-4-5" },
+    { type: "event", event_type: "toolcall_start", content_index: 0, id: "call-1", name: "lookup" },
+    { type: "event", event_type: "toolcall_delta", content_index: 0, delta: "{\"q\":" },
+    { type: "event", event_type: "toolcall_delta", content_index: 0, delta: "\"makai\"}" },
+    { type: "event", event_type: "toolcall_end", content_index: 0 },
+    { type: "message_end", usage: { input: 3, output: 5 }, stop_reason: "tool_use" },
+  ]));
+  const harness = await setupHarness({ MAKAI_TEST_PROVIDER_EVENTS_PATH: eventsPath });
+  try {
+    const provider = createMakaiProviderApi(harness.client);
+    const events = await collect(provider.stream(request()));
+    assert.deepEqual(events.map((event) => event.type), ["message_start", "tool_call", "message_end"]);
+    assert.deepEqual(events[1], {
+      type: "tool_call",
+      tool_call_id: "call-1",
+      name: "lookup",
+      arguments_json: "{\"q\":\"makai\"}",
+    });
+
+    const payload = readLoggedRequests(harness.logPath)[0]?.payload as Record<string, unknown>;
+    assert.equal(payload.include_partial, false);
+  } finally {
+    await harness.cleanup();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
 test("stream error paths throw MakaiStreamError", async () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "makai-exec-error-test-"));
   const eventsPath = path.join(tmpDir, "events.json");
@@ -157,12 +208,33 @@ test("stream error paths throw MakaiStreamError", async () => {
   }
 });
 
+test("agent stream error paths throw MakaiStreamError", async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "makai-agent-error-test-"));
+  const eventsPath = path.join(tmpDir, "events.json");
+  fs.writeFileSync(eventsPath, JSON.stringify([{ type: "agent_start" }, { type: "error", message: "agent boom", code: "provider_error" }]));
+  const harness = await setupHarness({ MAKAI_TEST_AGENT_EVENTS_PATH: eventsPath });
+  try {
+    const agent = createMakaiAgentApi(harness.client);
+    await assert.rejects(
+      async () => collect(agent.stream(request())),
+      (err: unknown) => err instanceof MakaiStreamError && err.message === "agent boom" && err.code === "provider_error",
+    );
+  } finally {
+    await harness.cleanup();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
 test("createMakaiClient wires all namespaces correctly", async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "makai-client-wiring-test-"));
+  const logPath = path.join(tmpDir, "request.log");
   const handle = await createMakaiClient({
     command: process.execPath,
     args: [fixtureScript],
+    env: { ...process.env, MAKAI_TEST_REQUEST_LOG: logPath },
     handshakeTimeoutMs: 5000,
     responseTimeoutMs: 5000,
+    auth: { auth_retry_policy: "auto_once" },
   });
   try {
     assert.equal(typeof handle.auth.listProviders, "function");
@@ -173,7 +245,11 @@ test("createMakaiClient wires all namespaces correctly", async () => {
     assert.equal(typeof handle.agent.stream, "function");
     assert.deepEqual(await handle.auth.listProviders(), []);
     assert.deepEqual((await handle.models.list()).models, []);
+    await collect(handle.provider.stream(request()));
+    const streamRequest = readLoggedRequests(logPath).find((entry) => entry.type === "stream_request");
+    assert.equal(((streamRequest?.payload as Record<string, unknown>).options as Record<string, unknown>).auth_retry_policy, "auto_once");
   } finally {
     await handle.close();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
   }
 });

--- a/typescript/test/execution_client.test.ts
+++ b/typescript/test/execution_client.test.ts
@@ -422,6 +422,32 @@ test("agent stream error paths throw MakaiStreamError", async () => {
   }
 });
 
+test("client.agent.run throws MakaiStreamError on malformed result_json", async () => {
+  const harness = await setupHarness({ MAKAI_TEST_AGENT_MALFORMED_RESULT_JSON: "1" });
+  try {
+    const agent = createMakaiAgentApi(harness.client);
+    await assert.rejects(
+      () => agent.run(request()),
+      (err: unknown) => err instanceof MakaiStreamError && err.message === "malformed JSON in result_json" && err.kind === "transport_error",
+    );
+  } finally {
+    await harness.cleanup();
+  }
+});
+
+test("client.agent.stream throws MakaiStreamError on malformed event_json", async () => {
+  const harness = await setupHarness({ MAKAI_TEST_AGENT_MALFORMED_EVENT_JSON: "1" });
+  try {
+    const agent = createMakaiAgentApi(harness.client);
+    await assert.rejects(
+      async () => collect(agent.stream(request())),
+      (err: unknown) => err instanceof MakaiStreamError && err.message === "malformed JSON in event_json" && err.kind === "transport_error",
+    );
+  } finally {
+    await harness.cleanup();
+  }
+});
+
 test("createMakaiClient wires all namespaces correctly", async () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "makai-client-wiring-test-"));
   const logPath = path.join(tmpDir, "request.log");

--- a/typescript/test/execution_client.test.ts
+++ b/typescript/test/execution_client.test.ts
@@ -46,7 +46,7 @@ async function setupHarness(envOverrides: NodeJS.ProcessEnv = {}): Promise<Harne
 
 function request() {
   return {
-    model_ref: "opaque-model-ref-with:colon",
+    model_ref: "anthropic/anthropic-messages@opaque-model-ref-with%3Acolon",
     messages: [{ role: "user" as const, content: "hello" }],
     options: { temperature: 0.2, session_id: "11111111-1111-4111-8111-111111111111" },
   };
@@ -83,10 +83,11 @@ test("client.provider.complete resolves with correct CompletionResponse shape", 
     assert.deepEqual(payload.model, {
       id: "opaque-model-ref-with:colon",
       name: "opaque-model-ref-with:colon",
-      api: "",
-      provider: "",
+      api: "anthropic-messages",
+      provider: "anthropic",
       base_url: "",
     });
+    assert.equal(payload.model_ref, request().model_ref);
     assert.deepEqual((payload.context as Record<string, unknown>).messages, request().messages);
   } finally {
     await harness.cleanup();
@@ -98,7 +99,7 @@ test("client.provider.complete maps system prompts and tool messages into provid
   try {
     const provider = createMakaiProviderApi(harness.client);
     await provider.complete({
-      model_ref: "opaque-model-ref-with:colon",
+      model_ref: "anthropic/anthropic-messages@opaque-model-ref-with%3Acolon",
       messages: [
         { role: "system", content: "You are helpful." },
         { role: "developer", content: [{ type: "text", text: "Prefer concise answers." }] },
@@ -296,7 +297,13 @@ test("client.provider.stream buffers incremental tool calls into one tool_call e
 
     const payload = readLoggedRequests(harness.logPath)[0]?.payload as Record<string, unknown>;
     assert.equal(payload.include_partial, false);
-    assert.equal((payload.model as Record<string, unknown>).id, "opaque-model-ref-with:colon");
+    assert.deepEqual(payload.model, {
+      id: "opaque-model-ref-with:colon",
+      name: "opaque-model-ref-with:colon",
+      api: "anthropic-messages",
+      provider: "anthropic",
+      base_url: "",
+    });
     assert.deepEqual((payload.context as Record<string, unknown>).messages, request().messages);
   } finally {
     await harness.cleanup();
@@ -378,7 +385,7 @@ test("createMakaiClient wires all namespaces correctly", async () => {
     await collect(handle.provider.stream(request()));
     const streamRequest = readLoggedRequests(logPath).find((entry) => entry.type === "stream_request");
     assert.equal(((streamRequest?.payload as Record<string, unknown>).options as Record<string, unknown>).auth_retry_policy, "auto_once");
-    assert.equal(((streamRequest?.payload as Record<string, unknown>).model as Record<string, unknown>).id, "opaque-model-ref-with:colon");
+    assert.equal(((streamRequest?.payload as Record<string, unknown>).model as Record<string, unknown>).api, "anthropic-messages");
   } finally {
     await handle.close();
     fs.rmSync(tmpDir, { recursive: true, force: true });

--- a/typescript/test/execution_client.test.ts
+++ b/typescript/test/execution_client.test.ts
@@ -94,21 +94,21 @@ test("client.provider.complete resolves with correct CompletionResponse shape", 
   }
 });
 
-test("client.provider.complete preserves non-canonical model_ref with fallback model fields", async () => {
+test("client.provider.complete keeps routing fields for non-canonical model_ref", async () => {
   const harness = await setupHarness();
   try {
     const provider = createMakaiProviderApi(harness.client);
-    await provider.complete({ ...request(), model_ref: "opaque-model-ref-with:colon" });
+    await provider.complete({ ...request(), model_ref: "anthropic/anthropic-messages@opaque-model-ref-with:colon" });
 
     const payload = readLoggedRequests(harness.logPath)[0]?.payload as Record<string, unknown>;
     assert.deepEqual(payload.model, {
       id: "opaque-model-ref-with:colon",
       name: "opaque-model-ref-with:colon",
-      api: "",
-      provider: "",
+      api: "anthropic-messages",
+      provider: "anthropic",
       base_url: "",
     });
-    assert.equal(payload.model_ref, "opaque-model-ref-with:colon");
+    assert.equal(payload.model_ref, "anthropic/anthropic-messages@opaque-model-ref-with:colon");
   } finally {
     await harness.cleanup();
   }

--- a/typescript/test/execution_client.test.ts
+++ b/typescript/test/execution_client.test.ts
@@ -94,6 +94,26 @@ test("client.provider.complete resolves with correct CompletionResponse shape", 
   }
 });
 
+test("client.provider.complete preserves non-canonical model_ref with fallback model fields", async () => {
+  const harness = await setupHarness();
+  try {
+    const provider = createMakaiProviderApi(harness.client);
+    await provider.complete({ ...request(), model_ref: "opaque-model-ref-with:colon" });
+
+    const payload = readLoggedRequests(harness.logPath)[0]?.payload as Record<string, unknown>;
+    assert.deepEqual(payload.model, {
+      id: "opaque-model-ref-with:colon",
+      name: "opaque-model-ref-with:colon",
+      api: "",
+      provider: "",
+      base_url: "",
+    });
+    assert.equal(payload.model_ref, "opaque-model-ref-with:colon");
+  } finally {
+    await harness.cleanup();
+  }
+});
+
 test("client.provider.complete maps system prompts and tool messages into provider context", async () => {
   const harness = await setupHarness();
   try {
@@ -302,10 +322,10 @@ test("client.provider.stream buffers incremental tool calls into one tool_call e
   const eventsPath = path.join(tmpDir, "events.json");
   fs.writeFileSync(eventsPath, JSON.stringify([
     { type: "message_start", provider_id: "anthropic", api: "anthropic-messages", model_id: "claude-sonnet-4-5" },
-    { type: "event", event_type: "toolcall_start", content_index: 0, id: "call-1", name: "lookup" },
-    { type: "event", event_type: "toolcall_delta", content_index: 0, delta: "{\"q\":" },
-    { type: "event", event_type: "toolcall_delta", content_index: 0, delta: "\"makai\"}" },
-    { type: "event", event_type: "toolcall_end", content_index: 0 },
+    { type: "toolcall_start", content_index: 0, id: "call-1", name: "lookup" },
+    { type: "toolcall_delta", content_index: 0, delta: "{\"q\":" },
+    { type: "toolcall_delta", content_index: 0, delta: "\"makai\"}" },
+    { type: "toolcall_end", content_index: 0 },
     { type: "message_end", usage: { input: 3, output: 5 }, stop_reason: "tool_use" },
   ]));
   const harness = await setupHarness({ MAKAI_TEST_PROVIDER_EVENTS_PATH: eventsPath });

--- a/typescript/test/execution_client.test.ts
+++ b/typescript/test/execution_client.test.ts
@@ -602,3 +602,66 @@ test("auto_once falls back to original auth_required error when login fails", as
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }
 });
+
+test("per-request manual auth_retry_policy overrides client auto_once", async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "makai-auth-override-manual-test-"));
+  const logPath = path.join(tmpDir, "request.log");
+  const handle = await createMakaiClient({
+    command: process.execPath,
+    args: [fixtureScript],
+    env: { ...process.env, MAKAI_TEST_REQUEST_LOG: logPath, MAKAI_TEST_AUTH_REQUIRED_ONCE: "1" },
+    handshakeTimeoutMs: 5000,
+    responseTimeoutMs: 5000,
+    auth: { auth_retry_policy: "auto_once" },
+  });
+  try {
+    await assert.rejects(
+      () => handle.provider.complete({ ...request(), options: { auth_retry_policy: "manual" } }),
+      (err: unknown) => err instanceof MakaiStreamError && err.code === "auth_required",
+    );
+    const logged = readLoggedRequests(logPath);
+    assert.equal(logged.filter((entry) => entry.type === "complete_request").length, 1);
+    assert.equal(logged.filter((entry) => entry.type === "auth_login_start").length, 0);
+  } finally {
+    await handle.close();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("per-request auto_once auth_retry_policy overrides client manual", async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "makai-auth-override-auto-test-"));
+  const logPath = path.join(tmpDir, "request.log");
+  const handle = await createMakaiClient({
+    command: process.execPath,
+    args: [fixtureScript],
+    env: { ...process.env, MAKAI_TEST_REQUEST_LOG: logPath, MAKAI_TEST_AUTH_REQUIRED_ONCE: "1" },
+    handshakeTimeoutMs: 5000,
+    responseTimeoutMs: 5000,
+    auth: { auth_retry_policy: "manual" },
+  });
+  try {
+    const result = await handle.provider.complete({ ...request(), options: { auth_retry_policy: "auto_once" } });
+    assert.deepEqual(result.message.content, [{ type: "text", text: "hello" }]);
+    const logged = readLoggedRequests(logPath);
+    assert.equal(logged.filter((entry) => entry.type === "complete_request").length, 2);
+    assert.equal(logged.filter((entry) => entry.type === "auth_login_start").length, 1);
+  } finally {
+    await handle.close();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("agent_start payload includes resume_session_id", async () => {
+  const harness = await setupHarness();
+  try {
+    const agent = createMakaiAgentApi(harness.client);
+    await collect(agent.stream(request()));
+    const logged = readLoggedRequests(harness.logPath);
+    const start = logged.find((entry) => entry.type === "agent_start");
+    assert.ok(start);
+    const payload = start?.payload as Record<string, unknown>;
+    assert.equal(payload.resume_session_id, "11111111-1111-4111-8111-111111111111");
+  } finally {
+    await harness.cleanup();
+  }
+});

--- a/typescript/test/execution_client.test.ts
+++ b/typescript/test/execution_client.test.ts
@@ -46,7 +46,7 @@ async function setupHarness(envOverrides: NodeJS.ProcessEnv = {}): Promise<Harne
 
 function request() {
   return {
-    model_ref: "opaque-model-ref-with:colon",
+    model_ref: "anthropic/anthropic-messages@claude-sonnet-4-5",
     messages: [{ role: "user" as const, content: "hello" }],
     options: { temperature: 0.2, session_id: "session-1" },
   };
@@ -79,7 +79,15 @@ test("client.provider.complete resolves with correct CompletionResponse shape", 
 
     const logged = readLoggedRequests(harness.logPath);
     assert.equal(logged[0]?.type, "complete_request");
-    assert.equal((logged[0]?.payload as Record<string, unknown>).model_ref, "opaque-model-ref-with:colon");
+    const payload = logged[0]?.payload as Record<string, unknown>;
+    assert.deepEqual(payload.model, {
+      id: "claude-sonnet-4-5",
+      name: "claude-sonnet-4-5",
+      api: "anthropic-messages",
+      provider: "anthropic",
+      base_url: "",
+    });
+    assert.deepEqual((payload.context as Record<string, unknown>).messages, request().messages);
   } finally {
     await harness.cleanup();
   }
@@ -155,6 +163,15 @@ test("client.agent.stream yields agent lifecycle events in order", async () => {
     ]);
     assert.deepEqual(events[0], { type: "agent_start", session_id: "session-1" } satisfies AgentStreamEvent);
     assert.deepEqual(events.at(-1), { type: "agent_end", usage: { input: 7, output: 9 }, stop_reason: "end_turn" } satisfies AgentStreamEvent);
+
+    const logged = readLoggedRequests(harness.logPath);
+    assert.equal(logged[0]?.type, "agent_start");
+    assert.equal(typeof logged[0]?.session_id, "string");
+    assert.equal(logged[0]?.stream_id, undefined);
+    assert.equal(logged[1]?.type, "agent_message");
+    assert.equal(logged[1]?.session_id, logged[0]?.session_id);
+    assert.equal(logged[1]?.stream_id, undefined);
+    assert.deepEqual(JSON.parse(((logged[1]?.payload as Record<string, unknown>).message_json as string)).messages, request().messages);
   } finally {
     await harness.cleanup();
   }
@@ -219,6 +236,8 @@ test("client.provider.stream buffers incremental tool calls into one tool_call e
 
     const payload = readLoggedRequests(harness.logPath)[0]?.payload as Record<string, unknown>;
     assert.equal(payload.include_partial, false);
+    assert.equal((payload.model as Record<string, unknown>).api, "anthropic-messages");
+    assert.deepEqual((payload.context as Record<string, unknown>).messages, request().messages);
   } finally {
     await harness.cleanup();
     fs.rmSync(tmpDir, { recursive: true, force: true });
@@ -299,6 +318,7 @@ test("createMakaiClient wires all namespaces correctly", async () => {
     await collect(handle.provider.stream(request()));
     const streamRequest = readLoggedRequests(logPath).find((entry) => entry.type === "stream_request");
     assert.equal(((streamRequest?.payload as Record<string, unknown>).options as Record<string, unknown>).auth_retry_policy, "auto_once");
+    assert.equal(((streamRequest?.payload as Record<string, unknown>).model as Record<string, unknown>).id, "claude-sonnet-4-5");
   } finally {
     await handle.close();
     fs.rmSync(tmpDir, { recursive: true, force: true });

--- a/typescript/test/execution_client.test.ts
+++ b/typescript/test/execution_client.test.ts
@@ -676,6 +676,110 @@ test("per-request auto_once auth_retry_policy overrides client manual", async ()
   }
 });
 
+test("client.provider.complete auto_once retries when error lacks provider_id", async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "makai-auth-retry-no-pid-complete-test-"));
+  const logPath = path.join(tmpDir, "request.log");
+  const handle = await createMakaiClient({
+    command: process.execPath,
+    args: [fixtureScript],
+    env: { ...process.env, MAKAI_TEST_REQUEST_LOG: logPath, MAKAI_TEST_AUTH_REQUIRED_ONCE: "1", MAKAI_TEST_AUTH_REQUIRED_NO_PROVIDER_ID: "1" },
+    handshakeTimeoutMs: 5000,
+    responseTimeoutMs: 5000,
+    auth: { auth_retry_policy: "auto_once" },
+  });
+  try {
+    const result = await handle.provider.complete(request());
+    assert.deepEqual(result.message.content, [{ type: "text", text: "hello" }]);
+    const logged = readLoggedRequests(logPath);
+    assert.equal(logged.filter((entry) => entry.type === "complete_request").length, 2);
+    assert.equal(logged.filter((entry) => entry.type === "auth_login_start").length, 1);
+  } finally {
+    await handle.close();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("client.provider.stream auto_once retries when error lacks provider_id", async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "makai-auth-retry-no-pid-stream-test-"));
+  const logPath = path.join(tmpDir, "request.log");
+  const handle = await createMakaiClient({
+    command: process.execPath,
+    args: [fixtureScript],
+    env: { ...process.env, MAKAI_TEST_REQUEST_LOG: logPath, MAKAI_TEST_AUTH_REQUIRED_ONCE: "1", MAKAI_TEST_AUTH_REQUIRED_NO_PROVIDER_ID: "1" },
+    handshakeTimeoutMs: 5000,
+    responseTimeoutMs: 5000,
+    auth: { auth_retry_policy: "auto_once" },
+  });
+  try {
+    const events = await collect(handle.provider.stream(request()));
+    assert.equal(events[0]?.type, "message_start");
+    const logged = readLoggedRequests(logPath);
+    assert.equal(logged.filter((entry) => entry.type === "stream_request").length, 2);
+    assert.equal(logged.filter((entry) => entry.type === "auth_login_start").length, 1);
+  } finally {
+    await handle.close();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("client.agent.run auto_once retries when error lacks provider_id", async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "makai-auth-retry-no-pid-agent-run-test-"));
+  const logPath = path.join(tmpDir, "request.log");
+  const resultPath = path.join(tmpDir, "agent-result.json");
+  fs.writeFileSync(resultPath, JSON.stringify({
+    messages: [{
+      role: "assistant",
+      content: "ok",
+      usage: { input: 1, output: 1 },
+      provider: "anthropic",
+      api: "anthropic-messages",
+      model: "claude-sonnet-4-5",
+      stop_reason: "end_turn",
+    }],
+  }));
+  const handle = await createMakaiClient({
+    command: process.execPath,
+    args: [fixtureScript],
+    env: { ...process.env, MAKAI_TEST_REQUEST_LOG: logPath, MAKAI_TEST_AUTH_REQUIRED_ONCE: "1", MAKAI_TEST_AUTH_REQUIRED_NO_PROVIDER_ID: "1", MAKAI_TEST_AGENT_RESULT_PATH: resultPath },
+    handshakeTimeoutMs: 5000,
+    responseTimeoutMs: 5000,
+    auth: { auth_retry_policy: "auto_once" },
+  });
+  try {
+    const result = await handle.agent.run(request());
+    assert.equal(result.message.content, "ok");
+    const logged = readLoggedRequests(logPath);
+    assert.equal(logged.filter((entry) => entry.type === "agent_start").length, 2);
+    assert.equal(logged.filter((entry) => entry.type === "auth_login_start").length, 1);
+  } finally {
+    await handle.close();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("client.agent.stream auto_once retries when error lacks provider_id", async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "makai-auth-retry-no-pid-agent-stream-test-"));
+  const logPath = path.join(tmpDir, "request.log");
+  const handle = await createMakaiClient({
+    command: process.execPath,
+    args: [fixtureScript],
+    env: { ...process.env, MAKAI_TEST_REQUEST_LOG: logPath, MAKAI_TEST_AUTH_REQUIRED_ONCE: "1", MAKAI_TEST_AUTH_REQUIRED_NO_PROVIDER_ID: "1" },
+    handshakeTimeoutMs: 5000,
+    responseTimeoutMs: 5000,
+    auth: { auth_retry_policy: "auto_once" },
+  });
+  try {
+    const events = await collect(handle.agent.stream(request()));
+    assert.equal(events[0]?.type, "agent_start");
+    const logged = readLoggedRequests(logPath);
+    assert.equal(logged.filter((entry) => entry.type === "agent_start").length, 2);
+    assert.equal(logged.filter((entry) => entry.type === "auth_login_start").length, 1);
+  } finally {
+    await handle.close();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
 test("agent_start payload includes resume_session_id", async () => {
   const harness = await setupHarness();
   try {

--- a/typescript/test/execution_client.test.ts
+++ b/typescript/test/execution_client.test.ts
@@ -46,7 +46,7 @@ async function setupHarness(envOverrides: NodeJS.ProcessEnv = {}): Promise<Harne
 
 function request() {
   return {
-    model_ref: "anthropic/anthropic-messages@claude-sonnet-4-5",
+    model_ref: "opaque-model-ref-with:colon",
     messages: [{ role: "user" as const, content: "hello" }],
     options: { temperature: 0.2, session_id: "session-1" },
   };
@@ -81,10 +81,10 @@ test("client.provider.complete resolves with correct CompletionResponse shape", 
     assert.equal(logged[0]?.type, "complete_request");
     const payload = logged[0]?.payload as Record<string, unknown>;
     assert.deepEqual(payload.model, {
-      id: "claude-sonnet-4-5",
-      name: "claude-sonnet-4-5",
-      api: "anthropic-messages",
-      provider: "anthropic",
+      id: "opaque-model-ref-with:colon",
+      name: "opaque-model-ref-with:colon",
+      api: "",
+      provider: "",
       base_url: "",
     });
     assert.deepEqual((payload.context as Record<string, unknown>).messages, request().messages);
@@ -236,7 +236,7 @@ test("client.provider.stream buffers incremental tool calls into one tool_call e
 
     const payload = readLoggedRequests(harness.logPath)[0]?.payload as Record<string, unknown>;
     assert.equal(payload.include_partial, false);
-    assert.equal((payload.model as Record<string, unknown>).api, "anthropic-messages");
+    assert.equal((payload.model as Record<string, unknown>).id, "opaque-model-ref-with:colon");
     assert.deepEqual((payload.context as Record<string, unknown>).messages, request().messages);
   } finally {
     await harness.cleanup();
@@ -318,7 +318,7 @@ test("createMakaiClient wires all namespaces correctly", async () => {
     await collect(handle.provider.stream(request()));
     const streamRequest = readLoggedRequests(logPath).find((entry) => entry.type === "stream_request");
     assert.equal(((streamRequest?.payload as Record<string, unknown>).options as Record<string, unknown>).auth_retry_policy, "auto_once");
-    assert.equal(((streamRequest?.payload as Record<string, unknown>).model as Record<string, unknown>).id, "claude-sonnet-4-5");
+    assert.equal(((streamRequest?.payload as Record<string, unknown>).model as Record<string, unknown>).id, "opaque-model-ref-with:colon");
   } finally {
     await handle.close();
     fs.rmSync(tmpDir, { recursive: true, force: true });

--- a/typescript/test/execution_client.test.ts
+++ b/typescript/test/execution_client.test.ts
@@ -1,0 +1,179 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+  createMakaiAgentApi,
+  createMakaiClient,
+  createMakaiProviderApi,
+  MakaiStdioClient,
+  MakaiStreamError,
+  type AgentStreamEvent,
+  type ProviderStreamEvent,
+} from "../src";
+
+const sourceFixturesDir = path.resolve(__dirname, "../../typescript/test/fixtures");
+const fixtureScript = path.join(sourceFixturesDir, "execution-server.js");
+
+type Harness = {
+  client: MakaiStdioClient;
+  tmpDir: string;
+  logPath: string;
+  cleanup(): Promise<void>;
+};
+
+async function setupHarness(envOverrides: NodeJS.ProcessEnv = {}): Promise<Harness> {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "makai-exec-test-"));
+  const logPath = path.join(tmpDir, "request.log");
+  const client = new MakaiStdioClient({
+    command: process.execPath,
+    args: [fixtureScript],
+    env: { ...process.env, MAKAI_TEST_REQUEST_LOG: logPath, ...envOverrides },
+    handshakeTimeoutMs: 5000,
+  });
+  await client.connect();
+  return {
+    client,
+    tmpDir,
+    logPath,
+    cleanup: async () => {
+      await client.close();
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    },
+  };
+}
+
+function request() {
+  return {
+    model_ref: "opaque-model-ref-with:colon",
+    messages: [{ role: "user" as const, content: "hello" }],
+    options: { temperature: 0.2, session_id: "session-1" },
+  };
+}
+
+function readLoggedRequests(logPath: string): Array<Record<string, unknown>> {
+  if (!fs.existsSync(logPath)) return [];
+  return fs.readFileSync(logPath, "utf8").trim().split(/\r?\n/).filter(Boolean).map((line) => JSON.parse(line));
+}
+
+async function collect<T>(iterable: AsyncIterable<T>): Promise<T[]> {
+  const out: T[] = [];
+  for await (const item of iterable) out.push(item);
+  return out;
+}
+
+test("client.provider.complete resolves with correct CompletionResponse shape", async () => {
+  const harness = await setupHarness();
+  try {
+    const provider = createMakaiProviderApi(harness.client);
+    const result = await provider.complete(request());
+
+    assert.equal(result.message.role, "assistant");
+    assert.deepEqual(result.message.content, [{ type: "text", text: "hello" }]);
+    assert.deepEqual(result.usage, { input: 3, output: 5, cache_read: 1, cache_write: 0 });
+    assert.equal(result.provider_id, "anthropic");
+    assert.equal(result.api, "anthropic-messages");
+    assert.equal(result.model_id, "claude-sonnet-4-5");
+    assert.equal(result.stop_reason, "end_turn");
+
+    const logged = readLoggedRequests(harness.logPath);
+    assert.equal(logged[0]?.type, "complete_request");
+    assert.equal((logged[0]?.payload as Record<string, unknown>).model_ref, "opaque-model-ref-with:colon");
+  } finally {
+    await harness.cleanup();
+  }
+});
+
+test("client.provider.stream yields ProviderStreamEvent sequence including message_end", async () => {
+  const harness = await setupHarness();
+  try {
+    const provider = createMakaiProviderApi(harness.client);
+    const events = await collect(provider.stream(request()));
+    assert.deepEqual(events, [
+      { type: "message_start", provider_id: "anthropic", api: "anthropic-messages", model_id: "claude-sonnet-4-5" },
+      { type: "text_delta", delta: "hel" },
+      { type: "thinking_delta", delta: "thinking" },
+      { type: "text_delta", delta: "lo" },
+      { type: "message_end", usage: { input: 3, output: 5 }, stop_reason: "end_turn" },
+    ] satisfies ProviderStreamEvent[]);
+  } finally {
+    await harness.cleanup();
+  }
+});
+
+test("client.agent.run resolves with correct AgentRunResponse", async () => {
+  const harness = await setupHarness();
+  try {
+    const agent = createMakaiAgentApi(harness.client);
+    const result = await agent.run(request());
+    assert.equal(result.message.content, "agent");
+    assert.deepEqual(result.usage, { input: 7, output: 9 });
+    assert.equal(result.provider_id, "anthropic");
+    assert.equal(result.api, "anthropic-messages");
+    assert.equal(result.model_id, "claude-sonnet-4-5");
+    assert.equal(result.stop_reason, "end_turn");
+  } finally {
+    await harness.cleanup();
+  }
+});
+
+test("client.agent.stream yields agent lifecycle events in order", async () => {
+  const harness = await setupHarness();
+  try {
+    const agent = createMakaiAgentApi(harness.client);
+    const events = await collect(agent.stream(request()));
+    assert.deepEqual(events.map((event) => event.type), [
+      "agent_start",
+      "turn_start",
+      "message_start",
+      "text_delta",
+      "tool_execution_start",
+      "tool_execution_end",
+      "turn_end",
+      "agent_end",
+    ]);
+    assert.deepEqual(events[0], { type: "agent_start", session_id: "session-1" } satisfies AgentStreamEvent);
+    assert.deepEqual(events.at(-1), { type: "agent_end", usage: { input: 7, output: 9 }, stop_reason: "end_turn" } satisfies AgentStreamEvent);
+  } finally {
+    await harness.cleanup();
+  }
+});
+
+test("stream error paths throw MakaiStreamError", async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "makai-exec-error-test-"));
+  const eventsPath = path.join(tmpDir, "events.json");
+  fs.writeFileSync(eventsPath, JSON.stringify([{ type: "message_start" }, { type: "error", message: "boom", code: "provider_error" }]));
+  const harness = await setupHarness({ MAKAI_TEST_PROVIDER_EVENTS_PATH: eventsPath });
+  try {
+    const provider = createMakaiProviderApi(harness.client);
+    await assert.rejects(
+      async () => collect(provider.stream(request())),
+      (err: unknown) => err instanceof MakaiStreamError && err.message === "boom" && err.code === "provider_error",
+    );
+  } finally {
+    await harness.cleanup();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("createMakaiClient wires all namespaces correctly", async () => {
+  const handle = await createMakaiClient({
+    command: process.execPath,
+    args: [fixtureScript],
+    handshakeTimeoutMs: 5000,
+    responseTimeoutMs: 5000,
+  });
+  try {
+    assert.equal(typeof handle.auth.listProviders, "function");
+    assert.equal(typeof handle.models.list, "function");
+    assert.equal(typeof handle.provider.complete, "function");
+    assert.equal(typeof handle.provider.stream, "function");
+    assert.equal(typeof handle.agent.run, "function");
+    assert.equal(typeof handle.agent.stream, "function");
+    assert.deepEqual(await handle.auth.listProviders(), []);
+    assert.deepEqual((await handle.models.list()).models, []);
+  } finally {
+    await handle.close();
+  }
+});

--- a/typescript/test/execution_client.test.ts
+++ b/typescript/test/execution_client.test.ts
@@ -603,6 +603,31 @@ test("auto_once falls back to original auth_required error when login fails", as
   }
 });
 
+test("client.agent.stream auto_once retries on auth_required nack and yields events", async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "makai-auth-retry-agent-stream-test-"));
+  const logPath = path.join(tmpDir, "request.log");
+  const handle = await createMakaiClient({
+    command: process.execPath,
+    args: [fixtureScript],
+    env: { ...process.env, MAKAI_TEST_REQUEST_LOG: logPath, MAKAI_TEST_AUTH_REQUIRED_ONCE: "1" },
+    handshakeTimeoutMs: 5000,
+    responseTimeoutMs: 5000,
+    auth: { auth_retry_policy: "auto_once" },
+  });
+  try {
+    const events = await collect(handle.agent.stream(request()));
+    assert.equal(events[0]?.type, "agent_start");
+    const logged = readLoggedRequests(logPath);
+    const agentStarts = logged.filter((entry) => entry.type === "agent_start");
+    assert.equal(agentStarts.length, 2);
+    const loginStarts = logged.filter((entry) => entry.type === "auth_login_start");
+    assert.equal(loginStarts.length, 1);
+  } finally {
+    await handle.close();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
 test("per-request manual auth_retry_policy overrides client auto_once", async () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "makai-auth-override-manual-test-"));
   const logPath = path.join(tmpDir, "request.log");

--- a/typescript/test/execution_client.test.ts
+++ b/typescript/test/execution_client.test.ts
@@ -160,6 +160,40 @@ test("client.agent.stream yields agent lifecycle events in order", async () => {
   }
 });
 
+test("client.agent.run event fallback returns only final assistant turn content", async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "makai-agent-final-turn-test-"));
+  const eventsPath = path.join(tmpDir, "events.json");
+  fs.writeFileSync(eventsPath, JSON.stringify([
+    { type: "agent_start", session_id: "session-1" },
+    { type: "turn_start" },
+    { type: "message_start", provider_id: "anthropic", api: "anthropic-messages", model_id: "claude-sonnet-4-5" },
+    { type: "text_delta", delta: "lookup first" },
+    { type: "tool_call", tool_call_id: "call-1", name: "lookup", arguments_json: "{\"q\":\"makai\"}" },
+    { type: "message_end", usage: { input: 5, output: 6 }, stop_reason: "tool_use" },
+    { type: "turn_end", stop_reason: "tool_use" },
+    { type: "turn_start" },
+    { type: "message_start", provider_id: "anthropic", api: "anthropic-messages", model_id: "claude-sonnet-4-5" },
+    { type: "text_delta", delta: "final answer" },
+    { type: "message_end", usage: { input: 7, output: 9 }, stop_reason: "end_turn" },
+    { type: "turn_end", stop_reason: "end_turn" },
+    { type: "agent_end", usage: { input: 7, output: 9 }, stop_reason: "end_turn" },
+  ]));
+  const harness = await setupHarness({ MAKAI_TEST_AGENT_EVENTS_PATH: eventsPath });
+  try {
+    const agent = createMakaiAgentApi(harness.client);
+    const result = await agent.run(request());
+    assert.equal(result.message.content, "final answer");
+    assert.deepEqual(result.usage, { input: 7, output: 9 });
+    assert.equal(result.provider_id, "anthropic");
+    assert.equal(result.api, "anthropic-messages");
+    assert.equal(result.model_id, "claude-sonnet-4-5");
+    assert.equal(result.stop_reason, "end_turn");
+  } finally {
+    await harness.cleanup();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
 test("client.provider.stream buffers incremental tool calls into one tool_call event", async () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "makai-tool-buffer-test-"));
   const eventsPath = path.join(tmpDir, "events.json");

--- a/typescript/test/fixtures/execution-server.js
+++ b/typescript/test/fixtures/execution-server.js
@@ -16,10 +16,11 @@ function appendLog(path, line) {
 }
 
 function ack(env) {
+  const id = env.stream_id || env.session_id;
   return {
     type: "ack",
-    stream_id: env.stream_id,
-    message_id: `${env.stream_id}-ack`,
+    ...(env.stream_id ? { stream_id: env.stream_id } : { session_id: env.session_id }),
+    message_id: `${id}-ack`,
     sequence: 2,
     timestamp: Date.now(),
     version: 1,
@@ -29,10 +30,11 @@ function ack(env) {
 }
 
 function frame(env, type, payload, sequence) {
+  const id = env.stream_id || env.session_id;
   return {
     type,
-    stream_id: env.stream_id,
-    message_id: `${env.stream_id}-${sequence}`,
+    ...(env.stream_id ? { stream_id: env.stream_id } : { session_id: env.session_id }),
+    message_id: `${id}-${sequence}`,
     sequence,
     timestamp: Date.now(),
     version: 1,
@@ -103,7 +105,9 @@ rl.on("line", (line) => {
       const event = providerEvents[i];
       emit(frame(env, event.type, event, i + 3));
     }
-  } else if (env.type === "agent_run_request") {
+  } else if (env.type === "agent_start") {
+    emit(frame(env, "agent_started", { session_id: env.session_id }, 3));
+  } else if (env.type === "agent_message") {
     if (agentError) {
       emit(frame(env, "agent_error", agentError, 3));
     } else if (agentResult) {

--- a/typescript/test/fixtures/execution-server.js
+++ b/typescript/test/fixtures/execution-server.js
@@ -86,6 +86,15 @@ const modelsResponse = loadJson(process.env.MAKAI_TEST_MODELS_RESPONSE_PATH, {
   cache_max_age_ms: 300000,
 });
 
+const requestCounts = new Map();
+
+function shouldAuthReject(envType) {
+  if (!process.env.MAKAI_TEST_AUTH_REQUIRED_ONCE) return false;
+  const count = requestCounts.get(envType) || 0;
+  requestCounts.set(envType, count + 1);
+  return count === 0;
+}
+
 const rl = readline.createInterface({ input: process.stdin, crlfDelay: Infinity });
 
 rl.on("line", (line) => {
@@ -99,13 +108,25 @@ rl.on("line", (line) => {
   emit(ack(env));
 
   if (env.type === "complete_request") {
+    if (shouldAuthReject("complete_request")) {
+      emit(frame(env, "nack", { error_code: "auth_required", reason: "login required", provider_id: "anthropic" }, 3));
+      return;
+    }
     emit(frame(env, "result", providerResult, 3));
   } else if (env.type === "stream_request") {
+    if (shouldAuthReject("stream_request")) {
+      emit(frame(env, "nack", { error_code: "auth_required", reason: "login required", provider_id: "anthropic" }, 3));
+      return;
+    }
     for (let i = 0; i < providerEvents.length; i += 1) {
       const event = providerEvents[i];
       emit(frame(env, event.type, event, i + 3));
     }
   } else if (env.type === "agent_start") {
+    if (shouldAuthReject("agent_start")) {
+      emit(frame(env, "nack", { error_code: "auth_required", reason: "login required", provider_id: "anthropic" }, 3));
+      return;
+    }
     emit(frame(env, "agent_started", { session_id: env.session_id }, 3));
   } else if (env.type === "agent_message") {
     if (agentError) {
@@ -119,6 +140,16 @@ rl.on("line", (line) => {
     }
   } else if (env.type === "auth_providers_request") {
     emit(frame(env, "auth_providers_response", { providers: [] }, 3));
+  } else if (env.type === "auth_login_start") {
+    const providerId = env.payload?.provider_id || "";
+    const flowId = env.stream_id || env.payload?.flow_id || "";
+    if (process.env.MAKAI_TEST_AUTH_REQUIRES_PROMPT) {
+      emit(frame(env, "auth_event", { prompt: { flow_id: flowId, prompt_id: "test-prompt", provider_id: providerId, message: "Enter code", allow_empty: false } }, 3));
+      emit(frame(env, "auth_login_result", { status: "cancelled", flow_id: flowId, provider_id: providerId }, 4));
+    } else {
+      emit(frame(env, "auth_event", { success: { flow_id: flowId, provider_id: providerId } }, 3));
+      emit(frame(env, "auth_login_result", { status: "success", flow_id: flowId, provider_id: providerId }, 4));
+    }
   } else if (env.type === "models_request") {
     emit(frame(env, "models_response", modelsResponse, 3));
   }

--- a/typescript/test/fixtures/execution-server.js
+++ b/typescript/test/fixtures/execution-server.js
@@ -62,7 +62,7 @@ const defaultProviderEvents = [
 ];
 
 const defaultAgentEvents = [
-  { type: "agent_start", session_id: "session-1" },
+  { type: "agent_start", session_id: "11111111-1111-4111-8111-111111111111" },
   { type: "turn_start" },
   { type: "message_start", provider_id: "anthropic", api: "anthropic-messages", model_id: "claude-sonnet-4-5" },
   { type: "text_delta", delta: "agent" },

--- a/typescript/test/fixtures/execution-server.js
+++ b/typescript/test/fixtures/execution-server.js
@@ -137,7 +137,12 @@ rl.on("line", (line) => {
     }
     emit(frame(env, "agent_started", { session_id: env.session_id }, 3));
   } else if (env.type === "agent_message") {
-    if (agentError) {
+    if (process.env.MAKAI_TEST_AGENT_MALFORMED_RESULT_JSON) {
+      emit(frame(env, "agent_result", { result_json: "not-json" }, 3));
+    } else if (process.env.MAKAI_TEST_AGENT_MALFORMED_EVENT_JSON) {
+      emit(frame(env, "agent_started", { session_id: env.session_id }, 3));
+      emit(frame(env, "agent_event", { event_json: "not-json" }, 4));
+    } else if (agentError) {
       emit(frame(env, "agent_error", agentError, 3));
     } else if (agentResult) {
       emit(frame(env, "agent_result", { result_json: JSON.stringify(agentResult) }, 3));

--- a/typescript/test/fixtures/execution-server.js
+++ b/typescript/test/fixtures/execution-server.js
@@ -95,6 +95,14 @@ function shouldAuthReject(envType) {
   return count === 0;
 }
 
+function authRequiredPayload() {
+  const payload = { error_code: "auth_required", reason: "login required" };
+  if (!process.env.MAKAI_TEST_AUTH_REQUIRED_NO_PROVIDER_ID) {
+    payload.provider_id = "anthropic";
+  }
+  return payload;
+}
+
 const rl = readline.createInterface({ input: process.stdin, crlfDelay: Infinity });
 
 rl.on("line", (line) => {
@@ -109,13 +117,13 @@ rl.on("line", (line) => {
 
   if (env.type === "complete_request") {
     if (shouldAuthReject("complete_request")) {
-      emit(frame(env, "nack", { error_code: "auth_required", reason: "login required", provider_id: "anthropic" }, 3));
+      emit(frame(env, "nack", authRequiredPayload(), 3));
       return;
     }
     emit(frame(env, "result", providerResult, 3));
   } else if (env.type === "stream_request") {
     if (shouldAuthReject("stream_request")) {
-      emit(frame(env, "nack", { error_code: "auth_required", reason: "login required", provider_id: "anthropic" }, 3));
+      emit(frame(env, "nack", authRequiredPayload(), 3));
       return;
     }
     for (let i = 0; i < providerEvents.length; i += 1) {
@@ -124,7 +132,7 @@ rl.on("line", (line) => {
     }
   } else if (env.type === "agent_start") {
     if (shouldAuthReject("agent_start")) {
-      emit(frame(env, "nack", { error_code: "auth_required", reason: "login required", provider_id: "anthropic" }, 3));
+      emit(frame(env, "nack", authRequiredPayload(), 3));
       return;
     }
     emit(frame(env, "agent_started", { session_id: env.session_id }, 3));

--- a/typescript/test/fixtures/execution-server.js
+++ b/typescript/test/fixtures/execution-server.js
@@ -62,7 +62,7 @@ const defaultProviderEvents = [
 ];
 
 const defaultAgentEvents = [
-  { type: "agent_start", session_id: "11111111-1111-4111-8111-111111111111" },
+  { type: "agent_start", session_id: "testNanoIdSess1234567" },
   { type: "turn_start" },
   { type: "message_start", provider_id: "anthropic", api: "anthropic-messages", model_id: "claude-sonnet-4-5" },
   { type: "text_delta", delta: "agent" },

--- a/typescript/test/fixtures/execution-server.js
+++ b/typescript/test/fixtures/execution-server.js
@@ -1,0 +1,115 @@
+const fs = require("node:fs");
+const readline = require("node:readline");
+
+function emit(frame) {
+  process.stdout.write(JSON.stringify(frame) + "\n");
+}
+
+function loadJson(path, fallback) {
+  if (!path) return fallback;
+  return JSON.parse(fs.readFileSync(path, "utf8"));
+}
+
+function appendLog(path, line) {
+  if (!path) return;
+  fs.appendFileSync(path, line + "\n");
+}
+
+function ack(env) {
+  return {
+    type: "ack",
+    stream_id: env.stream_id,
+    message_id: `${env.stream_id}-ack`,
+    sequence: 2,
+    timestamp: Date.now(),
+    version: 1,
+    in_reply_to: env.message_id,
+    payload: { acknowledged_id: env.message_id },
+  };
+}
+
+function frame(env, type, payload, sequence) {
+  return {
+    type,
+    stream_id: env.stream_id,
+    message_id: `${env.stream_id}-${sequence}`,
+    sequence,
+    timestamp: Date.now(),
+    version: 1,
+    in_reply_to: env.message_id,
+    payload,
+  };
+}
+
+const defaultProviderResult = {
+  role: "assistant",
+  content: [{ type: "text", text: "hello" }],
+  usage: { input: 3, output: 5, cache_read: 1, cache_write: 0 },
+  provider_id: "anthropic",
+  api: "anthropic-messages",
+  model_id: "claude-sonnet-4-5",
+  stop_reason: "end_turn",
+};
+
+const defaultProviderEvents = [
+  { type: "message_start", provider_id: "anthropic", api: "anthropic-messages", model_id: "claude-sonnet-4-5" },
+  { type: "text_delta", delta: "hel" },
+  { type: "reasoning", delta: "thinking" },
+  { type: "text_delta", delta: "lo" },
+  { type: "message_end", usage: { input: 3, output: 5 }, stop_reason: "end_turn" },
+];
+
+const defaultAgentEvents = [
+  { type: "agent_start", session_id: "session-1" },
+  { type: "turn_start" },
+  { type: "message_start", provider_id: "anthropic", api: "anthropic-messages", model_id: "claude-sonnet-4-5" },
+  { type: "text_delta", delta: "agent" },
+  { type: "tool_execution_start", tool_call_id: "tool-1", tool_name: "lookup" },
+  { type: "tool_execution_end", tool_call_id: "tool-1", is_error: false },
+  { type: "turn_end", stop_reason: "end_turn" },
+  { type: "agent_end", usage: { input: 7, output: 9 }, stop_reason: "end_turn" },
+];
+
+emit({ type: "ready", protocol_version: "1" });
+
+const requestLog = process.env.MAKAI_TEST_REQUEST_LOG || "";
+const providerResult = loadJson(process.env.MAKAI_TEST_PROVIDER_RESULT_PATH, defaultProviderResult);
+const providerEvents = loadJson(process.env.MAKAI_TEST_PROVIDER_EVENTS_PATH, defaultProviderEvents);
+const agentEvents = loadJson(process.env.MAKAI_TEST_AGENT_EVENTS_PATH, defaultAgentEvents);
+const modelsResponse = loadJson(process.env.MAKAI_TEST_MODELS_RESPONSE_PATH, {
+  models: [],
+  fetched_at_ms: 1,
+  cache_max_age_ms: 300000,
+});
+
+const rl = readline.createInterface({ input: process.stdin, crlfDelay: Infinity });
+
+rl.on("line", (line) => {
+  let env;
+  try {
+    env = JSON.parse(line);
+  } catch {
+    return;
+  }
+  appendLog(requestLog, JSON.stringify(env));
+  emit(ack(env));
+
+  if (env.type === "complete_request") {
+    emit(frame(env, "result", providerResult, 3));
+  } else if (env.type === "stream_request") {
+    for (let i = 0; i < providerEvents.length; i += 1) {
+      const event = providerEvents[i];
+      emit(frame(env, event.type, event, i + 3));
+    }
+  } else if (env.type === "agent_run_request") {
+    for (let i = 0; i < agentEvents.length; i += 1) {
+      emit(frame(env, "agent_event", { event_json: JSON.stringify(agentEvents[i]) }, i + 3));
+    }
+  } else if (env.type === "auth_providers_request") {
+    emit(frame(env, "auth_providers_response", { providers: [] }, 3));
+  } else if (env.type === "models_request") {
+    emit(frame(env, "models_response", modelsResponse, 3));
+  }
+});
+
+rl.on("close", () => process.exit(0));

--- a/typescript/test/fixtures/execution-server.js
+++ b/typescript/test/fixtures/execution-server.js
@@ -76,6 +76,8 @@ const requestLog = process.env.MAKAI_TEST_REQUEST_LOG || "";
 const providerResult = loadJson(process.env.MAKAI_TEST_PROVIDER_RESULT_PATH, defaultProviderResult);
 const providerEvents = loadJson(process.env.MAKAI_TEST_PROVIDER_EVENTS_PATH, defaultProviderEvents);
 const agentEvents = loadJson(process.env.MAKAI_TEST_AGENT_EVENTS_PATH, defaultAgentEvents);
+const agentResult = loadJson(process.env.MAKAI_TEST_AGENT_RESULT_PATH, null);
+const agentError = loadJson(process.env.MAKAI_TEST_AGENT_ERROR_PATH, null);
 const modelsResponse = loadJson(process.env.MAKAI_TEST_MODELS_RESPONSE_PATH, {
   models: [],
   fetched_at_ms: 1,
@@ -102,8 +104,14 @@ rl.on("line", (line) => {
       emit(frame(env, event.type, event, i + 3));
     }
   } else if (env.type === "agent_run_request") {
-    for (let i = 0; i < agentEvents.length; i += 1) {
-      emit(frame(env, "agent_event", { event_json: JSON.stringify(agentEvents[i]) }, i + 3));
+    if (agentError) {
+      emit(frame(env, "agent_error", agentError, 3));
+    } else if (agentResult) {
+      emit(frame(env, "agent_result", { result_json: JSON.stringify(agentResult) }, 3));
+    } else {
+      for (let i = 0; i < agentEvents.length; i += 1) {
+        emit(frame(env, "agent_event", { event_json: JSON.stringify(agentEvents[i]) }, i + 3));
+      }
     }
   } else if (env.type === "auth_providers_request") {
     emit(frame(env, "auth_providers_response", { providers: [] }, 3));

--- a/typescript/test/fixtures/execution-server.js
+++ b/typescript/test/fixtures/execution-server.js
@@ -89,6 +89,7 @@ const modelsResponse = loadJson(process.env.MAKAI_TEST_MODELS_RESPONSE_PATH, {
 const requestCounts = new Map();
 
 function shouldAuthReject(envType) {
+  if (process.env.MAKAI_TEST_AUTH_REQUIRED_ALWAYS) return true;
   if (!process.env.MAKAI_TEST_AUTH_REQUIRED_ONCE) return false;
   const count = requestCounts.get(envType) || 0;
   requestCounts.set(envType, count + 1);

--- a/typescript/test/fixtures/route-server.js
+++ b/typescript/test/fixtures/route-server.js
@@ -1,0 +1,25 @@
+const readline = require("node:readline");
+
+process.stdout.write(JSON.stringify({ type: "ready", protocol_version: "1" }) + "\n");
+
+const rl = readline.createInterface({
+  input: process.stdin,
+  crlfDelay: Infinity,
+});
+
+function write(frame) {
+  process.stdout.write(JSON.stringify(frame) + "\n");
+}
+
+rl.on("line", (line) => {
+  try {
+    const msg = JSON.parse(line);
+    if (msg.type === "stream_request") {
+      write({ type: "event", stream_id: msg.stream_id ?? "unknown", event_type: "text_delta", delta: "ok" });
+    } else if (msg.type === "agent_message") {
+      write({ type: "agent_event", session_id: msg.session_id ?? "unknown", payload: { event_json: JSON.stringify({ type: "text_delta", delta: "ok" }) } });
+    }
+  } catch {
+    // ignore malformed frames in fixture
+  }
+});

--- a/typescript/test/stdio_client.test.ts
+++ b/typescript/test/stdio_client.test.ts
@@ -28,7 +28,7 @@ test("connect succeeds with ready handshake and receives event frame", async () 
 test("nextFrameForStream preserves foreign frames for their owner", async () => {
   const client = new MakaiStdioClient({
     command: process.execPath,
-    args: [path.join(sourceFixturesDir, "ready-server.js")],
+    args: [path.join(sourceFixturesDir, "route-server.js")],
     handshakeTimeoutMs: 5000,
   });
 
@@ -44,6 +44,54 @@ test("nextFrameForStream preserves foreign frames for their owner", async () => 
     const firstFrame = await client.nextFrameForStream("s1", 5000);
     assert.equal(firstFrame.type, "event");
     assert.equal(firstFrame.stream_id, "s1");
+  } finally {
+    await client.close();
+  }
+});
+
+test("nextFrameForSession preserves foreign session frames for their owner", async () => {
+  const client = new MakaiStdioClient({
+    command: process.execPath,
+    args: [path.join(sourceFixturesDir, "route-server.js")],
+    handshakeTimeoutMs: 5000,
+  });
+
+  await client.connect();
+  try {
+    client.send({ type: "agent_message", session_id: "a1" });
+    client.send({ type: "agent_message", session_id: "a2" });
+
+    const secondFrame = await client.nextFrameForSession("a2", 5000);
+    assert.equal(secondFrame.type, "agent_event");
+    assert.equal(secondFrame.session_id, "a2");
+
+    const firstFrame = await client.nextFrameForSession("a1", 5000);
+    assert.equal(firstFrame.type, "agent_event");
+    assert.equal(firstFrame.session_id, "a1");
+  } finally {
+    await client.close();
+  }
+});
+
+test("targeted frame reads preserve frames across stream and session owners", async () => {
+  const client = new MakaiStdioClient({
+    command: process.execPath,
+    args: [path.join(sourceFixturesDir, "route-server.js")],
+    handshakeTimeoutMs: 5000,
+  });
+
+  await client.connect();
+  try {
+    client.send({ type: "stream_request", stream_id: "s1" });
+    client.send({ type: "agent_message", session_id: "a1" });
+
+    const agentFrame = await client.nextFrameForSession("a1", 5000);
+    assert.equal(agentFrame.type, "agent_event");
+    assert.equal(agentFrame.session_id, "a1");
+
+    const streamFrame = await client.nextFrameForStream("s1", 5000);
+    assert.equal(streamFrame.type, "event");
+    assert.equal(streamFrame.stream_id, "s1");
   } finally {
     await client.close();
   }

--- a/typescript/test/stdio_client.test.ts
+++ b/typescript/test/stdio_client.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import path from "node:path";
 import test from "node:test";
-import { createMakaiStdioClient, MakaiStdioClient, StdioProtocolError } from "../src";
+import { createMakaiStdioClient, MakaiStdioClient, StdioFrame, StdioProtocolError } from "../src";
 
 const sourceFixturesDir = path.resolve(__dirname, "../../typescript/test/fixtures");
 
@@ -149,7 +149,7 @@ test("createMakaiStdioClient forwards streamFrameQueueTtlMs", async () => {
   }
 });
 
-test("nextFrameForStream timeout includes time waiting for read lock", async () => {
+test("nextFrameForStream does not consume timeout budget while waiting for read lock", async () => {
   const client = new MakaiStdioClient({
     command: process.execPath,
     args: [path.join(sourceFixturesDir, "one-stream-server.js")],
@@ -167,15 +167,49 @@ test("nextFrameForStream timeout includes time waiting for read lock", async () 
     }, 110);
 
     const [delayedResult, blockedResult] = await Promise.allSettled([delayed, blocked]);
-    assert.equal(delayedResult.status, "rejected");
-    assert.match(
-      delayedResult.reason instanceof Error ? delayedResult.reason.message : String(delayedResult.reason),
-      /timed out waiting for frame for stream s2 after 80ms/,
-    );
+    // The s2 frame is sent at t=110 while blocked holds the lock. blocked
+    // enqueues it as a foreign frame and continues waiting for s1. At t=160
+    // blocked times out, releasing the lock. delayed then acquires the lock,
+    // checks the queue, and finds the s2 frame already enqueued — so it
+    // succeeds even though it started waiting for the lock at t=40.
+    assert.equal(delayedResult.status, "fulfilled");
+    assert.equal((delayedResult as PromiseFulfilledResult<StdioFrame>).value.type, "event");
+    assert.equal((delayedResult as PromiseFulfilledResult<StdioFrame>).value.stream_id, "s2");
     assert.equal(blockedResult.status, "rejected");
     assert.match(
       blockedResult.reason instanceof Error ? blockedResult.reason.message : String(blockedResult.reason),
       /timed out waiting for frame for stream s1 after 160ms/,
+    );
+  } finally {
+    await client.close();
+  }
+});
+
+test("nextFrameForSession does not consume timeout budget while waiting for read lock", async () => {
+  const client = new MakaiStdioClient({
+    command: process.execPath,
+    args: [path.join(sourceFixturesDir, "route-server.js")],
+    handshakeTimeoutMs: 5000,
+  });
+
+  await client.connect();
+  try {
+    const blocked = client.nextFrameForSession("a1", 160);
+    const delayed = new Promise((resolve) => setTimeout(resolve, 40))
+      .then(() => client.nextFrameForSession("a2", 80));
+
+    setTimeout(() => {
+      client.send({ type: "agent_message", session_id: "a2" });
+    }, 110);
+
+    const [delayedResult, blockedResult] = await Promise.allSettled([delayed, blocked]);
+    assert.equal(delayedResult.status, "fulfilled");
+    assert.equal((delayedResult as PromiseFulfilledResult<StdioFrame>).value.type, "agent_event");
+    assert.equal((delayedResult as PromiseFulfilledResult<StdioFrame>).value.session_id, "a2");
+    assert.equal(blockedResult.status, "rejected");
+    assert.match(
+      blockedResult.reason instanceof Error ? blockedResult.reason.message : String(blockedResult.reason),
+      /timed out waiting for frame for session a1 after 160ms/,
     );
   } finally {
     await client.close();


### PR DESCRIPTION
## Summary
- Add high-level `client.provider.*` and `client.agent.*` APIs over the stdio protocol transport.
- Normalize provider stream events, including reasoning to `thinking_delta` and buffered tool call emission.
- Add unified `createMakaiClient()` wiring auth, models, provider, and agent namespaces.

## Test plan
- [x] `npm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)