### PR TITLE
M-010: enforce TS stream lifecycle guarantees

### DIFF
--- a/typescript/src/execution_client.ts
+++ b/typescript/src/execution_client.ts
@@ -284,7 +284,7 @@ class StdioAgentApi implements MakaiAgentApi {
     let terminal = false;
     let messageSent = false;
     let started = false;
-    let aggregateUsage: UsageSummary = { input: 0, output: 0, cache_read: 0, cache_write: 0 };
+    let aggregateUsage: UsageSummary | undefined;
     const toolBuffers = new Map<number, { id?: string; name?: string; args: string }>();
     try {
       while (!terminal) {
@@ -299,6 +299,10 @@ class StdioAgentApi implements MakaiAgentApi {
         const events = normalizeAgentFrame(frame, toolBuffers);
         for (const rawEvent of events) {
           let event = rawEvent;
+          if (event.type === "error" && event.code === "auth_required") {
+            terminal = true;
+            throw new MakaiStreamError(event.message, { kind: "provider_error", code: event.code, provider_id: event.provider_id });
+          }
           if (!started) {
             started = true;
             if (event.type !== "agent_start") {
@@ -306,16 +310,13 @@ class StdioAgentApi implements MakaiAgentApi {
             }
           }
           if (event.type === "message_end" && event.usage) {
-            aggregateUsage = addUsage(aggregateUsage, event.usage);
+            aggregateUsage = aggregateUsage ? addUsage(aggregateUsage, event.usage) : event.usage;
           }
           if (event.type === "agent_end") {
-            event = { ...event, usage: event.usage ?? aggregateUsage };
+            event = { ...event, usage: aggregateUsage ?? event.usage };
             terminal = true;
           } else if (event.type === "error") {
             terminal = true;
-            if (event.code === "auth_required") {
-              throw new MakaiStreamError(event.message, { kind: "provider_error", code: event.code, provider_id: event.provider_id });
-            }
           }
           yield event;
           if (terminal) break;

--- a/typescript/src/execution_client.ts
+++ b/typescript/src/execution_client.ts
@@ -154,7 +154,11 @@ class StdioProviderApi implements MakaiProviderApi {
         if (!event) continue;
         if (event.type === "error") {
           terminal = true;
-          throw new MakaiStreamError(event.message, { kind: "provider_error", code: event.code, provider_id: event.provider_id });
+          if (event.code === "auth_required") {
+            throw new MakaiStreamError(event.message, { kind: "provider_error", code: event.code, provider_id: event.provider_id });
+          }
+          yield event;
+          continue;
         }
         if (event.type === "message_end") terminal = true;
         yield event;
@@ -279,6 +283,8 @@ class StdioAgentApi implements MakaiAgentApi {
     this.transport.send(buildAgentEnvelope("agent_start", sessionId, 1, buildAgentStartPayload(request, sessionId)));
     let terminal = false;
     let messageSent = false;
+    let started = false;
+    let aggregateUsage: UsageSummary = { input: 0, output: 0, cache_read: 0, cache_write: 0 };
     const toolBuffers = new Map<number, { id?: string; name?: string; args: string }>();
     try {
       while (!terminal) {
@@ -291,13 +297,28 @@ class StdioAgentApi implements MakaiAgentApi {
           continue;
         }
         const events = normalizeAgentFrame(frame, toolBuffers);
-        for (const event of events) {
-          if (event.type === "error") {
-            terminal = true;
-            throw new MakaiStreamError(event.message, { kind: "provider_error", code: event.code, provider_id: event.provider_id });
+        for (const rawEvent of events) {
+          let event = rawEvent;
+          if (!started) {
+            started = true;
+            if (event.type !== "agent_start") {
+              yield { type: "agent_start", session_id: sessionId };
+            }
           }
-          if (event.type === "agent_end") terminal = true;
+          if (event.type === "message_end" && event.usage) {
+            aggregateUsage = addUsage(aggregateUsage, event.usage);
+          }
+          if (event.type === "agent_end") {
+            event = { ...event, usage: event.usage ?? aggregateUsage };
+            terminal = true;
+          } else if (event.type === "error") {
+            terminal = true;
+            if (event.code === "auth_required") {
+              throw new MakaiStreamError(event.message, { kind: "provider_error", code: event.code, provider_id: event.provider_id });
+            }
+          }
           yield event;
+          if (terminal) break;
         }
       }
     } catch (error) {
@@ -571,8 +592,8 @@ function normalizeProviderEvent(
   }
   if (type === "toolcall_end") return parseBufferedToolCall(payload, toolBuffers);
   if (type === "tool_call") return parseToolCall(payload);
-  if (type === "done") return messageEndFrom(payload);
-  if (type === "error") return parseError(payload);
+  if (type === "done" || type === "message_end") return messageEndFrom(payload);
+  if (type === "stream_error" || type === "error") return parseError(payload);
   return undefined;
 }
 
@@ -583,6 +604,12 @@ function normalizeAgentFrame(
   if (frame.type === "agent_result") return [agentEndFrom(readJsonStringPayload(frame, "result_json"))];
   if (frame.type === "agent_error") return [parseError(readPayloadOrFrame(frame))];
   if (frame.type === "agent_event") return normalizeAgentEvent(readJsonStringPayload(frame, "event_json"), toolBuffers);
+  if (frame.type === "event") {
+    const payload = readPayloadOrFrame(frame);
+    const inner = payload.event && isObject(payload.event) ? payload.event as Record<string, unknown> : payload;
+    const type = stringValue(inner.type ?? inner.event_type);
+    if (isAgentEventType(type)) return normalizeAgentEvent(inner, toolBuffers);
+  }
   const providerEvent = normalizeProviderFrame(frame, toolBuffers);
   return providerEvent ? [providerEvent] : [];
 }
@@ -604,6 +631,8 @@ function normalizeAgentEvent(
       return [{ type: "tool_execution_start", tool_call_id: stringValue(data.tool_call_id), tool_name: stringValue(data.tool_name) }];
     case "tool_execution_end":
       return [{ type: "tool_execution_end", tool_call_id: stringValue(data.tool_call_id), ...(typeof data.is_error === "boolean" ? { is_error: data.is_error } : {}) }];
+    case "tool_execution_update":
+      return [];
     case "agent_end":
       return [agentEndFrom(data)];
     case "message_start":
@@ -792,6 +821,15 @@ function parseUsage(raw: unknown): UsageSummary | undefined {
   return usage;
 }
 
+function addUsage(left: UsageSummary, right: UsageSummary): UsageSummary {
+  return {
+    input: left.input + right.input,
+    output: left.output + right.output,
+    cache_read: (left.cache_read ?? 0) + (right.cache_read ?? 0),
+    cache_write: (left.cache_write ?? 0) + (right.cache_write ?? 0),
+  };
+}
+
 function nackToStreamError(frame: StdioFrame, fallbackProviderId?: string): MakaiStreamError {
   const payload = readPayloadOrFrame(frame);
   const code = optionalString(payload.error_code);
@@ -831,6 +869,16 @@ function readJsonStringPayload(frame: StdioFrame, key: string): Record<string, u
     }
   }
   return payload;
+}
+
+function isAgentEventType(type: string): boolean {
+  return type === "agent_start" ||
+    type === "agent_end" ||
+    type === "turn_start" ||
+    type === "turn_end" ||
+    type === "tool_execution_start" ||
+    type === "tool_execution_end" ||
+    type === "tool_execution_update";
 }
 
 function stringValue(value: unknown, fallback = ""): string {

--- a/typescript/src/execution_client.ts
+++ b/typescript/src/execution_client.ts
@@ -313,7 +313,9 @@ class StdioAgentApi implements MakaiAgentApi {
             aggregateUsage = aggregateUsage ? addUsage(aggregateUsage, event.usage) : event.usage;
           }
           if (event.type === "agent_end") {
-            event = { ...event, usage: aggregateUsage ?? event.usage };
+            const usage = aggregateUsage ?? event.usage;
+            event = usage ? { ...event, usage } : { ...event };
+            if (!usage) delete event.usage;
             terminal = true;
           } else if (event.type === "error") {
             terminal = true;
@@ -606,10 +608,10 @@ function normalizeAgentFrame(
   if (frame.type === "agent_error") return [parseError(readPayloadOrFrame(frame))];
   if (frame.type === "agent_event") return normalizeAgentEvent(readJsonStringPayload(frame, "event_json"), toolBuffers);
   if (frame.type === "event") {
-    const payload = readPayloadOrFrame(frame);
+    const payload = eventEnvelopePayload(frame);
     const inner = payload.event && isObject(payload.event) ? payload.event as Record<string, unknown> : payload;
-    const type = stringValue(inner.type ?? inner.event_type);
-    if (isAgentEventType(type)) return normalizeAgentEvent(inner, toolBuffers);
+    const type = eventKind(inner);
+    if (isAgentEventType(type)) return normalizeAgentEvent({ ...inner, type }, toolBuffers);
   }
   const providerEvent = normalizeProviderFrame(frame, toolBuffers);
   return providerEvent ? [providerEvent] : [];
@@ -619,8 +621,8 @@ function normalizeAgentEvent(
   event: Record<string, unknown>,
   toolBuffers: Map<number, { id?: string; name?: string; args: string }>,
 ): AgentStreamEvent[] {
-  const type = stringValue(event.type ?? firstKey(event));
-  const data = event.type ? event : (event[type] && isObject(event[type]) ? event[type] as Record<string, unknown> : event);
+  const type = eventKind(event);
+  const data = event.type || event.event_type ? event : (event[type] && isObject(event[type]) ? event[type] as Record<string, unknown> : event);
   switch (type) {
     case "agent_start":
       return [{ type: "agent_start", ...(optionalString(data.session_id) ? { session_id: optionalString(data.session_id) } : {}) }];
@@ -785,7 +787,12 @@ function messageEndFrom(data: Record<string, unknown>): ProviderStreamEvent {
 }
 
 function agentEndFrom(data: Record<string, unknown>): AgentStreamEvent {
-  return { type: "agent_end", usage: parseUsage(data.usage ?? data), stop_reason: optionalString(data.stop_reason ?? data.reason) };
+  const usage = parseUsage(data.usage ?? data);
+  return {
+    type: "agent_end",
+    ...(usage ? { usage } : {}),
+    ...(optionalString(data.stop_reason ?? data.reason) ? { stop_reason: optionalString(data.stop_reason ?? data.reason) } : {}),
+  };
 }
 
 function parseToolCall(data: Record<string, unknown>): ProviderStreamEvent {
@@ -823,12 +830,17 @@ function parseUsage(raw: unknown): UsageSummary | undefined {
 }
 
 function addUsage(left: UsageSummary, right: UsageSummary): UsageSummary {
-  return {
+  const usage: UsageSummary = {
     input: left.input + right.input,
     output: left.output + right.output,
-    cache_read: (left.cache_read ?? 0) + (right.cache_read ?? 0),
-    cache_write: (left.cache_write ?? 0) + (right.cache_write ?? 0),
   };
+  if (left.cache_read !== undefined || right.cache_read !== undefined) {
+    usage.cache_read = (left.cache_read ?? 0) + (right.cache_read ?? 0);
+  }
+  if (left.cache_write !== undefined || right.cache_write !== undefined) {
+    usage.cache_write = (left.cache_write ?? 0) + (right.cache_write ?? 0);
+  }
+  return usage;
 }
 
 function nackToStreamError(frame: StdioFrame, fallbackProviderId?: string): MakaiStreamError {
@@ -858,6 +870,12 @@ function readPayloadOrFrame(frame: StdioFrame): Record<string, unknown> {
   return frame.payload && isObject(frame.payload) ? frame.payload : frame;
 }
 
+function eventEnvelopePayload(frame: StdioFrame): Record<string, unknown> {
+  const payload = readPayloadOrFrame(frame);
+  if (payload === frame) return payload;
+  return { ...frame, ...payload };
+}
+
 function readJsonStringPayload(frame: StdioFrame, key: string): Record<string, unknown> {
   const payload = readPayloadOrFrame(frame);
   const json = payload[key] ?? payload.event_json ?? payload.result_json;
@@ -870,6 +888,12 @@ function readJsonStringPayload(frame: StdioFrame, key: string): Record<string, u
     }
   }
   return payload;
+}
+
+function eventKind(event: Record<string, unknown>): string {
+  const explicitType = optionalString(event.type);
+  const eventType = optionalString(event.event_type);
+  return explicitType === "event" && eventType ? eventType : (explicitType ?? eventType ?? firstKey(event));
 }
 
 function isAgentEventType(type: string): boolean {

--- a/typescript/test/execution_client.test.ts
+++ b/typescript/test/execution_client.test.ts
@@ -371,17 +371,16 @@ test("client.provider.stream buffers incremental tool calls into one tool_call e
   }
 });
 
-test("stream error paths throw MakaiStreamError", async () => {
+test("stream error paths emit one terminal error event", async () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "makai-exec-error-test-"));
   const eventsPath = path.join(tmpDir, "events.json");
   fs.writeFileSync(eventsPath, JSON.stringify([{ type: "message_start" }, { type: "error", message: "boom", code: "provider_error" }]));
   const harness = await setupHarness({ MAKAI_TEST_PROVIDER_EVENTS_PATH: eventsPath });
   try {
     const provider = createMakaiProviderApi(harness.client);
-    await assert.rejects(
-      async () => collect(provider.stream(request())),
-      (err: unknown) => err instanceof MakaiStreamError && err.message === "boom" && err.code === "provider_error",
-    );
+    const events = await collect(provider.stream(request()));
+    assert.equal(events.filter((event) => event.type === "error").length, 1);
+    assert.deepEqual(events.at(-1), { type: "error", message: "boom", code: "provider_error" });
   } finally {
     await harness.cleanup();
     fs.rmSync(tmpDir, { recursive: true, force: true });
@@ -405,17 +404,17 @@ test("provider stream_error frames preserve MakaiStreamError code", async () => 
   }
 });
 
-test("agent stream error paths throw MakaiStreamError", async () => {
+test("agent stream error paths emit one terminal error event", async () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "makai-agent-error-test-"));
   const eventsPath = path.join(tmpDir, "events.json");
   fs.writeFileSync(eventsPath, JSON.stringify([{ type: "agent_start" }, { type: "error", message: "agent boom", code: "provider_error" }]));
   const harness = await setupHarness({ MAKAI_TEST_AGENT_EVENTS_PATH: eventsPath });
   try {
     const agent = createMakaiAgentApi(harness.client);
-    await assert.rejects(
-      async () => collect(agent.stream(request())),
-      (err: unknown) => err instanceof MakaiStreamError && err.message === "agent boom" && err.code === "provider_error",
-    );
+    const events = await collect(agent.stream(request()));
+    assert.equal(events.filter((event) => event.type === "error").length, 1);
+    assert.equal(events.some((event) => event.type === "agent_end"), false);
+    assert.deepEqual(events.at(-1), { type: "error", message: "agent boom", code: "provider_error" });
   } finally {
     await harness.cleanup();
     fs.rmSync(tmpDir, { recursive: true, force: true });

--- a/typescript/test/stream_client.test.ts
+++ b/typescript/test/stream_client.test.ts
@@ -145,6 +145,35 @@ test("agent stream preserves missing aggregate usage as unknown", async () => {
   assert.equal(agentEnd?.usage, undefined);
 });
 
+test("agent stream preserves unknown cache usage while aggregating turns", async () => {
+  const transport = new ScriptedTransport([
+    { type: "agent_started", payload: {} },
+    { type: "agent_event", payload: { type: "agent_start", session_id: "abc" } },
+    { type: "event", payload: { type: "message_end", usage: { input: 2, output: 3 } } },
+    { type: "event", payload: { type: "message_end", usage: { input: 5, output: 7 } } },
+    { type: "agent_event", payload: { type: "agent_end", stop_reason: "end_turn" } },
+  ]);
+  const events = await collect(createMakaiAgentApi(transport as never).stream(REQUEST));
+  const agentEnd = events.at(-1);
+
+  assert.equal(agentEnd?.type, "agent_end");
+  assert.deepEqual(agentEnd?.usage, { input: 7, output: 10 });
+});
+
+test("agent stream parses event_type encoded lifecycle events", async () => {
+  const transport = new ScriptedTransport([
+    { type: "agent_started", payload: {} },
+    { type: "event", event_type: "turn_start" },
+    { type: "event", payload: { event: { event_type: "turn_end", stop_reason: "tool_use" } } },
+    { type: "event", event_type: "agent_end", payload: { stop_reason: "end_turn" } },
+  ]);
+  const events = await collect(createMakaiAgentApi(transport as never).stream(REQUEST));
+
+  assert.deepEqual(events.map((event) => event.type), ["agent_start", "turn_start", "turn_end", "agent_end"]);
+  assert.deepEqual(events[2], { type: "turn_end", stop_reason: "tool_use" });
+  assert.deepEqual(events.at(-1), { type: "agent_end", stop_reason: "end_turn" });
+});
+
 test("agent stream auth_required error retries before synthetic agent_start", async () => {
   const attempts: StdioFrame[][] = [
     [

--- a/typescript/test/stream_client.test.ts
+++ b/typescript/test/stream_client.test.ts
@@ -118,7 +118,7 @@ test("agent stream aggregates usage across multiple turns", async () => {
     { type: "event", payload: { type: "turn_start" } },
     { type: "event", payload: { type: "message_end", usage: { input: 11, output: 13, cache_read: 17, cache_write: 19 } } },
     { type: "event", payload: { type: "turn_end", stop_reason: "end_turn" } },
-    { type: "agent_event", payload: { type: "agent_end", stop_reason: "max_turns" } },
+    { type: "agent_event", payload: { type: "agent_end", usage: { input: 11, output: 13 }, stop_reason: "max_turns" } },
   ]);
   const events = await collect(createMakaiAgentApi(transport as never).stream(REQUEST));
   const agentEnd = events.at(-1);
@@ -127,6 +127,56 @@ test("agent stream aggregates usage across multiple turns", async () => {
   assert.deepEqual(agentEnd?.usage, { input: 13, output: 16, cache_read: 22, cache_write: 26 });
   assert.equal(agentEnd?.stop_reason, "max_turns");
   assert.equal(events.filter((event) => event.type === "turn_end").length, 2);
+});
+
+test("agent stream preserves missing aggregate usage as unknown", async () => {
+  const transport = new ScriptedTransport([
+    { type: "agent_started", payload: {} },
+    { type: "agent_event", payload: { type: "agent_start", session_id: "abc" } },
+    { type: "event", payload: { type: "turn_start" } },
+    { type: "event", payload: { type: "message_end", stop_reason: "end_turn" } },
+    { type: "event", payload: { type: "turn_end", stop_reason: "end_turn" } },
+    { type: "agent_event", payload: { type: "agent_end", stop_reason: "end_turn" } },
+  ]);
+  const events = await collect(createMakaiAgentApi(transport as never).stream(REQUEST));
+  const agentEnd = events.at(-1);
+
+  assert.equal(agentEnd?.type, "agent_end");
+  assert.equal(agentEnd?.usage, undefined);
+});
+
+test("agent stream auth_required error retries before synthetic agent_start", async () => {
+  const attempts: StdioFrame[][] = [
+    [
+      { type: "agent_started", payload: {} },
+      { type: "event", payload: { type: "error", message: "login required", code: "auth_required", provider_id: "fixture" } },
+    ],
+    [
+      { type: "agent_started", payload: {} },
+      { type: "agent_event", payload: { type: "agent_start", session_id: "abc" } },
+      { type: "event", payload: { type: "message_end", usage: { input: 1, output: 2 } } },
+      { type: "agent_event", payload: { type: "agent_end", stop_reason: "end_turn" } },
+    ],
+  ];
+  const transport = new ScriptedTransport([]);
+  transport.nextFrameForSession = async (sessionId: string) => {
+    const agentStartCount = transport.sent.filter((frame) => frame.type === "agent_start").length;
+    const frame = attempts[agentStartCount - 1]?.shift();
+    if (!frame) throw new Error(`no scripted frame for ${sessionId}`);
+    return { session_id: sessionId, ...frame };
+  };
+  const auth = {
+    loginCalls: 0,
+    async listProviders() { return []; },
+    async login() { this.loginCalls += 1; return { status: "success" as const }; },
+  };
+
+  const events = await collect(createMakaiAgentApi(transport as never, { auth, authRetryPolicy: "auto_once" }).stream(REQUEST));
+
+  assert.equal(auth.loginCalls, 1);
+  assert.equal(events[0]?.type, "agent_start");
+  assert.equal(events.at(-1)?.type, "agent_end");
+  assert.equal(events.some((event) => event.type === "error"), false);
 });
 
 test("agent stream single failure emits one error and no agent_end", async () => {

--- a/typescript/test/stream_client.test.ts
+++ b/typescript/test/stream_client.test.ts
@@ -144,7 +144,7 @@ test("agent stream single failure emits one error and no agent_end", async () =>
   assert.equal(events.some((event) => event.type === "agent_end"), false);
 });
 
-test("MakaiStreamError is thrown on async iterator failure", async () => {
+test("MakaiStreamError is thrown on provider async iterator failure", async () => {
   const transport = new ScriptedTransport([], new Error("transport failed"));
   const iterable = createMakaiProviderApi(transport as never).stream(REQUEST);
 
@@ -154,6 +154,19 @@ test("MakaiStreamError is thrown on async iterator failure", async () => {
       error instanceof MakaiStreamError &&
       error.kind === "transport_error" &&
       error.message === "transport failed",
+  );
+});
+
+test("MakaiStreamError is thrown on agent async iterator failure", async () => {
+  const transport = new ScriptedTransport([], new Error("agent transport failed"));
+  const iterable = createMakaiAgentApi(transport as never).stream(REQUEST);
+
+  await assert.rejects(
+    async () => collect(iterable),
+    (error: unknown) =>
+      error instanceof MakaiStreamError &&
+      error.kind === "transport_error" &&
+      error.message === "agent transport failed",
   );
 });
 

--- a/typescript/test/stream_client.test.ts
+++ b/typescript/test/stream_client.test.ts
@@ -1,0 +1,174 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  createMakaiAgentApi,
+  createMakaiProviderApi,
+  MakaiStreamError,
+  type ProviderCompleteRequest,
+  type StdioFrame,
+} from "../src";
+
+const REQUEST: ProviderCompleteRequest = {
+  model_ref: "fixture/anthropic-messages@model",
+  messages: [{ role: "user", content: "hello" }],
+};
+
+class ScriptedTransport {
+  public readonly sent: StdioFrame[] = [];
+  private readonly frames: StdioFrame[];
+  private readonly failWith?: Error;
+
+  constructor(frames: StdioFrame[], failWith?: Error) {
+    this.frames = [...frames];
+    this.failWith = failWith;
+  }
+
+  send(frame: StdioFrame): void {
+    this.sent.push(frame);
+  }
+
+  async nextFrameForStream(streamId: string): Promise<StdioFrame> {
+    if (this.failWith) throw this.failWith;
+    const frame = this.frames.shift();
+    if (!frame) throw new Error(`no scripted frame for ${streamId}`);
+    return { stream_id: streamId, ...frame };
+  }
+
+  async nextFrameForSession(sessionId: string): Promise<StdioFrame> {
+    if (this.failWith) throw this.failWith;
+    const frame = this.frames.shift();
+    if (!frame) throw new Error(`no scripted frame for ${sessionId}`);
+    return { session_id: sessionId, ...frame };
+  }
+}
+
+async function collect<T>(iterable: AsyncIterable<T>): Promise<T[]> {
+  const events: T[] = [];
+  for await (const event of iterable) events.push(event);
+  return events;
+}
+
+test("provider stream emits exactly one terminal event", async () => {
+  const transport = new ScriptedTransport([
+    { type: "event", payload: { type: "message_start" } },
+    { type: "event", payload: { type: "text_delta", delta: "hi" } },
+    { type: "event", payload: { type: "message_end", usage: { input: 1, output: 2 }, stop_reason: "end_turn" } },
+    { type: "event", payload: { type: "error", message: "late" } },
+  ]);
+  const events = await collect(createMakaiProviderApi(transport as never).stream(REQUEST));
+
+  const terminals = events.filter((event) => event.type === "message_end" || event.type === "error");
+  assert.equal(terminals.length, 1);
+  assert.equal(terminals[0]?.type, "message_end");
+  assert.equal(events.at(-1)?.type, "message_end");
+});
+
+test("provider stream does not emit error after message_end and normalizes reasoning", async () => {
+  const transport = new ScriptedTransport([
+    { type: "event", payload: { type: "start", provider: "anthropic", api: "anthropic-messages", model: "claude" } },
+    { type: "event", payload: { type: "reasoning", delta: "thinking" } },
+    { type: "event", payload: { type: "toolcall_start", content_index: 0, id: "tc1", name: "lookup" } },
+    { type: "event", payload: { type: "toolcall_delta", content_index: 0, delta: "{\"q\":" } },
+    { type: "event", payload: { type: "toolcall_delta", content_index: 0, delta: "\"x\"}" } },
+    { type: "event", payload: { type: "toolcall_end", content_index: 0 } },
+    { type: "event", payload: { type: "done", reason: "tool_use", message: { usage: { input: 4, output: 5 } } } },
+    { type: "stream_error", payload: { message: "late provider error" } },
+  ]);
+  const events = await collect(createMakaiProviderApi(transport as never).stream(REQUEST));
+
+  assert.deepEqual(events[0], {
+    type: "message_start",
+    provider_id: "anthropic",
+    api: "anthropic-messages",
+    model_id: "claude",
+  });
+  assert.deepEqual(events[1], { type: "thinking_delta", delta: "thinking" });
+  assert.deepEqual(events[2], {
+    type: "tool_call",
+    tool_call_id: "tc1",
+    name: "lookup",
+    arguments_json: "{\"q\":\"x\"}",
+  });
+  assert.equal(events.at(-1)?.type, "message_end");
+  assert.equal(events.some((event) => event.type === "error"), false);
+});
+
+test("agent stream emits agent_start first and agent_end last", async () => {
+  const transport = new ScriptedTransport([
+    { type: "agent_started", payload: {} },
+    { type: "event", payload: { type: "turn_start" } },
+    { type: "event", payload: { type: "message_end", usage: { input: 1, output: 1 }, stop_reason: "end_turn" } },
+    { type: "event", payload: { type: "turn_end", stop_reason: "end_turn" } },
+    { type: "agent_event", payload: { type: "agent_end", stop_reason: "end_turn" } },
+    { type: "event", payload: { type: "error", message: "late" } },
+  ]);
+  const events = await collect(createMakaiAgentApi(transport as never).stream(REQUEST));
+
+  assert.equal(events[0]?.type, "agent_start");
+  assert.equal(events.at(-1)?.type, "agent_end");
+});
+
+test("agent stream aggregates usage across multiple turns", async () => {
+  const transport = new ScriptedTransport([
+    { type: "agent_started", payload: {} },
+    { type: "agent_event", payload: { type: "agent_start", session_id: "abc" } },
+    { type: "event", payload: { type: "turn_start" } },
+    { type: "event", payload: { type: "message_end", usage: { input: 2, output: 3, cache_read: 5, cache_write: 7 } } },
+    { type: "event", payload: { type: "turn_end", stop_reason: "tool_use" } },
+    { type: "event", payload: { type: "turn_start" } },
+    { type: "event", payload: { type: "message_end", usage: { input: 11, output: 13, cache_read: 17, cache_write: 19 } } },
+    { type: "event", payload: { type: "turn_end", stop_reason: "end_turn" } },
+    { type: "agent_event", payload: { type: "agent_end", stop_reason: "max_turns" } },
+  ]);
+  const events = await collect(createMakaiAgentApi(transport as never).stream(REQUEST));
+  const agentEnd = events.at(-1);
+
+  assert.equal(agentEnd?.type, "agent_end");
+  assert.deepEqual(agentEnd?.usage, { input: 13, output: 16, cache_read: 22, cache_write: 26 });
+  assert.equal(agentEnd?.stop_reason, "max_turns");
+  assert.equal(events.filter((event) => event.type === "turn_end").length, 2);
+});
+
+test("agent stream single failure emits one error and no agent_end", async () => {
+  const transport = new ScriptedTransport([
+    { type: "agent_started", payload: {} },
+    { type: "agent_event", payload: { type: "agent_start" } },
+    { type: "event", payload: { type: "error", message: "boom", code: "provider_error" } },
+    { type: "agent_event", payload: { type: "agent_end", stop_reason: "end_turn" } },
+    { type: "stream_error", payload: { message: "duplicate" } },
+  ]);
+  const events = await collect(createMakaiAgentApi(transport as never).stream(REQUEST));
+
+  assert.equal(events.filter((event) => event.type === "error").length, 1);
+  assert.deepEqual(events.at(-1), { type: "error", message: "boom", code: "provider_error" });
+  assert.equal(events.some((event) => event.type === "agent_end"), false);
+});
+
+test("MakaiStreamError is thrown on async iterator failure", async () => {
+  const transport = new ScriptedTransport([], new Error("transport failed"));
+  const iterable = createMakaiProviderApi(transport as never).stream(REQUEST);
+
+  await assert.rejects(
+    async () => collect(iterable),
+    (error: unknown) =>
+      error instanceof MakaiStreamError &&
+      error.kind === "transport_error" &&
+      error.message === "transport failed",
+  );
+});
+
+test("envelope nacks surface as one MakaiStreamError failure", async () => {
+  const transport = new ScriptedTransport([
+    { type: "nack", payload: { reason: "invalid model", error_code: "invalid_request" } },
+    { type: "stream_error", payload: { message: "duplicate" } },
+  ]);
+
+  await assert.rejects(
+    async () => collect(createMakaiProviderApi(transport as never).stream(REQUEST)),
+    (error: unknown) =>
+      error instanceof MakaiStreamError &&
+      error.kind === "provider_error" &&
+      error.code === "invalid_request" &&
+      error.message === "invalid model",
+  );
+});


### PR DESCRIPTION
## Summary
- Enforce single terminal provider stream semantics while normalizing reasoning and fully-buffered tool calls.
- Ensure agent streams start with `agent_start`, terminate once, suppress deferred updates, and aggregate usage on `agent_end`.
- Cover lifecycle, aggregation, terminal error, and iterator failure behavior in TS SDK tests.

## Test plan
- [x] npm test

🤖 Generated with [Claude Code](https://claude.com/claude-code)