### PR TITLE
M-011: implement TS auth retry policy

### DIFF
--- a/typescript/src/execution_client.ts
+++ b/typescript/src/execution_client.ts
@@ -998,7 +998,15 @@ async function withAuthRetry<T>(
         throw loginError;
       }
       options.beforeRetry?.();
-      return await operation();
+      try {
+        return await operation();
+      } catch (retryError) {
+        if (isRetryableAuthError(retryError)) {
+          const retryProviderId = retryError.provider_id ?? providerId;
+          throw authRequiredError(retryProviderId, retryError.message);
+        }
+        throw retryError;
+      }
     }
     if (isRetryableAuthError(error)) {
       const providerId = error.provider_id ?? options.fallbackProviderId;

--- a/typescript/src/execution_client.ts
+++ b/typescript/src/execution_client.ts
@@ -6,6 +6,7 @@ import { createMakaiModelsApi } from "./models_client";
 import type { MakaiModelsApi } from "./models_types";
 import { type CreateMakaiStdioClientOptions, createMakaiStdioClient, MakaiStdioClient, type StdioFrame } from "./stdio_client";
 import {
+  MakaiAuthRequiredError,
   MakaiStreamError,
   type AgentRunRequest,
   type AgentRunResponse,
@@ -122,14 +123,21 @@ class StdioProviderApi implements MakaiProviderApi {
           if (providerId) {
             try {
               await this.auth.login(providerId, this.authHandlers);
-            } catch {
-              throw error;
+            } catch (loginError) {
+              if (this.authHandlers === undefined && isInteractiveAuthWithoutHandlers(loginError)) {
+                throw authRequiredError(providerId, error.message);
+              }
+              throw loginError;
             }
             retried = true;
             attempt = this.streamAttempt(request, effectivePolicy);
             iterator = attempt[Symbol.asyncIterator]();
             continue;
           }
+        }
+        if (isRetryableAuthError(error)) {
+          const providerId = error.provider_id ?? fallbackProviderId;
+          if (providerId) throw authRequiredError(providerId, error.message);
         }
         throw error;
       }
@@ -256,8 +264,11 @@ class StdioAgentApi implements MakaiAgentApi {
           if (providerId) {
             try {
               await this.auth.login(providerId, this.authHandlers);
-            } catch {
-              throw error;
+            } catch (loginError) {
+              if (this.authHandlers === undefined && isInteractiveAuthWithoutHandlers(loginError)) {
+                throw authRequiredError(providerId, error.message);
+              }
+              throw loginError;
             }
             retried = true;
             streamRequest = {
@@ -268,6 +279,10 @@ class StdioAgentApi implements MakaiAgentApi {
             iterator = attempt[Symbol.asyncIterator]();
             continue;
           }
+        }
+        if (isRetryableAuthError(error)) {
+          const providerId = error.provider_id ?? fallbackProviderId;
+          if (providerId) throw authRequiredError(providerId, error.message);
         }
         throw error;
       }
@@ -930,6 +945,14 @@ function isRetryableAuthError(error: unknown): error is MakaiStreamError {
   return error instanceof MakaiStreamError && error.code === "auth_required";
 }
 
+function authRequiredError(providerId: string, message: string): MakaiAuthRequiredError {
+  return new MakaiAuthRequiredError(providerId, message);
+}
+
+function isInteractiveAuthWithoutHandlers(error: unknown): boolean {
+  return error instanceof Error && /no onPrompt handler configured/.test(error.message);
+}
+
 function providerIdFromRequest(request: ProviderCompleteRequest | AgentRunRequest): string | undefined {
   // model_ref is opaque per spec, but canonical refs carry provider info.
   // We derive a fallback provider_id for auth retry only when the runtime
@@ -968,11 +991,18 @@ async function withAuthRetry<T>(
       if (!providerId) throw error;
       try {
         await options.auth.login(providerId, options.authHandlers);
-      } catch {
-        throw error;
+      } catch (loginError) {
+        if (options.authHandlers === undefined && isInteractiveAuthWithoutHandlers(loginError)) {
+          throw authRequiredError(providerId, error.message);
+        }
+        throw loginError;
       }
       options.beforeRetry?.();
       return await operation();
+    }
+    if (isRetryableAuthError(error)) {
+      const providerId = error.provider_id ?? options.fallbackProviderId;
+      if (providerId) throw authRequiredError(providerId, error.message);
     }
     throw error;
   }

--- a/typescript/src/execution_client.ts
+++ b/typescript/src/execution_client.ts
@@ -123,11 +123,8 @@ class StdioProviderApi implements MakaiProviderApi {
           if (providerId) {
             try {
               await this.auth.login(providerId, this.authHandlers);
-            } catch (loginError) {
-              if (this.authHandlers === undefined && isInteractiveAuthWithoutHandlers(loginError)) {
-                throw authRequiredError(providerId, error.message);
-              }
-              throw loginError;
+            } catch {
+              throw authRequiredError(providerId, error.message);
             }
             retried = true;
             attempt = this.streamAttempt(request, effectivePolicy);
@@ -264,11 +261,8 @@ class StdioAgentApi implements MakaiAgentApi {
           if (providerId) {
             try {
               await this.auth.login(providerId, this.authHandlers);
-            } catch (loginError) {
-              if (this.authHandlers === undefined && isInteractiveAuthWithoutHandlers(loginError)) {
-                throw authRequiredError(providerId, error.message);
-              }
-              throw loginError;
+            } catch {
+              throw authRequiredError(providerId, error.message);
             }
             retried = true;
             streamRequest = {
@@ -949,10 +943,6 @@ function authRequiredError(providerId: string, message: string): MakaiAuthRequir
   return new MakaiAuthRequiredError(providerId, message);
 }
 
-function isInteractiveAuthWithoutHandlers(error: unknown): boolean {
-  return error instanceof Error && /no onPrompt handler configured/.test(error.message);
-}
-
 function providerIdFromRequest(request: ProviderCompleteRequest | AgentRunRequest): string | undefined {
   // model_ref is opaque per spec, but canonical refs carry provider info.
   // We derive a fallback provider_id for auth retry only when the runtime
@@ -991,11 +981,8 @@ async function withAuthRetry<T>(
       if (!providerId) throw error;
       try {
         await options.auth.login(providerId, options.authHandlers);
-      } catch (loginError) {
-        if (options.authHandlers === undefined && isInteractiveAuthWithoutHandlers(loginError)) {
-          throw authRequiredError(providerId, error.message);
-        }
-        throw loginError;
+      } catch {
+        throw authRequiredError(providerId, error.message);
       }
       options.beforeRetry?.();
       try {

--- a/typescript/src/execution_types.ts
+++ b/typescript/src/execution_types.ts
@@ -154,6 +154,17 @@ export class MakaiStreamError extends Error {
   }
 }
 
+export class MakaiAuthRequiredError extends MakaiStreamError {
+  public readonly code = "auth_required";
+  public readonly provider_id: ProviderId;
+
+  constructor(providerId: ProviderId, message = `authentication required for provider ${providerId}`) {
+    super(message, { kind: "provider_error", code: "auth_required", provider_id: providerId });
+    this.name = "MakaiAuthRequiredError";
+    this.provider_id = providerId;
+  }
+}
+
 export interface MakaiClientOptions {
   auth?: {
     auth_retry_policy?: AuthRetryPolicy;

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -44,6 +44,7 @@ export {
 } from "./execution_client";
 
 export {
+  MakaiAuthRequiredError,
   MakaiStreamError,
   type AgentRunRequest,
   type AgentRunResponse,
@@ -69,6 +70,7 @@ export {
   type ToolResultContentPart,
   type UsageSummary,
 } from "./execution_types";
+
 export {
   MakaiProtocolError,
   // Note: `AuthStatus` and `ProviderId` are re-exported from `./auth_protocol`

--- a/typescript/test/auth_protocol.test.ts
+++ b/typescript/test/auth_protocol.test.ts
@@ -27,8 +27,23 @@ function fixtureClientOptions(
   };
 }
 
-test("flattenAuthEvent normalizes Zig union wire shape", () => {
-  const flatPrompt = flattenAuthEvent({
+test("flattenAuthEvent normalizes every Zig union wire variant", () => {
+  assert.deepEqual(flattenAuthEvent({
+    auth_url: {
+      flow_id: "00000000000000000000000000",
+      provider_id: "fixture",
+      url: "https://example.test/auth",
+      instructions: "open browser",
+    },
+  }), {
+    type: "auth_url",
+    flow_id: "00000000000000000000000000",
+    provider_id: "fixture",
+    url: "https://example.test/auth",
+    instructions: "open browser",
+  });
+
+  assert.deepEqual(flattenAuthEvent({
     prompt: {
       flow_id: "00000000000000000000000001",
       prompt_id: "device_code",
@@ -36,8 +51,7 @@ test("flattenAuthEvent normalizes Zig union wire shape", () => {
       message: "enter code",
       allow_empty: false,
     },
-  });
-  assert.deepEqual(flatPrompt, {
+  }), {
     type: "prompt",
     flow_id: "00000000000000000000000001",
     prompt_id: "device_code",
@@ -46,17 +60,40 @@ test("flattenAuthEvent normalizes Zig union wire shape", () => {
     allow_empty: false,
   });
 
-  const flatError = flattenAuthEvent({
-    error: {
+  assert.deepEqual(flattenAuthEvent({
+    progress: {
       flow_id: "00000000000000000000000002",
+      provider_id: "fixture",
+      message: "waiting",
+    },
+  }), {
+    type: "progress",
+    flow_id: "00000000000000000000000002",
+    provider_id: "fixture",
+    message: "waiting",
+  });
+
+  assert.deepEqual(flattenAuthEvent({
+    success: {
+      flow_id: "00000000000000000000000003",
+      provider_id: "fixture",
+    },
+  }), {
+    type: "success",
+    flow_id: "00000000000000000000000003",
+    provider_id: "fixture",
+  });
+
+  assert.deepEqual(flattenAuthEvent({
+    error: {
+      flow_id: "00000000000000000000000004",
       provider_id: "fixture",
       code: "auth_failed",
       message: "boom",
     },
-  });
-  assert.deepEqual(flatError, {
+  }), {
     type: "error",
-    flow_id: "00000000000000000000000002",
+    flow_id: "00000000000000000000000004",
     provider_id: "fixture",
     code: "auth_failed",
     message: "boom",

--- a/typescript/test/chat_client.test.ts
+++ b/typescript/test/chat_client.test.ts
@@ -1,0 +1,167 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  MakaiAuthError,
+  MakaiAuthRequiredError,
+  createMakaiProviderApi,
+  type AuthFlowHandlers,
+  type MakaiAuthApi,
+} from "../src";
+import type { RunOptions } from "../src/execution_types";
+import type { MakaiStdioClient, StdioFrame } from "../src/stdio_client";
+
+const REQUEST = {
+  model_ref: "fixture/openai-responses@gpt-test",
+  messages: [{ role: "user" as const, content: "hello" }],
+};
+
+class FakeTransport {
+  public sent: StdioFrame[] = [];
+  private streams: StdioFrame[][];
+
+  constructor(streams: StdioFrame[][]) {
+    this.streams = streams;
+  }
+
+  send(frame: StdioFrame): void {
+    this.sent.push(frame);
+  }
+
+  async nextFrameForStream(streamId: string, _timeoutMs?: number): Promise<StdioFrame> {
+    const stream = this.streams[0];
+    if (!stream) throw new Error("no frames configured");
+    const frame = stream.shift();
+    if (!frame) throw new Error("stream exhausted");
+    if (stream.length === 0) this.streams.shift();
+    return { stream_id: streamId, ...frame };
+  }
+}
+
+class FakeAuth implements MakaiAuthApi {
+  public loginCalls: Array<{ providerId: string; handlers?: AuthFlowHandlers }> = [];
+  constructor(private readonly outcomes: Array<"success" | "interactive_required"> = []) {}
+
+  async listProviders() { return []; }
+
+  async login(providerId: string, handlers?: AuthFlowHandlers): Promise<{ status: "success" }> {
+    this.loginCalls.push({ providerId, handlers });
+    const outcome = this.outcomes.shift() ?? "success";
+    if (outcome === "interactive_required") {
+      throw new MakaiAuthError("auth login cancelled (no onPrompt handler configured)", { kind: "cancelled" });
+    }
+    return { status: "success" };
+  }
+}
+
+const authRequired = (provider_id = "fixture"): StdioFrame[] => [
+  { type: "nack", payload: { error_code: "auth_required", reason: "login required", provider_id } },
+];
+
+const success = (text = "ok"): StdioFrame[] => [
+  { type: "ack" },
+  {
+    type: "result",
+    payload: {
+      message: { role: "assistant", content: text },
+      provider_id: "fixture",
+      api: "openai-responses",
+      model_id: "gpt-test",
+    },
+  },
+];
+
+test("manual policy throws typed auth_required error with provider_id", async () => {
+  const auth = new FakeAuth();
+  const provider = createMakaiProviderApi(
+    new FakeTransport([authRequired("fixture")]) as unknown as MakaiStdioClient,
+    { auth },
+  );
+
+  await assert.rejects(
+    () => provider.complete(REQUEST),
+    (error: unknown) => error instanceof MakaiAuthRequiredError && error.provider_id === "fixture",
+  );
+  assert.equal(auth.loginCalls.length, 0);
+});
+
+test("auto_once policy logs in then retries original request once", async () => {
+  const auth = new FakeAuth(["success"]);
+  const transport = new FakeTransport([authRequired("fixture"), success("retried")]);
+  const provider = createMakaiProviderApi(transport as unknown as MakaiStdioClient, {
+    auth,
+    authRetryPolicy: "auto_once",
+    authHandlers: { onPrompt: () => "code" },
+  });
+
+  const response = await provider.complete(REQUEST);
+  assert.equal(response.message.content, "retried");
+  assert.deepEqual(auth.loginCalls.map((call) => call.providerId), ["fixture"]);
+  assert.equal(transport.sent.length, 2);
+});
+
+test("auto_once with no handlers and required interaction fails fast as auth_required", async () => {
+  const auth = new FakeAuth(["interactive_required"]);
+  const provider = createMakaiProviderApi(
+    new FakeTransport([authRequired("fixture")]) as unknown as MakaiStdioClient,
+    { auth, authRetryPolicy: "auto_once" },
+  );
+
+  await assert.rejects(
+    () => provider.complete(REQUEST),
+    (error: unknown) => error instanceof MakaiAuthRequiredError && error.provider_id === "fixture",
+  );
+  assert.equal(auth.loginCalls.length, 1);
+});
+
+test("auto_once with non-interactive auth succeeds without handlers", async () => {
+  const auth = new FakeAuth(["success"]);
+  const provider = createMakaiProviderApi(
+    new FakeTransport([authRequired("fixture"), success("non-interactive")]) as unknown as MakaiStdioClient,
+    { auth, authRetryPolicy: "auto_once" },
+  );
+
+  const response = await provider.complete(REQUEST);
+  assert.equal(response.message.content, "non-interactive");
+  assert.equal(auth.loginCalls.length, 1);
+});
+
+test("per-call policy overrides client-level default", async () => {
+  const auth = new FakeAuth(["success"]);
+  const provider = createMakaiProviderApi(
+    new FakeTransport([authRequired("fixture"), success("per-call")]) as unknown as MakaiStdioClient,
+    { auth, authRetryPolicy: "manual", authHandlers: { onPrompt: () => "client" } },
+  );
+
+  const response = await provider.complete({
+    ...REQUEST,
+    options: { auth_retry_policy: "auto_once" },
+  });
+  assert.equal(response.message.content, "per-call");
+  assert.equal(auth.loginCalls.length, 1);
+});
+
+test("client-level auto_once is overridden by per-call manual", async () => {
+  const auth = new FakeAuth(["success"]);
+  const provider = createMakaiProviderApi(
+    new FakeTransport([authRequired("fixture")]) as unknown as MakaiStdioClient,
+    { auth, authRetryPolicy: "auto_once", authHandlers: { onPrompt: () => "client" } },
+  );
+
+  await assert.rejects(
+    () => provider.complete({ ...REQUEST, options: { auth_retry_policy: "manual" } }),
+    MakaiAuthRequiredError,
+  );
+  assert.equal(auth.loginCalls.length, 0);
+});
+
+test("auto_once uses client-level default handlers, not per-call request policy", async () => {
+  const auth = new FakeAuth(["success"]);
+  const handler = () => "client";
+  const provider = createMakaiProviderApi(
+    new FakeTransport([authRequired("fixture"), success("handler-default")]) as unknown as MakaiStdioClient,
+    { auth, authRetryPolicy: "auto_once", authHandlers: { onPrompt: handler } },
+  );
+
+  await provider.complete(REQUEST);
+  assert.equal(auth.loginCalls[0]?.handlers?.onPrompt, handler);
+});

--- a/typescript/test/execution_client.test.ts
+++ b/typescript/test/execution_client.test.ts
@@ -8,6 +8,7 @@ import {
   createMakaiClient,
   createMakaiProviderApi,
   MakaiStdioClient,
+  MakaiAuthRequiredError,
   MakaiStreamError,
   type AgentStreamEvent,
   type ProviderStreamEvent,
@@ -552,6 +553,31 @@ test("client.provider.stream auto_once retries on auth_required nack and yields 
   }
 });
 
+test("client.provider.complete auto_once retries at most once when auth_required persists", async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "makai-auth-retry-complete-limit-test-"));
+  const logPath = path.join(tmpDir, "request.log");
+  const handle = await createMakaiClient({
+    command: process.execPath,
+    args: [fixtureScript],
+    env: { ...process.env, MAKAI_TEST_REQUEST_LOG: logPath, MAKAI_TEST_AUTH_REQUIRED_ALWAYS: "1" },
+    handshakeTimeoutMs: 5000,
+    responseTimeoutMs: 5000,
+    auth: { auth_retry_policy: "auto_once" },
+  });
+  try {
+    await assert.rejects(
+      () => handle.provider.complete(request()),
+      (err: unknown) => err instanceof MakaiAuthRequiredError && err.provider_id === "anthropic",
+    );
+    const logged = readLoggedRequests(logPath);
+    assert.equal(logged.filter((entry) => entry.type === "complete_request").length, 2);
+    assert.equal(logged.filter((entry) => entry.type === "auth_login_start").length, 1);
+  } finally {
+    await handle.close();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
 test("client.provider.stream auto_once retries at most once when auth_required persists", async () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "makai-auth-retry-stream-limit-test-"));
   const logPath = path.join(tmpDir, "request.log");
@@ -608,6 +634,31 @@ test("client.agent.run auto_once retries on auth_required nack and succeeds", as
     assert.equal(agentStarts.length, 2);
     const loginStarts = logged.filter((entry) => entry.type === "auth_login_start");
     assert.equal(loginStarts.length, 1);
+  } finally {
+    await handle.close();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("client.agent.run auto_once retries at most once when auth_required persists", async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "makai-auth-retry-agent-limit-test-"));
+  const logPath = path.join(tmpDir, "request.log");
+  const handle = await createMakaiClient({
+    command: process.execPath,
+    args: [fixtureScript],
+    env: { ...process.env, MAKAI_TEST_REQUEST_LOG: logPath, MAKAI_TEST_AUTH_REQUIRED_ALWAYS: "1" },
+    handshakeTimeoutMs: 5000,
+    responseTimeoutMs: 5000,
+    auth: { auth_retry_policy: "auto_once" },
+  });
+  try {
+    await assert.rejects(
+      () => handle.agent.run(request()),
+      (err: unknown) => err instanceof MakaiAuthRequiredError && err.provider_id === "anthropic",
+    );
+    const logged = readLoggedRequests(logPath);
+    assert.equal(logged.filter((entry) => entry.type === "agent_start").length, 2);
+    assert.equal(logged.filter((entry) => entry.type === "auth_login_start").length, 1);
   } finally {
     await handle.close();
     fs.rmSync(tmpDir, { recursive: true, force: true });

--- a/typescript/test/execution_client.test.ts
+++ b/typescript/test/execution_client.test.ts
@@ -731,7 +731,7 @@ test("manual auth_retry_policy does not retry on auth_required", async () => {
   }
 });
 
-test("auto_once falls back to original auth_required error when login fails", async () => {
+test("auto_once normalizes login failure to auth_required with partial handlers", async () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "makai-auth-fail-test-"));
   const logPath = path.join(tmpDir, "request.log");
   const handle = await createMakaiClient({
@@ -740,12 +740,12 @@ test("auto_once falls back to original auth_required error when login fails", as
     env: { ...process.env, MAKAI_TEST_REQUEST_LOG: logPath, MAKAI_TEST_AUTH_REQUIRED_ONCE: "1", MAKAI_TEST_AUTH_REQUIRES_PROMPT: "1" },
     handshakeTimeoutMs: 5000,
     responseTimeoutMs: 5000,
-    auth: { auth_retry_policy: "auto_once" },
+    auth: { auth_retry_policy: "auto_once", handlers: { onEvent: () => undefined } },
   });
   try {
     await assert.rejects(
       () => handle.provider.complete(request()),
-      (err: unknown) => err instanceof MakaiStreamError && err.code === "auth_required" && err.provider_id === "anthropic",
+      (err: unknown) => err instanceof MakaiAuthRequiredError && err.provider_id === "anthropic",
     );
     const logged = readLoggedRequests(logPath);
     const completeRequests = logged.filter((entry) => entry.type === "complete_request");


### PR DESCRIPTION
## Summary
- Add typed `MakaiAuthRequiredError` and normalize manual `auth_required` failures with provider IDs.
- Update provider/agent auth retry handling so `auto_once` logs in once, retries once, preserves handler precedence, and fails fast when interaction needs missing handlers.
- Expand auth event flattening and retry-policy coverage in TS tests.

## Test plan
- [x] `npm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)