### PR TITLE
M-010: use NanoID session identifiers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "makai",
       "version": "0.0.1",
       "license": "ISC",
+      "dependencies": {
+        "nanoid": "^5.1.5"
+      },
       "devDependencies": {
         "@types/node": "^24.0.0",
         "typescript": "^5.8.3"
@@ -21,6 +24,24 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.11.tgz",
+      "integrity": "sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
       }
     },
     "node_modules/typescript": {

--- a/package.json
+++ b/package.json
@@ -22,5 +22,8 @@
   "devDependencies": {
     "@types/node": "^24.0.0",
     "typescript": "^5.8.3"
+  },
+  "dependencies": {
+    "nanoid": "^5.1.5"
   }
 }

--- a/zig/src/protocol/agent/client.zig
+++ b/zig/src/protocol/agent/client.zig
@@ -9,14 +9,14 @@ pub const AgentProtocolClient = struct {
     sender: ?transport.AsyncSender = null,
     /// Deprecated compatibility field; sequence is now tracked per session.
     sequence: u64 = 0,
-    session_id: ?agent_types.Uuid = null,
+    session_id: ?agent_types.SessionId = null,
     last_error: OwnedSlice(u8) = OwnedSlice(u8).initBorrowed(""),
     last_result_json: OwnedSlice(u8) = OwnedSlice(u8).initBorrowed(""),
     event_queue: std.ArrayList(OwnedSlice(u8)),
-    next_sequence_by_session: std.AutoHashMap(agent_types.Uuid, u64),
-    session_complete_flags: std.AutoHashMap(agent_types.Uuid, bool),
-    session_last_errors: std.AutoHashMap(agent_types.Uuid, OwnedSlice(u8)),
-    session_last_results: std.AutoHashMap(agent_types.Uuid, OwnedSlice(u8)),
+    next_sequence_by_session: std.AutoHashMap(agent_types.SessionId, u64),
+    session_complete_flags: std.AutoHashMap(agent_types.SessionId, bool),
+    session_last_errors: std.AutoHashMap(agent_types.SessionId, OwnedSlice(u8)),
+    session_last_results: std.AutoHashMap(agent_types.SessionId, OwnedSlice(u8)),
 
     const Self = @This();
 
@@ -24,10 +24,10 @@ pub const AgentProtocolClient = struct {
         return .{
             .allocator = allocator,
             .event_queue = std.ArrayList(OwnedSlice(u8)){},
-            .next_sequence_by_session = std.AutoHashMap(agent_types.Uuid, u64).init(allocator),
-            .session_complete_flags = std.AutoHashMap(agent_types.Uuid, bool).init(allocator),
-            .session_last_errors = std.AutoHashMap(agent_types.Uuid, OwnedSlice(u8)).init(allocator),
-            .session_last_results = std.AutoHashMap(agent_types.Uuid, OwnedSlice(u8)).init(allocator),
+            .next_sequence_by_session = std.AutoHashMap(agent_types.SessionId, u64).init(allocator),
+            .session_complete_flags = std.AutoHashMap(agent_types.SessionId, bool).init(allocator),
+            .session_last_errors = std.AutoHashMap(agent_types.SessionId, OwnedSlice(u8)).init(allocator),
+            .session_last_results = std.AutoHashMap(agent_types.SessionId, OwnedSlice(u8)).init(allocator),
         };
     }
 
@@ -58,7 +58,7 @@ pub const AgentProtocolClient = struct {
         self.sender = sender;
     }
 
-    fn nextSequence(self: *Self, session_id: agent_types.Uuid) !u64 {
+    fn nextSequence(self: *Self, session_id: agent_types.SessionId) !u64 {
         const next = if (self.next_sequence_by_session.get(session_id)) |cur| cur + 1 else 1;
         try self.next_sequence_by_session.put(session_id, next);
         self.sequence = next; // compatibility mirror
@@ -66,7 +66,7 @@ pub const AgentProtocolClient = struct {
     }
 
     pub fn sendAgentStart(self: *Self, config_json: []const u8, system_prompt: ?[]const u8) !agent_types.Uuid {
-        const sid = agent_types.generateUuid();
+        const sid = agent_types.generateSessionId();
         const msg_id = agent_types.generateUuid();
         const seq = try self.nextSequence(sid);
 
@@ -87,7 +87,7 @@ pub const AgentProtocolClient = struct {
         return msg_id;
     }
 
-    pub fn sendAgentMessage(self: *Self, session_id: agent_types.Uuid, message_json: []const u8, options_json: ?[]const u8) !agent_types.Uuid {
+    pub fn sendAgentMessage(self: *Self, session_id: agent_types.SessionId, message_json: []const u8, options_json: ?[]const u8) !agent_types.Uuid {
         const msg_id = agent_types.generateUuid();
         const seq = try self.nextSequence(session_id);
 
@@ -108,7 +108,7 @@ pub const AgentProtocolClient = struct {
         return msg_id;
     }
 
-    pub fn sendAgentStop(self: *Self, session_id: agent_types.Uuid, reason: ?[]const u8) !agent_types.Uuid {
+    pub fn sendAgentStop(self: *Self, session_id: agent_types.SessionId, reason: ?[]const u8) !agent_types.Uuid {
         const msg_id = agent_types.generateUuid();
         const seq = try self.nextSequence(session_id);
 
@@ -134,7 +134,7 @@ pub const AgentProtocolClient = struct {
         try self.sender.?.flush();
     }
 
-    fn setSessionError(self: *Self, session_id: agent_types.Uuid, msg: []const u8) !void {
+    fn setSessionError(self: *Self, session_id: agent_types.SessionId, msg: []const u8) !void {
         if (self.session_last_errors.getPtr(session_id)) |existing| {
             existing.deinit(self.allocator);
             existing.* = OwnedSlice(u8).initOwned(try self.allocator.dupe(u8, msg));
@@ -144,7 +144,7 @@ pub const AgentProtocolClient = struct {
         try self.session_complete_flags.put(session_id, true);
     }
 
-    fn setSessionResult(self: *Self, session_id: agent_types.Uuid, result_json: []const u8) !void {
+    fn setSessionResult(self: *Self, session_id: agent_types.SessionId, result_json: []const u8) !void {
         if (self.session_last_results.getPtr(session_id)) |existing| {
             existing.deinit(self.allocator);
             existing.* = OwnedSlice(u8).initOwned(try self.allocator.dupe(u8, result_json));
@@ -154,7 +154,7 @@ pub const AgentProtocolClient = struct {
         try self.session_complete_flags.put(session_id, true);
     }
 
-    fn clearSessionTerminalState(self: *Self, session_id: agent_types.Uuid) void {
+    fn clearSessionTerminalState(self: *Self, session_id: agent_types.SessionId) void {
         if (self.session_last_errors.fetchRemove(session_id)) |entry| {
             var err = entry.value;
             err.deinit(self.allocator);
@@ -209,11 +209,11 @@ pub const AgentProtocolClient = struct {
         return if (json.len == 0) null else json;
     }
 
-    pub fn isSessionComplete(self: *Self, session_id: agent_types.Uuid) bool {
+    pub fn isSessionComplete(self: *Self, session_id: agent_types.SessionId) bool {
         return self.session_complete_flags.get(session_id) orelse false;
     }
 
-    pub fn getLastErrorForSession(self: *Self, session_id: agent_types.Uuid) ?[]const u8 {
+    pub fn getLastErrorForSession(self: *Self, session_id: agent_types.SessionId) ?[]const u8 {
         if (self.session_last_errors.get(session_id)) |err| {
             const msg = err.slice();
             if (msg.len > 0) return msg;
@@ -221,7 +221,7 @@ pub const AgentProtocolClient = struct {
         return null;
     }
 
-    pub fn getLastResultJsonForSession(self: *Self, session_id: agent_types.Uuid) ?[]const u8 {
+    pub fn getLastResultJsonForSession(self: *Self, session_id: agent_types.SessionId) ?[]const u8 {
         if (self.session_last_results.get(session_id)) |result| {
             const json = result.slice();
             if (json.len > 0) return json;
@@ -229,7 +229,7 @@ pub const AgentProtocolClient = struct {
         return null;
     }
 
-    pub fn removeSessionState(self: *Self, session_id: agent_types.Uuid) void {
+    pub fn removeSessionState(self: *Self, session_id: agent_types.SessionId) void {
         _ = self.next_sequence_by_session.remove(session_id);
         _ = self.session_complete_flags.remove(session_id);
 
@@ -259,7 +259,7 @@ test "AgentProtocolClient processes events and results" {
     var client = AgentProtocolClient.init(allocator);
     defer client.deinit();
 
-    const sid = agent_types.generateUuid();
+    const sid = agent_types.generateSessionId();
 
     try client.processEnvelope(.{
         .session_id = sid,
@@ -302,7 +302,7 @@ test "AgentProtocolClient removeSessionState clears per-session and legacy curre
     var client = AgentProtocolClient.init(allocator);
     defer client.deinit();
 
-    const sid = agent_types.generateUuid();
+    const sid = agent_types.generateSessionId();
     client.session_id = sid;
     try client.session_complete_flags.put(sid, true);
     try client.session_last_errors.put(sid, OwnedSlice(u8).initOwned(try allocator.dupe(u8, "session err")));
@@ -353,8 +353,8 @@ test "AgentProtocolClient maintains per-session sequence continuity across stop 
     defer client.deinit();
     client.setSender(sender);
 
-    const sid1 = agent_types.generateUuid();
-    const sid2 = agent_types.generateUuid();
+    const sid1 = agent_types.generateSessionId();
+    const sid2 = agent_types.generateSessionId();
 
     _ = try client.sendAgentMessage(sid1, "{\"m\":1}", null); // sid1 seq 1
     _ = try client.sendAgentMessage(sid2, "{\"m\":2}", null); // sid2 seq 1

--- a/zig/src/protocol/agent/envelope.zig
+++ b/zig/src/protocol/agent/envelope.zig
@@ -14,7 +14,7 @@ pub fn serializeEnvelope(env: agent_types.Envelope, allocator: std.mem.Allocator
     try w.beginObject();
     try w.writeStringField("type", @tagName(env.payload));
 
-    const session_id_str = try agent_types.uuidToString(env.session_id, allocator);
+    const session_id_str = try agent_types.sessionIdToString(env.session_id, allocator);
     defer allocator.free(session_id_str);
     try w.writeStringField("session_id", session_id_str);
 
@@ -49,26 +49,26 @@ fn serializePayload(w: *json_writer.JsonWriter, payload: agent_types.Payload, al
             try w.writeStringField("config_json", p.config_json);
             if (p.getSystemPrompt()) |prompt| try w.writeStringField("system_prompt", prompt);
             if (p.session_id) |id| {
-                const id_str = try agent_types.uuidToString(id, allocator);
+                const id_str = try agent_types.sessionIdToString(id, allocator);
                 defer allocator.free(id_str);
                 try w.writeStringField("resume_session_id", id_str);
             }
         },
         .agent_message => |p| {
-            const session_id = try agent_types.uuidToString(p.session_id, allocator);
+            const session_id = try agent_types.sessionIdToString(p.session_id, allocator);
             defer allocator.free(session_id);
             try w.writeStringField("session_id", session_id);
             try w.writeStringField("message_json", p.message_json);
             if (p.getOptionsJson()) |opts| try w.writeStringField("options_json", opts);
         },
         .agent_stop => |p| {
-            const session_id = try agent_types.uuidToString(p.session_id, allocator);
+            const session_id = try agent_types.sessionIdToString(p.session_id, allocator);
             defer allocator.free(session_id);
             try w.writeStringField("session_id", session_id);
             if (p.getReason()) |reason| try w.writeStringField("reason", reason);
         },
         .agent_status => |p| {
-            const session_id = try agent_types.uuidToString(p.session_id, allocator);
+            const session_id = try agent_types.sessionIdToString(p.session_id, allocator);
             defer allocator.free(session_id);
             try w.writeStringField("session_id", session_id);
         },
@@ -76,14 +76,14 @@ fn serializePayload(w: *json_writer.JsonWriter, payload: agent_types.Payload, al
             if (p.getPrefix()) |prefix| try w.writeStringField("prefix", prefix);
         },
         .agent_started => |p| {
-            const session_id = try agent_types.uuidToString(p.session_id, allocator);
+            const session_id = try agent_types.sessionIdToString(p.session_id, allocator);
             defer allocator.free(session_id);
             try w.writeStringField("session_id", session_id);
         },
         .agent_event => |p| try w.writeStringField("event_json", p),
         .agent_result => |p| try w.writeStringField("result_json", p),
         .agent_stopped => |p| {
-            const session_id = try agent_types.uuidToString(p.session_id, allocator);
+            const session_id = try agent_types.sessionIdToString(p.session_id, allocator);
             defer allocator.free(session_id);
             try w.writeStringField("session_id", session_id);
             if (p.getReason()) |reason| try w.writeStringField("reason", reason);
@@ -93,7 +93,7 @@ fn serializePayload(w: *json_writer.JsonWriter, payload: agent_types.Payload, al
             try w.writeStringField("message", p.message);
         },
         .session_info => |p| {
-            const session_id = try agent_types.uuidToString(p.session_id, allocator);
+            const session_id = try agent_types.sessionIdToString(p.session_id, allocator);
             defer allocator.free(session_id);
             try w.writeStringField("session_id", session_id);
             try w.writeStringField("status", @tagName(p.status));
@@ -223,7 +223,7 @@ pub fn deserializeEnvelope(json: []const u8, allocator: std.mem.Allocator) !agen
 
     const root = parsed.value.object;
     const type_str = root.get("type").?.string;
-    const session_id = parseUuidOrError(root.get("session_id").?.string) orelse return error.InvalidUuid;
+    const session_id = try parseSessionIdRequired(root.get("session_id").?.string);
     const message_id = parseUuidOrError(root.get("message_id").?.string) orelse return error.InvalidUuid;
     const sequence = @as(u64, @intCast(root.get("sequence").?.integer));
     const timestamp = root.get("timestamp").?.integer;
@@ -250,6 +250,10 @@ fn parseUuidRequired(str: []const u8) !agent_types.Uuid {
     return agent_types.parseUuid(str) orelse error.InvalidUuid;
 }
 
+fn parseSessionIdRequired(str: []const u8) !agent_types.SessionId {
+    return agent_types.parseSessionId(str) orelse error.InvalidSessionId;
+}
+
 fn parseUuidOrError(str: []const u8) ?agent_types.Uuid {
     return agent_types.parseUuid(str);
 }
@@ -259,25 +263,25 @@ fn deserializePayload(type_str: []const u8, payload: std.json.ObjectMap, allocat
         const config = try allocator.dupe(u8, payload.get("config_json").?.string);
         var result = agent_types.AgentStartRequest{ .config_json = config };
         if (payload.get("system_prompt")) |v| result.system_prompt = OwnedSlice(u8).initOwned(try allocator.dupe(u8, v.string));
-        if (payload.get("resume_session_id")) |v| result.session_id = try parseUuidRequired(v.string);
+        if (payload.get("resume_session_id")) |v| result.session_id = try parseSessionIdRequired(v.string);
         return .{ .agent_start = result };
     }
     if (std.mem.eql(u8, type_str, "agent_message")) {
         const msg = try allocator.dupe(u8, payload.get("message_json").?.string);
         var req = agent_types.AgentMessageRequest{
-            .session_id = try parseUuidRequired(payload.get("session_id").?.string),
+            .session_id = try parseSessionIdRequired(payload.get("session_id").?.string),
             .message_json = msg,
         };
         if (payload.get("options_json")) |v| req.options_json = OwnedSlice(u8).initOwned(try allocator.dupe(u8, v.string));
         return .{ .agent_message = req };
     }
     if (std.mem.eql(u8, type_str, "agent_stop")) {
-        var req = agent_types.AgentStopRequest{ .session_id = try parseUuidRequired(payload.get("session_id").?.string) };
+        var req = agent_types.AgentStopRequest{ .session_id = try parseSessionIdRequired(payload.get("session_id").?.string) };
         if (payload.get("reason")) |v| req.reason = OwnedSlice(u8).initOwned(try allocator.dupe(u8, v.string));
         return .{ .agent_stop = req };
     }
     if (std.mem.eql(u8, type_str, "agent_status")) {
-        return .{ .agent_status = .{ .session_id = try parseUuidRequired(payload.get("session_id").?.string) } };
+        return .{ .agent_status = .{ .session_id = try parseSessionIdRequired(payload.get("session_id").?.string) } };
     }
     if (std.mem.eql(u8, type_str, "tool_list")) {
         var req = agent_types.ToolListRequest{};
@@ -285,12 +289,12 @@ fn deserializePayload(type_str: []const u8, payload: std.json.ObjectMap, allocat
         return .{ .tool_list = req };
     }
     if (std.mem.eql(u8, type_str, "agent_started")) {
-        return .{ .agent_started = .{ .session_id = try parseUuidRequired(payload.get("session_id").?.string) } };
+        return .{ .agent_started = .{ .session_id = try parseSessionIdRequired(payload.get("session_id").?.string) } };
     }
     if (std.mem.eql(u8, type_str, "agent_event")) return .{ .agent_event = try allocator.dupe(u8, payload.get("event_json").?.string) };
     if (std.mem.eql(u8, type_str, "agent_result")) return .{ .agent_result = try allocator.dupe(u8, payload.get("result_json").?.string) };
     if (std.mem.eql(u8, type_str, "agent_stopped")) {
-        var stopped = agent_types.AgentStopped{ .session_id = try parseUuidRequired(payload.get("session_id").?.string) };
+        var stopped = agent_types.AgentStopped{ .session_id = try parseSessionIdRequired(payload.get("session_id").?.string) };
         if (payload.get("reason")) |v| stopped.reason = OwnedSlice(u8).initOwned(try allocator.dupe(u8, v.string));
         return .{ .agent_stopped = stopped };
     }
@@ -302,7 +306,7 @@ fn deserializePayload(type_str: []const u8, payload: std.json.ObjectMap, allocat
     }
     if (std.mem.eql(u8, type_str, "session_info")) {
         return .{ .session_info = .{
-            .session_id = try parseUuidRequired(payload.get("session_id").?.string),
+            .session_id = try parseSessionIdRequired(payload.get("session_id").?.string),
             .status = std.meta.stringToEnum(agent_types.AgentStatus, payload.get("status").?.string) orelse .@"error",
             .model = try allocator.dupe(u8, payload.get("model").?.string),
             .message_count = @as(u32, @intCast(payload.get("message_count").?.integer)),
@@ -600,13 +604,13 @@ fn parseReasoningLevel(str: []const u8) error{InvalidEnumValue}!model_catalog_ty
 test "deserializeEnvelope rejects invalid uuid" {
     const allocator = std.testing.allocator;
     const bad =
-        "{\"type\":\"ping\",\"session_id\":\"not-a-uuid\",\"message_id\":\"not-a-uuid\",\"sequence\":1,\"timestamp\":1,\"version\":1,\"payload\":{}}";
-    try std.testing.expectError(error.InvalidUuid, deserializeEnvelope(bad, allocator));
+        "{\"type\":\"ping\",\"session_id\":\"not-a-session-id\",\"message_id\":\"not-a-uuid\",\"sequence\":1,\"timestamp\":1,\"version\":1,\"payload\":{}}";
+    try std.testing.expectError(error.InvalidSessionId, deserializeEnvelope(bad, allocator));
 }
 
 test "deserializeEnvelope rejects unknown payload type" {
     const allocator = std.testing.allocator;
-    const sid = "00000000-0000-0000-0000-000000000001";
+    const sid = "0123456789ABCDEabcdeF";
     const mid = "00000000-0000-0000-0000-000000000002";
     const bad = try std.fmt.allocPrint(
         allocator,
@@ -621,12 +625,12 @@ test "agent envelope roundtrip" {
     const allocator = std.testing.allocator;
 
     var env = agent_types.Envelope{
-        .session_id = agent_types.generateUuid(),
+        .session_id = agent_types.generateSessionId(),
         .message_id = agent_types.generateUuid(),
         .sequence = 1,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .agent_message = .{
-            .session_id = agent_types.generateUuid(),
+            .session_id = agent_types.generateSessionId(),
             .message_json = try allocator.dupe(u8, "{\"role\":\"user\"}"),
             .options_json = OwnedSlice(u8).initOwned(try allocator.dupe(u8, "{\"temperature\":0.5}")),
         } },
@@ -647,7 +651,7 @@ test "agent envelope roundtrip for models_request" {
     const allocator = std.testing.allocator;
 
     var env = agent_types.Envelope{
-        .session_id = agent_types.generateUuid(),
+        .session_id = agent_types.generateSessionId(),
         .message_id = agent_types.generateUuid(),
         .sequence = 1,
         .timestamp = std.time.milliTimestamp(),
@@ -708,7 +712,7 @@ test "agent envelope roundtrip for models_response preserves shape" {
     };
 
     var env = agent_types.Envelope{
-        .session_id = agent_types.generateUuid(),
+        .session_id = agent_types.generateSessionId(),
         .message_id = agent_types.generateUuid(),
         .sequence = 2,
         .timestamp = std.time.milliTimestamp(),
@@ -751,7 +755,7 @@ test "agent envelope roundtrip for ack and nack" {
 
     const acked_id = agent_types.generateUuid();
     var ack_env = agent_types.Envelope{
-        .session_id = agent_types.generateUuid(),
+        .session_id = agent_types.generateSessionId(),
         .message_id = agent_types.generateUuid(),
         .sequence = 1,
         .timestamp = std.time.milliTimestamp(),
@@ -770,7 +774,7 @@ test "agent envelope roundtrip for ack and nack" {
 
     const rejected_id = agent_types.generateUuid();
     var nack_env = agent_types.Envelope{
-        .session_id = agent_types.generateUuid(),
+        .session_id = agent_types.generateSessionId(),
         .message_id = agent_types.generateUuid(),
         .sequence = 1,
         .timestamp = std.time.milliTimestamp(),

--- a/zig/src/protocol/agent/server.zig
+++ b/zig/src/protocol/agent/server.zig
@@ -3,7 +3,7 @@ const agent_types = @import("agent_types");
 const OwnedSlice = @import("owned_slice").OwnedSlice;
 
 pub const SessionState = struct {
-    session_id: agent_types.Uuid,
+    session_id: agent_types.SessionId,
     status: agent_types.AgentStatus,
     model: []const u8,
     message_count: u32,
@@ -46,9 +46,9 @@ pub const Options = struct {
 
 pub const AgentProtocolServer = struct {
     allocator: std.mem.Allocator,
-    sessions: std.AutoHashMap(agent_types.Uuid, SessionState),
-    expected_sequences: std.AutoHashMap(agent_types.Uuid, u64),
-    outgoing_sequences: std.AutoHashMap(agent_types.Uuid, u64),
+    sessions: std.AutoHashMap(agent_types.SessionId, SessionState),
+    expected_sequences: std.AutoHashMap(agent_types.SessionId, u64),
+    outgoing_sequences: std.AutoHashMap(agent_types.SessionId, u64),
     outbox: std.ArrayList(agent_types.Envelope),
     options: Options,
 
@@ -61,9 +61,9 @@ pub const AgentProtocolServer = struct {
     pub fn initWithOptions(allocator: std.mem.Allocator, options: Options) Self {
         return .{
             .allocator = allocator,
-            .sessions = std.AutoHashMap(agent_types.Uuid, SessionState).init(allocator),
-            .expected_sequences = std.AutoHashMap(agent_types.Uuid, u64).init(allocator),
-            .outgoing_sequences = std.AutoHashMap(agent_types.Uuid, u64).init(allocator),
+            .sessions = std.AutoHashMap(agent_types.SessionId, SessionState).init(allocator),
+            .expected_sequences = std.AutoHashMap(agent_types.SessionId, u64).init(allocator),
+            .outgoing_sequences = std.AutoHashMap(agent_types.SessionId, u64).init(allocator),
             .outbox = std.ArrayList(agent_types.Envelope){},
             .options = options,
         };
@@ -128,7 +128,7 @@ pub const AgentProtocolServer = struct {
             return try self.makeError(env.session_id, env.message_id, .invalid_request, "agent_start sequence must be 1");
         }
 
-        const session_id = req.session_id orelse agent_types.generateUuid();
+        const session_id = req.session_id orelse agent_types.generateSessionId();
         if (self.sessions.contains(session_id)) {
             return try self.makeError(env.session_id, env.message_id, .agent_busy, "session already exists");
         }
@@ -299,7 +299,7 @@ pub const AgentProtocolServer = struct {
 
     fn makeModelsNack(
         self: *Self,
-        session_id: agent_types.Uuid,
+        session_id: agent_types.SessionId,
         in_reply_to: agent_types.Uuid,
         code: agent_types.ErrorCode,
         msg: []const u8,
@@ -319,7 +319,7 @@ pub const AgentProtocolServer = struct {
         };
     }
 
-    fn makeError(self: *Self, session_id: agent_types.Uuid, in_reply_to: agent_types.Uuid, code: agent_types.AgentErrorCode, msg: []const u8) !agent_types.Envelope {
+    fn makeError(self: *Self, session_id: agent_types.SessionId, in_reply_to: agent_types.Uuid, code: agent_types.AgentErrorCode, msg: []const u8) !agent_types.Envelope {
         return .{
             .session_id = session_id,
             .message_id = agent_types.generateUuid(),
@@ -333,14 +333,14 @@ pub const AgentProtocolServer = struct {
         };
     }
 
-    fn nextOutgoingSequence(self: *Self, session_id: agent_types.Uuid) u64 {
+    fn nextOutgoingSequence(self: *Self, session_id: agent_types.SessionId) u64 {
         const cur = self.outgoing_sequences.get(session_id) orelse 0;
         const next = cur + 1;
         self.outgoing_sequences.put(session_id, next) catch {};
         return next;
     }
 
-    pub fn publishAgentEvent(self: *Self, session_id: agent_types.Uuid, event_json: []const u8) !void {
+    pub fn publishAgentEvent(self: *Self, session_id: agent_types.SessionId, event_json: []const u8) !void {
         if (!self.sessions.contains(session_id)) return error.SessionNotFound;
         try self.outbox.append(self.allocator, .{
             .session_id = session_id,
@@ -351,7 +351,7 @@ pub const AgentProtocolServer = struct {
         });
     }
 
-    pub fn publishAgentResult(self: *Self, session_id: agent_types.Uuid, result_json: []const u8) !void {
+    pub fn publishAgentResult(self: *Self, session_id: agent_types.SessionId, result_json: []const u8) !void {
         if (!self.sessions.contains(session_id)) return error.SessionNotFound;
         try self.outbox.append(self.allocator, .{
             .session_id = session_id,
@@ -374,7 +374,7 @@ test "AgentProtocolServer rejects invalid start sequence" {
     defer server.deinit();
 
     var start = agent_types.Envelope{
-        .session_id = agent_types.generateUuid(),
+        .session_id = agent_types.generateSessionId(),
         .message_id = agent_types.generateUuid(),
         .sequence = 2,
         .timestamp = std.time.milliTimestamp(),
@@ -394,7 +394,7 @@ test "AgentProtocolServer rejects unknown session message" {
     var server = AgentProtocolServer.init(allocator);
     defer server.deinit();
 
-    const sid = agent_types.generateUuid();
+    const sid = agent_types.generateSessionId();
     var msg = agent_types.Envelope{
         .session_id = sid,
         .message_id = agent_types.generateUuid(),
@@ -505,7 +505,7 @@ test "handleModelsRequest emits ack then models_response with same shape as prov
     defer server.deinit();
 
     var request = agent_types.Envelope{
-        .session_id = agent_types.generateUuid(),
+        .session_id = agent_types.generateSessionId(),
         .message_id = agent_types.generateUuid(),
         .sequence = 1,
         .timestamp = std.time.milliTimestamp(),
@@ -559,7 +559,7 @@ test "handleModelsRequest returns not_implemented nack when unsupported" {
     defer server.deinit();
 
     var request = agent_types.Envelope{
-        .session_id = agent_types.generateUuid(),
+        .session_id = agent_types.generateSessionId(),
         .message_id = agent_types.generateUuid(),
         .sequence = 1,
         .timestamp = std.time.milliTimestamp(),
@@ -586,7 +586,7 @@ test "handleModelsRequest returns not_implemented nack when delegate is missing"
     defer server.deinit();
 
     var request = agent_types.Envelope{
-        .session_id = agent_types.generateUuid(),
+        .session_id = agent_types.generateSessionId(),
         .message_id = agent_types.generateUuid(),
         .sequence = 1,
         .timestamp = std.time.milliTimestamp(),
@@ -621,7 +621,7 @@ test "handleModelsRequest maps delegate NotImplemented error to not_implemented 
     defer server.deinit();
 
     var request = agent_types.Envelope{
-        .session_id = agent_types.generateUuid(),
+        .session_id = agent_types.generateSessionId(),
         .message_id = agent_types.generateUuid(),
         .sequence = 1,
         .timestamp = std.time.milliTimestamp(),
@@ -645,7 +645,7 @@ test "AgentProtocolServer start message status stop" {
     defer server.deinit();
 
     var start = agent_types.Envelope{
-        .session_id = agent_types.generateUuid(),
+        .session_id = agent_types.generateSessionId(),
         .message_id = agent_types.generateUuid(),
         .sequence = 1,
         .timestamp = std.time.milliTimestamp(),

--- a/zig/src/protocol/agent/types.zig
+++ b/zig/src/protocol/agent/types.zig
@@ -8,6 +8,10 @@ pub const Uuid = provider_types.Uuid;
 pub const generateUuid = provider_types.generateUuid;
 pub const uuidToString = provider_types.uuidToString;
 pub const parseUuid = provider_types.parseUuid;
+pub const SessionId = provider_types.SessionId;
+pub const generateSessionId = provider_types.generateSessionId;
+pub const sessionIdToString = provider_types.sessionIdToString;
+pub const parseSessionId = provider_types.parseSessionId;
 
 /// Re-export provider ack/nack/error-code envelope types so that the agent
 /// passthrough emits the same shape as the provider protocol.
@@ -73,7 +77,7 @@ pub const AgentStartRequest = struct {
     /// Initial system prompt
     system_prompt: OwnedSlice(u8) = OwnedSlice(u8).initBorrowed(""),
     /// Session ID for resumption (null for new session)
-    session_id: ?Uuid = null,
+    session_id: ?SessionId = null,
 
     pub fn getSystemPrompt(self: *const AgentStartRequest) ?[]const u8 {
         const prompt = self.system_prompt.slice();
@@ -84,7 +88,7 @@ pub const AgentStartRequest = struct {
 /// Request to send a message to an agent
 pub const AgentMessageRequest = struct {
     /// Target agent session
-    session_id: Uuid,
+    session_id: SessionId,
     /// Message to send
     message_json: []const u8,
     /// Options for this message
@@ -99,7 +103,7 @@ pub const AgentMessageRequest = struct {
 /// Request to stop an agent session
 pub const AgentStopRequest = struct {
     /// Target agent session
-    session_id: Uuid,
+    session_id: SessionId,
     /// Reason for stopping
     reason: OwnedSlice(u8) = OwnedSlice(u8).initBorrowed(""),
 
@@ -179,7 +183,7 @@ pub const AgentStatus = enum {
 
 /// Agent session info
 pub const AgentSessionInfo = struct {
-    session_id: Uuid,
+    session_id: SessionId,
     status: AgentStatus,
     model: []const u8,
     message_count: u32,
@@ -188,7 +192,7 @@ pub const AgentSessionInfo = struct {
 };
 
 pub const AgentStopped = struct {
-    session_id: Uuid,
+    session_id: SessionId,
     reason: OwnedSlice(u8) = OwnedSlice(u8).initBorrowed(""),
 
     pub fn getReason(self: *const AgentStopped) ?[]const u8 {
@@ -220,14 +224,14 @@ pub const Payload = union(enum) {
     agent_start: AgentStartRequest,
     agent_message: AgentMessageRequest,
     agent_stop: AgentStopRequest,
-    agent_status: struct { session_id: Uuid },
+    agent_status: struct { session_id: SessionId },
     tool_list: ToolListRequest,
     /// Passthrough model discovery request — delegates to the provider protocol
     /// and returns the same `ModelsResponse` shape. See spec §6.
     models_request: ModelsRequest,
 
     // Agent Server -> Client
-    agent_started: struct { session_id: Uuid },
+    agent_started: struct { session_id: SessionId },
     agent_event: []const u8, // JSON-encoded AgentEvent
     agent_result: []const u8, // JSON-encoded AgentLoopResult
     agent_stopped: AgentStopped,
@@ -315,7 +319,7 @@ pub const Envelope = struct {
     /// Protocol version
     version: u8 = 1,
     /// Session identifier (stable for session lifecycle)
-    session_id: Uuid,
+    session_id: SessionId,
     /// Message ID (unique per message)
     message_id: Uuid,
     /// Sequence number within session (starts at 1)

--- a/zig/src/protocol/provider/types.zig
+++ b/zig/src/protocol/provider/types.zig
@@ -18,6 +18,39 @@ pub const ModelsResponse = model_catalog_types.ModelsResponse;
 /// UUID type for stream/message identification
 pub const Uuid = [16]u8;
 
+/// NanoID-compatible session identifier for agent sessions.
+pub const SESSION_ID_LENGTH: usize = 21;
+pub const SESSION_ID_ALPHABET = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+pub const SessionId = [SESSION_ID_LENGTH]u8;
+
+/// Generate a random NanoID-style session ID with an alphanumeric alphabet.
+pub fn generateSessionId() SessionId {
+    var session_id: SessionId = undefined;
+    for (&session_id) |*byte| {
+        const idx = std.crypto.random.intRangeLessThan(usize, 0, SESSION_ID_ALPHABET.len);
+        byte.* = SESSION_ID_ALPHABET[idx];
+    }
+    return session_id;
+}
+
+/// Convert session ID to string representation (21 alphanumeric chars).
+pub fn sessionIdToString(session_id: SessionId, allocator: std.mem.Allocator) ![]const u8 {
+    return allocator.dupe(u8, session_id[0..]);
+}
+
+/// Parse session ID from string.
+pub fn parseSessionId(str: []const u8) ?SessionId {
+    if (str.len != SESSION_ID_LENGTH) return null;
+    var session_id: SessionId = undefined;
+    for (str, 0..) |c, i| {
+        switch (c) {
+            '0'...'9', 'A'...'Z', 'a'...'z' => session_id[i] = c,
+            else => return null,
+        }
+    }
+    return session_id;
+}
+
 /// Generate a random UUID v4
 pub fn generateUuid() Uuid {
     var uuid: Uuid = undefined;
@@ -395,6 +428,47 @@ pub const ModelsRequest = struct {
 };
 
 // Tests
+
+test "generateSessionId produces valid NanoID session IDs" {
+    const session_id = generateSessionId();
+    const str = try sessionIdToString(session_id, std.testing.allocator);
+    defer std.testing.allocator.free(str);
+
+    try std.testing.expectEqual(@as(usize, SESSION_ID_LENGTH), str.len);
+    for (str) |c| {
+        try std.testing.expect(std.ascii.isAlphanumeric(c));
+        try std.testing.expect(c != '_' and c != '-');
+    }
+
+    const session_id2 = generateSessionId();
+    try std.testing.expect(!std.mem.eql(u8, session_id[0..], session_id2[0..]));
+}
+
+test "sessionIdToString and parseSessionId roundtrip" {
+    const session_id = generateSessionId();
+    const str = try sessionIdToString(session_id, std.testing.allocator);
+    defer std.testing.allocator.free(str);
+
+    const parsed = parseSessionId(str);
+    try std.testing.expect(parsed != null);
+    try std.testing.expectEqualSlices(u8, session_id[0..], parsed.?[0..]);
+
+    const known = "0123456789ABCDEabcdeF";
+    const parsed_known = parseSessionId(known);
+    try std.testing.expect(parsed_known != null);
+    const known_str = try sessionIdToString(parsed_known.?, std.testing.allocator);
+    defer std.testing.allocator.free(known_str);
+    try std.testing.expectEqualStrings(known, known_str);
+}
+
+test "parseSessionId returns null for invalid strings" {
+    try std.testing.expect(parseSessionId("0123456789ABCDEabcde") == null);
+    try std.testing.expect(parseSessionId("0123456789ABCDEabcdeFG") == null);
+    try std.testing.expect(parseSessionId("0123456789ABCDEabcd-") == null);
+    try std.testing.expect(parseSessionId("0123456789ABCDEabcd_") == null);
+    try std.testing.expect(parseSessionId("") == null);
+}
+
 
 test "ModelsRequest getters return null for empty borrowed filters" {
     const req = ModelsRequest{};

--- a/zig/src/protocol/provider/types.zig
+++ b/zig/src/protocol/provider/types.zig
@@ -469,7 +469,6 @@ test "parseSessionId returns null for invalid strings" {
     try std.testing.expect(parseSessionId("") == null);
 }
 
-
 test "ModelsRequest getters return null for empty borrowed filters" {
     const req = ModelsRequest{};
     try std.testing.expect(req.getProviderId() == null);

--- a/zig/src/tools/makai.zig
+++ b/zig/src/tools/makai.zig
@@ -582,7 +582,7 @@ fn makeProviderPingEnvelopeJson(allocator: std.mem.Allocator) ![]u8 {
 
 fn makeAgentPingEnvelopeJson(allocator: std.mem.Allocator) ![]u8 {
     const env = AgentProtocolTypes.Envelope{
-        .session_id = AgentProtocolTypes.generateUuid(),
+        .session_id = AgentProtocolTypes.generateSessionId(),
         .message_id = AgentProtocolTypes.generateUuid(),
         .sequence = 1,
         .timestamp = std.time.milliTimestamp(),


### PR DESCRIPTION
## Summary
- Add a shared alphanumeric 21-character SessionId type and generation/parsing helpers for agent sessions.
- Switch agent protocol session_id fields, serialization/deserialization, maps, and CLI generation to SessionId while leaving message/stream/auth IDs as UUIDs.
- Add NanoID as the TS package dependency for the upcoming execution client use sites; this branch's TS execution-client files are not present in this worktree.

## Test plan
- [x] npm test
- [ ] zig build test --build-file zig/build.zig (blocked by existing Zig 0.16 compatibility compile errors in std.crypto.random/std.time.milliTimestamp/std.Thread.Mutex and ArrayList initializers outside this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)