### PR TITLE
M-011: Replace protocol UUIDs with ULIDs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,7 +135,7 @@ Ownership and auth boundary:
 **`transport.zig`** - Defines transport interfaces (`Sender`, `Receiver`, `AsyncSender`, `AsyncReceiver`) and wire message types (`MessageOrControl`, `ControlMessage`). Also defines `ByteStream = EventStream(ByteChunk, void)` for async byte-level I/O. Transports implement these interfaces over different backends.
 
 **`protocol/provider/`** - Client-server wire protocol:
-- `types.zig`: UUID generation, `Envelope` (stream_id, message_id, sequence, timestamp, payload), `ErrorCode` enum
+- `types.zig`: ULID generation, `Envelope` (stream_id, message_id, sequence, timestamp, payload), `ErrorCode` enum
 - `envelope.zig`: JSON serialization/deserialization of protocol envelopes, creation helpers (createStreamStart, createAck, createNack, etc.)
 - `server.zig`: Server-side protocol handler — validates sequences, manages streams, routes envelopes to providers
 - `client.zig`: Client-side `ProtocolClient` — sends requests via transport, reconstructs `AssistantMessage` from streamed events, manages pending requests. v1.0: single-stream only

--- a/docs/v1-sdk-agent-provider-spec.md
+++ b/docs/v1-sdk-agent-provider-spec.md
@@ -526,25 +526,25 @@ pub const AuthLoginStartRequest = struct {
 };
 
 pub const AuthPromptResponse = struct {
-    flow_id: Uuid,
+    flow_id: ULID,
     prompt_id: OwnedSlice(u8),
     answer: OwnedSlice(u8),
 };
 
 pub const AuthCancelRequest = struct {
-    flow_id: Uuid,
+    flow_id: ULID,
 };
 
 pub const AuthEvent = union(enum) {
-    auth_url: struct { flow_id: Uuid, provider_id: OwnedSlice(u8), url: OwnedSlice(u8), instructions: OwnedSlice(u8) = OwnedSlice(u8).initBorrowed("") },
-    prompt: struct { flow_id: Uuid, prompt_id: OwnedSlice(u8), provider_id: OwnedSlice(u8), message: OwnedSlice(u8), allow_empty: bool = false },
-    progress: struct { flow_id: Uuid, provider_id: OwnedSlice(u8), message: OwnedSlice(u8) },
-    success: struct { flow_id: Uuid, provider_id: OwnedSlice(u8) },
-    error: struct { flow_id: Uuid, provider_id: OwnedSlice(u8), code: OwnedSlice(u8) = OwnedSlice(u8).initBorrowed(""), message: OwnedSlice(u8) },
+    auth_url: struct { flow_id: ULID, provider_id: OwnedSlice(u8), url: OwnedSlice(u8), instructions: OwnedSlice(u8) = OwnedSlice(u8).initBorrowed("") },
+    prompt: struct { flow_id: ULID, prompt_id: OwnedSlice(u8), provider_id: OwnedSlice(u8), message: OwnedSlice(u8), allow_empty: bool = false },
+    progress: struct { flow_id: ULID, provider_id: OwnedSlice(u8), message: OwnedSlice(u8) },
+    success: struct { flow_id: ULID, provider_id: OwnedSlice(u8) },
+    error: struct { flow_id: ULID, provider_id: OwnedSlice(u8), code: OwnedSlice(u8) = OwnedSlice(u8).initBorrowed(""), message: OwnedSlice(u8) },
 };
 
 pub const AuthLoginResult = struct {
-    flow_id: Uuid,
+    flow_id: ULID,
     provider_id: OwnedSlice(u8),
     status: enum { success, cancelled, failed },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "makai",
       "version": "0.0.1",
       "license": "ISC",
+      "dependencies": {
+        "ulid": "^3.0.2"
+      },
       "devDependencies": {
         "@types/node": "^24.0.0",
         "typescript": "^5.8.3"
@@ -35,6 +38,15 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/ulid": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/ulid/-/ulid-3.0.2.tgz",
+      "integrity": "sha512-yu26mwteFYzBAot7KVMqFGCVpsF6g8wXfJzQUHvu1no3+rRRSFcSV2nKeYvNPLD2J4b08jYBDhHUjeH0ygIl9w==",
+      "license": "MIT",
+      "bin": {
+        "ulid": "dist/cli.js"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -22,5 +22,8 @@
   "devDependencies": {
     "@types/node": "^24.0.0",
     "typescript": "^5.8.3"
+  },
+  "dependencies": {
+    "ulid": "^3.0.2"
   }
 }

--- a/typescript/demo/server.ts
+++ b/typescript/demo/server.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import { ulid } from "ulid";
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
 import { promises as fs } from "node:fs";
 import path from "node:path";
@@ -316,7 +316,7 @@ export function createDemoServer(options: DemoServerOptions = {}): Server {
       }
 
       const session: AuthSession = {
-        id: randomUUID(),
+        id: ulid(),
         provider: body.provider,
         status: "running",
         events: [],

--- a/typescript/src/auth_protocol.ts
+++ b/typescript/src/auth_protocol.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import { ulid } from "ulid";
 import { BinaryResolverOptions } from "./binary_resolver";
 import {
   MakaiStdioClient,
@@ -257,8 +257,8 @@ export class MakaiAuthClient implements MakaiAuthApi {
   }
 
   async listProviders(): Promise<ProviderAuthInfo[]> {
-    const streamId = randomUUID();
-    const messageId = randomUUID();
+    const streamId = ulid();
+    const messageId = ulid();
     const envelope = {
       type: "auth_providers_request",
       stream_id: streamId,
@@ -296,13 +296,13 @@ export class MakaiAuthClient implements MakaiAuthApi {
     // (not per-property merge), so `{ onPrompt }` intentionally drops a
     // client-level `onEvent`.
     const effective = handlers ?? this.defaultHandlers;
-    const flowId = randomUUID();
+    const flowId = ulid();
     let outboundSequence = 1;
 
     this.sendOrThrow({
       type: "auth_login_start",
       stream_id: flowId,
-      message_id: randomUUID(),
+      message_id: ulid(),
       sequence: outboundSequence++,
       timestamp: Date.now(),
       version: PROTOCOL_VERSION,
@@ -362,7 +362,7 @@ export class MakaiAuthClient implements MakaiAuthApi {
           this.sendOrThrow({
             type: "auth_prompt_response",
             stream_id: flowId,
-            message_id: randomUUID(),
+            message_id: ulid(),
             sequence: outboundSequence++,
             timestamp: Date.now(),
             version: PROTOCOL_VERSION,
@@ -445,7 +445,7 @@ export class MakaiAuthClient implements MakaiAuthApi {
       this.transport.send({
         type: "auth_cancel",
         stream_id: flowId,
-        message_id: randomUUID(),
+        message_id: ulid(),
         sequence,
         timestamp: Date.now(),
         version: PROTOCOL_VERSION,

--- a/typescript/src/models_client.ts
+++ b/typescript/src/models_client.ts
@@ -19,7 +19,7 @@
  * - If the runtime omits `cache_max_age_ms` (non-conformant), default to 5 min.
  */
 
-import { randomUUID } from "node:crypto";
+import { ulid } from "ulid";
 import {
   AuthStatus,
   ListModelsRequest,
@@ -165,7 +165,7 @@ class StdioModelsApi implements MakaiModelsApi {
   }
 
   private async dispatch(request: ListModelsRequest): Promise<ListModelsResponse> {
-    const streamId = randomUUID();
+    const streamId = ulid();
     const envelope: StdioFrame = {
       type: "models_request",
       stream_id: streamId,

--- a/typescript/test/auth_protocol.test.ts
+++ b/typescript/test/auth_protocol.test.ts
@@ -27,7 +27,7 @@ function fixtureClientOptions(
 test("flattenAuthEvent normalizes Zig union wire shape", () => {
   const flatPrompt = flattenAuthEvent({
     prompt: {
-      flow_id: "00000000-0000-0000-0000-000000000001",
+      flow_id: "00000000000000000000000001",
       prompt_id: "device_code",
       provider_id: "fixture",
       message: "enter code",
@@ -36,7 +36,7 @@ test("flattenAuthEvent normalizes Zig union wire shape", () => {
   });
   assert.deepEqual(flatPrompt, {
     type: "prompt",
-    flow_id: "00000000-0000-0000-0000-000000000001",
+    flow_id: "00000000000000000000000001",
     prompt_id: "device_code",
     provider_id: "fixture",
     message: "enter code",
@@ -45,7 +45,7 @@ test("flattenAuthEvent normalizes Zig union wire shape", () => {
 
   const flatError = flattenAuthEvent({
     error: {
-      flow_id: "00000000-0000-0000-0000-000000000002",
+      flow_id: "00000000000000000000000002",
       provider_id: "fixture",
       code: "auth_failed",
       message: "boom",
@@ -53,7 +53,7 @@ test("flattenAuthEvent normalizes Zig union wire shape", () => {
   });
   assert.deepEqual(flatError, {
     type: "error",
-    flow_id: "00000000-0000-0000-0000-000000000002",
+    flow_id: "00000000000000000000000002",
     provider_id: "fixture",
     code: "auth_failed",
     message: "boom",

--- a/typescript/test/fixtures/auth-protocol-concurrent-server.js
+++ b/typescript/test/fixtures/auth-protocol-concurrent-server.js
@@ -2,7 +2,7 @@
 // auth protocol streams. Used to verify the SDK routes frames by stream_id
 // instead of discarding frames that belong to another in-flight auth call.
 const readline = require("node:readline");
-const crypto = require("node:crypto");
+const { ulid } = require("ulid");
 
 process.stdout.write(JSON.stringify({ type: "ready", protocol_version: "1" }) + "\n");
 
@@ -25,7 +25,7 @@ function providerResponseEnvelope(envelope) {
   return {
     type: "auth_providers_response",
     stream_id: envelope.stream_id,
-    message_id: crypto.randomUUID(),
+    message_id: ulid(),
     sequence: nextSeq(envelope.stream_id),
     in_reply_to: envelope.message_id,
     timestamp: Date.now(),
@@ -52,7 +52,7 @@ rl.on("line", (line) => {
   send({
     type: "ack",
     stream_id: envelope.stream_id,
-    message_id: crypto.randomUUID(),
+    message_id: ulid(),
     sequence: nextSeq(envelope.stream_id),
     in_reply_to: envelope.message_id,
     timestamp: Date.now(),

--- a/typescript/test/fixtures/auth-protocol-login-cancelled-server.js
+++ b/typescript/test/fixtures/auth-protocol-login-cancelled-server.js
@@ -2,7 +2,7 @@
 // Emits ack, `auth_event.error`, then terminal
 // `auth_login_result.status = cancelled`. Used by the SDK auth client tests.
 const readline = require("node:readline");
-const crypto = require("node:crypto");
+const { ulid } = require("ulid");
 
 process.stdout.write(JSON.stringify({ type: "ready", protocol_version: "1" }) + "\n");
 
@@ -31,7 +31,7 @@ rl.on("line", (line) => {
     JSON.stringify({
       type: "ack",
       stream_id: flowId,
-      message_id: crypto.randomUUID(),
+      message_id: ulid(),
       sequence: nextSeq(flowId),
       in_reply_to: envelope.message_id,
       timestamp: Date.now(),
@@ -43,7 +43,7 @@ rl.on("line", (line) => {
     JSON.stringify({
       type: "auth_event",
       stream_id: flowId,
-      message_id: crypto.randomUUID(),
+      message_id: ulid(),
       sequence: nextSeq(flowId),
       timestamp: Date.now(),
       version: 1,
@@ -61,7 +61,7 @@ rl.on("line", (line) => {
     JSON.stringify({
       type: "auth_login_result",
       stream_id: flowId,
-      message_id: crypto.randomUUID(),
+      message_id: ulid(),
       sequence: nextSeq(flowId),
       timestamp: Date.now(),
       version: 1,

--- a/typescript/test/fixtures/auth-protocol-login-failed-server.js
+++ b/typescript/test/fixtures/auth-protocol-login-failed-server.js
@@ -3,7 +3,7 @@
 // `auth_login_result.status = failed`. Used by the SDK auth client tests
 // to verify error code/message propagation per spec §8.
 const readline = require("node:readline");
-const crypto = require("node:crypto");
+const { ulid } = require("ulid");
 
 process.stdout.write(JSON.stringify({ type: "ready", protocol_version: "1" }) + "\n");
 
@@ -32,7 +32,7 @@ rl.on("line", (line) => {
     JSON.stringify({
       type: "ack",
       stream_id: flowId,
-      message_id: crypto.randomUUID(),
+      message_id: ulid(),
       sequence: nextSeq(flowId),
       in_reply_to: envelope.message_id,
       timestamp: Date.now(),
@@ -44,7 +44,7 @@ rl.on("line", (line) => {
     JSON.stringify({
       type: "auth_event",
       stream_id: flowId,
-      message_id: crypto.randomUUID(),
+      message_id: ulid(),
       sequence: nextSeq(flowId),
       timestamp: Date.now(),
       version: 1,
@@ -62,7 +62,7 @@ rl.on("line", (line) => {
     JSON.stringify({
       type: "auth_login_result",
       stream_id: flowId,
-      message_id: crypto.randomUUID(),
+      message_id: ulid(),
       sequence: nextSeq(flowId),
       timestamp: Date.now(),
       version: 1,

--- a/typescript/test/fixtures/auth-protocol-login-success-server.js
+++ b/typescript/test/fixtures/auth-protocol-login-success-server.js
@@ -1,6 +1,6 @@
 // Fixture stdio server that emulates a successful auth login flow.
 const readline = require("node:readline");
-const crypto = require("node:crypto");
+const { ulid } = require("ulid");
 
 process.stdout.write(JSON.stringify({ type: "ready", protocol_version: "1" }) + "\n");
 
@@ -21,7 +21,7 @@ function ack(envelope) {
   send({
     type: "ack",
     stream_id: envelope.stream_id,
-    message_id: crypto.randomUUID(),
+    message_id: ulid(),
     sequence: nextSeq(envelope.stream_id),
     in_reply_to: envelope.message_id,
     timestamp: Date.now(),
@@ -49,7 +49,7 @@ rl.on("line", (line) => {
     send({
       type: "auth_event",
       stream_id: flowId,
-      message_id: crypto.randomUUID(),
+      message_id: ulid(),
       sequence: nextSeq(flowId),
       timestamp: Date.now(),
       version: 1,
@@ -66,7 +66,7 @@ rl.on("line", (line) => {
     send({
       type: "auth_event",
       stream_id: flowId,
-      message_id: crypto.randomUUID(),
+      message_id: ulid(),
       sequence: nextSeq(flowId),
       timestamp: Date.now(),
       version: 1,
@@ -91,7 +91,7 @@ rl.on("line", (line) => {
       send({
         type: "auth_event",
         stream_id: flowState.flowId,
-        message_id: crypto.randomUUID(),
+        message_id: ulid(),
         sequence: nextSeq(flowState.flowId),
         timestamp: Date.now(),
         version: 1,
@@ -102,7 +102,7 @@ rl.on("line", (line) => {
       send({
         type: "auth_login_result",
         stream_id: flowState.flowId,
-        message_id: crypto.randomUUID(),
+        message_id: ulid(),
         sequence: nextSeq(flowState.flowId),
         timestamp: Date.now(),
         version: 1,
@@ -117,7 +117,7 @@ rl.on("line", (line) => {
     send({
       type: "auth_event",
       stream_id: flowState.flowId,
-      message_id: crypto.randomUUID(),
+      message_id: ulid(),
       sequence: nextSeq(flowState.flowId),
       timestamp: Date.now(),
       version: 1,
@@ -133,7 +133,7 @@ rl.on("line", (line) => {
     send({
       type: "auth_login_result",
       stream_id: flowState.flowId,
-      message_id: crypto.randomUUID(),
+      message_id: ulid(),
       sequence: nextSeq(flowState.flowId),
       timestamp: Date.now(),
       version: 1,
@@ -151,7 +151,7 @@ rl.on("line", (line) => {
     send({
       type: "auth_login_result",
       stream_id: flowState.flowId,
-      message_id: crypto.randomUUID(),
+      message_id: ulid(),
       sequence: nextSeq(flowState.flowId),
       timestamp: Date.now(),
       version: 1,

--- a/typescript/test/fixtures/auth-protocol-prompt-throw-cleanup-server.js
+++ b/typescript/test/fixtures/auth-protocol-prompt-throw-cleanup-server.js
@@ -4,7 +4,7 @@
 // the same transport, proving the first flow did not leave orphaned frames that
 // poison future calls.
 const readline = require("node:readline");
-const crypto = require("node:crypto");
+const { ulid } = require("ulid");
 
 process.stdout.write(JSON.stringify({ type: "ready", protocol_version: "1" }) + "\n");
 
@@ -25,7 +25,7 @@ function ack(envelope) {
   send({
     type: "ack",
     stream_id: envelope.stream_id,
-    message_id: crypto.randomUUID(),
+    message_id: ulid(),
     sequence: nextSeq(envelope.stream_id),
     in_reply_to: envelope.message_id,
     timestamp: Date.now(),
@@ -52,7 +52,7 @@ rl.on("line", (line) => {
     send({
       type: "auth_event",
       stream_id: flowId,
-      message_id: crypto.randomUUID(),
+      message_id: ulid(),
       sequence: nextSeq(flowId),
       timestamp: Date.now(),
       version: 1,
@@ -76,7 +76,7 @@ rl.on("line", (line) => {
     send({
       type: "auth_event",
       stream_id: envelope.stream_id,
-      message_id: crypto.randomUUID(),
+      message_id: ulid(),
       sequence: nextSeq(envelope.stream_id),
       timestamp: Date.now(),
       version: 1,
@@ -92,7 +92,7 @@ rl.on("line", (line) => {
     send({
       type: "auth_login_result",
       stream_id: envelope.stream_id,
-      message_id: crypto.randomUUID(),
+      message_id: ulid(),
       sequence: nextSeq(envelope.stream_id),
       timestamp: Date.now(),
       version: 1,
@@ -113,7 +113,7 @@ rl.on("line", (line) => {
     send({
       type: "auth_event",
       stream_id: envelope.stream_id,
-      message_id: crypto.randomUUID(),
+      message_id: ulid(),
       sequence: nextSeq(envelope.stream_id),
       timestamp: Date.now(),
       version: 1,
@@ -124,7 +124,7 @@ rl.on("line", (line) => {
     send({
       type: "auth_login_result",
       stream_id: envelope.stream_id,
-      message_id: crypto.randomUUID(),
+      message_id: ulid(),
       sequence: nextSeq(envelope.stream_id),
       timestamp: Date.now(),
       version: 1,

--- a/typescript/test/fixtures/auth-protocol-providers-server.js
+++ b/typescript/test/fixtures/auth-protocol-providers-server.js
@@ -1,7 +1,7 @@
 // Fixture stdio server that emulates the auth protocol path of `makai --stdio`
 // for the `auth_providers_request` envelope. Used by typescript SDK tests.
 const readline = require("node:readline");
-const crypto = require("node:crypto");
+const { ulid } = require("ulid");
 
 process.stdout.write(JSON.stringify({ type: "ready", protocol_version: "1" }) + "\n");
 
@@ -30,7 +30,7 @@ rl.on("line", (line) => {
     send({
       type: "ack",
       stream_id: envelope.stream_id,
-      message_id: crypto.randomUUID(),
+      message_id: ulid(),
       sequence: nextSeq(envelope.stream_id),
       in_reply_to: envelope.message_id,
       timestamp: Date.now(),
@@ -40,7 +40,7 @@ rl.on("line", (line) => {
     send({
       type: "auth_providers_response",
       stream_id: envelope.stream_id,
-      message_id: crypto.randomUUID(),
+      message_id: ulid(),
       sequence: nextSeq(envelope.stream_id),
       in_reply_to: envelope.message_id,
       timestamp: Date.now(),

--- a/zig/src/protocol/agent/client.zig
+++ b/zig/src/protocol/agent/client.zig
@@ -9,14 +9,14 @@ pub const AgentProtocolClient = struct {
     sender: ?transport.AsyncSender = null,
     /// Deprecated compatibility field; sequence is now tracked per session.
     sequence: u64 = 0,
-    session_id: ?agent_types.Uuid = null,
+    session_id: ?agent_types.SessionId = null,
     last_error: OwnedSlice(u8) = OwnedSlice(u8).initBorrowed(""),
     last_result_json: OwnedSlice(u8) = OwnedSlice(u8).initBorrowed(""),
     event_queue: std.ArrayList(OwnedSlice(u8)),
-    next_sequence_by_session: std.AutoHashMap(agent_types.Uuid, u64),
-    session_complete_flags: std.AutoHashMap(agent_types.Uuid, bool),
-    session_last_errors: std.AutoHashMap(agent_types.Uuid, OwnedSlice(u8)),
-    session_last_results: std.AutoHashMap(agent_types.Uuid, OwnedSlice(u8)),
+    next_sequence_by_session: std.AutoHashMap(agent_types.Ulid, u64),
+    session_complete_flags: std.AutoHashMap(agent_types.Ulid, bool),
+    session_last_errors: std.AutoHashMap(agent_types.Ulid, OwnedSlice(u8)),
+    session_last_results: std.AutoHashMap(agent_types.Ulid, OwnedSlice(u8)),
 
     const Self = @This();
 
@@ -24,10 +24,10 @@ pub const AgentProtocolClient = struct {
         return .{
             .allocator = allocator,
             .event_queue = std.ArrayList(OwnedSlice(u8)){},
-            .next_sequence_by_session = std.AutoHashMap(agent_types.Uuid, u64).init(allocator),
-            .session_complete_flags = std.AutoHashMap(agent_types.Uuid, bool).init(allocator),
-            .session_last_errors = std.AutoHashMap(agent_types.Uuid, OwnedSlice(u8)).init(allocator),
-            .session_last_results = std.AutoHashMap(agent_types.Uuid, OwnedSlice(u8)).init(allocator),
+            .next_sequence_by_session = std.AutoHashMap(agent_types.Ulid, u64).init(allocator),
+            .session_complete_flags = std.AutoHashMap(agent_types.Ulid, bool).init(allocator),
+            .session_last_errors = std.AutoHashMap(agent_types.Ulid, OwnedSlice(u8)).init(allocator),
+            .session_last_results = std.AutoHashMap(agent_types.Ulid, OwnedSlice(u8)).init(allocator),
         };
     }
 
@@ -58,16 +58,16 @@ pub const AgentProtocolClient = struct {
         self.sender = sender;
     }
 
-    fn nextSequence(self: *Self, session_id: agent_types.Uuid) !u64 {
+    fn nextSequence(self: *Self, session_id: agent_types.SessionId) !u64 {
         const next = if (self.next_sequence_by_session.get(session_id)) |cur| cur + 1 else 1;
         try self.next_sequence_by_session.put(session_id, next);
         self.sequence = next; // compatibility mirror
         return next;
     }
 
-    pub fn sendAgentStart(self: *Self, config_json: []const u8, system_prompt: ?[]const u8) !agent_types.Uuid {
-        const sid = agent_types.generateUuid();
-        const msg_id = agent_types.generateUuid();
+    pub fn sendAgentStart(self: *Self, config_json: []const u8, system_prompt: ?[]const u8) !agent_types.SessionId {
+        const sid = agent_types.generateUlid();
+        const msg_id = agent_types.generateUlid();
         const seq = try self.nextSequence(sid);
 
         var payload = agent_types.Payload{ .agent_start = .{ .config_json = try self.allocator.dupe(u8, config_json), .session_id = sid } };
@@ -87,8 +87,8 @@ pub const AgentProtocolClient = struct {
         return msg_id;
     }
 
-    pub fn sendAgentMessage(self: *Self, session_id: agent_types.Uuid, message_json: []const u8, options_json: ?[]const u8) !agent_types.Uuid {
-        const msg_id = agent_types.generateUuid();
+    pub fn sendAgentMessage(self: *Self, session_id: agent_types.SessionId, message_json: []const u8, options_json: ?[]const u8) !agent_types.SessionId {
+        const msg_id = agent_types.generateUlid();
         const seq = try self.nextSequence(session_id);
 
         var payload = agent_types.Payload{ .agent_message = .{
@@ -108,8 +108,8 @@ pub const AgentProtocolClient = struct {
         return msg_id;
     }
 
-    pub fn sendAgentStop(self: *Self, session_id: agent_types.Uuid, reason: ?[]const u8) !agent_types.Uuid {
-        const msg_id = agent_types.generateUuid();
+    pub fn sendAgentStop(self: *Self, session_id: agent_types.SessionId, reason: ?[]const u8) !agent_types.SessionId {
+        const msg_id = agent_types.generateUlid();
         const seq = try self.nextSequence(session_id);
 
         var payload = agent_types.Payload{ .agent_stop = .{ .session_id = session_id } };
@@ -134,7 +134,7 @@ pub const AgentProtocolClient = struct {
         try self.sender.?.flush();
     }
 
-    fn setSessionError(self: *Self, session_id: agent_types.Uuid, msg: []const u8) !void {
+    fn setSessionError(self: *Self, session_id: agent_types.SessionId, msg: []const u8) !void {
         if (self.session_last_errors.getPtr(session_id)) |existing| {
             existing.deinit(self.allocator);
             existing.* = OwnedSlice(u8).initOwned(try self.allocator.dupe(u8, msg));
@@ -144,7 +144,7 @@ pub const AgentProtocolClient = struct {
         try self.session_complete_flags.put(session_id, true);
     }
 
-    fn setSessionResult(self: *Self, session_id: agent_types.Uuid, result_json: []const u8) !void {
+    fn setSessionResult(self: *Self, session_id: agent_types.SessionId, result_json: []const u8) !void {
         if (self.session_last_results.getPtr(session_id)) |existing| {
             existing.deinit(self.allocator);
             existing.* = OwnedSlice(u8).initOwned(try self.allocator.dupe(u8, result_json));
@@ -154,7 +154,7 @@ pub const AgentProtocolClient = struct {
         try self.session_complete_flags.put(session_id, true);
     }
 
-    fn clearSessionTerminalState(self: *Self, session_id: agent_types.Uuid) void {
+    fn clearSessionTerminalState(self: *Self, session_id: agent_types.SessionId) void {
         if (self.session_last_errors.fetchRemove(session_id)) |entry| {
             var err = entry.value;
             err.deinit(self.allocator);
@@ -209,11 +209,11 @@ pub const AgentProtocolClient = struct {
         return if (json.len == 0) null else json;
     }
 
-    pub fn isSessionComplete(self: *Self, session_id: agent_types.Uuid) bool {
+    pub fn isSessionComplete(self: *Self, session_id: agent_types.SessionId) bool {
         return self.session_complete_flags.get(session_id) orelse false;
     }
 
-    pub fn getLastErrorForSession(self: *Self, session_id: agent_types.Uuid) ?[]const u8 {
+    pub fn getLastErrorForSession(self: *Self, session_id: agent_types.SessionId) ?[]const u8 {
         if (self.session_last_errors.get(session_id)) |err| {
             const msg = err.slice();
             if (msg.len > 0) return msg;
@@ -221,7 +221,7 @@ pub const AgentProtocolClient = struct {
         return null;
     }
 
-    pub fn getLastResultJsonForSession(self: *Self, session_id: agent_types.Uuid) ?[]const u8 {
+    pub fn getLastResultJsonForSession(self: *Self, session_id: agent_types.SessionId) ?[]const u8 {
         if (self.session_last_results.get(session_id)) |result| {
             const json = result.slice();
             if (json.len > 0) return json;
@@ -229,7 +229,7 @@ pub const AgentProtocolClient = struct {
         return null;
     }
 
-    pub fn removeSessionState(self: *Self, session_id: agent_types.Uuid) void {
+    pub fn removeSessionState(self: *Self, session_id: agent_types.SessionId) void {
         _ = self.next_sequence_by_session.remove(session_id);
         _ = self.session_complete_flags.remove(session_id);
 
@@ -259,11 +259,11 @@ test "AgentProtocolClient processes events and results" {
     var client = AgentProtocolClient.init(allocator);
     defer client.deinit();
 
-    const sid = agent_types.generateUuid();
+    const sid = agent_types.generateUlid();
 
     try client.processEnvelope(.{
         .session_id = sid,
-        .message_id = agent_types.generateUuid(),
+        .message_id = agent_types.generateUlid(),
         .sequence = 1,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .agent_started = .{ .session_id = sid } },
@@ -271,7 +271,7 @@ test "AgentProtocolClient processes events and results" {
 
     var event_env = agent_types.Envelope{
         .session_id = sid,
-        .message_id = agent_types.generateUuid(),
+        .message_id = agent_types.generateUlid(),
         .sequence = 2,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .agent_event = try allocator.dupe(u8, "{\"type\":\"turn_start\"}") },
@@ -281,7 +281,7 @@ test "AgentProtocolClient processes events and results" {
 
     var result_env = agent_types.Envelope{
         .session_id = sid,
-        .message_id = agent_types.generateUuid(),
+        .message_id = agent_types.generateUlid(),
         .sequence = 3,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .agent_result = try allocator.dupe(u8, "{\"ok\":true}") },
@@ -302,7 +302,7 @@ test "AgentProtocolClient removeSessionState clears per-session and legacy curre
     var client = AgentProtocolClient.init(allocator);
     defer client.deinit();
 
-    const sid = agent_types.generateUuid();
+    const sid = agent_types.generateUlid();
     client.session_id = sid;
     try client.session_complete_flags.put(sid, true);
     try client.session_last_errors.put(sid, OwnedSlice(u8).initOwned(try allocator.dupe(u8, "session err")));
@@ -353,8 +353,8 @@ test "AgentProtocolClient maintains per-session sequence continuity across stop 
     defer client.deinit();
     client.setSender(sender);
 
-    const sid1 = agent_types.generateUuid();
-    const sid2 = agent_types.generateUuid();
+    const sid1 = agent_types.generateUlid();
+    const sid2 = agent_types.generateUlid();
 
     _ = try client.sendAgentMessage(sid1, "{\"m\":1}", null); // sid1 seq 1
     _ = try client.sendAgentMessage(sid2, "{\"m\":2}", null); // sid2 seq 1
@@ -362,7 +362,7 @@ test "AgentProtocolClient maintains per-session sequence continuity across stop 
 
     var stopped_env = agent_types.Envelope{
         .session_id = sid1,
-        .message_id = agent_types.generateUuid(),
+        .message_id = agent_types.generateUlid(),
         .sequence = 10,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .agent_stopped = .{ .session_id = sid1 } },

--- a/zig/src/protocol/agent/envelope.zig
+++ b/zig/src/protocol/agent/envelope.zig
@@ -14,11 +14,11 @@ pub fn serializeEnvelope(env: agent_types.Envelope, allocator: std.mem.Allocator
     try w.beginObject();
     try w.writeStringField("type", @tagName(env.payload));
 
-    const session_id_str = try agent_types.uuidToString(env.session_id, allocator);
+    const session_id_str = try agent_types.ulidToString(env.session_id, allocator);
     defer allocator.free(session_id_str);
     try w.writeStringField("session_id", session_id_str);
 
-    const message_id_str = try agent_types.uuidToString(env.message_id, allocator);
+    const message_id_str = try agent_types.ulidToString(env.message_id, allocator);
     defer allocator.free(message_id_str);
     try w.writeStringField("message_id", message_id_str);
 
@@ -27,7 +27,7 @@ pub fn serializeEnvelope(env: agent_types.Envelope, allocator: std.mem.Allocator
     try w.writeIntField("version", env.version);
 
     if (env.in_reply_to) |reply_to| {
-        const reply_str = try agent_types.uuidToString(reply_to, allocator);
+        const reply_str = try agent_types.ulidToString(reply_to, allocator);
         defer allocator.free(reply_str);
         try w.writeStringField("in_reply_to", reply_str);
     }
@@ -49,26 +49,26 @@ fn serializePayload(w: *json_writer.JsonWriter, payload: agent_types.Payload, al
             try w.writeStringField("config_json", p.config_json);
             if (p.getSystemPrompt()) |prompt| try w.writeStringField("system_prompt", prompt);
             if (p.session_id) |id| {
-                const id_str = try agent_types.uuidToString(id, allocator);
+                const id_str = try agent_types.ulidToString(id, allocator);
                 defer allocator.free(id_str);
                 try w.writeStringField("resume_session_id", id_str);
             }
         },
         .agent_message => |p| {
-            const session_id = try agent_types.uuidToString(p.session_id, allocator);
+            const session_id = try agent_types.ulidToString(p.session_id, allocator);
             defer allocator.free(session_id);
             try w.writeStringField("session_id", session_id);
             try w.writeStringField("message_json", p.message_json);
             if (p.getOptionsJson()) |opts| try w.writeStringField("options_json", opts);
         },
         .agent_stop => |p| {
-            const session_id = try agent_types.uuidToString(p.session_id, allocator);
+            const session_id = try agent_types.ulidToString(p.session_id, allocator);
             defer allocator.free(session_id);
             try w.writeStringField("session_id", session_id);
             if (p.getReason()) |reason| try w.writeStringField("reason", reason);
         },
         .agent_status => |p| {
-            const session_id = try agent_types.uuidToString(p.session_id, allocator);
+            const session_id = try agent_types.ulidToString(p.session_id, allocator);
             defer allocator.free(session_id);
             try w.writeStringField("session_id", session_id);
         },
@@ -76,14 +76,14 @@ fn serializePayload(w: *json_writer.JsonWriter, payload: agent_types.Payload, al
             if (p.getPrefix()) |prefix| try w.writeStringField("prefix", prefix);
         },
         .agent_started => |p| {
-            const session_id = try agent_types.uuidToString(p.session_id, allocator);
+            const session_id = try agent_types.ulidToString(p.session_id, allocator);
             defer allocator.free(session_id);
             try w.writeStringField("session_id", session_id);
         },
         .agent_event => |p| try w.writeStringField("event_json", p),
         .agent_result => |p| try w.writeStringField("result_json", p),
         .agent_stopped => |p| {
-            const session_id = try agent_types.uuidToString(p.session_id, allocator);
+            const session_id = try agent_types.ulidToString(p.session_id, allocator);
             defer allocator.free(session_id);
             try w.writeStringField("session_id", session_id);
             if (p.getReason()) |reason| try w.writeStringField("reason", reason);
@@ -93,7 +93,7 @@ fn serializePayload(w: *json_writer.JsonWriter, payload: agent_types.Payload, al
             try w.writeStringField("message", p.message);
         },
         .session_info => |p| {
-            const session_id = try agent_types.uuidToString(p.session_id, allocator);
+            const session_id = try agent_types.ulidToString(p.session_id, allocator);
             defer allocator.free(session_id);
             try w.writeStringField("session_id", session_id);
             try w.writeStringField("status", @tagName(p.status));
@@ -136,12 +136,12 @@ fn serializePayload(w: *json_writer.JsonWriter, payload: agent_types.Payload, al
             if (p.getReason()) |reason| try w.writeStringField("reason", reason);
         },
         .ack => |p| {
-            const ack_id = try agent_types.uuidToString(p.acknowledged_id, allocator);
+            const ack_id = try agent_types.ulidToString(p.acknowledged_id, allocator);
             defer allocator.free(ack_id);
             try w.writeStringField("acknowledged_id", ack_id);
         },
         .nack => |p| {
-            const rejected_id = try agent_types.uuidToString(p.rejected_id, allocator);
+            const rejected_id = try agent_types.ulidToString(p.rejected_id, allocator);
             defer allocator.free(rejected_id);
             try w.writeStringField("rejected_id", rejected_id);
             try w.writeStringField("reason", p.reason.slice());
@@ -223,14 +223,14 @@ pub fn deserializeEnvelope(json: []const u8, allocator: std.mem.Allocator) !agen
 
     const root = parsed.value.object;
     const type_str = root.get("type").?.string;
-    const session_id = parseUuidOrError(root.get("session_id").?.string) orelse return error.InvalidUuid;
-    const message_id = parseUuidOrError(root.get("message_id").?.string) orelse return error.InvalidUuid;
+    const session_id = parseUlidOrError(root.get("session_id").?.string) orelse return error.InvalidUlid;
+    const message_id = parseUlidOrError(root.get("message_id").?.string) orelse return error.InvalidUlid;
     const sequence = @as(u64, @intCast(root.get("sequence").?.integer));
     const timestamp = root.get("timestamp").?.integer;
     const version = @as(u8, @intCast(root.get("version").?.integer));
 
-    var in_reply_to: ?agent_types.Uuid = null;
-    if (root.get("in_reply_to")) |v| in_reply_to = try parseUuidRequired(v.string);
+    var in_reply_to: ?agent_types.SessionId = null;
+    if (root.get("in_reply_to")) |v| in_reply_to = try parseUlidRequired(v.string);
 
     const payload_obj = root.get("payload").?.object;
     const payload = try deserializePayload(type_str, payload_obj, allocator);
@@ -246,12 +246,12 @@ pub fn deserializeEnvelope(json: []const u8, allocator: std.mem.Allocator) !agen
     };
 }
 
-fn parseUuidRequired(str: []const u8) !agent_types.Uuid {
-    return agent_types.parseUuid(str) orelse error.InvalidUuid;
+fn parseUlidRequired(str: []const u8) !agent_types.SessionId {
+    return agent_types.parseUlid(str) orelse error.InvalidUlid;
 }
 
-fn parseUuidOrError(str: []const u8) ?agent_types.Uuid {
-    return agent_types.parseUuid(str);
+fn parseUlidOrError(str: []const u8) ?agent_types.SessionId {
+    return agent_types.parseUlid(str);
 }
 
 fn deserializePayload(type_str: []const u8, payload: std.json.ObjectMap, allocator: std.mem.Allocator) !agent_types.Payload {
@@ -259,25 +259,25 @@ fn deserializePayload(type_str: []const u8, payload: std.json.ObjectMap, allocat
         const config = try allocator.dupe(u8, payload.get("config_json").?.string);
         var result = agent_types.AgentStartRequest{ .config_json = config };
         if (payload.get("system_prompt")) |v| result.system_prompt = OwnedSlice(u8).initOwned(try allocator.dupe(u8, v.string));
-        if (payload.get("resume_session_id")) |v| result.session_id = try parseUuidRequired(v.string);
+        if (payload.get("resume_session_id")) |v| result.session_id = try parseUlidRequired(v.string);
         return .{ .agent_start = result };
     }
     if (std.mem.eql(u8, type_str, "agent_message")) {
         const msg = try allocator.dupe(u8, payload.get("message_json").?.string);
         var req = agent_types.AgentMessageRequest{
-            .session_id = try parseUuidRequired(payload.get("session_id").?.string),
+            .session_id = try parseUlidRequired(payload.get("session_id").?.string),
             .message_json = msg,
         };
         if (payload.get("options_json")) |v| req.options_json = OwnedSlice(u8).initOwned(try allocator.dupe(u8, v.string));
         return .{ .agent_message = req };
     }
     if (std.mem.eql(u8, type_str, "agent_stop")) {
-        var req = agent_types.AgentStopRequest{ .session_id = try parseUuidRequired(payload.get("session_id").?.string) };
+        var req = agent_types.AgentStopRequest{ .session_id = try parseUlidRequired(payload.get("session_id").?.string) };
         if (payload.get("reason")) |v| req.reason = OwnedSlice(u8).initOwned(try allocator.dupe(u8, v.string));
         return .{ .agent_stop = req };
     }
     if (std.mem.eql(u8, type_str, "agent_status")) {
-        return .{ .agent_status = .{ .session_id = try parseUuidRequired(payload.get("session_id").?.string) } };
+        return .{ .agent_status = .{ .session_id = try parseUlidRequired(payload.get("session_id").?.string) } };
     }
     if (std.mem.eql(u8, type_str, "tool_list")) {
         var req = agent_types.ToolListRequest{};
@@ -285,12 +285,12 @@ fn deserializePayload(type_str: []const u8, payload: std.json.ObjectMap, allocat
         return .{ .tool_list = req };
     }
     if (std.mem.eql(u8, type_str, "agent_started")) {
-        return .{ .agent_started = .{ .session_id = try parseUuidRequired(payload.get("session_id").?.string) } };
+        return .{ .agent_started = .{ .session_id = try parseUlidRequired(payload.get("session_id").?.string) } };
     }
     if (std.mem.eql(u8, type_str, "agent_event")) return .{ .agent_event = try allocator.dupe(u8, payload.get("event_json").?.string) };
     if (std.mem.eql(u8, type_str, "agent_result")) return .{ .agent_result = try allocator.dupe(u8, payload.get("result_json").?.string) };
     if (std.mem.eql(u8, type_str, "agent_stopped")) {
-        var stopped = agent_types.AgentStopped{ .session_id = try parseUuidRequired(payload.get("session_id").?.string) };
+        var stopped = agent_types.AgentStopped{ .session_id = try parseUlidRequired(payload.get("session_id").?.string) };
         if (payload.get("reason")) |v| stopped.reason = OwnedSlice(u8).initOwned(try allocator.dupe(u8, v.string));
         return .{ .agent_stopped = stopped };
     }
@@ -302,7 +302,7 @@ fn deserializePayload(type_str: []const u8, payload: std.json.ObjectMap, allocat
     }
     if (std.mem.eql(u8, type_str, "session_info")) {
         return .{ .session_info = .{
-            .session_id = try parseUuidRequired(payload.get("session_id").?.string),
+            .session_id = try parseUlidRequired(payload.get("session_id").?.string),
             .status = std.meta.stringToEnum(agent_types.AgentStatus, payload.get("status").?.string) orelse .@"error",
             .model = try allocator.dupe(u8, payload.get("model").?.string),
             .message_count = @as(u32, @intCast(payload.get("message_count").?.integer)),
@@ -354,10 +354,10 @@ fn deserializePayload(type_str: []const u8, payload: std.json.ObjectMap, allocat
         return .{ .goodbye = g };
     }
     if (std.mem.eql(u8, type_str, "ack")) {
-        return .{ .ack = .{ .acknowledged_id = try parseUuidRequired(payload.get("acknowledged_id").?.string) } };
+        return .{ .ack = .{ .acknowledged_id = try parseUlidRequired(payload.get("acknowledged_id").?.string) } };
     }
     if (std.mem.eql(u8, type_str, "nack")) {
-        const rejected_id = try parseUuidRequired(payload.get("rejected_id").?.string);
+        const rejected_id = try parseUlidRequired(payload.get("rejected_id").?.string);
         const reason = OwnedSlice(u8).initOwned(try allocator.dupe(u8, payload.get("reason").?.string));
         // forward-compat: unknown error codes degrade to null rather than
         // failing deserialization. This is intentional asymmetry from the
@@ -597,17 +597,17 @@ fn parseReasoningLevel(str: []const u8) error{InvalidEnumValue}!model_catalog_ty
     return error.InvalidEnumValue;
 }
 
-test "deserializeEnvelope rejects invalid uuid" {
+test "deserializeEnvelope rejects invalid ulid" {
     const allocator = std.testing.allocator;
     const bad =
-        "{\"type\":\"ping\",\"session_id\":\"not-a-uuid\",\"message_id\":\"not-a-uuid\",\"sequence\":1,\"timestamp\":1,\"version\":1,\"payload\":{}}";
-    try std.testing.expectError(error.InvalidUuid, deserializeEnvelope(bad, allocator));
+        "{\"type\":\"ping\",\"session_id\":\"not-a-ulid\",\"message_id\":\"not-a-ulid\",\"sequence\":1,\"timestamp\":1,\"version\":1,\"payload\":{}}";
+    try std.testing.expectError(error.InvalidUlid, deserializeEnvelope(bad, allocator));
 }
 
 test "deserializeEnvelope rejects unknown payload type" {
     const allocator = std.testing.allocator;
-    const sid = "00000000-0000-0000-0000-000000000001";
-    const mid = "00000000-0000-0000-0000-000000000002";
+    const sid = "00000000000000000000000001";
+    const mid = "00000000000000000000000002";
     const bad = try std.fmt.allocPrint(
         allocator,
         "{{\"type\":\"not_real\",\"session_id\":\"{s}\",\"message_id\":\"{s}\",\"sequence\":1,\"timestamp\":1,\"version\":1,\"payload\":{{}}}}",
@@ -621,12 +621,12 @@ test "agent envelope roundtrip" {
     const allocator = std.testing.allocator;
 
     var env = agent_types.Envelope{
-        .session_id = agent_types.generateUuid(),
-        .message_id = agent_types.generateUuid(),
+        .session_id = agent_types.generateUlid(),
+        .message_id = agent_types.generateUlid(),
         .sequence = 1,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .agent_message = .{
-            .session_id = agent_types.generateUuid(),
+            .session_id = agent_types.generateUlid(),
             .message_json = try allocator.dupe(u8, "{\"role\":\"user\"}"),
             .options_json = OwnedSlice(u8).initOwned(try allocator.dupe(u8, "{\"temperature\":0.5}")),
         } },
@@ -647,8 +647,8 @@ test "agent envelope roundtrip for models_request" {
     const allocator = std.testing.allocator;
 
     var env = agent_types.Envelope{
-        .session_id = agent_types.generateUuid(),
-        .message_id = agent_types.generateUuid(),
+        .session_id = agent_types.generateUlid(),
+        .message_id = agent_types.generateUlid(),
         .sequence = 1,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .models_request = .{
@@ -708,8 +708,8 @@ test "agent envelope roundtrip for models_response preserves shape" {
     };
 
     var env = agent_types.Envelope{
-        .session_id = agent_types.generateUuid(),
-        .message_id = agent_types.generateUuid(),
+        .session_id = agent_types.generateUlid(),
+        .message_id = agent_types.generateUlid(),
         .sequence = 2,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .models_response = .{
@@ -749,10 +749,10 @@ test "agent envelope roundtrip for models_response preserves shape" {
 test "agent envelope roundtrip for ack and nack" {
     const allocator = std.testing.allocator;
 
-    const acked_id = agent_types.generateUuid();
+    const acked_id = agent_types.generateUlid();
     var ack_env = agent_types.Envelope{
-        .session_id = agent_types.generateUuid(),
-        .message_id = agent_types.generateUuid(),
+        .session_id = agent_types.generateUlid(),
+        .message_id = agent_types.generateUlid(),
         .sequence = 1,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .ack = .{ .acknowledged_id = acked_id } },
@@ -768,10 +768,10 @@ test "agent envelope roundtrip for ack and nack" {
     try std.testing.expect(parsed_ack.payload == .ack);
     try std.testing.expectEqualSlices(u8, &acked_id, &parsed_ack.payload.ack.acknowledged_id);
 
-    const rejected_id = agent_types.generateUuid();
+    const rejected_id = agent_types.generateUlid();
     var nack_env = agent_types.Envelope{
-        .session_id = agent_types.generateUuid(),
-        .message_id = agent_types.generateUuid(),
+        .session_id = agent_types.generateUlid(),
+        .message_id = agent_types.generateUlid(),
         .sequence = 1,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .nack = .{

--- a/zig/src/protocol/agent/server.zig
+++ b/zig/src/protocol/agent/server.zig
@@ -3,7 +3,7 @@ const agent_types = @import("agent_types");
 const OwnedSlice = @import("owned_slice").OwnedSlice;
 
 pub const SessionState = struct {
-    session_id: agent_types.Uuid,
+    session_id: agent_types.SessionId,
     status: agent_types.AgentStatus,
     model: []const u8,
     message_count: u32,
@@ -46,9 +46,9 @@ pub const Options = struct {
 
 pub const AgentProtocolServer = struct {
     allocator: std.mem.Allocator,
-    sessions: std.AutoHashMap(agent_types.Uuid, SessionState),
-    expected_sequences: std.AutoHashMap(agent_types.Uuid, u64),
-    outgoing_sequences: std.AutoHashMap(agent_types.Uuid, u64),
+    sessions: std.AutoHashMap(agent_types.Ulid, SessionState),
+    expected_sequences: std.AutoHashMap(agent_types.Ulid, u64),
+    outgoing_sequences: std.AutoHashMap(agent_types.Ulid, u64),
     outbox: std.ArrayList(agent_types.Envelope),
     options: Options,
 
@@ -61,9 +61,9 @@ pub const AgentProtocolServer = struct {
     pub fn initWithOptions(allocator: std.mem.Allocator, options: Options) Self {
         return .{
             .allocator = allocator,
-            .sessions = std.AutoHashMap(agent_types.Uuid, SessionState).init(allocator),
-            .expected_sequences = std.AutoHashMap(agent_types.Uuid, u64).init(allocator),
-            .outgoing_sequences = std.AutoHashMap(agent_types.Uuid, u64).init(allocator),
+            .sessions = std.AutoHashMap(agent_types.Ulid, SessionState).init(allocator),
+            .expected_sequences = std.AutoHashMap(agent_types.Ulid, u64).init(allocator),
+            .outgoing_sequences = std.AutoHashMap(agent_types.Ulid, u64).init(allocator),
             .outbox = std.ArrayList(agent_types.Envelope){},
             .options = options,
         };
@@ -98,7 +98,7 @@ pub const AgentProtocolServer = struct {
             .tool_list => |_| {
                 return .{
                     .session_id = env.session_id,
-                    .message_id = agent_types.generateUuid(),
+                    .message_id = agent_types.generateUlid(),
                     .sequence = env.sequence,
                     .in_reply_to = env.message_id,
                     .timestamp = std.time.milliTimestamp(),
@@ -106,10 +106,10 @@ pub const AgentProtocolServer = struct {
                 };
             },
             .ping => {
-                const ping_id = try agent_types.uuidToString(env.message_id, self.allocator);
+                const ping_id = try agent_types.ulidToString(env.message_id, self.allocator);
                 return .{
                     .session_id = env.session_id,
-                    .message_id = agent_types.generateUuid(),
+                    .message_id = agent_types.generateUlid(),
                     .sequence = env.sequence,
                     .in_reply_to = env.message_id,
                     .timestamp = std.time.milliTimestamp(),
@@ -128,7 +128,7 @@ pub const AgentProtocolServer = struct {
             return try self.makeError(env.session_id, env.message_id, .invalid_request, "agent_start sequence must be 1");
         }
 
-        const session_id = req.session_id orelse agent_types.generateUuid();
+        const session_id = req.session_id orelse agent_types.generateUlid();
         if (self.sessions.contains(session_id)) {
             return try self.makeError(env.session_id, env.message_id, .agent_busy, "session already exists");
         }
@@ -147,7 +147,7 @@ pub const AgentProtocolServer = struct {
 
         return .{
             .session_id = session_id,
-            .message_id = agent_types.generateUuid(),
+            .message_id = agent_types.generateUlid(),
             .sequence = self.nextOutgoingSequence(session_id),
             .in_reply_to = env.message_id,
             .timestamp = now,
@@ -184,7 +184,7 @@ pub const AgentProtocolServer = struct {
         const reason = if (req.getReason()) |r| try self.allocator.dupe(u8, r) else try self.allocator.dupe(u8, "stopped");
         return .{
             .session_id = req.session_id,
-            .message_id = agent_types.generateUuid(),
+            .message_id = agent_types.generateUlid(),
             .sequence = env.sequence,
             .in_reply_to = env.message_id,
             .timestamp = std.time.milliTimestamp(),
@@ -202,7 +202,7 @@ pub const AgentProtocolServer = struct {
 
         return .{
             .session_id = req.session_id,
-            .message_id = agent_types.generateUuid(),
+            .message_id = agent_types.generateUlid(),
             .sequence = env.sequence,
             .in_reply_to = env.message_id,
             .timestamp = std.time.milliTimestamp(),
@@ -277,7 +277,7 @@ pub const AgentProtocolServer = struct {
         const ack_seq = self.nextOutgoingSequence(env.session_id);
         const ack_envelope = agent_types.Envelope{
             .session_id = env.session_id,
-            .message_id = agent_types.generateUuid(),
+            .message_id = agent_types.generateUlid(),
             .sequence = ack_seq,
             .in_reply_to = env.message_id,
             .timestamp = std.time.milliTimestamp(),
@@ -287,7 +287,7 @@ pub const AgentProtocolServer = struct {
         const response_seq = self.nextOutgoingSequence(env.session_id);
         try self.outbox.append(self.allocator, .{
             .session_id = env.session_id,
-            .message_id = agent_types.generateUuid(),
+            .message_id = agent_types.generateUlid(),
             .sequence = response_seq,
             .in_reply_to = env.message_id,
             .timestamp = std.time.milliTimestamp(),
@@ -299,15 +299,15 @@ pub const AgentProtocolServer = struct {
 
     fn makeModelsNack(
         self: *Self,
-        session_id: agent_types.Uuid,
-        in_reply_to: agent_types.Uuid,
+        session_id: agent_types.SessionId,
+        in_reply_to: agent_types.SessionId,
         code: agent_types.ErrorCode,
         msg: []const u8,
     ) !agent_types.Envelope {
         const reason = try self.allocator.dupe(u8, msg);
         return .{
             .session_id = session_id,
-            .message_id = agent_types.generateUuid(),
+            .message_id = agent_types.generateUlid(),
             .sequence = self.nextOutgoingSequence(session_id),
             .in_reply_to = in_reply_to,
             .timestamp = std.time.milliTimestamp(),
@@ -319,10 +319,10 @@ pub const AgentProtocolServer = struct {
         };
     }
 
-    fn makeError(self: *Self, session_id: agent_types.Uuid, in_reply_to: agent_types.Uuid, code: agent_types.AgentErrorCode, msg: []const u8) !agent_types.Envelope {
+    fn makeError(self: *Self, session_id: agent_types.SessionId, in_reply_to: agent_types.SessionId, code: agent_types.AgentErrorCode, msg: []const u8) !agent_types.Envelope {
         return .{
             .session_id = session_id,
-            .message_id = agent_types.generateUuid(),
+            .message_id = agent_types.generateUlid(),
             .sequence = 0,
             .in_reply_to = in_reply_to,
             .timestamp = std.time.milliTimestamp(),
@@ -333,29 +333,29 @@ pub const AgentProtocolServer = struct {
         };
     }
 
-    fn nextOutgoingSequence(self: *Self, session_id: agent_types.Uuid) u64 {
+    fn nextOutgoingSequence(self: *Self, session_id: agent_types.SessionId) u64 {
         const cur = self.outgoing_sequences.get(session_id) orelse 0;
         const next = cur + 1;
         self.outgoing_sequences.put(session_id, next) catch {};
         return next;
     }
 
-    pub fn publishAgentEvent(self: *Self, session_id: agent_types.Uuid, event_json: []const u8) !void {
+    pub fn publishAgentEvent(self: *Self, session_id: agent_types.SessionId, event_json: []const u8) !void {
         if (!self.sessions.contains(session_id)) return error.SessionNotFound;
         try self.outbox.append(self.allocator, .{
             .session_id = session_id,
-            .message_id = agent_types.generateUuid(),
+            .message_id = agent_types.generateUlid(),
             .sequence = self.nextOutgoingSequence(session_id),
             .timestamp = std.time.milliTimestamp(),
             .payload = .{ .agent_event = try self.allocator.dupe(u8, event_json) },
         });
     }
 
-    pub fn publishAgentResult(self: *Self, session_id: agent_types.Uuid, result_json: []const u8) !void {
+    pub fn publishAgentResult(self: *Self, session_id: agent_types.SessionId, result_json: []const u8) !void {
         if (!self.sessions.contains(session_id)) return error.SessionNotFound;
         try self.outbox.append(self.allocator, .{
             .session_id = session_id,
-            .message_id = agent_types.generateUuid(),
+            .message_id = agent_types.generateUlid(),
             .sequence = self.nextOutgoingSequence(session_id),
             .timestamp = std.time.milliTimestamp(),
             .payload = .{ .agent_result = try self.allocator.dupe(u8, result_json) },
@@ -374,8 +374,8 @@ test "AgentProtocolServer rejects invalid start sequence" {
     defer server.deinit();
 
     var start = agent_types.Envelope{
-        .session_id = agent_types.generateUuid(),
-        .message_id = agent_types.generateUuid(),
+        .session_id = agent_types.generateUlid(),
+        .message_id = agent_types.generateUlid(),
         .sequence = 2,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .agent_start = .{ .config_json = try allocator.dupe(u8, "{}") } },
@@ -394,10 +394,10 @@ test "AgentProtocolServer rejects unknown session message" {
     var server = AgentProtocolServer.init(allocator);
     defer server.deinit();
 
-    const sid = agent_types.generateUuid();
+    const sid = agent_types.generateUlid();
     var msg = agent_types.Envelope{
         .session_id = sid,
-        .message_id = agent_types.generateUuid(),
+        .message_id = agent_types.generateUlid(),
         .sequence = 1,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .agent_message = .{
@@ -505,8 +505,8 @@ test "handleModelsRequest emits ack then models_response with same shape as prov
     defer server.deinit();
 
     var request = agent_types.Envelope{
-        .session_id = agent_types.generateUuid(),
-        .message_id = agent_types.generateUuid(),
+        .session_id = agent_types.generateUlid(),
+        .message_id = agent_types.generateUlid(),
         .sequence = 1,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .models_request = .{
@@ -559,8 +559,8 @@ test "handleModelsRequest returns not_implemented nack when unsupported" {
     defer server.deinit();
 
     var request = agent_types.Envelope{
-        .session_id = agent_types.generateUuid(),
-        .message_id = agent_types.generateUuid(),
+        .session_id = agent_types.generateUlid(),
+        .message_id = agent_types.generateUlid(),
         .sequence = 1,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .models_request = .{} },
@@ -586,8 +586,8 @@ test "handleModelsRequest returns not_implemented nack when delegate is missing"
     defer server.deinit();
 
     var request = agent_types.Envelope{
-        .session_id = agent_types.generateUuid(),
-        .message_id = agent_types.generateUuid(),
+        .session_id = agent_types.generateUlid(),
+        .message_id = agent_types.generateUlid(),
         .sequence = 1,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .models_request = .{} },
@@ -621,8 +621,8 @@ test "handleModelsRequest maps delegate NotImplemented error to not_implemented 
     defer server.deinit();
 
     var request = agent_types.Envelope{
-        .session_id = agent_types.generateUuid(),
-        .message_id = agent_types.generateUuid(),
+        .session_id = agent_types.generateUlid(),
+        .message_id = agent_types.generateUlid(),
         .sequence = 1,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .models_request = .{} },
@@ -645,8 +645,8 @@ test "AgentProtocolServer start message status stop" {
     defer server.deinit();
 
     var start = agent_types.Envelope{
-        .session_id = agent_types.generateUuid(),
-        .message_id = agent_types.generateUuid(),
+        .session_id = agent_types.generateUlid(),
+        .message_id = agent_types.generateUlid(),
         .sequence = 1,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .agent_start = .{ .config_json = try allocator.dupe(u8, "{}") } },
@@ -661,7 +661,7 @@ test "AgentProtocolServer start message status stop" {
 
     var msg = agent_types.Envelope{
         .session_id = sid,
-        .message_id = agent_types.generateUuid(),
+        .message_id = agent_types.generateUlid(),
         .sequence = 2,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .agent_message = .{
@@ -674,7 +674,7 @@ test "AgentProtocolServer start message status stop" {
 
     var status = agent_types.Envelope{
         .session_id = sid,
-        .message_id = agent_types.generateUuid(),
+        .message_id = agent_types.generateUlid(),
         .sequence = 3,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .agent_status = .{ .session_id = sid } },
@@ -688,7 +688,7 @@ test "AgentProtocolServer start message status stop" {
 
     var stop = agent_types.Envelope{
         .session_id = sid,
-        .message_id = agent_types.generateUuid(),
+        .message_id = agent_types.generateUlid(),
         .sequence = 4,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .agent_stop = .{ .session_id = sid } },

--- a/zig/src/protocol/agent/types.zig
+++ b/zig/src/protocol/agent/types.zig
@@ -3,11 +3,11 @@ const provider_types = @import("protocol_types");
 const model_catalog_types = @import("model_catalog_types");
 const OwnedSlice = @import("owned_slice").OwnedSlice;
 
-/// Re-export Uuid from provider types for convenience
-pub const Uuid = provider_types.Uuid;
-pub const generateUuid = provider_types.generateUuid;
-pub const uuidToString = provider_types.uuidToString;
-pub const parseUuid = provider_types.parseUuid;
+/// Re-export Ulid from provider types for convenience
+pub const Ulid = provider_types.Ulid;
+pub const generateUlid = provider_types.generateUlid;
+pub const ulidToString = provider_types.ulidToString;
+pub const parseUlid = provider_types.parseUlid;
 
 /// Re-export provider ack/nack/error-code envelope types so that the agent
 /// passthrough emits the same shape as the provider protocol.
@@ -73,7 +73,7 @@ pub const AgentStartRequest = struct {
     /// Initial system prompt
     system_prompt: OwnedSlice(u8) = OwnedSlice(u8).initBorrowed(""),
     /// Session ID for resumption (null for new session)
-    session_id: ?Uuid = null,
+    session_id: ?Ulid = null,
 
     pub fn getSystemPrompt(self: *const AgentStartRequest) ?[]const u8 {
         const prompt = self.system_prompt.slice();
@@ -84,7 +84,7 @@ pub const AgentStartRequest = struct {
 /// Request to send a message to an agent
 pub const AgentMessageRequest = struct {
     /// Target agent session
-    session_id: Uuid,
+    session_id: Ulid,
     /// Message to send
     message_json: []const u8,
     /// Options for this message
@@ -99,7 +99,7 @@ pub const AgentMessageRequest = struct {
 /// Request to stop an agent session
 pub const AgentStopRequest = struct {
     /// Target agent session
-    session_id: Uuid,
+    session_id: Ulid,
     /// Reason for stopping
     reason: OwnedSlice(u8) = OwnedSlice(u8).initBorrowed(""),
 
@@ -179,7 +179,7 @@ pub const AgentStatus = enum {
 
 /// Agent session info
 pub const AgentSessionInfo = struct {
-    session_id: Uuid,
+    session_id: Ulid,
     status: AgentStatus,
     model: []const u8,
     message_count: u32,
@@ -188,7 +188,7 @@ pub const AgentSessionInfo = struct {
 };
 
 pub const AgentStopped = struct {
-    session_id: Uuid,
+    session_id: Ulid,
     reason: OwnedSlice(u8) = OwnedSlice(u8).initBorrowed(""),
 
     pub fn getReason(self: *const AgentStopped) ?[]const u8 {
@@ -220,14 +220,14 @@ pub const Payload = union(enum) {
     agent_start: AgentStartRequest,
     agent_message: AgentMessageRequest,
     agent_stop: AgentStopRequest,
-    agent_status: struct { session_id: Uuid },
+    agent_status: struct { session_id: Ulid },
     tool_list: ToolListRequest,
     /// Passthrough model discovery request — delegates to the provider protocol
     /// and returns the same `ModelsResponse` shape. See spec §6.
     models_request: ModelsRequest,
 
     // Agent Server -> Client
-    agent_started: struct { session_id: Uuid },
+    agent_started: struct { session_id: Ulid },
     agent_event: []const u8, // JSON-encoded AgentEvent
     agent_result: []const u8, // JSON-encoded AgentLoopResult
     agent_stopped: AgentStopped,
@@ -315,13 +315,13 @@ pub const Envelope = struct {
     /// Protocol version
     version: u8 = 1,
     /// Session identifier (stable for session lifecycle)
-    session_id: Uuid,
+    session_id: Ulid,
     /// Message ID (unique per message)
-    message_id: Uuid,
+    message_id: Ulid,
     /// Sequence number within session (starts at 1)
     sequence: u64,
     /// For request/response correlation
-    in_reply_to: ?Uuid = null,
+    in_reply_to: ?Ulid = null,
     /// Unix timestamp in milliseconds
     timestamp: i64,
     /// The actual payload
@@ -409,7 +409,7 @@ test "Payload deinit for nack frees reason" {
 
     var payload = Payload{
         .nack = .{
-            .rejected_id = generateUuid(),
+            .rejected_id = generateUlid(),
             .reason = OwnedSlice(u8).initOwned(try allocator.dupe(u8, "not implemented")),
             .error_code = .not_implemented,
         },

--- a/zig/src/protocol/auth/envelope.zig
+++ b/zig/src/protocol/auth/envelope.zig
@@ -13,11 +13,11 @@ pub fn serializeEnvelope(env: auth_types.Envelope, allocator: std.mem.Allocator)
     try writer.beginObject();
     try writer.writeStringField("type", @tagName(env.payload));
 
-    const stream_id = try auth_types.uuidToString(env.stream_id, allocator);
+    const stream_id = try auth_types.ulidToString(env.stream_id, allocator);
     defer allocator.free(stream_id);
     try writer.writeStringField("stream_id", stream_id);
 
-    const message_id = try auth_types.uuidToString(env.message_id, allocator);
+    const message_id = try auth_types.ulidToString(env.message_id, allocator);
     defer allocator.free(message_id);
     try writer.writeStringField("message_id", message_id);
 
@@ -26,7 +26,7 @@ pub fn serializeEnvelope(env: auth_types.Envelope, allocator: std.mem.Allocator)
     try writer.writeIntField("version", env.version);
 
     if (env.in_reply_to) |reply_to| {
-        const in_reply_to = try auth_types.uuidToString(reply_to, allocator);
+        const in_reply_to = try auth_types.ulidToString(reply_to, allocator);
         defer allocator.free(in_reply_to);
         try writer.writeStringField("in_reply_to", in_reply_to);
     }
@@ -49,24 +49,24 @@ fn serializePayload(writer: *json_writer.JsonWriter, payload: auth_types.Payload
             try writer.writeStringField("provider_id", request.provider_id.slice());
         },
         .auth_prompt_response => |response| {
-            const flow_id = try auth_types.uuidToString(response.flow_id, allocator);
+            const flow_id = try auth_types.ulidToString(response.flow_id, allocator);
             defer allocator.free(flow_id);
             try writer.writeStringField("flow_id", flow_id);
             try writer.writeStringField("prompt_id", response.prompt_id.slice());
             try writer.writeStringField("answer", response.answer.slice());
         },
         .auth_cancel => |request| {
-            const flow_id = try auth_types.uuidToString(request.flow_id, allocator);
+            const flow_id = try auth_types.ulidToString(request.flow_id, allocator);
             defer allocator.free(flow_id);
             try writer.writeStringField("flow_id", flow_id);
         },
         .ack => |ack| {
-            const acknowledged_id = try auth_types.uuidToString(ack.acknowledged_id, allocator);
+            const acknowledged_id = try auth_types.ulidToString(ack.acknowledged_id, allocator);
             defer allocator.free(acknowledged_id);
             try writer.writeStringField("acknowledged_id", acknowledged_id);
         },
         .nack => |nack| {
-            const rejected_id = try auth_types.uuidToString(nack.rejected_id, allocator);
+            const rejected_id = try auth_types.ulidToString(nack.rejected_id, allocator);
             defer allocator.free(rejected_id);
             try writer.writeStringField("rejected_id", rejected_id);
             try writer.writeStringField("reason", nack.reason.slice());
@@ -93,7 +93,7 @@ fn serializePayload(writer: *json_writer.JsonWriter, payload: auth_types.Payload
             try serializeAuthEvent(writer, event, allocator);
         },
         .auth_login_result => |result| {
-            const flow_id = try auth_types.uuidToString(result.flow_id, allocator);
+            const flow_id = try auth_types.ulidToString(result.flow_id, allocator);
             defer allocator.free(flow_id);
             try writer.writeStringField("flow_id", flow_id);
             try writer.writeStringField("provider_id", result.provider_id.slice());
@@ -116,7 +116,7 @@ fn serializePayload(writer: *json_writer.JsonWriter, payload: auth_types.Payload
 fn serializeAuthEvent(writer: *json_writer.JsonWriter, event: auth_types.AuthEvent, allocator: std.mem.Allocator) !void {
     switch (event) {
         .auth_url => |payload| {
-            const flow_id = try auth_types.uuidToString(payload.flow_id, allocator);
+            const flow_id = try auth_types.ulidToString(payload.flow_id, allocator);
             defer allocator.free(flow_id);
 
             try writer.writeKey("auth_url");
@@ -130,7 +130,7 @@ fn serializeAuthEvent(writer: *json_writer.JsonWriter, event: auth_types.AuthEve
             try writer.endObject();
         },
         .prompt => |payload| {
-            const flow_id = try auth_types.uuidToString(payload.flow_id, allocator);
+            const flow_id = try auth_types.ulidToString(payload.flow_id, allocator);
             defer allocator.free(flow_id);
 
             try writer.writeKey("prompt");
@@ -143,7 +143,7 @@ fn serializeAuthEvent(writer: *json_writer.JsonWriter, event: auth_types.AuthEve
             try writer.endObject();
         },
         .progress => |payload| {
-            const flow_id = try auth_types.uuidToString(payload.flow_id, allocator);
+            const flow_id = try auth_types.ulidToString(payload.flow_id, allocator);
             defer allocator.free(flow_id);
 
             try writer.writeKey("progress");
@@ -154,7 +154,7 @@ fn serializeAuthEvent(writer: *json_writer.JsonWriter, event: auth_types.AuthEve
             try writer.endObject();
         },
         .success => |payload| {
-            const flow_id = try auth_types.uuidToString(payload.flow_id, allocator);
+            const flow_id = try auth_types.ulidToString(payload.flow_id, allocator);
             defer allocator.free(flow_id);
 
             try writer.writeKey("success");
@@ -164,7 +164,7 @@ fn serializeAuthEvent(writer: *json_writer.JsonWriter, event: auth_types.AuthEve
             try writer.endObject();
         },
         .@"error" => |payload| {
-            const flow_id = try auth_types.uuidToString(payload.flow_id, allocator);
+            const flow_id = try auth_types.ulidToString(payload.flow_id, allocator);
             defer allocator.free(flow_id);
 
             try writer.writeKey("error");
@@ -186,15 +186,15 @@ pub fn deserializeEnvelope(json: []const u8, allocator: std.mem.Allocator) !auth
 
     const root = parsed.value.object;
     const type_str = root.get("type").?.string;
-    const stream_id = try parseUuidRequired(root.get("stream_id").?.string);
-    const message_id = try parseUuidRequired(root.get("message_id").?.string);
+    const stream_id = try parseUlidRequired(root.get("stream_id").?.string);
+    const message_id = try parseUlidRequired(root.get("message_id").?.string);
     const sequence = @as(u64, @intCast(root.get("sequence").?.integer));
     const timestamp = root.get("timestamp").?.integer;
     const version = @as(u8, @intCast(root.get("version").?.integer));
 
-    var in_reply_to: ?auth_types.Uuid = null;
+    var in_reply_to: ?auth_types.Ulid = null;
     if (root.get("in_reply_to")) |value| {
-        in_reply_to = try parseUuidRequired(value.string);
+        in_reply_to = try parseUlidRequired(value.string);
     }
 
     const payload = try deserializePayload(type_str, root.get("payload").?.object, allocator);
@@ -210,8 +210,8 @@ pub fn deserializeEnvelope(json: []const u8, allocator: std.mem.Allocator) !auth
     };
 }
 
-fn parseUuidRequired(value: []const u8) !auth_types.Uuid {
-    return auth_types.parseUuid(value) orelse error.InvalidUuid;
+fn parseUlidRequired(value: []const u8) !auth_types.Ulid {
+    return auth_types.parseUlid(value) orelse error.InvalidUlid;
 }
 
 fn deserializePayload(type_str: []const u8, payload: std.json.ObjectMap, allocator: std.mem.Allocator) !auth_types.Payload {
@@ -227,7 +227,7 @@ fn deserializePayload(type_str: []const u8, payload: std.json.ObjectMap, allocat
 
     if (std.mem.eql(u8, type_str, "auth_prompt_response")) {
         return .{ .auth_prompt_response = .{
-            .flow_id = try parseUuidRequired(payload.get("flow_id").?.string),
+            .flow_id = try parseUlidRequired(payload.get("flow_id").?.string),
             .prompt_id = OwnedSlice(u8).initOwned(try allocator.dupe(u8, payload.get("prompt_id").?.string)),
             .answer = OwnedSlice(u8).initOwned(try allocator.dupe(u8, payload.get("answer").?.string)),
         } };
@@ -235,19 +235,19 @@ fn deserializePayload(type_str: []const u8, payload: std.json.ObjectMap, allocat
 
     if (std.mem.eql(u8, type_str, "auth_cancel")) {
         return .{ .auth_cancel = .{
-            .flow_id = try parseUuidRequired(payload.get("flow_id").?.string),
+            .flow_id = try parseUlidRequired(payload.get("flow_id").?.string),
         } };
     }
 
     if (std.mem.eql(u8, type_str, "ack")) {
         return .{ .ack = .{
-            .acknowledged_id = try parseUuidRequired(payload.get("acknowledged_id").?.string),
+            .acknowledged_id = try parseUlidRequired(payload.get("acknowledged_id").?.string),
         } };
     }
 
     if (std.mem.eql(u8, type_str, "nack")) {
         var nack = auth_types.Nack{
-            .rejected_id = try parseUuidRequired(payload.get("rejected_id").?.string),
+            .rejected_id = try parseUlidRequired(payload.get("rejected_id").?.string),
             .reason = OwnedSlice(u8).initOwned(try allocator.dupe(u8, payload.get("reason").?.string)),
         };
 
@@ -296,7 +296,7 @@ fn deserializePayload(type_str: []const u8, payload: std.json.ObjectMap, allocat
 
     if (std.mem.eql(u8, type_str, "auth_login_result")) {
         return .{ .auth_login_result = .{
-            .flow_id = try parseUuidRequired(payload.get("flow_id").?.string),
+            .flow_id = try parseUlidRequired(payload.get("flow_id").?.string),
             .provider_id = OwnedSlice(u8).initOwned(try allocator.dupe(u8, payload.get("provider_id").?.string)),
             .status = std.meta.stringToEnum(auth_types.AuthLoginStatus, payload.get("status").?.string) orelse .failed,
         } };
@@ -329,7 +329,7 @@ fn deserializeAuthEvent(payload: std.json.ObjectMap, allocator: std.mem.Allocato
         const auth_url = auth_url_value.object;
 
         var result: auth_types.AuthEvent = .{ .auth_url = .{
-            .flow_id = try parseUuidRequired(auth_url.get("flow_id").?.string),
+            .flow_id = try parseUlidRequired(auth_url.get("flow_id").?.string),
             .provider_id = OwnedSlice(u8).initOwned(try allocator.dupe(u8, auth_url.get("provider_id").?.string)),
             .url = OwnedSlice(u8).initOwned(try allocator.dupe(u8, auth_url.get("url").?.string)),
         } };
@@ -345,7 +345,7 @@ fn deserializeAuthEvent(payload: std.json.ObjectMap, allocator: std.mem.Allocato
         if (prompt_value != .object) return error.InvalidPayloadType;
         const prompt = prompt_value.object;
         return .{ .prompt = .{
-            .flow_id = try parseUuidRequired(prompt.get("flow_id").?.string),
+            .flow_id = try parseUlidRequired(prompt.get("flow_id").?.string),
             .prompt_id = OwnedSlice(u8).initOwned(try allocator.dupe(u8, prompt.get("prompt_id").?.string)),
             .provider_id = OwnedSlice(u8).initOwned(try allocator.dupe(u8, prompt.get("provider_id").?.string)),
             .message = OwnedSlice(u8).initOwned(try allocator.dupe(u8, prompt.get("message").?.string)),
@@ -357,7 +357,7 @@ fn deserializeAuthEvent(payload: std.json.ObjectMap, allocator: std.mem.Allocato
         if (progress_value != .object) return error.InvalidPayloadType;
         const progress = progress_value.object;
         return .{ .progress = .{
-            .flow_id = try parseUuidRequired(progress.get("flow_id").?.string),
+            .flow_id = try parseUlidRequired(progress.get("flow_id").?.string),
             .provider_id = OwnedSlice(u8).initOwned(try allocator.dupe(u8, progress.get("provider_id").?.string)),
             .message = OwnedSlice(u8).initOwned(try allocator.dupe(u8, progress.get("message").?.string)),
         } };
@@ -367,7 +367,7 @@ fn deserializeAuthEvent(payload: std.json.ObjectMap, allocator: std.mem.Allocato
         if (success_value != .object) return error.InvalidPayloadType;
         const success = success_value.object;
         return .{ .success = .{
-            .flow_id = try parseUuidRequired(success.get("flow_id").?.string),
+            .flow_id = try parseUlidRequired(success.get("flow_id").?.string),
             .provider_id = OwnedSlice(u8).initOwned(try allocator.dupe(u8, success.get("provider_id").?.string)),
         } };
     }
@@ -377,7 +377,7 @@ fn deserializeAuthEvent(payload: std.json.ObjectMap, allocator: std.mem.Allocato
         const event_error = error_value.object;
 
         var result: auth_types.AuthEvent = .{ .@"error" = .{
-            .flow_id = try parseUuidRequired(event_error.get("flow_id").?.string),
+            .flow_id = try parseUlidRequired(event_error.get("flow_id").?.string),
             .provider_id = OwnedSlice(u8).initOwned(try allocator.dupe(u8, event_error.get("provider_id").?.string)),
             .message = OwnedSlice(u8).initOwned(try allocator.dupe(u8, event_error.get("message").?.string)),
         } };
@@ -394,11 +394,11 @@ fn deserializeAuthEvent(payload: std.json.ObjectMap, allocator: std.mem.Allocato
 
 test "auth envelope roundtrip with auth_event prompt" {
     const allocator = std.testing.allocator;
-    const flow_id = auth_types.generateUuid();
+    const flow_id = auth_types.generateUlid();
 
     var envelope = auth_types.Envelope{
         .stream_id = flow_id,
-        .message_id = auth_types.generateUuid(),
+        .message_id = auth_types.generateUlid(),
         .sequence = 2,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .auth_event = .{ .prompt = .{
@@ -426,6 +426,6 @@ test "auth envelope roundtrip with auth_event prompt" {
 test "auth envelope rejects unknown payload type" {
     const allocator = std.testing.allocator;
     const bad =
-        "{\"type\":\"not_real\",\"stream_id\":\"00000000-0000-0000-0000-000000000001\",\"message_id\":\"00000000-0000-0000-0000-000000000002\",\"sequence\":1,\"timestamp\":1,\"version\":1,\"payload\":{}}";
+        "{\"type\":\"not_real\",\"stream_id\":\"00000000000000000000000001\",\"message_id\":\"00000000000000000000000002\",\"sequence\":1,\"timestamp\":1,\"version\":1,\"payload\":{}}";
     try std.testing.expectError(error.InvalidPayloadType, deserializeEnvelope(bad, allocator));
 }

--- a/zig/src/protocol/auth/server.zig
+++ b/zig/src/protocol/auth/server.zig
@@ -7,7 +7,7 @@ const oauth_storage = @import("oauth/storage");
 const OwnedSlice = @import("owned_slice").OwnedSlice;
 
 const FlowState = struct {
-    flow_id: auth_types.Uuid,
+    flow_id: auth_types.Ulid,
     provider_id: []u8,
     cancelled: bool = false,
     terminal_emitted: bool = false,
@@ -19,7 +19,7 @@ const FlowState = struct {
     mutex: std.Thread.Mutex = .{},
     cond: std.Thread.Condition = .{},
 
-    fn init(allocator: std.mem.Allocator, flow_id: auth_types.Uuid, provider_id: []const u8) !FlowState {
+    fn init(allocator: std.mem.Allocator, flow_id: auth_types.Ulid, provider_id: []const u8) !FlowState {
         return .{
             .flow_id = flow_id,
             .provider_id = try allocator.dupe(u8, provider_id),
@@ -42,9 +42,9 @@ const FlowState = struct {
 
 pub const AuthProtocolServer = struct {
     allocator: std.mem.Allocator,
-    expected_sequences: std.AutoHashMap(auth_types.Uuid, u64),
-    outgoing_sequences: std.AutoHashMap(auth_types.Uuid, u64),
-    flows: std.AutoHashMap(auth_types.Uuid, *FlowState),
+    expected_sequences: std.AutoHashMap(auth_types.Ulid, u64),
+    outgoing_sequences: std.AutoHashMap(auth_types.Ulid, u64),
+    flows: std.AutoHashMap(auth_types.Ulid, *FlowState),
     outbox: std.ArrayList(auth_types.Envelope),
     mutex: std.Thread.Mutex = .{},
     options: Options,
@@ -60,9 +60,9 @@ pub const AuthProtocolServer = struct {
     pub fn init(allocator: std.mem.Allocator, options: Options) Self {
         return .{
             .allocator = allocator,
-            .expected_sequences = std.AutoHashMap(auth_types.Uuid, u64).init(allocator),
-            .outgoing_sequences = std.AutoHashMap(auth_types.Uuid, u64).init(allocator),
-            .flows = std.AutoHashMap(auth_types.Uuid, *FlowState).init(allocator),
+            .expected_sequences = std.AutoHashMap(auth_types.Ulid, u64).init(allocator),
+            .outgoing_sequences = std.AutoHashMap(auth_types.Ulid, u64).init(allocator),
+            .flows = std.AutoHashMap(auth_types.Ulid, *FlowState).init(allocator),
             .outbox = std.ArrayList(auth_types.Envelope){},
             .options = options,
         };
@@ -139,10 +139,10 @@ pub const AuthProtocolServer = struct {
             .auth_prompt_response => |response| return try self.handlePromptResponseLocked(env, response),
             .auth_cancel => |request| return try self.handleCancelLocked(env, request),
             .ping => {
-                const ping_id = try auth_types.uuidToString(env.message_id, self.allocator);
+                const ping_id = try auth_types.ulidToString(env.message_id, self.allocator);
                 return .{
                     .stream_id = env.stream_id,
-                    .message_id = auth_types.generateUuid(),
+                    .message_id = auth_types.generateUlid(),
                     .sequence = self.nextOutgoingSequenceLocked(env.stream_id),
                     .in_reply_to = env.message_id,
                     .timestamp = std.time.milliTimestamp(),
@@ -194,7 +194,7 @@ pub const AuthProtocolServer = struct {
         const providers = try self.buildProvidersResponse();
         const response = auth_types.Envelope{
             .stream_id = env.stream_id,
-            .message_id = auth_types.generateUuid(),
+            .message_id = auth_types.generateUlid(),
             .sequence = self.nextOutgoingSequenceLocked(env.stream_id),
             .in_reply_to = env.message_id,
             .timestamp = std.time.milliTimestamp(),
@@ -338,7 +338,7 @@ pub const AuthProtocolServer = struct {
         if (should_emit_cancel_result) {
             try self.outbox.append(self.allocator, auth_types.Envelope{
                 .stream_id = request.flow_id,
-                .message_id = auth_types.generateUuid(),
+                .message_id = auth_types.generateUlid(),
                 .sequence = self.nextOutgoingSequenceLocked(request.flow_id),
                 .timestamp = std.time.milliTimestamp(),
                 .payload = .{ .auth_login_result = .{
@@ -353,7 +353,7 @@ pub const AuthProtocolServer = struct {
     }
 
     fn cleanupCompletedFlowsLocked(self: *Self) void {
-        var completed = std.ArrayList(auth_types.Uuid){};
+        var completed = std.ArrayList(auth_types.Ulid){};
         defer completed.deinit(self.allocator);
 
         var iter = self.flows.iterator();
@@ -418,7 +418,7 @@ pub const AuthProtocolServer = struct {
         };
     }
 
-    fn validateAndUpdateSequenceLocked(self: *Self, _: ScopeKind, scope_id: auth_types.Uuid, received: u64) !void {
+    fn validateAndUpdateSequenceLocked(self: *Self, _: ScopeKind, scope_id: auth_types.Ulid, received: u64) !void {
         if (received == 0) return error.InvalidSequence;
         const expected = self.expected_sequences.get(scope_id) orelse 1;
         if (received < expected) return error.DuplicateSequence;
@@ -426,17 +426,17 @@ pub const AuthProtocolServer = struct {
         try self.expected_sequences.put(scope_id, received + 1);
     }
 
-    fn nextOutgoingSequenceLocked(self: *Self, scope_id: auth_types.Uuid) u64 {
+    fn nextOutgoingSequenceLocked(self: *Self, scope_id: auth_types.Ulid) u64 {
         const current = self.outgoing_sequences.get(scope_id) orelse 0;
         const next = current + 1;
         self.outgoing_sequences.put(scope_id, next) catch {};
         return next;
     }
 
-    fn makeAckLocked(self: *Self, scope_id: auth_types.Uuid, in_reply_to: auth_types.Uuid) auth_types.Envelope {
+    fn makeAckLocked(self: *Self, scope_id: auth_types.Ulid, in_reply_to: auth_types.Ulid) auth_types.Envelope {
         return .{
             .stream_id = scope_id,
-            .message_id = auth_types.generateUuid(),
+            .message_id = auth_types.generateUlid(),
             .sequence = self.nextOutgoingSequenceLocked(scope_id),
             .in_reply_to = in_reply_to,
             .timestamp = std.time.milliTimestamp(),
@@ -446,7 +446,7 @@ pub const AuthProtocolServer = struct {
         };
     }
 
-    fn sequenceNackLocked(self: *Self, scope_id: auth_types.Uuid, in_reply_to: auth_types.Uuid, err: anyerror) !auth_types.Envelope {
+    fn sequenceNackLocked(self: *Self, scope_id: auth_types.Ulid, in_reply_to: auth_types.Ulid, err: anyerror) !auth_types.Envelope {
         return switch (err) {
             error.InvalidSequence => try self.makeNackLocked(scope_id, in_reply_to, .invalid_sequence, "invalid sequence"),
             error.DuplicateSequence => try self.makeNackLocked(scope_id, in_reply_to, .duplicate_sequence, "duplicate sequence"),
@@ -457,14 +457,14 @@ pub const AuthProtocolServer = struct {
 
     fn makeNackLocked(
         self: *Self,
-        scope_id: auth_types.Uuid,
-        in_reply_to: auth_types.Uuid,
+        scope_id: auth_types.Ulid,
+        in_reply_to: auth_types.Ulid,
         error_code: auth_types.ErrorCode,
         reason: []const u8,
     ) !auth_types.Envelope {
         return .{
             .stream_id = scope_id,
-            .message_id = auth_types.generateUuid(),
+            .message_id = auth_types.generateUlid(),
             .sequence = self.nextOutgoingSequenceLocked(scope_id),
             .in_reply_to = in_reply_to,
             .timestamp = std.time.milliTimestamp(),
@@ -670,7 +670,7 @@ pub const AuthProtocolServer = struct {
 
         const env = auth_types.Envelope{
             .stream_id = flow.flow_id,
-            .message_id = auth_types.generateUuid(),
+            .message_id = auth_types.generateUlid(),
             .sequence = self.nextOutgoingSequenceLocked(flow.flow_id),
             .timestamp = std.time.milliTimestamp(),
             .payload = .{ .auth_event = .{ .prompt = .{
@@ -694,7 +694,7 @@ pub const AuthProtocolServer = struct {
 
         try self.outbox.append(self.allocator, auth_types.Envelope{
             .stream_id = flow.flow_id,
-            .message_id = auth_types.generateUuid(),
+            .message_id = auth_types.generateUlid(),
             .sequence = self.nextOutgoingSequenceLocked(flow.flow_id),
             .timestamp = std.time.milliTimestamp(),
             .payload = .{ .auth_event = .{ .progress = .{
@@ -724,7 +724,7 @@ pub const AuthProtocolServer = struct {
 
         try self.outbox.append(self.allocator, auth_types.Envelope{
             .stream_id = flow.flow_id,
-            .message_id = auth_types.generateUuid(),
+            .message_id = auth_types.generateUlid(),
             .sequence = self.nextOutgoingSequenceLocked(flow.flow_id),
             .timestamp = std.time.milliTimestamp(),
             .payload = .{ .auth_event = event },
@@ -748,7 +748,7 @@ pub const AuthProtocolServer = struct {
 
         try self.outbox.append(self.allocator, auth_types.Envelope{
             .stream_id = flow.flow_id,
-            .message_id = auth_types.generateUuid(),
+            .message_id = auth_types.generateUlid(),
             .sequence = self.nextOutgoingSequenceLocked(flow.flow_id),
             .timestamp = std.time.milliTimestamp(),
             .payload = .{ .auth_event = .{ .success = .{
@@ -759,7 +759,7 @@ pub const AuthProtocolServer = struct {
 
         try self.outbox.append(self.allocator, auth_types.Envelope{
             .stream_id = flow.flow_id,
-            .message_id = auth_types.generateUuid(),
+            .message_id = auth_types.generateUlid(),
             .sequence = self.nextOutgoingSequenceLocked(flow.flow_id),
             .timestamp = std.time.milliTimestamp(),
             .payload = .{ .auth_login_result = .{
@@ -778,7 +778,7 @@ pub const AuthProtocolServer = struct {
 
         try self.outbox.append(self.allocator, auth_types.Envelope{
             .stream_id = flow.flow_id,
-            .message_id = auth_types.generateUuid(),
+            .message_id = auth_types.generateUlid(),
             .sequence = self.nextOutgoingSequenceLocked(flow.flow_id),
             .timestamp = std.time.milliTimestamp(),
             .payload = .{ .auth_event = .{ .@"error" = .{
@@ -791,7 +791,7 @@ pub const AuthProtocolServer = struct {
 
         try self.outbox.append(self.allocator, auth_types.Envelope{
             .stream_id = flow.flow_id,
-            .message_id = auth_types.generateUuid(),
+            .message_id = auth_types.generateUlid(),
             .sequence = self.nextOutgoingSequenceLocked(flow.flow_id),
             .timestamp = std.time.milliTimestamp(),
             .payload = .{ .auth_login_result = .{
@@ -810,7 +810,7 @@ pub const AuthProtocolServer = struct {
 
         try self.outbox.append(self.allocator, auth_types.Envelope{
             .stream_id = flow.flow_id,
-            .message_id = auth_types.generateUuid(),
+            .message_id = auth_types.generateUlid(),
             .sequence = self.nextOutgoingSequenceLocked(flow.flow_id),
             .timestamp = std.time.milliTimestamp(),
             .payload = .{ .auth_login_result = .{

--- a/zig/src/protocol/auth/types.zig
+++ b/zig/src/protocol/auth/types.zig
@@ -2,10 +2,10 @@ const std = @import("std");
 const provider_types = @import("protocol_types");
 pub const OwnedSlice = @import("owned_slice").OwnedSlice;
 
-pub const Uuid = provider_types.Uuid;
-pub const generateUuid = provider_types.generateUuid;
-pub const uuidToString = provider_types.uuidToString;
-pub const parseUuid = provider_types.parseUuid;
+pub const Ulid = provider_types.Ulid;
+pub const generateUlid = provider_types.generateUlid;
+pub const ulidToString = provider_types.ulidToString;
+pub const parseUlid = provider_types.parseUlid;
 
 pub const PROTOCOL_VERSION: u8 = 1;
 
@@ -52,7 +52,7 @@ pub const AuthLoginStartRequest = struct {
 };
 
 pub const AuthPromptResponse = struct {
-    flow_id: Uuid,
+    flow_id: Ulid,
     prompt_id: OwnedSlice(u8),
     answer: OwnedSlice(u8),
 
@@ -64,34 +64,34 @@ pub const AuthPromptResponse = struct {
 };
 
 pub const AuthCancelRequest = struct {
-    flow_id: Uuid,
+    flow_id: Ulid,
 };
 
 pub const AuthEvent = union(enum) {
     auth_url: struct {
-        flow_id: Uuid,
+        flow_id: Ulid,
         provider_id: OwnedSlice(u8),
         url: OwnedSlice(u8),
         instructions: OwnedSlice(u8) = OwnedSlice(u8).initBorrowed(""),
     },
     prompt: struct {
-        flow_id: Uuid,
+        flow_id: Ulid,
         prompt_id: OwnedSlice(u8),
         provider_id: OwnedSlice(u8),
         message: OwnedSlice(u8),
         allow_empty: bool = false,
     },
     progress: struct {
-        flow_id: Uuid,
+        flow_id: Ulid,
         provider_id: OwnedSlice(u8),
         message: OwnedSlice(u8),
     },
     success: struct {
-        flow_id: Uuid,
+        flow_id: Ulid,
         provider_id: OwnedSlice(u8),
     },
     @"error": struct {
-        flow_id: Uuid,
+        flow_id: Ulid,
         provider_id: OwnedSlice(u8),
         code: OwnedSlice(u8) = OwnedSlice(u8).initBorrowed(""),
         message: OwnedSlice(u8),
@@ -134,7 +134,7 @@ pub const AuthLoginStatus = enum {
 };
 
 pub const AuthLoginResult = struct {
-    flow_id: Uuid,
+    flow_id: Ulid,
     provider_id: OwnedSlice(u8),
     status: AuthLoginStatus,
 
@@ -145,7 +145,7 @@ pub const AuthLoginResult = struct {
 };
 
 pub const Ack = struct {
-    acknowledged_id: Uuid,
+    acknowledged_id: Ulid,
 };
 
 pub const ErrorCode = enum {
@@ -160,7 +160,7 @@ pub const ErrorCode = enum {
 };
 
 pub const Nack = struct {
-    rejected_id: Uuid,
+    rejected_id: Ulid,
     reason: OwnedSlice(u8),
     error_code: ?ErrorCode = null,
 
@@ -224,10 +224,10 @@ pub const Payload = union(enum) {
 
 pub const Envelope = struct {
     version: u8 = PROTOCOL_VERSION,
-    stream_id: Uuid,
-    message_id: Uuid,
+    stream_id: Ulid,
+    message_id: Ulid,
     sequence: u64,
-    in_reply_to: ?Uuid = null,
+    in_reply_to: ?Ulid = null,
     timestamp: i64,
     payload: Payload,
 

--- a/zig/src/protocol/provider/client.zig
+++ b/zig/src/protocol/provider/client.zig
@@ -16,8 +16,8 @@ const OwnedSlice = owned_slice_mod.OwnedSlice;
 pub const ProtocolClient = struct {
     // Declarations must come before fields
     pub const PendingRequest = struct {
-        message_id: protocol_types.Uuid,
-        stream_id: protocol_types.Uuid = [_]u8{0} ** 16,
+        message_id: protocol_types.Ulid,
+        stream_id: protocol_types.Ulid = [_]u8{0} ** 16,
         sent_at: i64,
         timeout_ms: u64,
     };
@@ -28,8 +28,8 @@ pub const ProtocolClient = struct {
     };
 
     pub const StreamRequestRef = struct {
-        stream_id: protocol_types.Uuid,
-        message_id: protocol_types.Uuid,
+        stream_id: protocol_types.Ulid,
+        message_id: protocol_types.Ulid,
     };
 
     const Self = @This();
@@ -44,28 +44,28 @@ pub const ProtocolClient = struct {
     reconstructor: partial_reconstructor.PartialReconstructor,
 
     /// Pending requests awaiting ACK/NACK
-    pending_requests: std.AutoHashMap(protocol_types.Uuid, PendingRequest),
+    pending_requests: std.AutoHashMap(protocol_types.Ulid, PendingRequest),
 
     /// Per-stream outgoing sequence counters
-    stream_sequences: std.AutoHashMap(protocol_types.Uuid, u64),
+    stream_sequences: std.AutoHashMap(protocol_types.Ulid, u64),
 
     /// Per-stream reconstructors
-    reconstructors: std.AutoHashMap(protocol_types.Uuid, partial_reconstructor.PartialReconstructor),
+    reconstructors: std.AutoHashMap(protocol_types.Ulid, partial_reconstructor.PartialReconstructor),
 
     /// Per-stream final results
-    stream_results: std.AutoHashMap(protocol_types.Uuid, ai_types.AssistantMessage),
+    stream_results: std.AutoHashMap(protocol_types.Ulid, ai_types.AssistantMessage),
 
     /// Per-stream errors
-    stream_errors: std.AutoHashMap(protocol_types.Uuid, OwnedSlice(u8)),
+    stream_errors: std.AutoHashMap(protocol_types.Ulid, OwnedSlice(u8)),
 
     /// Per-stream completion flags
-    stream_complete_flags: std.AutoHashMap(protocol_types.Uuid, bool),
+    stream_complete_flags: std.AutoHashMap(protocol_types.Ulid, bool),
 
     /// Per-stream event streams (owned events)
-    stream_event_streams: std.AutoHashMap(protocol_types.Uuid, *event_stream.AssistantMessageEventStream),
+    stream_event_streams: std.AutoHashMap(protocol_types.Ulid, *event_stream.AssistantMessageEventStream),
 
     /// Current stream ID (compatibility for legacy single-stream callers)
-    current_stream_id: ?protocol_types.Uuid = null,
+    current_stream_id: ?protocol_types.Ulid = null,
 
     /// Event stream for consuming events
     event_stream: *event_stream.AssistantMessageEventStream,
@@ -96,13 +96,13 @@ pub const ProtocolClient = struct {
         return .{
             .allocator = allocator,
             .reconstructor = partial_reconstructor.PartialReconstructor.init(allocator),
-            .pending_requests = std.AutoHashMap(protocol_types.Uuid, PendingRequest).init(allocator),
-            .stream_sequences = std.AutoHashMap(protocol_types.Uuid, u64).init(allocator),
-            .reconstructors = std.AutoHashMap(protocol_types.Uuid, partial_reconstructor.PartialReconstructor).init(allocator),
-            .stream_results = std.AutoHashMap(protocol_types.Uuid, ai_types.AssistantMessage).init(allocator),
-            .stream_errors = std.AutoHashMap(protocol_types.Uuid, OwnedSlice(u8)).init(allocator),
-            .stream_complete_flags = std.AutoHashMap(protocol_types.Uuid, bool).init(allocator),
-            .stream_event_streams = std.AutoHashMap(protocol_types.Uuid, *event_stream.AssistantMessageEventStream).init(allocator),
+            .pending_requests = std.AutoHashMap(protocol_types.Ulid, PendingRequest).init(allocator),
+            .stream_sequences = std.AutoHashMap(protocol_types.Ulid, u64).init(allocator),
+            .reconstructors = std.AutoHashMap(protocol_types.Ulid, partial_reconstructor.PartialReconstructor).init(allocator),
+            .stream_results = std.AutoHashMap(protocol_types.Ulid, ai_types.AssistantMessage).init(allocator),
+            .stream_errors = std.AutoHashMap(protocol_types.Ulid, OwnedSlice(u8)).init(allocator),
+            .stream_complete_flags = std.AutoHashMap(protocol_types.Ulid, bool).init(allocator),
+            .stream_event_streams = std.AutoHashMap(protocol_types.Ulid, *event_stream.AssistantMessageEventStream).init(allocator),
             .event_stream = es,
             .options = options,
         };
@@ -177,20 +177,20 @@ pub const ProtocolClient = struct {
         self.last_error = OwnedSlice(u8).initOwned(try self.allocator.dupe(u8, msg));
     }
 
-    fn nextSequenceForStream(self: *Self, stream_id: protocol_types.Uuid) !u64 {
+    fn nextSequenceForStream(self: *Self, stream_id: protocol_types.Ulid) !u64 {
         const next = if (self.stream_sequences.get(stream_id)) |cur| cur + 1 else 1;
         try self.stream_sequences.put(stream_id, next);
         self.sequence = next; // compatibility mirror
         return next;
     }
 
-    fn ensureReconstructor(self: *Self, stream_id: protocol_types.Uuid) !*partial_reconstructor.PartialReconstructor {
+    fn ensureReconstructor(self: *Self, stream_id: protocol_types.Ulid) !*partial_reconstructor.PartialReconstructor {
         if (self.reconstructors.getPtr(stream_id)) |r| return r;
         try self.reconstructors.put(stream_id, partial_reconstructor.PartialReconstructor.init(self.allocator));
         return self.reconstructors.getPtr(stream_id).?;
     }
 
-    fn ensureStreamEventStream(self: *Self, stream_id: protocol_types.Uuid) !*event_stream.AssistantMessageEventStream {
+    fn ensureStreamEventStream(self: *Self, stream_id: protocol_types.Ulid) !*event_stream.AssistantMessageEventStream {
         if (self.stream_event_streams.get(stream_id)) |es| return es;
         const es = oom.unreachableOnOom(self.allocator.create(event_stream.AssistantMessageEventStream));
         es.* = event_stream.AssistantMessageEventStream.init(self.allocator);
@@ -199,7 +199,7 @@ pub const ProtocolClient = struct {
         return es;
     }
 
-    fn setStreamError(self: *Self, stream_id: protocol_types.Uuid, msg: []const u8) !void {
+    fn setStreamError(self: *Self, stream_id: protocol_types.Ulid, msg: []const u8) !void {
         const already_complete = self.stream_complete_flags.get(stream_id) orelse false;
 
         if (self.stream_errors.getPtr(stream_id)) |existing| {
@@ -216,7 +216,7 @@ pub const ProtocolClient = struct {
         }
     }
 
-    fn setStreamResult(self: *Self, stream_id: protocol_types.Uuid, result: ai_types.AssistantMessage) !void {
+    fn setStreamResult(self: *Self, stream_id: protocol_types.Ulid, result: ai_types.AssistantMessage) !void {
         const already_complete = self.stream_complete_flags.get(stream_id) orelse false;
 
         if (self.stream_results.getPtr(stream_id)) |existing| {
@@ -244,7 +244,7 @@ pub const ProtocolClient = struct {
             return error.NoSender;
         }
 
-        const message_id = protocol_types.generateUuid();
+        const message_id = protocol_types.generateUlid();
         const stream_id = message_id;
         const seq = try self.nextSequenceForStream(stream_id);
 
@@ -292,7 +292,7 @@ pub const ProtocolClient = struct {
         model: ai_types.Model,
         context: ai_types.Context,
         options: ?ai_types.StreamOptions,
-    ) !protocol_types.Uuid {
+    ) !protocol_types.Ulid {
         const req = try self.startStream(model, context, options);
         return req.message_id;
     }
@@ -304,7 +304,7 @@ pub const ProtocolClient = struct {
     }
 
     /// Send abort_request for a specific stream
-    pub fn sendAbortRequestFor(self: *Self, stream_id: protocol_types.Uuid, reason: ?[]const u8) !void {
+    pub fn sendAbortRequestFor(self: *Self, stream_id: protocol_types.Ulid, reason: ?[]const u8) !void {
         if (self.sender == null) {
             return error.NoSender;
         }
@@ -324,7 +324,7 @@ pub const ProtocolClient = struct {
 
         var env = protocol_types.Envelope{
             .stream_id = stream_id,
-            .message_id = protocol_types.generateUuid(),
+            .message_id = protocol_types.generateUlid(),
             .sequence = seq,
             .timestamp = std.time.milliTimestamp(),
             .payload = payload,
@@ -435,7 +435,7 @@ pub const ProtocolClient = struct {
     }
 
     /// Get a per-stream event stream if it exists
-    pub fn getEventStreamFor(self: *Self, stream_id: protocol_types.Uuid) ?*event_stream.AssistantMessageEventStream {
+    pub fn getEventStreamFor(self: *Self, stream_id: protocol_types.Ulid) ?*event_stream.AssistantMessageEventStream {
         return self.stream_event_streams.get(stream_id);
     }
 
@@ -446,7 +446,7 @@ pub const ProtocolClient = struct {
     }
 
     /// Get result for a specific stream (blocking wait if not ready)
-    pub fn waitResultFor(self: *Self, stream_id: protocol_types.Uuid, timeout_ms: u64) !?ai_types.AssistantMessage {
+    pub fn waitResultFor(self: *Self, stream_id: protocol_types.Ulid, timeout_ms: u64) !?ai_types.AssistantMessage {
         const start_time = std.time.milliTimestamp();
         const deadline = start_time + @as(i64, @intCast(timeout_ms));
 
@@ -476,12 +476,12 @@ pub const ProtocolClient = struct {
     }
 
     /// Check if a specific stream is complete
-    pub fn isCompleteFor(self: *Self, stream_id: protocol_types.Uuid) bool {
+    pub fn isCompleteFor(self: *Self, stream_id: protocol_types.Ulid) bool {
         return self.stream_complete_flags.get(stream_id) orelse false;
     }
 
     /// Mark a specific stream as closed and complete with an explicit client-side error.
-    pub fn closeStream(self: *Self, stream_id: protocol_types.Uuid) !void {
+    pub fn closeStream(self: *Self, stream_id: protocol_types.Ulid) !void {
         if (self.stream_complete_flags.get(stream_id) orelse false) return;
 
         try self.setStreamError(stream_id, "Stream closed by client");
@@ -494,10 +494,10 @@ pub const ProtocolClient = struct {
     }
 
     /// Remove all tracked client state for a specific stream.
-    pub fn removeStreamState(self: *Self, stream_id: protocol_types.Uuid) void {
+    pub fn removeStreamState(self: *Self, stream_id: protocol_types.Ulid) void {
         // Remove any pending requests associated with this stream.
         while (true) {
-            var pending_to_remove: ?protocol_types.Uuid = null;
+            var pending_to_remove: ?protocol_types.Ulid = null;
             var pending_it = self.pending_requests.iterator();
             while (pending_it.next()) |entry| {
                 if (std.mem.eql(u8, &entry.value_ptr.stream_id, &stream_id)) {
@@ -589,7 +589,7 @@ pub const ProtocolClient = struct {
     }
 
     /// Get the current stream ID
-    pub fn getCurrentStreamId(self: *Self) ?protocol_types.Uuid {
+    pub fn getCurrentStreamId(self: *Self) ?protocol_types.Ulid {
         return self.current_stream_id;
     }
 
@@ -600,7 +600,7 @@ pub const ProtocolClient = struct {
     }
 
     /// Get error for a specific stream
-    pub fn getLastErrorFor(self: *Self, stream_id: protocol_types.Uuid) ?[]const u8 {
+    pub fn getLastErrorFor(self: *Self, stream_id: protocol_types.Ulid) ?[]const u8 {
         if (self.stream_errors.get(stream_id)) |err| {
             const msg = err.slice();
             if (msg.len > 0) return msg;
@@ -763,8 +763,8 @@ test "processEnvelope routes events to per-stream event stream" {
     var client = ProtocolClient.init(allocator, .{});
     defer client.deinit();
 
-    const sid1 = protocol_types.generateUuid();
-    const sid2 = protocol_types.generateUuid();
+    const sid1 = protocol_types.generateUlid();
+    const sid2 = protocol_types.generateUlid();
 
     const partial = ai_types.AssistantMessage{
         .content = &.{},
@@ -778,7 +778,7 @@ test "processEnvelope routes events to per-stream event stream" {
 
     var env1 = protocol_types.Envelope{
         .stream_id = sid1,
-        .message_id = protocol_types.generateUuid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = 1,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .event = .{ .start = .{ .partial = partial } } },
@@ -787,7 +787,7 @@ test "processEnvelope routes events to per-stream event stream" {
 
     var env2 = protocol_types.Envelope{
         .stream_id = sid2,
-        .message_id = protocol_types.generateUuid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = 1,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .event = .{ .start = .{ .partial = partial } } },
@@ -813,7 +813,7 @@ test "processEnvelope handles ack" {
     defer client.deinit();
 
     // Add a pending request
-    const message_id = protocol_types.generateUuid();
+    const message_id = protocol_types.generateUlid();
     try client.pending_requests.put(message_id, .{
         .message_id = message_id,
         .sent_at = std.time.milliTimestamp(),
@@ -821,10 +821,10 @@ test "processEnvelope handles ack" {
     });
 
     // Create an ack envelope
-    const stream_id = protocol_types.generateUuid();
+    const stream_id = protocol_types.generateUlid();
     const env = protocol_types.Envelope{
         .stream_id = stream_id,
-        .message_id = protocol_types.generateUuid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = 2,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .ack = .{
@@ -849,7 +849,7 @@ test "processEnvelope handles nack" {
     defer client.deinit();
 
     // Add a pending request
-    const message_id = protocol_types.generateUuid();
+    const message_id = protocol_types.generateUlid();
     try client.pending_requests.put(message_id, .{
         .message_id = message_id,
         .sent_at = std.time.milliTimestamp(),
@@ -861,8 +861,8 @@ test "processEnvelope handles nack" {
     // Note: nack_reason ownership is transferred to envelope, will be freed by env.deinit()
 
     var env = protocol_types.Envelope{
-        .stream_id = protocol_types.generateUuid(),
-        .message_id = protocol_types.generateUuid(),
+        .stream_id = protocol_types.generateUlid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = 2,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .nack = .{
@@ -902,8 +902,8 @@ test "processEnvelope handles events" {
     };
 
     var env = protocol_types.Envelope{
-        .stream_id = protocol_types.generateUuid(),
-        .message_id = protocol_types.generateUuid(),
+        .stream_id = protocol_types.generateUlid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = 1,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .event = .{ .start = .{ .partial = partial } } },
@@ -937,8 +937,8 @@ test "processEnvelope accumulates to reconstructor" {
 
     // Send start event
     var env1 = protocol_types.Envelope{
-        .stream_id = protocol_types.generateUuid(),
-        .message_id = protocol_types.generateUuid(),
+        .stream_id = protocol_types.generateUlid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = 1,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .event = .{ .start = .{ .partial = partial } } },
@@ -948,8 +948,8 @@ test "processEnvelope accumulates to reconstructor" {
 
     // Send text_start event
     var env2 = protocol_types.Envelope{
-        .stream_id = protocol_types.generateUuid(),
-        .message_id = protocol_types.generateUuid(),
+        .stream_id = protocol_types.generateUlid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = 2,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .event = .{ .text_start = .{ .content_index = 0, .partial = partial } } },
@@ -962,8 +962,8 @@ test "processEnvelope accumulates to reconstructor" {
     const delta_str = try allocator.dupe(u8, "Hello");
 
     var env3 = protocol_types.Envelope{
-        .stream_id = protocol_types.generateUuid(),
-        .message_id = protocol_types.generateUuid(),
+        .stream_id = protocol_types.generateUlid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = 3,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .event = .{ .text_delta = .{
@@ -1050,7 +1050,7 @@ test "sendAbortRequest sends valid envelope" {
     client.setSender(sender);
 
     // Set a stream ID first
-    client.current_stream_id = protocol_types.generateUuid();
+    client.current_stream_id = protocol_types.generateUlid();
 
     try client.sendAbortRequest("User cancelled");
 
@@ -1085,8 +1085,8 @@ test "processEnvelope handles done event and builds result" {
 
     // Send start event
     var env1 = protocol_types.Envelope{
-        .stream_id = protocol_types.generateUuid(),
-        .message_id = protocol_types.generateUuid(),
+        .stream_id = protocol_types.generateUlid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = 1,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .event = .{ .start = .{ .partial = partial } } },
@@ -1096,8 +1096,8 @@ test "processEnvelope handles done event and builds result" {
 
     // Send text_start event
     var env2 = protocol_types.Envelope{
-        .stream_id = protocol_types.generateUuid(),
-        .message_id = protocol_types.generateUuid(),
+        .stream_id = protocol_types.generateUlid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = 2,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .event = .{ .text_start = .{ .content_index = 0, .partial = partial } } },
@@ -1110,8 +1110,8 @@ test "processEnvelope handles done event and builds result" {
     const delta_str = try allocator.dupe(u8, "Hello world");
 
     var env3 = protocol_types.Envelope{
-        .stream_id = protocol_types.generateUuid(),
-        .message_id = protocol_types.generateUuid(),
+        .stream_id = protocol_types.generateUlid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = 3,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .event = .{ .text_delta = .{
@@ -1135,8 +1135,8 @@ test "processEnvelope handles done event and builds result" {
     };
 
     var env4 = protocol_types.Envelope{
-        .stream_id = protocol_types.generateUuid(),
-        .message_id = protocol_types.generateUuid(),
+        .stream_id = protocol_types.generateUlid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = 4,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .event = .{ .done = .{
@@ -1182,8 +1182,8 @@ test "processEnvelope handles result payload" {
     };
 
     var env = protocol_types.Envelope{
-        .stream_id = protocol_types.generateUuid(),
-        .message_id = protocol_types.generateUuid(),
+        .stream_id = protocol_types.generateUlid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = 1,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .result = result_msg },
@@ -1212,8 +1212,8 @@ test "processEnvelope handles stream_error payload" {
     const error_msg = try allocator.dupe(u8, "Connection timeout");
 
     var env = protocol_types.Envelope{
-        .stream_id = protocol_types.generateUuid(),
-        .message_id = protocol_types.generateUuid(),
+        .stream_id = protocol_types.generateUlid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = 1,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .stream_error = .{
@@ -1241,7 +1241,7 @@ test "reset clears all state" {
     defer client.deinit();
 
     // Set up some state
-    client.current_stream_id = protocol_types.generateUuid();
+    client.current_stream_id = protocol_types.generateUlid();
     client.stream_complete = true;
     client.sequence = 10;
 
@@ -1278,7 +1278,7 @@ test "getCurrentStreamId returns correct value" {
     try std.testing.expect(client.getCurrentStreamId() == null);
 
     // After setting
-    const stream_id = protocol_types.generateUuid();
+    const stream_id = protocol_types.generateUlid();
     client.current_stream_id = stream_id;
 
     const result = client.getCurrentStreamId();
@@ -1319,7 +1319,7 @@ test "closeStream marks stream complete with client-side error" {
     var client = ProtocolClient.init(allocator, .{});
     defer client.deinit();
 
-    const sid = protocol_types.generateUuid();
+    const sid = protocol_types.generateUlid();
     try client.stream_complete_flags.put(sid, false);
     _ = try client.ensureStreamEventStream(sid);
 
@@ -1337,8 +1337,8 @@ test "removeStreamState clears per-stream maps and legacy current stream state" 
     var client = ProtocolClient.init(allocator, .{});
     defer client.deinit();
 
-    const sid = protocol_types.generateUuid();
-    const mid = protocol_types.generateUuid();
+    const sid = protocol_types.generateUlid();
+    const mid = protocol_types.generateUlid();
 
     try client.pending_requests.put(mid, .{
         .message_id = mid,
@@ -1397,9 +1397,9 @@ test "processEnvelope keeps interleaved terminal state isolated per stream" {
     var client = ProtocolClient.init(allocator, .{});
     defer client.deinit();
 
-    const sid_result = protocol_types.generateUuid();
-    const sid_error = protocol_types.generateUuid();
-    const sid_done = protocol_types.generateUuid();
+    const sid_result = protocol_types.generateUlid();
+    const sid_error = protocol_types.generateUlid();
+    const sid_done = protocol_types.generateUlid();
 
     const result_text = try allocator.dupe(u8, "result stream text");
     const result_api = try allocator.dupe(u8, "test-api");
@@ -1410,7 +1410,7 @@ test "processEnvelope keeps interleaved terminal state isolated per stream" {
 
     var env_result = protocol_types.Envelope{
         .stream_id = sid_result,
-        .message_id = protocol_types.generateUuid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = 1,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .result = .{
@@ -1429,7 +1429,7 @@ test "processEnvelope keeps interleaved terminal state isolated per stream" {
     const err_msg = try allocator.dupe(u8, "stream two failed");
     var env_error = protocol_types.Envelope{
         .stream_id = sid_error,
-        .message_id = protocol_types.generateUuid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = 1,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .stream_error = .{
@@ -1450,7 +1450,7 @@ test "processEnvelope keeps interleaved terminal state isolated per stream" {
     };
     var env_done_start = protocol_types.Envelope{
         .stream_id = sid_done,
-        .message_id = protocol_types.generateUuid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = 1,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .event = .{ .start = .{ .partial = done_partial } } },
@@ -1468,7 +1468,7 @@ test "processEnvelope keeps interleaved terminal state isolated per stream" {
     };
     var env_done = protocol_types.Envelope{
         .stream_id = sid_done,
-        .message_id = protocol_types.generateUuid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = 2,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .event = .{ .done = .{

--- a/zig/src/protocol/provider/envelope.zig
+++ b/zig/src/protocol/provider/envelope.zig
@@ -26,12 +26,12 @@ pub fn serializeEnvelope(
     }
 
     // Write stream_id
-    const stream_id_str = try protocol_types.uuidToString(envelope.stream_id, allocator);
+    const stream_id_str = try protocol_types.ulidToString(envelope.stream_id, allocator);
     defer allocator.free(stream_id_str);
     try w.writeStringField("stream_id", stream_id_str);
 
     // Write message_id
-    const message_id_str = try protocol_types.uuidToString(envelope.message_id, allocator);
+    const message_id_str = try protocol_types.ulidToString(envelope.message_id, allocator);
     defer allocator.free(message_id_str);
     try w.writeStringField("message_id", message_id_str);
 
@@ -46,7 +46,7 @@ pub fn serializeEnvelope(
 
     // Write in_reply_to if present
     if (envelope.in_reply_to) |reply_to| {
-        const reply_to_str = try protocol_types.uuidToString(reply_to, allocator);
+        const reply_to_str = try protocol_types.ulidToString(reply_to, allocator);
         defer allocator.free(reply_to_str);
         try w.writeStringField("in_reply_to", reply_to_str);
     }
@@ -83,12 +83,12 @@ fn serializePayload(
             }
         },
         .sync_request => |sync_req| {
-            const target_str = try protocol_types.uuidToString(sync_req.target_stream_id, allocator);
+            const target_str = try protocol_types.ulidToString(sync_req.target_stream_id, allocator);
             defer allocator.free(target_str);
             try w.writeStringField("target_stream_id", target_str);
         },
         .sync => |sync_msg| {
-            const target_str = try protocol_types.uuidToString(sync_msg.target_stream_id, allocator);
+            const target_str = try protocol_types.ulidToString(sync_msg.target_stream_id, allocator);
             defer allocator.free(target_str);
             try w.writeStringField("target_stream_id", target_str);
             if (sync_msg.partial) |partial| {
@@ -140,7 +140,7 @@ fn serializePayload(
             }
         },
         .abort_request => |req| {
-            const target_str = try protocol_types.uuidToString(req.target_stream_id, allocator);
+            const target_str = try protocol_types.ulidToString(req.target_stream_id, allocator);
             defer allocator.free(target_str);
             try w.writeStringField("target_stream_id", target_str);
             if (req.getReason()) |reason| {
@@ -148,12 +148,12 @@ fn serializePayload(
             }
         },
         .ack => |ack| {
-            const acknowledged_id_str = try protocol_types.uuidToString(ack.acknowledged_id, allocator);
+            const acknowledged_id_str = try protocol_types.ulidToString(ack.acknowledged_id, allocator);
             defer allocator.free(acknowledged_id_str);
             try w.writeStringField("acknowledged_id", acknowledged_id_str);
         },
         .nack => |nack| {
-            const rejected_id_str = try protocol_types.uuidToString(nack.rejected_id, allocator);
+            const rejected_id_str = try protocol_types.ulidToString(nack.rejected_id, allocator);
             defer allocator.free(rejected_id_str);
             try w.writeStringField("rejected_id", rejected_id_str);
             try w.writeStringField("reason", nack.reason.slice());
@@ -601,11 +601,11 @@ pub fn deserializeEnvelope(
 
     // Parse stream_id
     const stream_id_str = obj.get("stream_id").?.string;
-    const stream_id = protocol_types.parseUuid(stream_id_str) orelse return error.InvalidUuid;
+    const stream_id = protocol_types.parseUlid(stream_id_str) orelse return error.InvalidUlid;
 
     // Parse message_id
     const message_id_str = obj.get("message_id").?.string;
-    const message_id = protocol_types.parseUuid(message_id_str) orelse return error.InvalidUuid;
+    const message_id = protocol_types.parseUlid(message_id_str) orelse return error.InvalidUlid;
 
     // Parse sequence
     const sequence: u64 = @intCast(obj.get("sequence").?.integer);
@@ -614,9 +614,9 @@ pub fn deserializeEnvelope(
     const timestamp: i64 = obj.get("timestamp").?.integer;
 
     // Parse in_reply_to if present
-    var in_reply_to: ?protocol_types.Uuid = null;
+    var in_reply_to: ?protocol_types.Ulid = null;
     if (obj.get("in_reply_to")) |reply_val| {
-        in_reply_to = protocol_types.parseUuid(reply_val.string) orelse return error.InvalidUuid;
+        in_reply_to = protocol_types.parseUlid(reply_val.string) orelse return error.InvalidUlid;
     }
 
     // Parse type
@@ -836,7 +836,7 @@ fn deserializeAbortRequest(
     allocator: std.mem.Allocator,
 ) !protocol_types.AbortRequest {
     const target_str = obj.get("target_stream_id").?.string;
-    const target_id = protocol_types.parseUuid(target_str) orelse return error.InvalidUuid;
+    const target_id = protocol_types.parseUlid(target_str) orelse return error.InvalidUlid;
 
     const reason = if (obj.get("reason")) |r|
         protocol_types.OwnedSlice(u8).initOwned(try allocator.dupe(u8, r.string))
@@ -1018,7 +1018,7 @@ fn deserializeModelDescriptor(
 /// Deserialize ack
 fn deserializeAck(obj: std.json.ObjectMap) !protocol_types.Ack {
     const acknowledged_id_str = obj.get("acknowledged_id").?.string;
-    const acknowledged_id = protocol_types.parseUuid(acknowledged_id_str) orelse return error.InvalidUuid;
+    const acknowledged_id = protocol_types.parseUlid(acknowledged_id_str) orelse return error.InvalidUlid;
 
     return .{
         .acknowledged_id = acknowledged_id,
@@ -1031,7 +1031,7 @@ fn deserializeNack(
     allocator: std.mem.Allocator,
 ) !protocol_types.Nack {
     const rejected_id_str = obj.get("rejected_id").?.string;
-    const rejected_id = protocol_types.parseUuid(rejected_id_str) orelse return error.InvalidUuid;
+    const rejected_id = protocol_types.parseUlid(rejected_id_str) orelse return error.InvalidUlid;
 
     const reason = protocol_types.OwnedSlice(u8).initOwned(try allocator.dupe(u8, obj.get("reason").?.string));
     errdefer {
@@ -1109,7 +1109,7 @@ fn deserializeGoodbye(
 /// Deserialize sync_request
 fn deserializeSyncRequest(obj: std.json.ObjectMap) !protocol_types.SyncRequest {
     const target_str = obj.get("target_stream_id").?.string;
-    const target_id = protocol_types.parseUuid(target_str) orelse return error.InvalidUuid;
+    const target_id = protocol_types.parseUlid(target_str) orelse return error.InvalidUlid;
 
     return .{ .target_stream_id = target_id };
 }
@@ -1120,7 +1120,7 @@ fn deserializeSync(
     allocator: std.mem.Allocator,
 ) !protocol_types.Sync {
     const target_str = obj.get("target_stream_id").?.string;
-    const target_stream_id = protocol_types.parseUuid(target_str) orelse return error.InvalidUuid;
+    const target_stream_id = protocol_types.parseUlid(target_str) orelse return error.InvalidUlid;
 
     const partial = if (obj.get("partial")) |p|
         try transport.parseAssistantMessage(p.object, allocator)
@@ -1466,7 +1466,7 @@ fn parseServiceTier(str: []const u8) ?ai_types.ServiceTier {
 
 /// Create a new envelope with auto-generated IDs and timestamp
 pub fn createEnvelope(
-    stream_id: protocol_types.Uuid,
+    stream_id: protocol_types.Ulid,
     sequence: u64,
     payload: protocol_types.Payload,
     allocator: std.mem.Allocator,
@@ -1474,7 +1474,7 @@ pub fn createEnvelope(
     _ = allocator; // Not needed for basic envelope creation
     return .{
         .stream_id = stream_id,
-        .message_id = protocol_types.generateUuid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = sequence,
         .timestamp = std.time.milliTimestamp(),
         .payload = payload,
@@ -1490,7 +1490,7 @@ pub fn createReply(
     _ = allocator;
     return .{
         .stream_id = original.stream_id,
-        .message_id = protocol_types.generateUuid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = original.sequence + 1,
         .in_reply_to = original.message_id,
         .timestamp = std.time.milliTimestamp(),
@@ -1506,7 +1506,7 @@ pub fn createAck(
     _ = allocator;
     return .{
         .stream_id = original.stream_id,
-        .message_id = protocol_types.generateUuid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = original.sequence + 1,
         .in_reply_to = original.message_id,
         .timestamp = std.time.milliTimestamp(),
@@ -1526,7 +1526,7 @@ pub fn createNack(
     const reason_copy = try allocator.dupe(u8, reason);
     return .{
         .stream_id = original.stream_id,
-        .message_id = protocol_types.generateUuid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = original.sequence + 1,
         .in_reply_to = original.message_id,
         .timestamp = std.time.milliTimestamp(),
@@ -1561,7 +1561,7 @@ pub fn createVersionMismatchNack(
 
     return .{
         .stream_id = original.stream_id,
-        .message_id = protocol_types.generateUuid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = original.sequence + 1,
         .in_reply_to = original.message_id,
         .timestamp = std.time.milliTimestamp(),
@@ -1576,7 +1576,7 @@ pub fn createVersionMismatchNack(
 
 // Custom error set
 pub const EnvelopeError = error{
-    InvalidUuid,
+    InvalidUlid,
     UnknownPayloadType,
     UnknownMessageRole,
     InvalidUserContent,
@@ -1591,8 +1591,8 @@ test "serializeEnvelope with ping payload" {
     const allocator = std.testing.allocator;
 
     const envelope = protocol_types.Envelope{
-        .stream_id = protocol_types.generateUuid(),
-        .message_id = protocol_types.generateUuid(),
+        .stream_id = protocol_types.generateUlid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = 1,
         .timestamp = 1708234567890,
         .payload = .ping,
@@ -1615,8 +1615,8 @@ test "serializeEnvelope with pong payload" {
     // Note: ping_id ownership is transferred to envelope, will be freed by envelope.deinit
 
     var envelope = protocol_types.Envelope{
-        .stream_id = protocol_types.generateUuid(),
-        .message_id = protocol_types.generateUuid(),
+        .stream_id = protocol_types.generateUlid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = 2,
         .timestamp = 1708234567900,
         .payload = .{ .pong = .{ .ping_id = protocol_types.OwnedSlice(u8).initOwned(ping_id) } },
@@ -1654,8 +1654,8 @@ test "serializeEnvelope with stream_request payload" {
     };
 
     var envelope = protocol_types.Envelope{
-        .stream_id = protocol_types.generateUuid(),
-        .message_id = protocol_types.generateUuid(),
+        .stream_id = protocol_types.generateUlid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = 1,
         .timestamp = 1708234567890,
         .payload = .{ .stream_request = .{
@@ -1686,8 +1686,8 @@ test "deserializeEnvelope parses valid JSON" {
     const json =
         \\{
         \\  "type": "ping",
-        \\  "stream_id": "01234567-89ab-cdef-fedc-ba9876543210",
-        \\  "message_id": "12345678-9abc-def0-fedc-ba9876543210",
+        \\  "stream_id": "018D2PF2DBSQQZWQ5TK1V58CGG",
+        \\  "message_id": "0J6HB7H6NWVVRFXX5TK1V58CGG",
         \\  "sequence": 1,
         \\  "timestamp": 1708234567890,
         \\  "version": 1,
@@ -1704,37 +1704,37 @@ test "deserializeEnvelope parses valid JSON" {
     try std.testing.expect(envelope.payload == .ping);
 
     // Verify stream_id
-    const expected_stream_id: protocol_types.Uuid = .{ 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0xfe, 0xdc, 0xba, 0x98, 0x76, 0x54, 0x32, 0x10 };
+    const expected_stream_id: protocol_types.Ulid = .{ 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0xfe, 0xdc, 0xba, 0x98, 0x76, 0x54, 0x32, 0x10 };
     try std.testing.expectEqualSlices(u8, &expected_stream_id, &envelope.stream_id);
 }
 
-test "deserializeEnvelope rejects invalid in_reply_to uuid" {
+test "deserializeEnvelope rejects invalid in_reply_to ulid" {
     const allocator = std.testing.allocator;
 
     const json =
         \\{
         \\  "type": "ping",
-        \\  "stream_id": "01234567-89ab-cdef-fedc-ba9876543210",
-        \\  "message_id": "12345678-9abc-def0-fedc-ba9876543210",
+        \\  "stream_id": "018D2PF2DBSQQZWQ5TK1V58CGG",
+        \\  "message_id": "0J6HB7H6NWVVRFXX5TK1V58CGG",
         \\  "sequence": 1,
         \\  "timestamp": 1708234567890,
-        \\  "in_reply_to": "not-a-uuid",
+        \\  "in_reply_to": "not-a-ulid",
         \\  "payload": {}
         \\}
     ;
 
-    try std.testing.expectError(error.InvalidUuid, deserializeEnvelope(json, allocator));
+    try std.testing.expectError(error.InvalidUlid, deserializeEnvelope(json, allocator));
 }
 
 test "serializeEnvelope and deserializeEnvelope roundtrip with ping" {
     const allocator = std.testing.allocator;
 
     const original = protocol_types.Envelope{
-        .stream_id = protocol_types.generateUuid(),
-        .message_id = protocol_types.generateUuid(),
+        .stream_id = protocol_types.generateUlid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = 42,
         .timestamp = std.time.milliTimestamp(),
-        .in_reply_to = protocol_types.generateUuid(),
+        .in_reply_to = protocol_types.generateUlid(),
         .payload = .ping,
     };
 
@@ -1756,11 +1756,11 @@ test "serializeEnvelope and deserializeEnvelope roundtrip with ping" {
 test "serializeEnvelope and deserializeEnvelope roundtrip with ack" {
     const allocator = std.testing.allocator;
 
-    const acknowledged_id = protocol_types.generateUuid();
+    const acknowledged_id = protocol_types.generateUlid();
 
     const original = protocol_types.Envelope{
-        .stream_id = protocol_types.generateUuid(),
-        .message_id = protocol_types.generateUuid(),
+        .stream_id = protocol_types.generateUlid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = 2,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .ack = .{
@@ -1781,13 +1781,13 @@ test "serializeEnvelope and deserializeEnvelope roundtrip with ack" {
 test "serializeEnvelope and deserializeEnvelope roundtrip with nack" {
     const allocator = std.testing.allocator;
 
-    const rejected_id = protocol_types.generateUuid();
+    const rejected_id = protocol_types.generateUlid();
     const reason = try allocator.dupe(u8, "Test error reason");
     // Note: reason ownership is transferred to original, will be freed by original.deinit
 
     var original = protocol_types.Envelope{
-        .stream_id = protocol_types.generateUuid(),
-        .message_id = protocol_types.generateUuid(),
+        .stream_id = protocol_types.generateUlid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = 2,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .nack = .{
@@ -1814,7 +1814,7 @@ test "serializeEnvelope and deserializeEnvelope roundtrip with nack" {
 test "createEnvelope generates valid envelope" {
     const allocator = std.testing.allocator;
 
-    const stream_id = protocol_types.generateUuid();
+    const stream_id = protocol_types.generateUlid();
     var envelope = createEnvelope(stream_id, 1, .ping, allocator);
     defer envelope.deinit(allocator);
 
@@ -1829,8 +1829,8 @@ test "createReply sets in_reply_to correctly" {
     const allocator = std.testing.allocator;
 
     var original = protocol_types.Envelope{
-        .stream_id = protocol_types.generateUuid(),
-        .message_id = protocol_types.generateUuid(),
+        .stream_id = protocol_types.generateUlid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = 5,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .stream_request = .{
@@ -1852,8 +1852,8 @@ test "createAck creates valid ack" {
     const allocator = std.testing.allocator;
 
     const original = protocol_types.Envelope{
-        .stream_id = protocol_types.generateUuid(),
-        .message_id = protocol_types.generateUuid(),
+        .stream_id = protocol_types.generateUlid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = 1,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .stream_request = .{
@@ -1875,8 +1875,8 @@ test "createNack creates valid nack" {
     const allocator = std.testing.allocator;
 
     var original = protocol_types.Envelope{
-        .stream_id = protocol_types.generateUuid(),
-        .message_id = protocol_types.generateUuid(),
+        .stream_id = protocol_types.generateUlid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = 1,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .stream_request = .{
@@ -1901,8 +1901,8 @@ test "createVersionMismatchNack includes supported versions" {
 
     const original = protocol_types.Envelope{
         .version = 2,
-        .stream_id = protocol_types.generateUuid(),
-        .message_id = protocol_types.generateUuid(),
+        .stream_id = protocol_types.generateUlid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = 1,
         .timestamp = std.time.milliTimestamp(),
         .payload = .ping,
@@ -1925,12 +1925,12 @@ test "serializeEnvelope with abort_request payload" {
     // Note: reason ownership is transferred to envelope, will be freed by envelope.deinit
 
     var envelope = protocol_types.Envelope{
-        .stream_id = protocol_types.generateUuid(),
-        .message_id = protocol_types.generateUuid(),
+        .stream_id = protocol_types.generateUlid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = 10,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .abort_request = .{
-            .target_stream_id = protocol_types.generateUuid(),
+            .target_stream_id = protocol_types.generateUlid(),
             .reason = protocol_types.OwnedSlice(u8).initOwned(reason),
         } },
     };
@@ -1952,8 +1952,8 @@ test "serializeEnvelope with stream_error payload" {
     // Note: msg ownership is transferred to envelope, will be freed by envelope.deinit
 
     var envelope = protocol_types.Envelope{
-        .stream_id = protocol_types.generateUuid(),
-        .message_id = protocol_types.generateUuid(),
+        .stream_id = protocol_types.generateUlid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = 20,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .stream_error = .{
@@ -1978,8 +1978,8 @@ test "deserializeEnvelope with version field defaults to 1" {
     const json =
         \\{
         \\  "type": "ping",
-        \\  "stream_id": "01234567-89ab-cdef-fedc-ba9876543210",
-        \\  "message_id": "12345678-9abc-def0-fedc-ba9876543210",
+        \\  "stream_id": "018D2PF2DBSQQZWQ5TK1V58CGG",
+        \\  "message_id": "0J6HB7H6NWVVRFXX5TK1V58CGG",
         \\  "sequence": 1,
         \\  "timestamp": 1708234567890,
         \\  "payload": {}
@@ -1999,8 +1999,8 @@ test "deserializeEnvelope with explicit version" {
     const json =
         \\{
         \\  "type": "ping",
-        \\  "stream_id": "01234567-89ab-cdef-fedc-ba9876543210",
-        \\  "message_id": "12345678-9abc-def0-fedc-ba9876543210",
+        \\  "stream_id": "018D2PF2DBSQQZWQ5TK1V58CGG",
+        \\  "message_id": "0J6HB7H6NWVVRFXX5TK1V58CGG",
         \\  "sequence": 1,
         \\  "timestamp": 1708234567890,
         \\  "version": 2,
@@ -2022,8 +2022,8 @@ test "deserializeEnvelope with stream_request frees all memory" {
     const json =
         \\{
         \\  "type": "stream_request",
-        \\  "stream_id": "01234567-89ab-cdef-fedc-ba9876543210",
-        \\  "message_id": "12345678-9abc-def0-fedc-ba9876543210",
+        \\  "stream_id": "018D2PF2DBSQQZWQ5TK1V58CGG",
+        \\  "message_id": "0J6HB7H6NWVVRFXX5TK1V58CGG",
         \\  "sequence": 1,
         \\  "timestamp": 1708234567890,
         \\  "version": 1,
@@ -2079,8 +2079,8 @@ test "deserializeEnvelope with complete_request frees all memory" {
     const json =
         \\{
         \\  "type": "complete_request",
-        \\  "stream_id": "01234567-89ab-cdef-fedc-ba9876543210",
-        \\  "message_id": "12345678-9abc-def0-fedc-ba9876543210",
+        \\  "stream_id": "018D2PF2DBSQQZWQ5TK1V58CGG",
+        \\  "message_id": "0J6HB7H6NWVVRFXX5TK1V58CGG",
         \\  "sequence": 1,
         \\  "timestamp": 1708234567890,
         \\  "version": 1,
@@ -2119,8 +2119,8 @@ test "deserializeEnvelope with complex context frees all memory" {
     const json =
         \\{
         \\  "type": "stream_request",
-        \\  "stream_id": "01234567-89ab-cdef-fedc-ba9876543210",
-        \\  "message_id": "12345678-9abc-def0-fedc-ba9876543210",
+        \\  "stream_id": "018D2PF2DBSQQZWQ5TK1V58CGG",
+        \\  "message_id": "0J6HB7H6NWVVRFXX5TK1V58CGG",
         \\  "sequence": 1,
         \\  "timestamp": 1708234567890,
         \\  "version": 1,
@@ -2171,8 +2171,8 @@ test "serializeEnvelope with goodbye payload" {
 
     const reason = try allocator.dupe(u8, "Server shutting down");
     var envelope = protocol_types.Envelope{
-        .stream_id = protocol_types.generateUuid(),
-        .message_id = protocol_types.generateUuid(),
+        .stream_id = protocol_types.generateUlid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = 100,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .goodbye = .{ .reason = protocol_types.OwnedSlice(u8).initOwned(reason) } },
@@ -2191,8 +2191,8 @@ test "serializeEnvelope with goodbye payload (no reason)" {
     const allocator = std.testing.allocator;
 
     var envelope = protocol_types.Envelope{
-        .stream_id = protocol_types.generateUuid(),
-        .message_id = protocol_types.generateUuid(),
+        .stream_id = protocol_types.generateUlid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = 100,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .goodbye = .{} },
@@ -2210,10 +2210,10 @@ test "serializeEnvelope with goodbye payload (no reason)" {
 test "serializeEnvelope with sync_request payload" {
     const allocator = std.testing.allocator;
 
-    const target_id = protocol_types.generateUuid();
+    const target_id = protocol_types.generateUlid();
     var envelope = protocol_types.Envelope{
-        .stream_id = protocol_types.generateUuid(),
-        .message_id = protocol_types.generateUuid(),
+        .stream_id = protocol_types.generateUlid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = 50,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .sync_request = .{ .target_stream_id = target_id } },
@@ -2243,12 +2243,12 @@ test "serializeEnvelope with sync payload" {
         .is_owned = false,
     };
     var envelope = protocol_types.Envelope{
-        .stream_id = protocol_types.generateUuid(),
-        .message_id = protocol_types.generateUuid(),
+        .stream_id = protocol_types.generateUlid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = 60,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .sync = .{
-            .target_stream_id = protocol_types.generateUuid(),
+            .target_stream_id = protocol_types.generateUlid(),
             .partial = partial,
         } },
     };
@@ -2269,8 +2269,8 @@ test "deserializeEnvelope with pong payload" {
     const json =
         \\{
         \\  "type": "pong",
-        \\  "stream_id": "01234567-89ab-cdef-fedc-ba9876543210",
-        \\  "message_id": "12345678-9abc-def0-fedc-ba9876543210",
+        \\  "stream_id": "018D2PF2DBSQQZWQ5TK1V58CGG",
+        \\  "message_id": "0J6HB7H6NWVVRFXX5TK1V58CGG",
         \\  "sequence": 2,
         \\  "timestamp": 1708234567900,
         \\  "payload": {
@@ -2292,8 +2292,8 @@ test "deserializeEnvelope with goodbye payload" {
     const json =
         \\{
         \\  "type": "goodbye",
-        \\  "stream_id": "01234567-89ab-cdef-fedc-ba9876543210",
-        \\  "message_id": "12345678-9abc-def0-fedc-ba9876543210",
+        \\  "stream_id": "018D2PF2DBSQQZWQ5TK1V58CGG",
+        \\  "message_id": "0J6HB7H6NWVVRFXX5TK1V58CGG",
         \\  "sequence": 100,
         \\  "timestamp": 1708234567900,
         \\  "payload": {
@@ -2315,8 +2315,8 @@ test "deserializeEnvelope with goodbye payload (no reason)" {
     const json =
         \\{
         \\  "type": "goodbye",
-        \\  "stream_id": "01234567-89ab-cdef-fedc-ba9876543210",
-        \\  "message_id": "12345678-9abc-def0-fedc-ba9876543210",
+        \\  "stream_id": "018D2PF2DBSQQZWQ5TK1V58CGG",
+        \\  "message_id": "0J6HB7H6NWVVRFXX5TK1V58CGG",
         \\  "sequence": 100,
         \\  "timestamp": 1708234567900,
         \\  "payload": {}
@@ -2336,12 +2336,12 @@ test "deserializeEnvelope with sync_request payload" {
     const json =
         \\{
         \\  "type": "sync_request",
-        \\  "stream_id": "01234567-89ab-cdef-fedc-ba9876543210",
-        \\  "message_id": "12345678-9abc-def0-fedc-ba9876543210",
+        \\  "stream_id": "018D2PF2DBSQQZWQ5TK1V58CGG",
+        \\  "message_id": "0J6HB7H6NWVVRFXX5TK1V58CGG",
         \\  "sequence": 50,
         \\  "timestamp": 1708234567900,
         \\  "payload": {
-        \\    "target_stream_id": "abcdef01-2345-6789-abcd-ef0123456789"
+        \\    "target_stream_id": "55QKQG28T5CY4TQKFF04HMASW9"
         \\  }
         \\}
     ;
@@ -2351,7 +2351,7 @@ test "deserializeEnvelope with sync_request payload" {
 
     try std.testing.expect(envelope.payload == .sync_request);
 
-    const expected_target: protocol_types.Uuid = .{ 0xab, 0xcd, 0xef, 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x01, 0x23, 0x45, 0x67, 0x89 };
+    const expected_target: protocol_types.Ulid = .{ 0xab, 0xcd, 0xef, 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x01, 0x23, 0x45, 0x67, 0x89 };
     try std.testing.expectEqualSlices(u8, &expected_target, &envelope.payload.sync_request.target_stream_id);
 }
 
@@ -2361,12 +2361,12 @@ test "deserializeEnvelope with sync payload" {
     const json =
         \\{
         \\  "type": "sync",
-        \\  "stream_id": "01234567-89ab-cdef-fedc-ba9876543210",
-        \\  "message_id": "12345678-9abc-def0-fedc-ba9876543210",
+        \\  "stream_id": "018D2PF2DBSQQZWQ5TK1V58CGG",
+        \\  "message_id": "0J6HB7H6NWVVRFXX5TK1V58CGG",
         \\  "sequence": 60,
         \\  "timestamp": 1708234567900,
         \\  "payload": {
-        \\    "target_stream_id": "abcdef01-2345-6789-abcd-ef0123456789",
+        \\    "target_stream_id": "55QKQG28T5CY4TQKFF04HMASW9",
         \\    "partial": {
         \\      "stop_reason": "stop",
         \\      "model": "test-model",
@@ -2383,7 +2383,7 @@ test "deserializeEnvelope with sync payload" {
     defer envelope.deinit(allocator);
 
     try std.testing.expect(envelope.payload == .sync);
-    const expected_target: protocol_types.Uuid = .{ 0xab, 0xcd, 0xef, 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x01, 0x23, 0x45, 0x67, 0x89 };
+    const expected_target: protocol_types.Ulid = .{ 0xab, 0xcd, 0xef, 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x01, 0x23, 0x45, 0x67, 0x89 };
     try std.testing.expectEqualSlices(u8, &expected_target, &envelope.payload.sync.target_stream_id);
     try std.testing.expect(envelope.payload.sync.partial != null);
 }
@@ -2393,8 +2393,8 @@ test "serializeEnvelope and deserializeEnvelope roundtrip with pong" {
 
     const ping_id = try allocator.dupe(u8, "roundtrip-ping-id");
     var original = protocol_types.Envelope{
-        .stream_id = protocol_types.generateUuid(),
-        .message_id = protocol_types.generateUuid(),
+        .stream_id = protocol_types.generateUlid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = 10,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .pong = .{ .ping_id = protocol_types.OwnedSlice(u8).initOwned(ping_id) } },
@@ -2417,8 +2417,8 @@ test "serializeEnvelope and deserializeEnvelope roundtrip with goodbye" {
 
     const reason = try allocator.dupe(u8, "Graceful shutdown");
     var original = protocol_types.Envelope{
-        .stream_id = protocol_types.generateUuid(),
-        .message_id = protocol_types.generateUuid(),
+        .stream_id = protocol_types.generateUlid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = 200,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .goodbye = .{ .reason = protocol_types.OwnedSlice(u8).initOwned(reason) } },
@@ -2440,8 +2440,8 @@ test "serializeEnvelope and deserializeEnvelope roundtrip with models_request" {
     const allocator = std.testing.allocator;
 
     var original = protocol_types.Envelope{
-        .stream_id = protocol_types.generateUuid(),
-        .message_id = protocol_types.generateUuid(),
+        .stream_id = protocol_types.generateUlid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = 1,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .models_request = .{
@@ -2501,8 +2501,8 @@ test "serializeEnvelope and deserializeEnvelope roundtrip with models_response" 
     };
 
     var original = protocol_types.Envelope{
-        .stream_id = protocol_types.generateUuid(),
-        .message_id = protocol_types.generateUuid(),
+        .stream_id = protocol_types.generateUlid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = 2,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .models_response = .{

--- a/zig/src/protocol/provider/runtime.zig
+++ b/zig/src/protocol/provider/runtime.zig
@@ -34,7 +34,7 @@ pub const ProviderProtocolRuntime = struct {
                 const seq = self.server.getNextSequence(stream_id);
                 const env = protocol_types.Envelope{
                     .stream_id = stream_id,
-                    .message_id = protocol_types.generateUuid(),
+                    .message_id = protocol_types.generateUlid(),
                     .sequence = seq,
                     .timestamp = std.time.milliTimestamp(),
                     .payload = .{ .event = event },
@@ -56,7 +56,7 @@ pub const ProviderProtocolRuntime = struct {
                     const seq = self.server.getNextSequence(stream_id);
                     const env = protocol_types.Envelope{
                         .stream_id = stream_id,
-                        .message_id = protocol_types.generateUuid(),
+                        .message_id = protocol_types.generateUlid(),
                         .sequence = seq,
                         .timestamp = std.time.milliTimestamp(),
                         .payload = .{ .result = result },
@@ -73,7 +73,7 @@ pub const ProviderProtocolRuntime = struct {
                     const err_copy = try self.allocator.dupe(u8, err_msg);
                     var env = protocol_types.Envelope{
                         .stream_id = stream_id,
-                        .message_id = protocol_types.generateUuid(),
+                        .message_id = protocol_types.generateUlid(),
                         .sequence = seq,
                         .timestamp = std.time.milliTimestamp(),
                         .payload = .{ .stream_error = .{

--- a/zig/src/protocol/provider/server.zig
+++ b/zig/src/protocol/provider/server.zig
@@ -31,8 +31,8 @@ fn validateSequence(expected: u64, received: u64) SequenceError!void {
 /// Helper to create a NACK for sequence errors
 fn createSequenceNack(
     allocator: std.mem.Allocator,
-    stream_id: protocol_types.Uuid,
-    message_id: protocol_types.Uuid,
+    stream_id: protocol_types.Ulid,
+    message_id: protocol_types.Ulid,
     err: SequenceError,
 ) !protocol_types.Envelope {
     const reason: []const u8 = switch (err) {
@@ -205,16 +205,16 @@ pub const ProtocolServer = struct {
     /// NOTE: While this map supports multiple streams, event forwarding is not
     /// yet implemented. The server currently handles stream creation/abortion
     /// but does not poll and forward events from provider streams.
-    active_streams: std.AutoHashMap(protocol_types.Uuid, ActiveStream),
+    active_streams: std.AutoHashMap(protocol_types.Ulid, ActiveStream),
 
     /// API registry for provider lookup
     registry: *api_registry.ApiRegistry,
 
     /// Sequence counter per stream (outgoing)
-    sequence_counters: std.AutoHashMap(protocol_types.Uuid, u64),
+    sequence_counters: std.AutoHashMap(protocol_types.Ulid, u64),
 
     /// Expected next sequence number per stream (incoming)
-    expected_sequences: std.AutoHashMap(protocol_types.Uuid, u64),
+    expected_sequences: std.AutoHashMap(protocol_types.Ulid, u64),
 
     /// Queued outbound server envelopes that must be emitted after immediate ACK.
     outbox: std.ArrayList(protocol_types.Envelope),
@@ -223,7 +223,7 @@ pub const ProtocolServer = struct {
     options: Options,
 
     pub const ActiveStream = struct {
-        stream_id: protocol_types.Uuid,
+        stream_id: protocol_types.Ulid,
         model: ai_types.Model,
         event_stream: *event_stream.AssistantMessageEventStream,
         partial_state: partial_serializer.PartialState,
@@ -263,10 +263,10 @@ pub const ProtocolServer = struct {
     pub fn init(allocator: std.mem.Allocator, registry: *api_registry.ApiRegistry, options: Options) ProtocolServer {
         return .{
             .allocator = allocator,
-            .active_streams = std.AutoHashMap(protocol_types.Uuid, ActiveStream).init(allocator),
+            .active_streams = std.AutoHashMap(protocol_types.Ulid, ActiveStream).init(allocator),
             .registry = registry,
-            .sequence_counters = std.AutoHashMap(protocol_types.Uuid, u64).init(allocator),
-            .expected_sequences = std.AutoHashMap(protocol_types.Uuid, u64).init(allocator),
+            .sequence_counters = std.AutoHashMap(protocol_types.Ulid, u64).init(allocator),
+            .expected_sequences = std.AutoHashMap(protocol_types.Ulid, u64).init(allocator),
             .outbox = std.ArrayList(protocol_types.Envelope){},
             .options = options,
         };
@@ -332,7 +332,7 @@ pub const ProtocolServer = struct {
             },
             .ping => {
                 // Respond with pong containing the ping's message_id as ping_id
-                const ping_id_str = try protocol_types.uuidToString(env.message_id, self.allocator);
+                const ping_id_str = try protocol_types.ulidToString(env.message_id, self.allocator);
                 const pong_payload: protocol_types.Payload = .{ .pong = .{ .ping_id = protocol_types.OwnedSlice(u8).initOwned(ping_id_str) } };
                 return envelope.createReply(env, pong_payload, self.allocator);
             },
@@ -366,14 +366,14 @@ pub const ProtocolServer = struct {
     pub fn cleanupCompletedStreams(self: *ProtocolServer) void {
         // Common path: avoid heap allocation by collecting IDs in a fixed pool.
         const CleanupNode = struct {
-            stream_id: protocol_types.Uuid,
+            stream_id: protocol_types.Ulid,
             next: ?*@This() = null,
         };
         var remove_pool = hive_array.HiveArray(CleanupNode, 128).init();
         var remove_head: ?*CleanupNode = null;
 
         // Overflow path for unusually large batches in a single cleanup pass.
-        var overflow = std.ArrayList(protocol_types.Uuid).initCapacity(self.allocator, 8) catch return;
+        var overflow = std.ArrayList(protocol_types.Ulid).initCapacity(self.allocator, 8) catch return;
         defer overflow.deinit(self.allocator);
 
         var iter = self.active_streams.iterator();
@@ -430,10 +430,10 @@ pub const ProtocolServer = struct {
 
     /// Public access to active streams for event polling
     pub const ActiveStreamIterator = struct {
-        iter: std.AutoHashMap(protocol_types.Uuid, ActiveStream).Iterator,
+        iter: std.AutoHashMap(protocol_types.Ulid, ActiveStream).Iterator,
 
         pub fn next(self: *ActiveStreamIterator) ?struct {
-            stream_id: protocol_types.Uuid,
+            stream_id: protocol_types.Ulid,
             stream: *ActiveStream,
         } {
             if (self.iter.next()) |entry| {
@@ -454,12 +454,12 @@ pub const ProtocolServer = struct {
     }
 
     /// Get next sequence number for a stream (public for event forwarding)
-    pub fn getNextSequence(self: *ProtocolServer, stream_id: protocol_types.Uuid) u64 {
+    pub fn getNextSequence(self: *ProtocolServer, stream_id: protocol_types.Ulid) u64 {
         return self.nextSequence(stream_id);
     }
 
     /// Get next sequence number for a stream
-    fn nextSequence(self: *ProtocolServer, stream_id: protocol_types.Uuid) u64 {
+    fn nextSequence(self: *ProtocolServer, stream_id: protocol_types.Ulid) u64 {
         const current = self.sequence_counters.get(stream_id) orelse 0;
         const next = current + 1;
         self.sequence_counters.put(stream_id, next) catch return next;
@@ -468,7 +468,7 @@ pub const ProtocolServer = struct {
 
     /// Validates and updates expected sequence for a stream/query scope.
     /// Used by request payloads that accept per-stream incremental sequencing.
-    fn validateAndUpdateSequence(self: *ProtocolServer, stream_id: protocol_types.Uuid, received: u64) SequenceError!void {
+    fn validateAndUpdateSequence(self: *ProtocolServer, stream_id: protocol_types.Ulid, received: u64) SequenceError!void {
         const expected = self.expected_sequences.get(stream_id) orelse 1;
         try validateSequence(expected, received);
         // Update expected sequence for next message
@@ -477,7 +477,7 @@ pub const ProtocolServer = struct {
 };
 
 /// Build a one-off envelope template suitable for `envelope.createNack`.
-fn nackTemplate(stream_id: protocol_types.Uuid, in_reply_to: protocol_types.Uuid) protocol_types.Envelope {
+fn nackTemplate(stream_id: protocol_types.Ulid, in_reply_to: protocol_types.Ulid) protocol_types.Envelope {
     return .{
         .stream_id = stream_id,
         .message_id = in_reply_to,
@@ -553,12 +553,13 @@ fn streamWithRefresh(
     defer if (loaded_storage) |*storage| storage.deinit();
     const storage = if (server.options.auth_storage) |auth_storage|
         auth_storage
-    else blk: {
-        loaded_storage = server.options.load_auth_storage_fn(server.options.load_auth_storage_ctx, server.allocator) catch
-            break :blk null;
-        break :blk @as(?*oauth_storage.AuthStorage, &loaded_storage.?);
-    } orelse
-        return streamWithResolvedKey(server, provider, provider_id, model, context, options);
+    else
+        blk: {
+            loaded_storage = server.options.load_auth_storage_fn(server.options.load_auth_storage_ctx, server.allocator) catch
+                break :blk null;
+            break :blk @as(?*oauth_storage.AuthStorage, &loaded_storage.?);
+        } orelse
+            return streamWithResolvedKey(server, provider, provider_id, model, context, options);
 
     if (!storage.hasRefreshableCredentials(provider_id)) {
         // Non-OAuth entry or missing entry. If the loaded storage has an api_key,
@@ -640,7 +641,7 @@ fn streamWithRefresh(
 }
 
 /// Handle stream_request - create stream, return ack with stream_id
-fn handleStreamRequest(server: *ProtocolServer, request: protocol_types.StreamRequest, stream_id: protocol_types.Uuid, in_reply_to: protocol_types.Uuid, received_seq: u64) !protocol_types.Envelope {
+fn handleStreamRequest(server: *ProtocolServer, request: protocol_types.StreamRequest, stream_id: protocol_types.Ulid, in_reply_to: protocol_types.Ulid, received_seq: u64) !protocol_types.Envelope {
     // Reject duplicate stream_id
     if (server.active_streams.contains(stream_id)) {
         return try envelope.createNack(
@@ -706,7 +707,7 @@ fn handleStreamRequest(server: *ProtocolServer, request: protocol_types.StreamRe
     // Return ack with acknowledged_id
     return .{
         .stream_id = stream_id,
-        .message_id = protocol_types.generateUuid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = 1,
         .in_reply_to = in_reply_to,
         .timestamp = std.time.milliTimestamp(),
@@ -717,7 +718,7 @@ fn handleStreamRequest(server: *ProtocolServer, request: protocol_types.StreamRe
 }
 
 /// Handle abort_request - cancel stream, return ack
-fn handleAbortRequest(server: *ProtocolServer, request: protocol_types.AbortRequest, stream_id: protocol_types.Uuid, in_reply_to: protocol_types.Uuid, received_seq: u64) !protocol_types.Envelope {
+fn handleAbortRequest(server: *ProtocolServer, request: protocol_types.AbortRequest, stream_id: protocol_types.Ulid, in_reply_to: protocol_types.Ulid, received_seq: u64) !protocol_types.Envelope {
     // Validate sequence for existing stream using validateAndUpdateSequence
     server.validateAndUpdateSequence(request.target_stream_id, received_seq) catch |err| {
         return try createSequenceNack(server.allocator, stream_id, in_reply_to, err);
@@ -743,7 +744,7 @@ fn handleAbortRequest(server: *ProtocolServer, request: protocol_types.AbortRequ
         // Return ack
         return .{
             .stream_id = request.target_stream_id,
-            .message_id = protocol_types.generateUuid(),
+            .message_id = protocol_types.generateUlid(),
             .sequence = seq,
             .in_reply_to = in_reply_to,
             .timestamp = std.time.milliTimestamp(),
@@ -756,7 +757,7 @@ fn handleAbortRequest(server: *ProtocolServer, request: protocol_types.AbortRequ
         // Per spec, abort is idempotent - return ACK even if stream not found
         return .{
             .stream_id = request.target_stream_id,
-            .message_id = protocol_types.generateUuid(),
+            .message_id = protocol_types.generateUlid(),
             .sequence = 0,
             .in_reply_to = in_reply_to,
             .timestamp = std.time.milliTimestamp(),
@@ -768,7 +769,7 @@ fn handleAbortRequest(server: *ProtocolServer, request: protocol_types.AbortRequ
 }
 
 /// Handle complete_request - get final result
-fn handleCompleteRequest(server: *ProtocolServer, request: protocol_types.CompleteRequest, stream_id: protocol_types.Uuid, in_reply_to: protocol_types.Uuid, received_seq: u64) !protocol_types.Envelope {
+fn handleCompleteRequest(server: *ProtocolServer, request: protocol_types.CompleteRequest, stream_id: protocol_types.Ulid, in_reply_to: protocol_types.Ulid, received_seq: u64) !protocol_types.Envelope {
     _ = received_seq; // Sequence validation is done in handleEnvelope
 
     // For complete_request, we use the stream_id from the envelope
@@ -807,7 +808,7 @@ fn handleCompleteRequest(server: *ProtocolServer, request: protocol_types.Comple
 
         return .{
             .stream_id = stream_id,
-            .message_id = protocol_types.generateUuid(),
+            .message_id = protocol_types.generateUlid(),
             .sequence = 1,
             .in_reply_to = in_reply_to,
             .timestamp = std.time.milliTimestamp(),
@@ -847,8 +848,8 @@ fn handleCompleteRequest(server: *ProtocolServer, request: protocol_types.Comple
 fn handleModelsRequest(
     server: *ProtocolServer,
     request: protocol_types.ModelsRequest,
-    stream_id: protocol_types.Uuid,
-    in_reply_to: protocol_types.Uuid,
+    stream_id: protocol_types.Ulid,
+    in_reply_to: protocol_types.Ulid,
     received_seq: u64,
 ) !protocol_types.Envelope {
     if (!server.options.supports_model_catalog) {
@@ -900,7 +901,7 @@ fn handleModelsRequest(
 
     const ack = protocol_types.Envelope{
         .stream_id = stream_id,
-        .message_id = protocol_types.generateUuid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = server.nextSequence(stream_id),
         .in_reply_to = in_reply_to,
         .timestamp = std.time.milliTimestamp(),
@@ -911,7 +912,7 @@ fn handleModelsRequest(
 
     try server.outbox.append(server.allocator, .{
         .stream_id = stream_id,
-        .message_id = protocol_types.generateUuid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = server.nextSequence(stream_id),
         .in_reply_to = in_reply_to,
         .timestamp = std.time.milliTimestamp(),
@@ -1114,14 +1115,14 @@ fn matchesModelFilters(
 
 fn makeModelsNack(
     server: *ProtocolServer,
-    stream_id: protocol_types.Uuid,
-    in_reply_to: protocol_types.Uuid,
+    stream_id: protocol_types.Ulid,
+    in_reply_to: protocol_types.Ulid,
     code: protocol_types.ErrorCode,
     reason: []const u8,
 ) !protocol_types.Envelope {
     return .{
         .stream_id = stream_id,
-        .message_id = protocol_types.generateUuid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = server.nextSequence(stream_id),
         .in_reply_to = in_reply_to,
         .timestamp = std.time.milliTimestamp(),
@@ -1346,8 +1347,8 @@ test "handleModelsRequest emits ack then models_response from static fallback" {
     defer server.deinit();
 
     var request = protocol_types.Envelope{
-        .stream_id = protocol_types.generateUuid(),
-        .message_id = protocol_types.generateUuid(),
+        .stream_id = protocol_types.generateUlid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = 1,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .models_request = .{} },
@@ -1385,8 +1386,8 @@ test "handleModelsRequest returns not_implemented nack when unsupported" {
     defer server.deinit();
 
     var request = protocol_types.Envelope{
-        .stream_id = protocol_types.generateUuid(),
-        .message_id = protocol_types.generateUuid(),
+        .stream_id = protocol_types.generateUlid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = 1,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .models_request = .{} },
@@ -1410,8 +1411,8 @@ test "handleModelsRequest applies provider api and exact model filters" {
     defer server.deinit();
 
     var by_provider = protocol_types.Envelope{
-        .stream_id = protocol_types.generateUuid(),
-        .message_id = protocol_types.generateUuid(),
+        .stream_id = protocol_types.generateUlid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = 1,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .models_request = .{
@@ -1432,8 +1433,8 @@ test "handleModelsRequest applies provider api and exact model filters" {
     }
 
     var by_api = protocol_types.Envelope{
-        .stream_id = protocol_types.generateUuid(),
-        .message_id = protocol_types.generateUuid(),
+        .stream_id = protocol_types.generateUlid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = 1,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .models_request = .{
@@ -1453,8 +1454,8 @@ test "handleModelsRequest applies provider api and exact model filters" {
     }
 
     var by_model_id = protocol_types.Envelope{
-        .stream_id = protocol_types.generateUuid(),
-        .message_id = protocol_types.generateUuid(),
+        .stream_id = protocol_types.generateUlid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = 1,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .models_request = .{
@@ -1481,8 +1482,8 @@ test "handleModelsRequest returns invalid_request for ambiguous or missing model
     defer server.deinit();
 
     var ambiguous = protocol_types.Envelope{
-        .stream_id = protocol_types.generateUuid(),
-        .message_id = protocol_types.generateUuid(),
+        .stream_id = protocol_types.generateUlid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = 1,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .models_request = .{
@@ -1501,8 +1502,8 @@ test "handleModelsRequest returns invalid_request for ambiguous or missing model
     try std.testing.expect(std.mem.indexOf(u8, ambiguous_nack.payload.nack.reason.slice(), "multiple APIs") != null);
 
     var missing = protocol_types.Envelope{
-        .stream_id = protocol_types.generateUuid(),
-        .message_id = protocol_types.generateUuid(),
+        .stream_id = protocol_types.generateUlid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = 1,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .models_request = .{
@@ -1533,8 +1534,8 @@ test "handleModelsRequest prefers dynamic fetch and falls back to static catalog
     defer server.deinit();
 
     var dynamic_request = protocol_types.Envelope{
-        .stream_id = protocol_types.generateUuid(),
-        .message_id = protocol_types.generateUuid(),
+        .stream_id = protocol_types.generateUlid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = 1,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .models_request = .{} },
@@ -1555,8 +1556,8 @@ test "handleModelsRequest prefers dynamic fetch and falls back to static catalog
     dynamic_ctx.mode = .unavailable;
 
     var fallback_request = protocol_types.Envelope{
-        .stream_id = protocol_types.generateUuid(),
-        .message_id = protocol_types.generateUuid(),
+        .stream_id = protocol_types.generateUlid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = 1,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .models_request = .{} },
@@ -1638,7 +1639,7 @@ fn expectAuthRefreshFailedNack(state: *AuthTestState) !void {
 
     var server = ProtocolServer.init(std.testing.allocator, &registry, .{ .load_auth_storage_fn = authTestLoadStorage, .load_auth_storage_ctx = state });
     defer server.deinit();
-    const env = protocol_types.Envelope{ .stream_id = protocol_types.generateUuid(), .message_id = protocol_types.generateUuid(), .sequence = 1, .timestamp = std.time.milliTimestamp(), .payload = .{ .stream_request = .{ .model = testModel(), .context = testContext() } } };
+    const env = protocol_types.Envelope{ .stream_id = protocol_types.generateUlid(), .message_id = protocol_types.generateUlid(), .sequence = 1, .timestamp = std.time.milliTimestamp(), .payload = .{ .stream_request = .{ .model = testModel(), .context = testContext() } } };
     var response = (try server.handleEnvelope(env)).?;
     defer response.deinit(std.testing.allocator);
     try std.testing.expectEqual(protocol_types.ErrorCode.auth_refresh_failed, response.payload.nack.error_code.?);
@@ -1688,7 +1689,7 @@ test "retry auth failure returns auth_required nack" {
 
     var server = ProtocolServer.init(std.testing.allocator, &registry, .{ .load_auth_storage_fn = authTestLoadStorage, .load_auth_storage_ctx = &state });
     defer server.deinit();
-    const env = protocol_types.Envelope{ .stream_id = protocol_types.generateUuid(), .message_id = protocol_types.generateUuid(), .sequence = 1, .timestamp = std.time.milliTimestamp(), .payload = .{ .stream_request = .{ .model = testModel(), .context = testContext() } } };
+    const env = protocol_types.Envelope{ .stream_id = protocol_types.generateUlid(), .message_id = protocol_types.generateUlid(), .sequence = 1, .timestamp = std.time.milliTimestamp(), .payload = .{ .stream_request = .{ .model = testModel(), .context = testContext() } } };
     var response = (try server.handleEnvelope(env)).?;
     defer response.deinit(std.testing.allocator);
     try std.testing.expectEqual(protocol_types.ErrorCode.auth_required, response.payload.nack.error_code.?);
@@ -1720,8 +1721,8 @@ test "handleEnvelope returns pong for ping" {
     defer server.deinit();
 
     const ping_env = protocol_types.Envelope{
-        .stream_id = protocol_types.generateUuid(),
-        .message_id = protocol_types.generateUuid(),
+        .stream_id = protocol_types.generateUlid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = 1,
         .timestamp = std.time.milliTimestamp(),
         .payload = .ping,
@@ -1758,10 +1759,10 @@ test "handleEnvelope returns nack for stream_request without provider" {
         .max_tokens = 4096,
     };
 
-    const client_stream_id = protocol_types.generateUuid();
+    const client_stream_id = protocol_types.generateUlid();
     var stream_req_env = protocol_types.Envelope{
         .stream_id = client_stream_id,
-        .message_id = protocol_types.generateUuid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = 1,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .stream_request = .{
@@ -1791,8 +1792,8 @@ test "handleEnvelope returns version_mismatch nack for unsupported version" {
 
     const ping_env = protocol_types.Envelope{
         .version = 2,
-        .stream_id = protocol_types.generateUuid(),
-        .message_id = protocol_types.generateUuid(),
+        .stream_id = protocol_types.generateUlid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = 1,
         .timestamp = std.time.milliTimestamp(),
         .payload = .ping,
@@ -1836,8 +1837,8 @@ test "handleStreamRequest creates stream and returns ack" {
         .max_tokens = 4096,
     };
 
-    const client_stream_id = protocol_types.generateUuid();
-    const msg_id = protocol_types.generateUuid();
+    const client_stream_id = protocol_types.generateUlid();
+    const msg_id = protocol_types.generateUlid();
     var stream_req_env = protocol_types.Envelope{
         .stream_id = client_stream_id,
         .message_id = msg_id,
@@ -1894,10 +1895,10 @@ test "handleStreamRequest rejects duplicate stream id" {
         .max_tokens = 4096,
     };
 
-    const client_stream_id = protocol_types.generateUuid();
+    const client_stream_id = protocol_types.generateUlid();
     var req1 = protocol_types.Envelope{
         .stream_id = client_stream_id,
-        .message_id = protocol_types.generateUuid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = 1,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .stream_request = .{
@@ -1914,7 +1915,7 @@ test "handleStreamRequest rejects duplicate stream id" {
 
     var req2 = protocol_types.Envelope{
         .stream_id = client_stream_id,
-        .message_id = protocol_types.generateUuid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = 1,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .stream_request = .{
@@ -1961,8 +1962,8 @@ test "handleAbortRequest cancels stream" {
 
     // First create a stream
     var stream_req_env = protocol_types.Envelope{
-        .stream_id = protocol_types.generateUuid(),
-        .message_id = protocol_types.generateUuid(),
+        .stream_id = protocol_types.generateUlid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = 1,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .stream_request = .{
@@ -1981,7 +1982,7 @@ test "handleAbortRequest cancels stream" {
     // Now abort the stream
     const abort_env = protocol_types.Envelope{
         .stream_id = stream_id,
-        .message_id = protocol_types.generateUuid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = 2,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .abort_request = .{
@@ -2006,11 +2007,11 @@ test "handleAbortRequest returns ack for unknown stream (idempotent)" {
     var server = ProtocolServer.init(std.testing.allocator, &registry, .{});
     defer server.deinit();
 
-    const unknown_stream_id = protocol_types.generateUuid();
+    const unknown_stream_id = protocol_types.generateUlid();
 
     const abort_env = protocol_types.Envelope{
         .stream_id = unknown_stream_id,
-        .message_id = protocol_types.generateUuid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = 1,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .abort_request = .{
@@ -2054,8 +2055,8 @@ test "cleanupCompletedStreams removes done streams" {
 
     // Create a stream
     var stream_req_env = protocol_types.Envelope{
-        .stream_id = protocol_types.generateUuid(),
-        .message_id = protocol_types.generateUuid(),
+        .stream_id = protocol_types.generateUlid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = 1,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .stream_request = .{
@@ -2105,10 +2106,10 @@ test "max streams limit enforced" {
     };
 
     // Create first stream - should succeed
-    const client_stream_id_1 = protocol_types.generateUuid();
+    const client_stream_id_1 = protocol_types.generateUlid();
     var req1 = protocol_types.Envelope{
         .stream_id = client_stream_id_1,
-        .message_id = protocol_types.generateUuid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = 1,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .stream_request = .{
@@ -2125,10 +2126,10 @@ test "max streams limit enforced" {
     req1.deinit(std.testing.allocator);
 
     // Create second stream - should succeed
-    const client_stream_id_2 = protocol_types.generateUuid();
+    const client_stream_id_2 = protocol_types.generateUlid();
     var req2 = protocol_types.Envelope{
         .stream_id = client_stream_id_2,
-        .message_id = protocol_types.generateUuid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = 1, // Each new stream starts at sequence 1
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .stream_request = .{
@@ -2145,10 +2146,10 @@ test "max streams limit enforced" {
     req2.deinit(std.testing.allocator);
 
     // Create third stream - should fail with rate_limited
-    const client_stream_id_3 = protocol_types.generateUuid();
+    const client_stream_id_3 = protocol_types.generateUlid();
     var req3 = protocol_types.Envelope{
         .stream_id = client_stream_id_3,
-        .message_id = protocol_types.generateUuid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = 1, // Each new stream starts at sequence 1
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .stream_request = .{
@@ -2213,12 +2214,12 @@ test "handleEnvelope rejects stream_request with invalid sequence" {
         .max_tokens = 4096,
     };
 
-    const client_stream_id = protocol_types.generateUuid();
+    const client_stream_id = protocol_types.generateUlid();
 
     // Test with sequence = 0 (invalid)
     const req_seq0 = protocol_types.Envelope{
         .stream_id = client_stream_id,
-        .message_id = protocol_types.generateUuid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = 0,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .stream_request = .{
@@ -2240,7 +2241,7 @@ test "handleEnvelope rejects stream_request with invalid sequence" {
     // Test with sequence = 2 (should be 1 for new stream)
     const req_seq2 = protocol_types.Envelope{
         .stream_id = client_stream_id,
-        .message_id = protocol_types.generateUuid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = 2,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .stream_request = .{
@@ -2280,12 +2281,12 @@ test "handleEnvelope rejects complete_request with invalid sequence" {
         .max_tokens = 4096,
     };
 
-    const client_stream_id = protocol_types.generateUuid();
+    const client_stream_id = protocol_types.generateUlid();
 
     // Test with sequence = 5 (should be 1 for complete_request)
     const req = protocol_types.Envelope{
         .stream_id = client_stream_id,
-        .message_id = protocol_types.generateUuid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = 5,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .complete_request = .{
@@ -2333,8 +2334,8 @@ test "handleAbortRequest rejects duplicate sequence" {
 
     // First create a stream with sequence 1
     var stream_req_env = protocol_types.Envelope{
-        .stream_id = protocol_types.generateUuid(),
-        .message_id = protocol_types.generateUuid(),
+        .stream_id = protocol_types.generateUlid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = 1,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .stream_request = .{
@@ -2352,7 +2353,7 @@ test "handleAbortRequest rejects duplicate sequence" {
     // Now try to abort with duplicate sequence (should be 2, not 1)
     const abort_env = protocol_types.Envelope{
         .stream_id = stream_id,
-        .message_id = protocol_types.generateUuid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = 1, // Duplicate - should be 2
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .abort_request = .{
@@ -2400,8 +2401,8 @@ test "handleAbortRequest rejects sequence gap" {
 
     // First create a stream with sequence 1
     var stream_req_env = protocol_types.Envelope{
-        .stream_id = protocol_types.generateUuid(),
-        .message_id = protocol_types.generateUuid(),
+        .stream_id = protocol_types.generateUlid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = 1,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .stream_request = .{
@@ -2419,7 +2420,7 @@ test "handleAbortRequest rejects sequence gap" {
     // Now try to abort with a sequence gap (should be 2, not 10)
     const abort_env = protocol_types.Envelope{
         .stream_id = stream_id,
-        .message_id = protocol_types.generateUuid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = 10, // Gap - expected 2
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .abort_request = .{
@@ -2545,8 +2546,8 @@ test "credential resolution: explicit api_key bypasses storage lookup" {
     };
 
     var stream_req_env = protocol_types.Envelope{
-        .stream_id = protocol_types.generateUuid(),
-        .message_id = protocol_types.generateUuid(),
+        .stream_id = protocol_types.generateUlid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = 1,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .stream_request = .{
@@ -2607,8 +2608,8 @@ test "credential resolution: missing api_key loads credentials from storage by p
 
     // No options → no explicit api_key; resolver must hit storage.
     var stream_req_env = protocol_types.Envelope{
-        .stream_id = protocol_types.generateUuid(),
-        .message_id = protocol_types.generateUuid(),
+        .stream_id = protocol_types.generateUlid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = 1,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .stream_request = .{
@@ -2660,8 +2661,8 @@ test "credential resolution: missing api_key and missing storage entry returns a
     };
 
     var stream_req_env = protocol_types.Envelope{
-        .stream_id = protocol_types.generateUuid(),
-        .message_id = protocol_types.generateUuid(),
+        .stream_id = protocol_types.generateUlid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = 1,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .stream_request = .{
@@ -2711,8 +2712,8 @@ test "credential resolution: complete_request without credentials returns auth_r
     };
 
     var complete_req_env = protocol_types.Envelope{
-        .stream_id = protocol_types.generateUuid(),
-        .message_id = protocol_types.generateUuid(),
+        .stream_id = protocol_types.generateUlid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = 1,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .complete_request = .{

--- a/zig/src/protocol/provider/types.zig
+++ b/zig/src/protocol/provider/types.zig
@@ -15,132 +15,119 @@ pub const MetadataEntry = model_catalog_types.MetadataEntry;
 pub const ModelDescriptor = model_catalog_types.ModelDescriptor;
 pub const ModelsResponse = model_catalog_types.ModelsResponse;
 
-/// UUID type for stream/message identification
-pub const Uuid = [16]u8;
+/// ULID type for stream/message identification.
+/// Internally this is the canonical 128-bit ULID payload: 48-bit
+/// millisecond timestamp followed by 80 bits of randomness.
+pub const Ulid = [16]u8;
 
-/// Generate a random UUID v4
-pub fn generateUuid() Uuid {
-    var uuid: Uuid = undefined;
-    std.crypto.random.bytes(&uuid);
+const ULID_ENCODE = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
 
-    // Set version to 4 (random UUID)
-    uuid[6] = (uuid[6] & 0x0f) | 0x40;
-    // Set variant to RFC 4122
-    uuid[8] = (uuid[8] & 0x3f) | 0x80;
-
-    return uuid;
+fn ulidDecode(c: u8) ?u5 {
+    return switch (c) {
+        '0', 'O', 'o' => 0,
+        '1', 'I', 'i', 'L', 'l' => 1,
+        '2'...'9' => @intCast(c - '0'),
+        'A', 'a' => 10,
+        'B', 'b' => 11,
+        'C', 'c' => 12,
+        'D', 'd' => 13,
+        'E', 'e' => 14,
+        'F', 'f' => 15,
+        'G', 'g' => 16,
+        'H', 'h' => 17,
+        'J', 'j' => 18,
+        'K', 'k' => 19,
+        'M', 'm' => 20,
+        'N', 'n' => 21,
+        'P', 'p' => 22,
+        'Q', 'q' => 23,
+        'R', 'r' => 24,
+        'S', 's' => 25,
+        'T', 't' => 26,
+        'V', 'v' => 27,
+        'W', 'w' => 28,
+        'X', 'x' => 29,
+        'Y', 'y' => 30,
+        'Z', 'z' => 31,
+        else => null,
+    };
 }
 
-/// Convert UUID to string representation (36 chars: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)
-pub fn uuidToString(uuid: Uuid, allocator: std.mem.Allocator) ![]const u8 {
-    const result = try allocator.alloc(u8, 36);
+/// Generate a ULID with the current millisecond timestamp and 80 random bits.
+pub fn generateUlid() Ulid {
+    var ulid: Ulid = undefined;
 
-    const hex_chars = "0123456789abcdef";
-    var idx: usize = 0;
+    const now_ms: u64 = @intCast(@max(std.time.milliTimestamp(), 0));
+    ulid[0] = @intCast((now_ms >> 40) & 0xff);
+    ulid[1] = @intCast((now_ms >> 32) & 0xff);
+    ulid[2] = @intCast((now_ms >> 24) & 0xff);
+    ulid[3] = @intCast((now_ms >> 16) & 0xff);
+    ulid[4] = @intCast((now_ms >> 8) & 0xff);
+    ulid[5] = @intCast(now_ms & 0xff);
+    std.crypto.random.bytes(ulid[6..16]);
 
-    for (uuid[0..4], 0..) |byte, i| {
-        result[idx] = hex_chars[byte >> 4];
-        result[idx + 1] = hex_chars[byte & 0x0f];
-        idx += 2;
-        if (i == 3) {
-            result[idx] = '-';
-            idx += 1;
-        }
-    }
+    return ulid;
+}
 
-    for (uuid[4..6], 0..) |byte, i| {
-        result[idx] = hex_chars[byte >> 4];
-        result[idx + 1] = hex_chars[byte & 0x0f];
-        idx += 2;
-        if (i == 1) {
-            result[idx] = '-';
-            idx += 1;
-        }
-    }
-
-    for (uuid[6..8], 0..) |byte, i| {
-        result[idx] = hex_chars[byte >> 4];
-        result[idx + 1] = hex_chars[byte & 0x0f];
-        idx += 2;
-        if (i == 1) {
-            result[idx] = '-';
-            idx += 1;
-        }
-    }
-
-    for (uuid[8..10], 0..) |byte, i| {
-        result[idx] = hex_chars[byte >> 4];
-        result[idx + 1] = hex_chars[byte & 0x0f];
-        idx += 2;
-        if (i == 1) {
-            result[idx] = '-';
-            idx += 1;
-        }
-    }
-
-    for (uuid[10..16]) |byte| {
-        result[idx] = hex_chars[byte >> 4];
-        result[idx + 1] = hex_chars[byte & 0x0f];
-        idx += 2;
-    }
-
+/// Convert ULID to Crockford Base32 string representation (26 chars).
+pub fn ulidToString(ulid: Ulid, allocator: std.mem.Allocator) ![]const u8 {
+    const result = try allocator.alloc(u8, 26);
+    result[0] = ULID_ENCODE[(ulid[0] & 0b11100000) >> 5];
+    result[1] = ULID_ENCODE[ulid[0] & 0b00011111];
+    result[2] = ULID_ENCODE[(ulid[1] & 0b11111000) >> 3];
+    result[3] = ULID_ENCODE[((ulid[1] & 0b00000111) << 2) | ((ulid[2] & 0b11000000) >> 6)];
+    result[4] = ULID_ENCODE[(ulid[2] & 0b00111110) >> 1];
+    result[5] = ULID_ENCODE[((ulid[2] & 0b00000001) << 4) | ((ulid[3] & 0b11110000) >> 4)];
+    result[6] = ULID_ENCODE[((ulid[3] & 0b00001111) << 1) | ((ulid[4] & 0b10000000) >> 7)];
+    result[7] = ULID_ENCODE[(ulid[4] & 0b01111100) >> 2];
+    result[8] = ULID_ENCODE[((ulid[4] & 0b00000011) << 3) | ((ulid[5] & 0b11100000) >> 5)];
+    result[9] = ULID_ENCODE[ulid[5] & 0b00011111];
+    result[10] = ULID_ENCODE[(ulid[6] & 0b11111000) >> 3];
+    result[11] = ULID_ENCODE[((ulid[6] & 0b00000111) << 2) | ((ulid[7] & 0b11000000) >> 6)];
+    result[12] = ULID_ENCODE[(ulid[7] & 0b00111110) >> 1];
+    result[13] = ULID_ENCODE[((ulid[7] & 0b00000001) << 4) | ((ulid[8] & 0b11110000) >> 4)];
+    result[14] = ULID_ENCODE[((ulid[8] & 0b00001111) << 1) | ((ulid[9] & 0b10000000) >> 7)];
+    result[15] = ULID_ENCODE[(ulid[9] & 0b01111100) >> 2];
+    result[16] = ULID_ENCODE[((ulid[9] & 0b00000011) << 3) | ((ulid[10] & 0b11100000) >> 5)];
+    result[17] = ULID_ENCODE[ulid[10] & 0b00011111];
+    result[18] = ULID_ENCODE[(ulid[11] & 0b11111000) >> 3];
+    result[19] = ULID_ENCODE[((ulid[11] & 0b00000111) << 2) | ((ulid[12] & 0b11000000) >> 6)];
+    result[20] = ULID_ENCODE[(ulid[12] & 0b00111110) >> 1];
+    result[21] = ULID_ENCODE[((ulid[12] & 0b00000001) << 4) | ((ulid[13] & 0b11110000) >> 4)];
+    result[22] = ULID_ENCODE[((ulid[13] & 0b00001111) << 1) | ((ulid[14] & 0b10000000) >> 7)];
+    result[23] = ULID_ENCODE[(ulid[14] & 0b01111100) >> 2];
+    result[24] = ULID_ENCODE[((ulid[14] & 0b00000011) << 3) | ((ulid[15] & 0b11100000) >> 5)];
+    result[25] = ULID_ENCODE[ulid[15] & 0b00011111];
     return result;
 }
 
-/// Parse UUID from string
-pub fn parseUuid(str: []const u8) ?Uuid {
-    // Expected format: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx (36 chars)
-    if (str.len != 36) return null;
+/// Parse ULID from a 26-character Crockford Base32 string.
+pub fn parseUlid(str: []const u8) ?Ulid {
+    if (str.len != 26) return null;
 
-    // Check hyphen positions
-    if (str[8] != '-' or str[13] != '-' or str[18] != '-' or str[23] != '-') return null;
+    var v: [26]u5 = undefined;
+    for (str, 0..) |c, i| v[i] = ulidDecode(c) orelse return null;
+    // 26 Base32 digits encode 130 bits; the top two overflow bits must be zero.
+    if (v[0] > 7) return null;
 
-    var uuid: Uuid = undefined;
-
-    const parseHexByte = struct {
-        fn parseHexByte(s: []const u8) ?u8 {
-            const hi = charToHex(s[0]) orelse return null;
-            const lo = charToHex(s[1]) orelse return null;
-            return (@as(u8, hi) << 4) | @as(u8, lo);
-        }
-
-        fn charToHex(c: u8) ?u4 {
-            return switch (c) {
-                '0'...'9' => @intCast(c - '0'),
-                'a'...'f' => @intCast(c - 'a' + 10),
-                'A'...'F' => @intCast(c - 'A' + 10),
-                else => null,
-            };
-        }
-    }.parseHexByte;
-
-    // Parse first group (8 hex chars = 4 bytes)
-    uuid[0] = parseHexByte(str[0..2]) orelse return null;
-    uuid[1] = parseHexByte(str[2..4]) orelse return null;
-    uuid[2] = parseHexByte(str[4..6]) orelse return null;
-    uuid[3] = parseHexByte(str[6..8]) orelse return null;
-
-    // Parse second group (4 hex chars = 2 bytes)
-    uuid[4] = parseHexByte(str[9..11]) orelse return null;
-    uuid[5] = parseHexByte(str[11..13]) orelse return null;
-
-    // Parse third group (4 hex chars = 2 bytes)
-    uuid[6] = parseHexByte(str[14..16]) orelse return null;
-    uuid[7] = parseHexByte(str[16..18]) orelse return null;
-
-    // Parse fourth group (4 hex chars = 2 bytes)
-    uuid[8] = parseHexByte(str[19..21]) orelse return null;
-    uuid[9] = parseHexByte(str[21..23]) orelse return null;
-
-    // Parse fifth group (12 hex chars = 6 bytes)
-    uuid[10] = parseHexByte(str[24..26]) orelse return null;
-    uuid[11] = parseHexByte(str[26..28]) orelse return null;
-    uuid[12] = parseHexByte(str[28..30]) orelse return null;
-    uuid[13] = parseHexByte(str[30..32]) orelse return null;
-    uuid[14] = parseHexByte(str[32..34]) orelse return null;
-    uuid[15] = parseHexByte(str[34..36]) orelse return null;
-
-    return uuid;
+    var ulid: Ulid = undefined;
+    ulid[0] = (@as(u8, v[0]) << 5) | @as(u8, v[1]);
+    ulid[1] = (@as(u8, v[2]) << 3) | (@as(u8, v[3]) >> 2);
+    ulid[2] = (@as(u8, v[3] & 0b00011) << 6) | (@as(u8, v[4]) << 1) | (@as(u8, v[5]) >> 4);
+    ulid[3] = (@as(u8, v[5] & 0b01111) << 4) | (@as(u8, v[6]) >> 1);
+    ulid[4] = (@as(u8, v[6] & 0b00001) << 7) | (@as(u8, v[7]) << 2) | (@as(u8, v[8]) >> 3);
+    ulid[5] = (@as(u8, v[8] & 0b00111) << 5) | @as(u8, v[9]);
+    ulid[6] = (@as(u8, v[10]) << 3) | (@as(u8, v[11]) >> 2);
+    ulid[7] = (@as(u8, v[11] & 0b00011) << 6) | (@as(u8, v[12]) << 1) | (@as(u8, v[13]) >> 4);
+    ulid[8] = (@as(u8, v[13] & 0b01111) << 4) | (@as(u8, v[14]) >> 1);
+    ulid[9] = (@as(u8, v[14] & 0b00001) << 7) | (@as(u8, v[15]) << 2) | (@as(u8, v[16]) >> 3);
+    ulid[10] = (@as(u8, v[16] & 0b00111) << 5) | @as(u8, v[17]);
+    ulid[11] = (@as(u8, v[18]) << 3) | (@as(u8, v[19]) >> 2);
+    ulid[12] = (@as(u8, v[19] & 0b00011) << 6) | (@as(u8, v[20]) << 1) | (@as(u8, v[21]) >> 4);
+    ulid[13] = (@as(u8, v[21] & 0b01111) << 4) | (@as(u8, v[22]) >> 1);
+    ulid[14] = (@as(u8, v[22] & 0b00001) << 7) | (@as(u8, v[23]) << 2) | (@as(u8, v[24]) >> 3);
+    ulid[15] = (@as(u8, v[24] & 0b00111) << 5) | @as(u8, v[25]);
+    return ulid;
 }
 
 /// Protocol envelope wrapping all messages
@@ -148,13 +135,13 @@ pub const Envelope = struct {
     /// Protocol version
     version: u8 = 1,
     /// Unique stream identifier (stable for stream lifecycle)
-    stream_id: Uuid,
+    stream_id: Ulid,
     /// Message ID (unique per message)
-    message_id: Uuid,
+    message_id: Ulid,
     /// Sequence number within stream (starts at 1)
     sequence: u64,
     /// For request/response correlation
-    in_reply_to: ?Uuid = null,
+    in_reply_to: ?Ulid = null,
     /// Unix timestamp in milliseconds
     timestamp: i64,
     /// The actual payload
@@ -251,7 +238,7 @@ pub const CompleteRequest = struct {
 
 /// Request to abort a stream
 pub const AbortRequest = struct {
-    target_stream_id: Uuid,
+    target_stream_id: Ulid,
     reason: OwnedSlice(u8) = OwnedSlice(u8).initBorrowed(""),
 
     pub fn getReason(self: *const AbortRequest) ?[]const u8 {
@@ -268,13 +255,13 @@ pub const AbortRequest = struct {
 /// Acknowledgment response
 pub const Ack = struct {
     /// The message_id being acknowledged
-    acknowledged_id: Uuid,
+    acknowledged_id: Ulid,
 };
 
 /// Negative acknowledgment response
 pub const Nack = struct {
     /// The message_id that was rejected
-    rejected_id: Uuid,
+    rejected_id: Ulid,
     /// Human-readable reason for rejection
     reason: OwnedSlice(u8),
     /// Optional error code
@@ -350,12 +337,12 @@ pub const Goodbye = struct {
 
 /// Request full state resync
 pub const SyncRequest = struct {
-    target_stream_id: Uuid,
+    target_stream_id: Ulid,
 };
 
 /// Full partial state resync response
 pub const Sync = struct {
-    target_stream_id: Uuid, // renamed from stream_id per spec
+    target_stream_id: Ulid, // renamed from stream_id per spec
     partial: ?ai_types.AssistantMessage = null, // AssistantMessage object, not string
 
     pub fn deinit(self: *Sync, allocator: std.mem.Allocator) void {
@@ -419,66 +406,68 @@ test "ModelsRequest deinit frees owned filter strings" {
     req.deinit(allocator);
 }
 
-test "generateUuid produces valid UUID" {
-    const uuid = generateUuid();
+test "generateUlid produces valid ULID" {
+    const ulid = generateUlid();
+    const now_ms: u64 = @intCast(@max(std.time.milliTimestamp(), 0));
+    const ulid_ms = (@as(u64, ulid[0]) << 40) |
+        (@as(u64, ulid[1]) << 32) |
+        (@as(u64, ulid[2]) << 24) |
+        (@as(u64, ulid[3]) << 16) |
+        (@as(u64, ulid[4]) << 8) |
+        @as(u64, ulid[5]);
 
-    // Check version bits (should be 0x4X for version 4)
-    try std.testing.expectEqual(@as(u8, 0x40), uuid[6] & 0xf0);
+    try std.testing.expect(ulid_ms <= now_ms);
+    try std.testing.expect(now_ms - ulid_ms < 1_000);
 
-    // Check variant bits (should be 0x8X or 0x9X, 0xaX, or 0xbX for RFC 4122)
-    try std.testing.expect(uuid[8] >= 0x80 and uuid[8] <= 0xbf);
-
-    // Generate multiple UUIDs and ensure they're different
-    const uuid2 = generateUuid();
-    try std.testing.expect(!std.mem.eql(u8, &uuid, &uuid2));
+    // Generate multiple ULIDs and ensure they're different
+    const ulid2 = generateUlid();
+    try std.testing.expect(!std.mem.eql(u8, &ulid, &ulid2));
 }
 
-test "uuidToString and parseUuid roundtrip" {
-    const uuid = generateUuid();
-    const str = try uuidToString(uuid, std.testing.allocator);
+test "ulidToString and parseUlid roundtrip" {
+    const ulid = generateUlid();
+    const str = try ulidToString(ulid, std.testing.allocator);
     defer std.testing.allocator.free(str);
 
-    // Check format: 36 chars with hyphens at correct positions
-    try std.testing.expectEqual(@as(usize, 36), str.len);
-    try std.testing.expectEqual(@as(u8, '-'), str[8]);
-    try std.testing.expectEqual(@as(u8, '-'), str[13]);
-    try std.testing.expectEqual(@as(u8, '-'), str[18]);
-    try std.testing.expectEqual(@as(u8, '-'), str[23]);
+    // Check format: 26 Crockford Base32 characters.
+    try std.testing.expectEqual(@as(usize, 26), str.len);
+    for (str) |c| {
+        try std.testing.expect(ulidDecode(c) != null);
+    }
 
     // Roundtrip
-    const parsed = parseUuid(str);
+    const parsed = parseUlid(str);
     try std.testing.expect(parsed != null);
-    try std.testing.expectEqualSlices(u8, &uuid, &parsed.?);
+    try std.testing.expectEqualSlices(u8, &ulid, &parsed.?);
 
-    // Test with known UUID
-    const known_uuid: Uuid = .{ 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0xfe, 0xdc, 0xba, 0x98, 0x76, 0x54, 0x32, 0x10 };
-    const known_str = try uuidToString(known_uuid, std.testing.allocator);
+    // Test with known ULID
+    const known_ulid: Ulid = .{ 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0xfe, 0xdc, 0xba, 0x98, 0x76, 0x54, 0x32, 0x10 };
+    const known_str = try ulidToString(known_ulid, std.testing.allocator);
     defer std.testing.allocator.free(known_str);
-    try std.testing.expectEqualStrings("01234567-89ab-cdef-fedc-ba9876543210", known_str);
+    try std.testing.expectEqualStrings("018D2PF2DBSQQZWQ5TK1V58CGG", known_str);
 
-    const parsed_known = parseUuid(known_str);
+    const parsed_known = parseUlid(known_str);
     try std.testing.expect(parsed_known != null);
-    try std.testing.expectEqualSlices(u8, &known_uuid, &parsed_known.?);
+    try std.testing.expectEqualSlices(u8, &known_ulid, &parsed_known.?);
 }
 
-test "parseUuid returns null for invalid strings" {
+test "parseUlid returns null for invalid strings" {
     // Wrong length
-    try std.testing.expect(parseUuid("01234567-89ab-cdef-fedc-ba987654321") == null); // 35 chars
-    try std.testing.expect(parseUuid("01234567-89ab-cdef-fedc-ba98765432100") == null); // 37 chars
+    try std.testing.expect(parseUlid("018D2PF2DBSQQZWQ5TK1V58CG") == null); // 25 chars
+    try std.testing.expect(parseUlid("018D2PF2DBSQQZWQ5TK1V58CGG0") == null); // 27 chars
 
-    // Missing hyphens
-    try std.testing.expect(parseUuid("0123456789abcdef0123456789abcdef0123") == null);
+    // Invalid Crockford Base32 characters
+    try std.testing.expect(parseUlid("018D2PF2DBSQQZWQ5TK1V58CGU") == null);
+    try std.testing.expect(parseUlid("018D2PF2DBSQQZWQ5TK1V58CG-") == null);
 
-    // Invalid hex characters
-    try std.testing.expect(parseUuid("01234567-89ab-cdef-xxxx-ba9876543210") == null);
-    try std.testing.expect(parseUuid("g1234567-89ab-cdef-fedc-ba9876543210") == null);
+    // Overflow in the 130-bit representation
+    try std.testing.expect(parseUlid("8ZZZZZZZZZZZZZZZZZZZZZZZZZ") == null);
 
-    // Hyphens in wrong positions
-    try std.testing.expect(parseUuid("0123456-789a-bcde-ffed-cba9876543210") == null);
-    try std.testing.expect(parseUuid("012345678-9ab-cdef-fedc-ba9876543210") == null);
+    // Ambiguous Crockford aliases are accepted
+    try std.testing.expect(parseUlid("0I8D2PF2DBSQQZWQ5TK1V58CGG") != null);
 
     // Empty string
-    try std.testing.expect(parseUuid("") == null);
+    try std.testing.expect(parseUlid("") == null);
 }
 
 test "ErrorCode enum values match protocol spec" {
@@ -511,10 +500,10 @@ test "ErrorCode enum values match protocol spec" {
 }
 
 test "Envelope with ping payload" {
-    const uuid = generateUuid();
+    const ulid = generateUlid();
     var envelope = Envelope{
-        .stream_id = uuid,
-        .message_id = generateUuid(),
+        .stream_id = ulid,
+        .message_id = generateUlid(),
         .sequence = 1,
         .timestamp = std.time.milliTimestamp(),
         .payload = .ping,
@@ -527,7 +516,7 @@ test "Envelope with ping payload" {
 test "Nack deinit frees reason and supported_versions" {
     const reason = try std.testing.allocator.dupe(u8, "Test error reason");
     var nack = Nack{
-        .rejected_id = generateUuid(),
+        .rejected_id = generateUlid(),
         .reason = OwnedSlice(u8).initOwned(reason),
         .error_code = .invalid_request,
     };
@@ -550,7 +539,7 @@ test "StreamError deinit frees message" {
 test "AbortRequest deinit frees reason" {
     const reason = try std.testing.allocator.dupe(u8, "User cancelled");
     var abort = AbortRequest{
-        .target_stream_id = generateUuid(),
+        .target_stream_id = generateUlid(),
         .reason = OwnedSlice(u8).initOwned(reason),
     };
 
@@ -560,7 +549,7 @@ test "AbortRequest deinit frees reason" {
 
 test "AbortRequest deinit handles empty reason" {
     var abort = AbortRequest{
-        .target_stream_id = generateUuid(),
+        .target_stream_id = generateUlid(),
     };
 
     abort.deinit(std.testing.allocator);
@@ -578,7 +567,7 @@ test "Payload deinit handles all variants" {
     pong_payload.deinit(std.testing.allocator);
 
     // Test ack
-    var ack_payload: Payload = .{ .ack = .{ .acknowledged_id = generateUuid() } };
+    var ack_payload: Payload = .{ .ack = .{ .acknowledged_id = generateUlid() } };
     ack_payload.deinit(std.testing.allocator);
 }
 
@@ -615,7 +604,7 @@ test "Sync deinit handles partial" {
         .is_owned = false,
     };
     var sync = Sync{
-        .target_stream_id = generateUuid(),
+        .target_stream_id = generateUlid(),
         .partial = partial,
     };
     sync.deinit(std.testing.allocator);
@@ -624,7 +613,7 @@ test "Sync deinit handles partial" {
 
 test "Sync deinit handles null partial" {
     var sync = Sync{
-        .target_stream_id = generateUuid(),
+        .target_stream_id = generateUlid(),
         .partial = null,
     };
     sync.deinit(std.testing.allocator);
@@ -632,7 +621,7 @@ test "Sync deinit handles null partial" {
 }
 
 test "SyncRequest has target_stream_id" {
-    const target_id = generateUuid();
+    const target_id = generateUlid();
     const sync_req = SyncRequest{ .target_stream_id = target_id };
     try std.testing.expectEqualSlices(u8, &target_id, &sync_req.target_stream_id);
 }

--- a/zig/src/protocol/tool/envelope.zig
+++ b/zig/src/protocol/tool/envelope.zig
@@ -13,11 +13,11 @@ pub fn serializeEnvelope(env: tool_types.Envelope, allocator: std.mem.Allocator)
     try w.beginObject();
     try w.writeStringField("type", @tagName(env.payload));
 
-    const server_id_str = try tool_types.uuidToString(env.server_id, allocator);
+    const server_id_str = try tool_types.ulidToString(env.server_id, allocator);
     defer allocator.free(server_id_str);
     try w.writeStringField("server_id", server_id_str);
 
-    const message_id_str = try tool_types.uuidToString(env.message_id, allocator);
+    const message_id_str = try tool_types.ulidToString(env.message_id, allocator);
     defer allocator.free(message_id_str);
     try w.writeStringField("message_id", message_id_str);
 
@@ -26,7 +26,7 @@ pub fn serializeEnvelope(env: tool_types.Envelope, allocator: std.mem.Allocator)
     try w.writeIntField("version", env.version);
 
     if (env.in_reply_to) |reply_to| {
-        const reply_to_str = try tool_types.uuidToString(reply_to, allocator);
+        const reply_to_str = try tool_types.ulidToString(reply_to, allocator);
         defer allocator.free(reply_to_str);
         try w.writeStringField("in_reply_to", reply_to_str);
     }
@@ -68,7 +68,7 @@ fn serializePayload(w: *json_writer.JsonWriter, payload: tool_types.Payload, all
             try w.endArray();
         },
         .tool_execute => |req| {
-            const execution_id_str = try tool_types.uuidToString(req.execution_id, allocator);
+            const execution_id_str = try tool_types.ulidToString(req.execution_id, allocator);
             defer allocator.free(execution_id_str);
             try w.writeStringField("execution_id", execution_id_str);
             try w.writeStringField("tool_call_id", req.tool_call_id);
@@ -78,7 +78,7 @@ fn serializePayload(w: *json_writer.JsonWriter, payload: tool_types.Payload, all
             if (req.getStreamCallbackUrl()) |url| try w.writeStringField("stream_callback_url", url);
         },
         .tool_stream => |update| {
-            const execution_id_str = try tool_types.uuidToString(update.execution_id, allocator);
+            const execution_id_str = try tool_types.ulidToString(update.execution_id, allocator);
             defer allocator.free(execution_id_str);
             try w.writeStringField("execution_id", execution_id_str);
             try w.writeStringField("tool_call_id", update.tool_call_id);
@@ -87,7 +87,7 @@ fn serializePayload(w: *json_writer.JsonWriter, payload: tool_types.Payload, all
             if (update.getStatus()) |status| try w.writeStringField("status", status);
         },
         .tool_result => |res| {
-            const execution_id_str = try tool_types.uuidToString(res.execution_id, allocator);
+            const execution_id_str = try tool_types.ulidToString(res.execution_id, allocator);
             defer allocator.free(execution_id_str);
             try w.writeStringField("execution_id", execution_id_str);
             try w.writeStringField("tool_call_id", res.tool_call_id);
@@ -98,30 +98,30 @@ fn serializePayload(w: *json_writer.JsonWriter, payload: tool_types.Payload, all
             try w.writeIntField("duration_ms", res.duration_ms);
         },
         .tool_cancel => |req| {
-            const execution_id_str = try tool_types.uuidToString(req.execution_id, allocator);
+            const execution_id_str = try tool_types.ulidToString(req.execution_id, allocator);
             defer allocator.free(execution_id_str);
             try w.writeStringField("execution_id", execution_id_str);
             if (req.getReason()) |reason| try w.writeStringField("reason", reason);
         },
         .tool_cancelled => |cancelled| {
-            const execution_id_str = try tool_types.uuidToString(cancelled.execution_id, allocator);
+            const execution_id_str = try tool_types.ulidToString(cancelled.execution_id, allocator);
             defer allocator.free(execution_id_str);
             try w.writeStringField("execution_id", execution_id_str);
         },
         .tool_error => |err| {
-            const execution_id_str = try tool_types.uuidToString(err.execution_id, allocator);
+            const execution_id_str = try tool_types.ulidToString(err.execution_id, allocator);
             defer allocator.free(execution_id_str);
             try w.writeStringField("execution_id", execution_id_str);
             try w.writeStringField("code", @tagName(err.code));
             try w.writeStringField("message", err.message);
         },
         .tool_status => |req| {
-            const execution_id_str = try tool_types.uuidToString(req.execution_id, allocator);
+            const execution_id_str = try tool_types.ulidToString(req.execution_id, allocator);
             defer allocator.free(execution_id_str);
             try w.writeStringField("execution_id", execution_id_str);
         },
         .tool_status_response => |info| {
-            const execution_id_str = try tool_types.uuidToString(info.execution_id, allocator);
+            const execution_id_str = try tool_types.ulidToString(info.execution_id, allocator);
             defer allocator.free(execution_id_str);
             try w.writeStringField("execution_id", execution_id_str);
             try w.writeStringField("tool_name", info.tool_name);
@@ -165,14 +165,14 @@ pub fn deserializeEnvelope(json: []const u8, allocator: std.mem.Allocator) !tool
 
     const root = parsed.value.object;
     const type_str = root.get("type").?.string;
-    const server_id = try parseUuidRequired(root.get("server_id").?.string);
-    const message_id = try parseUuidRequired(root.get("message_id").?.string);
+    const server_id = try parseUlidRequired(root.get("server_id").?.string);
+    const message_id = try parseUlidRequired(root.get("message_id").?.string);
     const sequence = @as(u64, @intCast(root.get("sequence").?.integer));
     const timestamp = root.get("timestamp").?.integer;
     const version = @as(u8, @intCast(root.get("version").?.integer));
 
-    var in_reply_to: ?tool_types.Uuid = null;
-    if (root.get("in_reply_to")) |v| in_reply_to = try parseUuidRequired(v.string);
+    var in_reply_to: ?tool_types.Ulid = null;
+    if (root.get("in_reply_to")) |v| in_reply_to = try parseUlidRequired(v.string);
 
     const payload_obj = root.get("payload").?.object;
     const payload = try deserializePayload(type_str, payload_obj, allocator);
@@ -188,8 +188,8 @@ pub fn deserializeEnvelope(json: []const u8, allocator: std.mem.Allocator) !tool
     };
 }
 
-fn parseUuidRequired(str: []const u8) !tool_types.Uuid {
-    return tool_types.parseUuid(str) orelse error.InvalidUuid;
+fn parseUlidRequired(str: []const u8) !tool_types.Ulid {
+    return tool_types.parseUlid(str) orelse error.InvalidUlid;
 }
 
 fn deserializePayload(type_str: []const u8, payload: std.json.ObjectMap, allocator: std.mem.Allocator) !tool_types.Payload {
@@ -235,7 +235,7 @@ fn deserializePayload(type_str: []const u8, payload: std.json.ObjectMap, allocat
         try validateJson(args_json, allocator);
 
         var req = tool_types.ToolExecuteRequest{
-            .execution_id = try parseUuidRequired(payload.get("execution_id").?.string),
+            .execution_id = try parseUlidRequired(payload.get("execution_id").?.string),
             .tool_call_id = try allocator.dupe(u8, payload.get("tool_call_id").?.string),
             .tool_name = try allocator.dupe(u8, payload.get("tool_name").?.string),
             .args_json = args_json,
@@ -246,7 +246,7 @@ fn deserializePayload(type_str: []const u8, payload: std.json.ObjectMap, allocat
     }
     if (std.mem.eql(u8, type_str, "tool_stream")) {
         var update = tool_types.ToolStreamUpdate{
-            .execution_id = try parseUuidRequired(payload.get("execution_id").?.string),
+            .execution_id = try parseUlidRequired(payload.get("execution_id").?.string),
             .tool_call_id = try allocator.dupe(u8, payload.get("tool_call_id").?.string),
             .partial_result_json = try allocator.dupe(u8, payload.get("partial_result_json").?.string),
         };
@@ -256,7 +256,7 @@ fn deserializePayload(type_str: []const u8, payload: std.json.ObjectMap, allocat
     }
     if (std.mem.eql(u8, type_str, "tool_result")) {
         var result = tool_types.ToolExecuteResult{
-            .execution_id = try parseUuidRequired(payload.get("execution_id").?.string),
+            .execution_id = try parseUlidRequired(payload.get("execution_id").?.string),
             .tool_call_id = try allocator.dupe(u8, payload.get("tool_call_id").?.string),
             .result_json = try allocator.dupe(u8, payload.get("result_json").?.string),
             .is_error = if (payload.get("is_error")) |v| v.bool else false,
@@ -268,31 +268,31 @@ fn deserializePayload(type_str: []const u8, payload: std.json.ObjectMap, allocat
     }
     if (std.mem.eql(u8, type_str, "tool_cancel")) {
         var req = tool_types.ToolCancelRequest{
-            .execution_id = try parseUuidRequired(payload.get("execution_id").?.string),
+            .execution_id = try parseUlidRequired(payload.get("execution_id").?.string),
         };
         if (payload.get("reason")) |v| req.reason = OwnedSlice(u8).initOwned(try allocator.dupe(u8, v.string));
         return .{ .tool_cancel = req };
     }
     if (std.mem.eql(u8, type_str, "tool_cancelled")) {
         return .{ .tool_cancelled = .{
-            .execution_id = try parseUuidRequired(payload.get("execution_id").?.string),
+            .execution_id = try parseUlidRequired(payload.get("execution_id").?.string),
         } };
     }
     if (std.mem.eql(u8, type_str, "tool_error")) {
         return .{ .tool_error = .{
-            .execution_id = try parseUuidRequired(payload.get("execution_id").?.string),
+            .execution_id = try parseUlidRequired(payload.get("execution_id").?.string),
             .code = std.meta.stringToEnum(tool_types.ToolErrorCode, payload.get("code").?.string) orelse return error.InvalidPayloadType,
             .message = try allocator.dupe(u8, payload.get("message").?.string),
         } };
     }
     if (std.mem.eql(u8, type_str, "tool_status")) {
         return .{ .tool_status = .{
-            .execution_id = try parseUuidRequired(payload.get("execution_id").?.string),
+            .execution_id = try parseUlidRequired(payload.get("execution_id").?.string),
         } };
     }
     if (std.mem.eql(u8, type_str, "tool_status_response")) {
         return .{ .tool_status_response = .{
-            .execution_id = try parseUuidRequired(payload.get("execution_id").?.string),
+            .execution_id = try parseUlidRequired(payload.get("execution_id").?.string),
             .tool_name = try allocator.dupe(u8, payload.get("tool_name").?.string),
             .status = std.meta.stringToEnum(tool_types.ToolExecutionStatus, payload.get("status").?.string) orelse return error.InvalidPayloadType,
             .started_at = payload.get("started_at").?.integer,
@@ -346,12 +346,12 @@ test "tool envelope roundtrip execute request" {
     const allocator = std.testing.allocator;
 
     var env = tool_types.Envelope{
-        .server_id = tool_types.generateUuid(),
-        .message_id = tool_types.generateUuid(),
+        .server_id = tool_types.generateUlid(),
+        .message_id = tool_types.generateUlid(),
         .sequence = 1,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .tool_execute = .{
-            .execution_id = tool_types.generateUuid(),
+            .execution_id = tool_types.generateUlid(),
             .tool_call_id = try allocator.dupe(u8, "call_123"),
             .tool_name = try allocator.dupe(u8, "search"),
             .args_json = try allocator.dupe(u8, "{\"query\":\"zig\"}"),
@@ -390,8 +390,8 @@ test "tool envelope roundtrip list response" {
     };
 
     var env = tool_types.Envelope{
-        .server_id = tool_types.generateUuid(),
-        .message_id = tool_types.generateUuid(),
+        .server_id = tool_types.generateUlid(),
+        .message_id = tool_types.generateUlid(),
         .sequence = 2,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .tool_list_response = .{ .tools = tools } },
@@ -412,7 +412,7 @@ test "tool envelope roundtrip list response" {
 test "tool envelope negative unknown tool error" {
     const allocator = std.testing.allocator;
     const json =
-        "{\"type\":\"tool_error\",\"server_id\":\"00000000-0000-0000-0000-000000000001\",\"message_id\":\"00000000-0000-0000-0000-000000000002\",\"sequence\":1,\"timestamp\":1,\"version\":1,\"payload\":{\"execution_id\":\"00000000-0000-0000-0000-000000000003\",\"code\":\"tool_not_found\",\"message\":\"unknown tool\"}}";
+        "{\"type\":\"tool_error\",\"server_id\":\"00000000000000000000000001\",\"message_id\":\"00000000000000000000000002\",\"sequence\":1,\"timestamp\":1,\"version\":1,\"payload\":{\"execution_id\":\"00000000000000000000000003\",\"code\":\"tool_not_found\",\"message\":\"unknown tool\"}}";
 
     var env = try deserializeEnvelope(json, allocator);
     defer env.deinit(allocator);
@@ -424,7 +424,7 @@ test "tool envelope negative unknown tool error" {
 test "tool envelope negative malformed args" {
     const allocator = std.testing.allocator;
     const json =
-        "{\"type\":\"tool_execute\",\"server_id\":\"00000000-0000-0000-0000-000000000001\",\"message_id\":\"00000000-0000-0000-0000-000000000002\",\"sequence\":1,\"timestamp\":1,\"version\":1,\"payload\":{\"execution_id\":\"00000000-0000-0000-0000-000000000003\",\"tool_call_id\":\"call_1\",\"tool_name\":\"grep\",\"args_json\":\"{bad json\"}}";
+        "{\"type\":\"tool_execute\",\"server_id\":\"00000000000000000000000001\",\"message_id\":\"00000000000000000000000002\",\"sequence\":1,\"timestamp\":1,\"version\":1,\"payload\":{\"execution_id\":\"00000000000000000000000003\",\"tool_call_id\":\"call_1\",\"tool_name\":\"grep\",\"args_json\":\"{bad json\"}}";
 
     try std.testing.expectError(error.InvalidArgumentsJson, deserializeEnvelope(json, allocator));
 }
@@ -432,7 +432,7 @@ test "tool envelope negative malformed args" {
 test "tool envelope negative timeout error" {
     const allocator = std.testing.allocator;
     const json =
-        "{\"type\":\"tool_error\",\"server_id\":\"00000000-0000-0000-0000-000000000001\",\"message_id\":\"00000000-0000-0000-0000-000000000002\",\"sequence\":1,\"timestamp\":1,\"version\":1,\"payload\":{\"execution_id\":\"00000000-0000-0000-0000-000000000003\",\"code\":\"tool_timeout\",\"message\":\"timed out\"}}";
+        "{\"type\":\"tool_error\",\"server_id\":\"00000000000000000000000001\",\"message_id\":\"00000000000000000000000002\",\"sequence\":1,\"timestamp\":1,\"version\":1,\"payload\":{\"execution_id\":\"00000000000000000000000003\",\"code\":\"tool_timeout\",\"message\":\"timed out\"}}";
 
     var env = try deserializeEnvelope(json, allocator);
     defer env.deinit(allocator);

--- a/zig/src/protocol/tool/runtime.zig
+++ b/zig/src/protocol/tool/runtime.zig
@@ -115,7 +115,7 @@ test "ToolProtocolRuntime pumps request, response, and outbox" {
 
             return protocol_types.Envelope{
                 .server_id = env.server_id,
-                .message_id = protocol_types.generateUuid(),
+                .message_id = protocol_types.generateUlid(),
                 .sequence = env.sequence + 1,
                 .in_reply_to = env.message_id,
                 .timestamp = std.time.milliTimestamp(),
@@ -135,12 +135,12 @@ test "ToolProtocolRuntime pumps request, response, and outbox" {
             server.outbox_sent = true;
 
             return protocol_types.Envelope{
-                .server_id = protocol_types.generateUuid(),
-                .message_id = protocol_types.generateUuid(),
+                .server_id = protocol_types.generateUlid(),
+                .message_id = protocol_types.generateUlid(),
                 .sequence = 99,
                 .timestamp = std.time.milliTimestamp(),
                 .payload = .{ .tool_stream = .{
-                    .execution_id = protocol_types.generateUuid(),
+                    .execution_id = protocol_types.generateUlid(),
                     .tool_call_id = try test_allocator.dupe(u8, "call_1"),
                     .partial_result_json = try test_allocator.dupe(u8, "{\"progress\":50}"),
                     .progress = 50,
@@ -176,12 +176,12 @@ test "ToolProtocolRuntime pumps request, response, and outbox" {
     };
 
     const request = protocol_types.Envelope{
-        .server_id = protocol_types.generateUuid(),
-        .message_id = protocol_types.generateUuid(),
+        .server_id = protocol_types.generateUlid(),
+        .message_id = protocol_types.generateUlid(),
         .sequence = 1,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .tool_status = .{
-            .execution_id = protocol_types.generateUuid(),
+            .execution_id = protocol_types.generateUlid(),
         } },
     };
     const request_json = try tool_envelope.serializeEnvelope(request, allocator);

--- a/zig/src/protocol/tool/types.zig
+++ b/zig/src/protocol/tool/types.zig
@@ -2,11 +2,11 @@ const std = @import("std");
 const provider_types = @import("protocol_types");
 const OwnedSlice = @import("owned_slice").OwnedSlice;
 
-/// Re-export Uuid from provider types for convenience
-pub const Uuid = provider_types.Uuid;
-pub const generateUuid = provider_types.generateUuid;
-pub const uuidToString = provider_types.uuidToString;
-pub const parseUuid = provider_types.parseUuid;
+/// Re-export Ulid from provider types for convenience
+pub const Ulid = provider_types.Ulid;
+pub const generateUlid = provider_types.generateUlid;
+pub const ulidToString = provider_types.ulidToString;
+pub const parseUlid = provider_types.parseUlid;
 
 // ============================================================================
 // Tool Protocol Types
@@ -104,7 +104,7 @@ pub const ToolListResponse = struct {
 /// Request to execute a tool
 pub const ToolExecuteRequest = struct {
     /// Execution ID for correlation
-    execution_id: Uuid,
+    execution_id: Ulid,
     /// Tool call ID (from LLM)
     tool_call_id: []const u8,
     /// Tool name
@@ -124,7 +124,7 @@ pub const ToolExecuteRequest = struct {
 
 /// Streaming update during tool execution
 pub const ToolStreamUpdate = struct {
-    execution_id: Uuid,
+    execution_id: Ulid,
     tool_call_id: []const u8,
     /// Partial result as JSON
     partial_result_json: []const u8,
@@ -141,7 +141,7 @@ pub const ToolStreamUpdate = struct {
 
 /// Final result from tool execution
 pub const ToolExecuteResult = struct {
-    execution_id: Uuid,
+    execution_id: Ulid,
     tool_call_id: []const u8,
     /// Result content as JSON array of UserContentPart
     result_json: []const u8,
@@ -167,7 +167,7 @@ pub const ToolExecuteResult = struct {
 
 /// Request to cancel a tool execution
 pub const ToolCancelRequest = struct {
-    execution_id: Uuid,
+    execution_id: Ulid,
     reason: OwnedSlice(u8) = OwnedSlice(u8).initBorrowed(""),
 
     pub fn getReason(self: *const ToolCancelRequest) ?[]const u8 {
@@ -189,7 +189,7 @@ pub const ToolExecutionStatus = enum {
 
 /// Tool execution info
 pub const ToolExecutionInfo = struct {
-    execution_id: Uuid,
+    execution_id: Ulid,
     tool_name: []const u8,
     status: ToolExecutionStatus,
     started_at: i64,
@@ -226,9 +226,9 @@ pub const Payload = union(enum) {
     tool_stream: ToolStreamUpdate,
     tool_result: ToolExecuteResult,
     tool_cancel: ToolCancelRequest,
-    tool_cancelled: struct { execution_id: Uuid },
-    tool_error: struct { execution_id: Uuid, code: ToolErrorCode, message: []const u8 },
-    tool_status: struct { execution_id: Uuid },
+    tool_cancelled: struct { execution_id: Ulid },
+    tool_error: struct { execution_id: Ulid, code: ToolErrorCode, message: []const u8 },
+    tool_status: struct { execution_id: Ulid },
     tool_status_response: ToolExecutionInfo,
 
     // Keepalive
@@ -301,13 +301,13 @@ pub const Envelope = struct {
     /// Protocol version
     version: u8 = 1,
     /// Tool server identifier
-    server_id: Uuid,
+    server_id: Ulid,
     /// Message ID (unique per message)
-    message_id: Uuid,
+    message_id: Ulid,
     /// Sequence number within connection
     sequence: u64,
     /// For request/response correlation
-    in_reply_to: ?Uuid = null,
+    in_reply_to: ?Ulid = null,
     /// Unix timestamp in milliseconds
     timestamp: i64,
     /// The actual payload

--- a/zig/src/tools/auth_cli.zig
+++ b/zig/src/tools/auth_cli.zig
@@ -83,12 +83,12 @@ pub fn runProvidersCommand(
     var pipe = in_process.createSerializedPipe(allocator);
     defer pipe.deinit();
 
-    const stream_id = auth_types.generateUuid();
+    const stream_id = auth_types.generateUlid();
 
     {
         const env = auth_types.Envelope{
             .stream_id = stream_id,
-            .message_id = auth_types.generateUuid(),
+            .message_id = auth_types.generateUlid(),
             .sequence = 1,
             .timestamp = std.time.milliTimestamp(),
             .payload = .{ .auth_providers_request = .{} },
@@ -154,7 +154,7 @@ pub fn runLoginCommand(
     var pipe = in_process.createSerializedPipe(allocator);
     defer pipe.deinit();
 
-    const flow_id = auth_types.generateUuid();
+    const flow_id = auth_types.generateUlid();
     var next_client_seq: u64 = 1;
 
     try sendLoginStart(allocator, &pipe, flow_id, options.provider_id, next_client_seq);
@@ -238,13 +238,13 @@ pub fn runLoginCommand(
 fn sendLoginStart(
     allocator: std.mem.Allocator,
     pipe: *SerializedPipe,
-    flow_id: auth_types.Uuid,
+    flow_id: auth_types.Ulid,
     provider_id: []const u8,
     sequence: u64,
 ) !void {
     var env = auth_types.Envelope{
         .stream_id = flow_id,
-        .message_id = auth_types.generateUuid(),
+        .message_id = auth_types.generateUlid(),
         .sequence = sequence,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .auth_login_start = .{
@@ -264,14 +264,14 @@ fn sendLoginStart(
 fn sendPromptResponse(
     allocator: std.mem.Allocator,
     pipe: *SerializedPipe,
-    flow_id: auth_types.Uuid,
+    flow_id: auth_types.Ulid,
     sequence: u64,
     prompt_id: []const u8,
     answer: []const u8,
 ) !void {
     var env = auth_types.Envelope{
         .stream_id = flow_id,
-        .message_id = auth_types.generateUuid(),
+        .message_id = auth_types.generateUlid(),
         .sequence = sequence,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .auth_prompt_response = .{
@@ -296,7 +296,7 @@ fn handleAuthEvent(
     options: LoginOptions,
     event: auth_types.AuthEvent,
     pipe: *SerializedPipe,
-    flow_id: auth_types.Uuid,
+    flow_id: auth_types.Ulid,
     next_client_seq: *u64,
     captured_error_code: *?[]u8,
     captured_error_message: *?[]u8,

--- a/zig/src/tools/makai.zig
+++ b/zig/src/tools/makai.zig
@@ -571,8 +571,8 @@ fn fixtureErrorStreamSimple(
 
 fn makeProviderPingEnvelopeJson(allocator: std.mem.Allocator) ![]u8 {
     const env = ProviderProtocolTypes.Envelope{
-        .stream_id = ProviderProtocolTypes.generateUuid(),
-        .message_id = ProviderProtocolTypes.generateUuid(),
+        .stream_id = ProviderProtocolTypes.generateUlid(),
+        .message_id = ProviderProtocolTypes.generateUlid(),
         .sequence = 1,
         .timestamp = std.time.milliTimestamp(),
         .payload = .ping,
@@ -582,8 +582,8 @@ fn makeProviderPingEnvelopeJson(allocator: std.mem.Allocator) ![]u8 {
 
 fn makeAgentPingEnvelopeJson(allocator: std.mem.Allocator) ![]u8 {
     const env = AgentProtocolTypes.Envelope{
-        .session_id = AgentProtocolTypes.generateUuid(),
-        .message_id = AgentProtocolTypes.generateUuid(),
+        .session_id = AgentProtocolTypes.generateUlid(),
+        .message_id = AgentProtocolTypes.generateUlid(),
         .sequence = 1,
         .timestamp = std.time.milliTimestamp(),
         .payload = .ping,
@@ -591,10 +591,10 @@ fn makeAgentPingEnvelopeJson(allocator: std.mem.Allocator) ![]u8 {
     return agent_protocol_envelope.serializeEnvelope(env, allocator);
 }
 
-fn makeAuthProvidersRequestEnvelopeJson(allocator: std.mem.Allocator, flow_id: AuthProtocolTypes.Uuid, sequence: u64) ![]u8 {
+fn makeAuthProvidersRequestEnvelopeJson(allocator: std.mem.Allocator, flow_id: AuthProtocolTypes.Ulid, sequence: u64) ![]u8 {
     const env = AuthProtocolTypes.Envelope{
         .stream_id = flow_id,
-        .message_id = AuthProtocolTypes.generateUuid(),
+        .message_id = AuthProtocolTypes.generateUlid(),
         .sequence = sequence,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .auth_providers_request = .{} },
@@ -604,13 +604,13 @@ fn makeAuthProvidersRequestEnvelopeJson(allocator: std.mem.Allocator, flow_id: A
 
 fn makeAuthLoginStartEnvelopeJson(
     allocator: std.mem.Allocator,
-    flow_id: AuthProtocolTypes.Uuid,
+    flow_id: AuthProtocolTypes.Ulid,
     sequence: u64,
     provider_id: []const u8,
 ) ![]u8 {
     var env = AuthProtocolTypes.Envelope{
         .stream_id = flow_id,
-        .message_id = AuthProtocolTypes.generateUuid(),
+        .message_id = AuthProtocolTypes.generateUlid(),
         .sequence = sequence,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .auth_login_start = .{
@@ -623,14 +623,14 @@ fn makeAuthLoginStartEnvelopeJson(
 
 fn makeAuthPromptResponseEnvelopeJson(
     allocator: std.mem.Allocator,
-    flow_id: AuthProtocolTypes.Uuid,
+    flow_id: AuthProtocolTypes.Ulid,
     sequence: u64,
     prompt_id: []const u8,
     answer: []const u8,
 ) ![]u8 {
     var env = AuthProtocolTypes.Envelope{
         .stream_id = flow_id,
-        .message_id = AuthProtocolTypes.generateUuid(),
+        .message_id = AuthProtocolTypes.generateUlid(),
         .sequence = sequence,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .auth_prompt_response = .{
@@ -645,12 +645,12 @@ fn makeAuthPromptResponseEnvelopeJson(
 
 fn makeAuthCancelEnvelopeJson(
     allocator: std.mem.Allocator,
-    flow_id: AuthProtocolTypes.Uuid,
+    flow_id: AuthProtocolTypes.Ulid,
     sequence: u64,
 ) ![]u8 {
     const env = AuthProtocolTypes.Envelope{
         .stream_id = flow_id,
-        .message_id = AuthProtocolTypes.generateUuid(),
+        .message_id = AuthProtocolTypes.generateUlid(),
         .sequence = sequence,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .auth_cancel = .{
@@ -665,18 +665,20 @@ fn makeProviderStreamRequestEnvelopeJson(
     api: []const u8,
 ) ![]u8 {
     var env = ProviderProtocolTypes.Envelope{
-        .stream_id = ProviderProtocolTypes.generateUuid(),
-        .message_id = ProviderProtocolTypes.generateUuid(),
+        .stream_id = ProviderProtocolTypes.generateUlid(),
+        .message_id = ProviderProtocolTypes.generateUlid(),
         .sequence = 1,
         .timestamp = std.time.milliTimestamp(),
-        .payload = .{ .stream_request = .{
-            .model = fixtureModel(api),
-            .context = .{ .messages = &.{} },
-            // Provide an explicit api_key so the binary's credential resolver
-            // (M-006) does not reject the request with `auth_required`. The
-            // fixture providers do not validate the key value.
-            .options = .{ .api_key = ai_types.OwnedSlice(u8).initBorrowed("test-fixture-key") },
-        } },
+        .payload = .{
+            .stream_request = .{
+                .model = fixtureModel(api),
+                .context = .{ .messages = &.{} },
+                // Provide an explicit api_key so the binary's credential resolver
+                // (M-006) does not reject the request with `auth_required`. The
+                // fixture providers do not validate the key value.
+                .options = .{ .api_key = ai_types.OwnedSlice(u8).initBorrowed("test-fixture-key") },
+            },
+        },
     };
     defer env.deinit(allocator);
     return provider_protocol_envelope.serializeEnvelope(env, allocator);
@@ -748,7 +750,7 @@ test "stdio protocol loop decodes and dispatches auth providers request and emit
         outbound.deinit(allocator);
     }
 
-    const flow_id = AuthProtocolTypes.generateUuid();
+    const flow_id = AuthProtocolTypes.generateUlid();
     const request = try makeAuthProvidersRequestEnvelopeJson(allocator, flow_id, 1);
     defer allocator.free(request);
 
@@ -787,7 +789,7 @@ test "stdio auth login flow supports prompt loop terminal ordering and no secret
         outbound.deinit(allocator);
     }
 
-    const flow_id = AuthProtocolTypes.generateUuid();
+    const flow_id = AuthProtocolTypes.generateUlid();
     const login_start = try makeAuthLoginStartEnvelopeJson(allocator, flow_id, 1, "test-fixture");
     defer allocator.free(login_start);
     try std.testing.expect(try stdio_loop.dispatchInboundLine(login_start));
@@ -899,7 +901,7 @@ test "stdio auth login flow cancellation emits cancelled result and ignores late
         outbound.deinit(allocator);
     }
 
-    const flow_id = AuthProtocolTypes.generateUuid();
+    const flow_id = AuthProtocolTypes.generateUlid();
     const login_start = try makeAuthLoginStartEnvelopeJson(allocator, flow_id, 1, "test-fixture");
     defer allocator.free(login_start);
     try std.testing.expect(try stdio_loop.dispatchInboundLine(login_start));
@@ -1003,7 +1005,7 @@ test "stdio auth login failure emits auth_event.error before auth_login_result" 
         outbound.deinit(allocator);
     }
 
-    const flow_id = AuthProtocolTypes.generateUuid();
+    const flow_id = AuthProtocolTypes.generateUlid();
     const login_start = try makeAuthLoginStartEnvelopeJson(allocator, flow_id, 1, "unknown-provider");
     defer allocator.free(login_start);
     try std.testing.expect(try stdio_loop.dispatchInboundLine(login_start));
@@ -1058,7 +1060,7 @@ test "stdio protocol loop rejects ambiguous dispatch envelope with both ids" {
     defer stdio_loop.deinit();
 
     const ambiguous =
-        \\{"type":"ping","stream_id":"11111111-1111-1111-1111-111111111111","session_id":"22222222-2222-2222-2222-222222222222","message_id":"33333333-3333-3333-3333-333333333333","sequence":1,"timestamp":1760000000000,"version":1,"payload":{}}
+        \\{"type":"ping","stream_id":"0H248H248H248H248H248H248H","session_id":"test-session","message_id":"1K6CSK6CSK6CSK6CSK6CSK6CSK","sequence":1,"timestamp":1760000000000,"version":1,"payload":{}}
     ;
 
     try std.testing.expect(!(try stdio_loop.dispatchInboundLine(ambiguous)));

--- a/zig/test/e2e/distributed_fullstack.zig
+++ b/zig/test/e2e/distributed_fullstack.zig
@@ -148,7 +148,7 @@ fn remoteSumToolExecute(
 
             return .{
                 .server_id = env.server_id,
-                .message_id = tool_types.generateUuid(),
+                .message_id = tool_types.generateUlid(),
                 .sequence = env.sequence + 1,
                 .in_reply_to = env.message_id,
                 .timestamp = std.time.milliTimestamp(),
@@ -191,12 +191,12 @@ fn remoteSumToolExecute(
     };
 
     var req_env = tool_types.Envelope{
-        .server_id = tool_types.generateUuid(),
-        .message_id = tool_types.generateUuid(),
+        .server_id = tool_types.generateUlid(),
+        .message_id = tool_types.generateUlid(),
         .sequence = 1,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .tool_execute = .{
-            .execution_id = tool_types.generateUuid(),
+            .execution_id = tool_types.generateUlid(),
             .tool_call_id = try allocator.dupe(u8, tool_call_id),
             .tool_name = try allocator.dupe(u8, "remote_sum"),
             .args_json = try allocator.dupe(u8, args_json),

--- a/zig/test/e2e/distributed_fullstack_github.zig
+++ b/zig/test/e2e/distributed_fullstack_github.zig
@@ -71,7 +71,7 @@ fn handleToolClientEnvelope(
     const result_json = try std.fmt.allocPrint(allocator, "[{{\"type\":\"text\",\"text\":\"sum={d}\"}}]", .{sum});
     return .{
         .server_id = env.server_id,
-        .message_id = tool_types.generateUuid(),
+        .message_id = tool_types.generateUlid(),
         .sequence = env.sequence + 1,
         .in_reply_to = env.message_id,
         .timestamp = std.time.milliTimestamp(),
@@ -141,12 +141,12 @@ fn executeToolViaProtocol(
     };
 
     var req_env = tool_types.Envelope{
-        .server_id = tool_types.generateUuid(),
-        .message_id = tool_types.generateUuid(),
+        .server_id = tool_types.generateUlid(),
+        .message_id = tool_types.generateUlid(),
         .sequence = 1,
         .timestamp = std.time.milliTimestamp(),
         .payload = .{ .tool_execute = .{
-            .execution_id = tool_types.generateUuid(),
+            .execution_id = tool_types.generateUlid(),
             .tool_call_id = try allocator.dupe(u8, tool_call_id),
             .tool_name = try allocator.dupe(u8, tool_name),
             .args_json = try allocator.dupe(u8, args_json),

--- a/zig/test/e2e/protocol.zig
+++ b/zig/test/e2e/protocol.zig
@@ -90,8 +90,8 @@ test "Envelope serialization roundtrip with ping" {
     const json =
         \\{
         \\  "type": "ping",
-        \\  "stream_id": "01234567-89ab-cdef-fedc-ba9876543210",
-        \\  "message_id": "12345678-9abc-def0-fedc-ba9876543210",
+        \\  "stream_id": "018D2PF2DBSQQZWQ5TK1V58CGG",
+        \\  "message_id": "0J6HB7H6NWVVRFXX5TK1V58CGG",
         \\  "sequence": 1,
         \\  "timestamp": 1708234567890,
         \\  "version": 1,
@@ -118,8 +118,8 @@ test "Envelope serialization roundtrip with pong" {
     const json =
         \\{
         \\  "type": "pong",
-        \\  "stream_id": "01234567-89ab-cdef-fedc-ba9876543210",
-        \\  "message_id": "12345678-9abc-def0-fedc-ba9876543210",
+        \\  "stream_id": "018D2PF2DBSQQZWQ5TK1V58CGG",
+        \\  "message_id": "0J6HB7H6NWVVRFXX5TK1V58CGG",
         \\  "sequence": 2,
         \\  "timestamp": 1708234567900,
         \\  "version": 1,
@@ -145,13 +145,13 @@ test "Envelope roundtrip preserves ACK structure" {
     const json =
         \\{
         \\  "type": "ack",
-        \\  "stream_id": "01234567-89ab-cdef-fedc-ba9876543210",
-        \\  "message_id": "12345678-9abc-def0-fedc-ba9876543210",
+        \\  "stream_id": "018D2PF2DBSQQZWQ5TK1V58CGG",
+        \\  "message_id": "0J6HB7H6NWVVRFXX5TK1V58CGG",
         \\  "sequence": 2,
         \\  "timestamp": 1708234567900,
         \\  "version": 1,
         \\  "payload": {
-        \\    "acknowledged_id": "abcdef01-2345-6789-abcd-ef0123456789"
+        \\    "acknowledged_id": "55QKQG28T5CY4TQKFF04HMASW9"
         \\  }
         \\}
     ;
@@ -173,13 +173,13 @@ test "Envelope roundtrip preserves NACK structure" {
     const json =
         \\{
         \\  "type": "nack",
-        \\  "stream_id": "01234567-89ab-cdef-fedc-ba9876543210",
-        \\  "message_id": "12345678-9abc-def0-fedc-ba9876543210",
+        \\  "stream_id": "018D2PF2DBSQQZWQ5TK1V58CGG",
+        \\  "message_id": "0J6HB7H6NWVVRFXX5TK1V58CGG",
         \\  "sequence": 3,
         \\  "timestamp": 1708234567900,
         \\  "version": 1,
         \\  "payload": {
-        \\    "rejected_id": "abcdef01-2345-6789-abcd-ef0123456789",
+        \\    "rejected_id": "55QKQG28T5CY4TQKFF04HMASW9",
         \\    "reason": "Model not found",
         \\    "error_code": "model_not_found"
         \\  }
@@ -202,13 +202,13 @@ test "Envelope roundtrip preserves abort_request" {
     const json =
         \\{
         \\  "type": "abort_request",
-        \\  "stream_id": "01234567-89ab-cdef-fedc-ba9876543210",
-        \\  "message_id": "12345678-9abc-def0-fedc-ba9876543210",
+        \\  "stream_id": "018D2PF2DBSQQZWQ5TK1V58CGG",
+        \\  "message_id": "0J6HB7H6NWVVRFXX5TK1V58CGG",
         \\  "sequence": 10,
         \\  "timestamp": 1708234567900,
         \\  "version": 1,
         \\  "payload": {
-        \\    "target_stream_id": "abcdef01-2345-6789-abcd-ef0123456789",
+        \\    "target_stream_id": "55QKQG28T5CY4TQKFF04HMASW9",
         \\    "reason": "User cancelled"
         \\  }
         \\}
@@ -227,8 +227,8 @@ test "Envelope roundtrip preserves stream_error" {
     const json =
         \\{
         \\  "type": "stream_error",
-        \\  "stream_id": "01234567-89ab-cdef-fedc-ba9876543210",
-        \\  "message_id": "12345678-9abc-def0-fedc-ba9876543210",
+        \\  "stream_id": "018D2PF2DBSQQZWQ5TK1V58CGG",
+        \\  "message_id": "0J6HB7H6NWVVRFXX5TK1V58CGG",
         \\  "sequence": 20,
         \\  "timestamp": 1708234567900,
         \\  "version": 1,
@@ -252,8 +252,8 @@ test "Envelope roundtrip preserves goodbye" {
     const json =
         \\{
         \\  "type": "goodbye",
-        \\  "stream_id": "01234567-89ab-cdef-fedc-ba9876543210",
-        \\  "message_id": "12345678-9abc-def0-fedc-ba9876543210",
+        \\  "stream_id": "018D2PF2DBSQQZWQ5TK1V58CGG",
+        \\  "message_id": "0J6HB7H6NWVVRFXX5TK1V58CGG",
         \\  "sequence": 100,
         \\  "timestamp": 1708234567900,
         \\  "version": 1,
@@ -503,8 +503,8 @@ test "Event streaming through byte stream with envelope framing" {
     const ping_json =
         \\{
         \\  "type": "ping",
-        \\  "stream_id": "01234567-89ab-cdef-fedc-ba9876543210",
-        \\  "message_id": "12345678-9abc-def0-fedc-ba9876543210",
+        \\  "stream_id": "018D2PF2DBSQQZWQ5TK1V58CGG",
+        \\  "message_id": "0J6HB7H6NWVVRFXX5TK1V58CGG",
         \\  "sequence": 1,
         \\  "timestamp": 1708234567900,
         \\  "version": 1,
@@ -517,8 +517,8 @@ test "Event streaming through byte stream with envelope framing" {
     const pong_json =
         \\{
         \\  "type": "pong",
-        \\  "stream_id": "01234567-89ab-cdef-fedc-ba9876543210",
-        \\  "message_id": "12345678-9abc-def0-fedc-ba9876543211",
+        \\  "stream_id": "018D2PF2DBSQQZWQ5TK1V58CGG",
+        \\  "message_id": "0J6HB7H6NWVVRFXX5TK1V58CGH",
         \\  "sequence": 2,
         \\  "timestamp": 1708234567901,
         \\  "version": 1,
@@ -709,8 +709,8 @@ test "Envelope defaults version to 1 when not specified" {
     const json_without_version =
         \\{
         \\  "type": "ping",
-        \\  "stream_id": "01234567-89ab-cdef-fedc-ba9876543210",
-        \\  "message_id": "12345678-9abc-def0-fedc-ba9876543210",
+        \\  "stream_id": "018D2PF2DBSQQZWQ5TK1V58CGG",
+        \\  "message_id": "0J6HB7H6NWVVRFXX5TK1V58CGG",
         \\  "sequence": 1,
         \\  "timestamp": 1708234567890,
         \\  "payload": {}
@@ -729,8 +729,8 @@ test "Envelope preserves explicit version" {
     const json_with_version =
         \\{
         \\  "type": "ping",
-        \\  "stream_id": "01234567-89ab-cdef-fedc-ba9876543210",
-        \\  "message_id": "12345678-9abc-def0-fedc-ba9876543210",
+        \\  "stream_id": "018D2PF2DBSQQZWQ5TK1V58CGG",
+        \\  "message_id": "0J6HB7H6NWVVRFXX5TK1V58CGG",
         \\  "sequence": 1,
         \\  "timestamp": 1708234567890,
         \\  "version": 2,
@@ -754,14 +754,14 @@ test "Envelope preserves in_reply_to field" {
     const json =
         \\{
         \\  "type": "ack",
-        \\  "stream_id": "01234567-89ab-cdef-fedc-ba9876543210",
-        \\  "message_id": "12345678-9abc-def0-fedc-ba9876543210",
+        \\  "stream_id": "018D2PF2DBSQQZWQ5TK1V58CGG",
+        \\  "message_id": "0J6HB7H6NWVVRFXX5TK1V58CGG",
         \\  "sequence": 2,
         \\  "timestamp": 1708234567890,
         \\  "version": 1,
-        \\  "in_reply_to": "abcdef01-2345-6789-abcd-ef0123456789",
+        \\  "in_reply_to": "55QKQG28T5CY4TQKFF04HMASW9",
         \\  "payload": {
-        \\    "acknowledged_id": "abcdef01-2345-6789-abcd-ef0123456789"
+        \\    "acknowledged_id": "55QKQG28T5CY4TQKFF04HMASW9"
         \\  }
         \\}
     ;

--- a/zig/test/e2e/protocol_pump.zig
+++ b/zig/test/e2e/protocol_pump.zig
@@ -37,7 +37,7 @@ pub const ProtocolPump = struct {
                 const seq = self.server.getNextSequence(stream_id);
                 const env = protocol_types.Envelope{
                     .stream_id = stream_id,
-                    .message_id = protocol_types.generateUuid(),
+                    .message_id = protocol_types.generateUlid(),
                     .sequence = seq,
                     .timestamp = std.time.milliTimestamp(),
                     .payload = .{ .event = event },
@@ -63,7 +63,7 @@ pub const ProtocolPump = struct {
                     const seq = self.server.getNextSequence(stream_id);
                     const env = protocol_types.Envelope{
                         .stream_id = stream_id,
-                        .message_id = protocol_types.generateUuid(),
+                        .message_id = protocol_types.generateUlid(),
                         .sequence = seq,
                         .timestamp = std.time.milliTimestamp(),
                         .payload = .{ .result = result },
@@ -83,7 +83,7 @@ pub const ProtocolPump = struct {
                     const err_copy = try self.allocator.dupe(u8, err_msg);
                     var env = protocol_types.Envelope{
                         .stream_id = stream_id,
-                        .message_id = protocol_types.generateUuid(),
+                        .message_id = protocol_types.generateUlid(),
                         .sequence = seq,
                         .timestamp = std.time.milliTimestamp(),
                         .payload = .{ .stream_error = .{


### PR DESCRIPTION
## Summary
- Replace TypeScript SDK protocol ID generation with the `ulid` package and update auth/model fixtures to 26-character ULID wire values.
- Replace Zig protocol `Uuid` helpers/types with `Ulid`, including Crockford Base32 encode/decode and ULID fixture updates across provider, auth, tool, and agent envelopes.
- Update protocol docs/comments to refer to ULID-based flow/message/stream IDs.

## Test plan
- [x] `npm test`
- [ ] `zig build test --build-file zig/build.zig` (fails with existing Zig 0.16/std API incompatibilities such as `std.Thread.Mutex`, `std.ArrayList` init, and `std.time.milliTimestamp`; this task's ULID code is also blocked by that toolchain mismatch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)