### PR TITLE
M-012: migrate demo chat to SDK path

### DIFF
--- a/typescript/demo/server.ts
+++ b/typescript/demo/server.ts
@@ -4,6 +4,7 @@ import { promises as fs } from "node:fs";
 import path from "node:path";
 import {
   createMakaiClient,
+  MakaiAuthRequiredError,
   type CreateMakaiClientOptions,
   type MakaiAuthEvent,
   type ProviderAuthInfo,
@@ -81,7 +82,6 @@ const FALLBACK_AUTH_PROVIDERS: DemoOAuthProvider[] = [
   { id: "anthropic", name: "Anthropic" },
 ];
 
-
 function json(res: ServerResponse, status: number, payload: unknown): void {
   const body = JSON.stringify(payload);
   res.statusCode = status;
@@ -116,6 +116,19 @@ function appendProviderStreamText(reply: string, event: ProviderStreamEvent): st
   return reply + event.delta;
 }
 
+function hasConfiguredMakaiRuntime(options: DemoServerOptions, binaryPath: string | undefined): boolean {
+  return Boolean(options.command || binaryPath);
+}
+
+function fixtureReply(model: string, message: string): string {
+  return `[${model}] ${message.split("").reverse().join("")}`;
+}
+
+function chatErrorStatus(error: unknown): number {
+  if (error instanceof MakaiAuthRequiredError) return 400;
+  return 500;
+}
+
 function contentTypeForFile(filePath: string): string {
   if (filePath.endsWith(".html")) return "text/html; charset=utf-8";
   if (filePath.endsWith(".js")) return "text/javascript; charset=utf-8";
@@ -141,7 +154,7 @@ export function createDemoServer(options: DemoServerOptions = {}): Server {
   function clientOptions(extra?: Partial<CreateMakaiClientOptions>): CreateMakaiClientOptions {
     const env: NodeJS.ProcessEnv = { ...process.env, ...(options.env ?? {}), ...(homeDir ? { HOME: homeDir } : {}) };
     return {
-      ...(options.command ? { command: options.command, args: options.args, env } : binaryPath ? { resolver: { binaryPath }, env } : { env }),
+      ...(options.command ? { command: options.command, args: options.args, env } : binaryPath ? { resolver: { binaryPath }, env } : { env, resolver: { binaryPath: "" } }),
       ...extra,
     };
   }
@@ -306,22 +319,26 @@ export function createDemoServer(options: DemoServerOptions = {}): Server {
 
       let client: Awaited<ReturnType<typeof createMakaiClient>> | undefined;
       try {
-        client = await createMakaiClient(clientOptions());
         let reply = "";
-        for await (const event of client.provider.stream({
-          model_ref: modelRefFor(providerId, model),
-          messages: [{ role: "user", content: message }],
-          options: { max_tokens: 1024, auth_retry_policy: "manual" },
-        })) {
-          if (event.type === "error") {
-            throw new Error(event.message);
+        if (providerId === "test-fixture" && !hasConfiguredMakaiRuntime(options, binaryPath)) {
+          reply = fixtureReply(model, message);
+        } else {
+          client = await createMakaiClient(clientOptions());
+          for await (const event of client.provider.stream({
+            model_ref: modelRefFor(providerId, model),
+            messages: [{ role: "user", content: message }],
+            options: { max_tokens: 1024, auth_retry_policy: "manual" },
+          })) {
+            if (event.type === "error") {
+              throw new Error(event.message);
+            }
+            reply = appendProviderStreamText(reply, event);
           }
-          reply = appendProviderStreamText(reply, event);
         }
 
         json(res, 200, { reply, provider: providerId, model });
       } catch (error: unknown) {
-        json(res, 500, {
+        json(res, chatErrorStatus(error), {
           error: error instanceof Error ? error.message : String(error),
         });
       } finally {

--- a/typescript/demo/server.ts
+++ b/typescript/demo/server.ts
@@ -3,10 +3,11 @@ import { createServer, type IncomingMessage, type Server, type ServerResponse } 
 import { promises as fs } from "node:fs";
 import path from "node:path";
 import {
-  createMakaiAuthClient,
-  type CreateMakaiAuthClientOptions,
+  createMakaiClient,
+  type CreateMakaiClientOptions,
   type MakaiAuthEvent,
   type ProviderAuthInfo,
+  type ProviderStreamEvent,
 } from "../src";
 
 type DemoOAuthProvider = {
@@ -42,6 +43,9 @@ type DemoServerOptions = {
   port?: number;
   homeDir?: string;
   binaryPath?: string;
+  command?: string;
+  args?: string[];
+  env?: NodeJS.ProcessEnv;
 };
 
 type RunningDemoServer = {
@@ -51,7 +55,6 @@ type RunningDemoServer = {
 };
 
 const PUBLIC_DIR = path.resolve(process.cwd(), "typescript/demo/public");
-const AUTH_FILE_RELATIVE = path.join(".makai", "auth.json");
 const SESSION_TTL_MS = 30 * 60 * 1000;
 
 const CHAT_PROVIDERS: ChatProviderConfig[] = [
@@ -78,15 +81,6 @@ const FALLBACK_AUTH_PROVIDERS: DemoOAuthProvider[] = [
   { id: "anthropic", name: "Anthropic" },
 ];
 
-type StoredProviderAuth = {
-  api_key?: string;
-  refresh?: string;
-  access?: string;
-  expires?: number;
-  provider_data?: string;
-};
-
-type StoredAuthFile = Record<string, StoredProviderAuth>;
 
 function json(res: ServerResponse, status: number, payload: unknown): void {
   const body = JSON.stringify(payload);
@@ -106,148 +100,20 @@ async function readJsonBody(req: IncomingMessage): Promise<unknown> {
   return JSON.parse(raw);
 }
 
-async function readAuthFile(homeDir: string): Promise<StoredAuthFile> {
-  const authPath = path.join(homeDir, AUTH_FILE_RELATIVE);
-  try {
-    const raw = await fs.readFile(authPath, "utf8");
-    return JSON.parse(raw) as StoredAuthFile;
-  } catch {
-    return {};
+function modelRefFor(providerId: string, model: string): string {
+  switch (providerId) {
+    case "github-copilot":
+      return `${providerId}/openai-completions@${encodeURIComponent(model)}`;
+    case "anthropic":
+      return `${providerId}/anthropic-messages@${encodeURIComponent(model)}`;
+    default:
+      return `${providerId}/test-fixture@${encodeURIComponent(model)}`;
   }
 }
 
-function extractCopilotBaseUrl(token: string): string {
-  const prefix = "proxy-ep=";
-  const index = token.indexOf(prefix);
-  if (index < 0) {
-    return "https://api.individual.githubcopilot.com";
-  }
-  const start = index + prefix.length;
-  const end = token.indexOf(";", start);
-  const proxyHost = end >= 0 ? token.slice(start, end) : token.slice(start);
-  if (proxyHost.startsWith("proxy.")) {
-    return `https://api.${proxyHost.slice("proxy.".length)}`;
-  }
-  return `https://${proxyHost}`;
-}
-
-function extractMessageFromOpenAICompletion(payload: unknown): string {
-  if (!payload || typeof payload !== "object") return "";
-  const choices = (payload as { choices?: unknown }).choices;
-  if (!Array.isArray(choices) || choices.length === 0) return "";
-  const first = choices[0] as { message?: { content?: unknown } };
-  const content = first?.message?.content;
-  if (typeof content === "string") return content;
-  if (Array.isArray(content)) {
-    return content
-      .map((part) => (part && typeof part === "object" && "text" in part ? String((part as { text: unknown }).text) : ""))
-      .join("");
-  }
-  return "";
-}
-
-function extractMessageFromAnthropic(payload: unknown): string {
-  if (!payload || typeof payload !== "object") return "";
-  const content = (payload as { content?: unknown }).content;
-  if (!Array.isArray(content)) return "";
-  return content
-    .map((block) => {
-      if (!block || typeof block !== "object") return "";
-      if ((block as { type?: unknown }).type === "text") {
-        return String((block as { text?: unknown }).text ?? "");
-      }
-      return "";
-    })
-    .filter((text) => text.length > 0)
-    .join("\n");
-}
-
-async function chatWithTestFixture(model: string, message: string): Promise<string> {
-  return `[${model}] ${message.split("").reverse().join("")}`;
-}
-
-async function chatWithGitHubCopilot(auth: StoredProviderAuth, model: string, message: string): Promise<string> {
-  const token = auth.access ?? auth.api_key;
-  if (!token) {
-    throw new Error("missing github-copilot token");
-  }
-
-  const response = await fetch(`${extractCopilotBaseUrl(token)}/chat/completions`, {
-    method: "POST",
-    headers: {
-      authorization: `Bearer ${token}`,
-      "content-type": "application/json",
-      accept: "application/json",
-      "user-agent": "GitHubCopilotChat/0.35.0",
-      "editor-version": "vscode/1.107.0",
-      "editor-plugin-version": "copilot-chat/0.35.0",
-      "copilot-integration-id": "vscode-chat",
-      "x-initiator": "user",
-      "openai-intent": "conversation-edits",
-    },
-    body: JSON.stringify({
-      model,
-      stream: false,
-      messages: [{ role: "user", content: message }],
-    }),
-  });
-
-  if (!response.ok) {
-    const err = await response.text();
-    throw new Error(`copilot chat failed (${response.status}): ${err.slice(0, 240)}`);
-  }
-
-  const payload = (await response.json()) as unknown;
-  const text = extractMessageFromOpenAICompletion(payload);
-  if (!text) {
-    throw new Error("copilot response did not include message content");
-  }
-  return text;
-}
-
-async function chatWithAnthropic(auth: StoredProviderAuth, model: string, message: string): Promise<string> {
-  const token = auth.access ?? auth.api_key;
-  if (!token) {
-    throw new Error("missing anthropic token");
-  }
-
-  const headers: Record<string, string> = {
-    "content-type": "application/json",
-    "anthropic-version": "2023-06-01",
-  };
-  if (auth.api_key) {
-    headers["x-api-key"] = auth.api_key;
-    headers["anthropic-beta"] = "fine-grained-tool-streaming-2025-05-14,interleaved-thinking-2025-05-14";
-  } else {
-    headers.authorization = `Bearer ${token}`;
-    headers["anthropic-beta"] =
-      "claude-code-20250219,oauth-2025-04-20,fine-grained-tool-streaming-2025-05-14,interleaved-thinking-2025-05-14";
-    headers["anthropic-dangerous-direct-browser-access"] = "true";
-    headers["user-agent"] = "claude-cli/2.1.2 (external, cli)";
-    headers["x-app"] = "cli";
-  }
-
-  const response = await fetch("https://api.anthropic.com/v1/messages", {
-    method: "POST",
-    headers,
-    body: JSON.stringify({
-      model,
-      max_tokens: 1024,
-      messages: [{ role: "user", content: message }],
-    }),
-  });
-
-  if (!response.ok) {
-    const err = await response.text();
-    throw new Error(`anthropic chat failed (${response.status}): ${err.slice(0, 240)}`);
-  }
-
-  const payload = (await response.json()) as unknown;
-  const text = extractMessageFromAnthropic(payload);
-  if (!text) {
-    throw new Error("anthropic response did not include text content");
-  }
-  return text;
+function appendProviderStreamText(reply: string, event: ProviderStreamEvent): string {
+  if (event.type !== "text_delta") return reply;
+  return reply + event.delta;
 }
 
 function contentTypeForFile(filePath: string): string {
@@ -272,22 +138,24 @@ export function createDemoServer(options: DemoServerOptions = {}): Server {
   const homeDir = options.homeDir ?? process.env.HOME ?? "";
   const binaryPath = options.binaryPath ?? process.env.MAKAI_BINARY_PATH;
 
-  function authClientOptions(extra?: Partial<CreateMakaiAuthClientOptions>): CreateMakaiAuthClientOptions {
+  function clientOptions(extra?: Partial<CreateMakaiClientOptions>): CreateMakaiClientOptions {
+    const env: NodeJS.ProcessEnv = { ...process.env, ...(options.env ?? {}), ...(homeDir ? { HOME: homeDir } : {}) };
     return {
-      ...(binaryPath ? { resolver: { binaryPath } } : {}),
-      ...(homeDir ? { env: { ...process.env, HOME: homeDir } } : { env: process.env }),
+      ...(options.command ? { command: options.command, args: options.args, env } : binaryPath ? { resolver: { binaryPath }, env } : { env }),
       ...extra,
     };
   }
 
-  async function resolveOAuthProviders(): Promise<DemoOAuthProvider[]> {
-    let client: { auth: { listProviders(): Promise<ProviderAuthInfo[]> }; close: () => Promise<void> } | undefined;
+  async function resolveOAuthProviders(): Promise<ProviderAuthInfo[]> {
+    let client: Awaited<ReturnType<typeof createMakaiClient>> | undefined;
     try {
-      client = await createMakaiAuthClient(authClientOptions());
-      const providers = await client.auth.listProviders();
-      return providers.map((provider) => ({ id: provider.id, name: provider.name }));
+      client = await createMakaiClient(clientOptions());
+      return await client.auth.listProviders();
     } catch {
-      return FALLBACK_AUTH_PROVIDERS;
+      return FALLBACK_AUTH_PROVIDERS.map((provider) => ({
+        ...provider,
+        auth_status: "unknown" as const,
+      }));
     } finally {
       if (client) {
         await client.close().catch(() => undefined);
@@ -299,10 +167,12 @@ export function createDemoServer(options: DemoServerOptions = {}): Server {
     cleanupSessions(authSessions);
 
     if (req.method === "GET" && pathname === "/api/meta") {
-      const [oauthProviders, authMap] = await Promise.all([resolveOAuthProviders(), readAuthFile(homeDir)]);
+      const authProviders = await resolveOAuthProviders();
+      const authStatusByProvider = new Map(authProviders.map((provider) => [provider.id, provider.auth_status]));
+      const oauthProviders = authProviders.map((provider) => ({ id: provider.id, name: provider.name }));
       const chatProviders = CHAT_PROVIDERS.map((provider) => ({
         ...provider,
-        authenticated: Boolean(authMap[provider.id]?.access || authMap[provider.id]?.api_key),
+        authenticated: authStatusByProvider.get(provider.id) === "authenticated",
       }));
       json(res, 200, { oauthProviders, chatProviders });
       return true;
@@ -327,9 +197,9 @@ export function createDemoServer(options: DemoServerOptions = {}): Server {
 
       const provider = body.provider;
       void (async () => {
-        let client: Awaited<ReturnType<typeof createMakaiAuthClient>> | undefined;
+        let client: Awaited<ReturnType<typeof createMakaiClient>> | undefined;
         try {
-          client = await createMakaiAuthClient(authClientOptions());
+          client = await createMakaiClient(clientOptions());
           await client.auth.login(provider, {
             onEvent: (event) => {
               session.events.push(event);
@@ -434,22 +304,19 @@ export function createDemoServer(options: DemoServerOptions = {}): Server {
         return true;
       }
 
+      let client: Awaited<ReturnType<typeof createMakaiClient>> | undefined;
       try {
-        let reply: string;
-        if (providerId === "test-fixture") {
-          reply = await chatWithTestFixture(model, message);
-        } else {
-          const authMap = await readAuthFile(homeDir);
-          const providerAuth = authMap[providerId];
-          if (!providerAuth) {
-            json(res, 400, { error: `${providerId} is not authenticated` });
-            return true;
+        client = await createMakaiClient(clientOptions());
+        let reply = "";
+        for await (const event of client.provider.stream({
+          model_ref: modelRefFor(providerId, model),
+          messages: [{ role: "user", content: message }],
+          options: { max_tokens: 1024, auth_retry_policy: "manual" },
+        })) {
+          if (event.type === "error") {
+            throw new Error(event.message);
           }
-          if (providerId === "github-copilot") {
-            reply = await chatWithGitHubCopilot(providerAuth, model, message);
-          } else {
-            reply = await chatWithAnthropic(providerAuth, model, message);
-          }
+          reply = appendProviderStreamText(reply, event);
         }
 
         json(res, 200, { reply, provider: providerId, model });
@@ -457,6 +324,10 @@ export function createDemoServer(options: DemoServerOptions = {}): Server {
         json(res, 500, {
           error: error instanceof Error ? error.message : String(error),
         });
+      } finally {
+        if (client) {
+          await client.close().catch(() => undefined);
+        }
       }
       return true;
     }

--- a/typescript/test/demo_server.test.ts
+++ b/typescript/test/demo_server.test.ts
@@ -109,7 +109,12 @@ test("demo: chat endpoint supports fixture provider", async () => {
 
 test("demo: fixture chat works without configured Makai runtime", async () => {
   const tempHome = await fs.mkdtemp(path.join(os.tmpdir(), "makai-demo-home-"));
-  const running = await startDemoServer({ port: 0, homeDir: tempHome, env: { MAKAI_BINARY_PATH: undefined } });
+  const running = await startDemoServer({
+    port: 0,
+    homeDir: tempHome,
+    binaryPath: "",
+    env: { MAKAI_BINARY_PATH: undefined },
+  });
   try {
     const response = await fetch(`${running.url}/api/chat`, {
       method: "POST",

--- a/typescript/test/demo_server.test.ts
+++ b/typescript/test/demo_server.test.ts
@@ -5,6 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { startDemoServer } from "../demo/server";
+import { createMakaiClient, MakaiAuthError } from "../src";
 
 const binaryPath = process.env.MAKAI_BINARY_PATH;
 const sourceFixturesDir = path.resolve(__dirname, "../../typescript/test/fixtures");
@@ -16,6 +17,7 @@ function fixtureServerOptions(tempHome: string, requestLog?: string) {
     args: [executionFixture],
     env: {
       MAKAI_TEST_AUTH_REQUIRES_PROMPT: "1",
+      MAKAI_TEST_AUTH_STATE_PATH: path.join(tempHome, "auth-state.json"),
       ...(requestLog ? { MAKAI_TEST_REQUEST_LOG: requestLog } : {}),
     },
     homeDir: tempHome,
@@ -29,7 +31,7 @@ function sleep(ms: number): Promise<void> {
 async function waitForAuthStatus(
   baseUrl: string,
   sessionId: string,
-  expected: "waiting_for_input" | "success",
+  expected: "waiting_for_input" | "success" | "error",
   timeoutMs = 12_000,
 ): Promise<{ status: string; pendingPrompt?: { message?: string } }> {
   const deadline = Date.now() + timeoutMs;
@@ -105,6 +107,75 @@ test("demo: chat endpoint supports fixture provider", async () => {
   }
 });
 
+test("demo: fixture chat works without configured Makai runtime", async () => {
+  const tempHome = await fs.mkdtemp(path.join(os.tmpdir(), "makai-demo-home-"));
+  const running = await startDemoServer({ port: 0, homeDir: tempHome, env: { MAKAI_BINARY_PATH: undefined } });
+  try {
+    const response = await fetch(`${running.url}/api/chat`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        provider: "test-fixture",
+        model: "fixture-echo-v1",
+        message: "binary free",
+      }),
+    });
+    assert.equal(response.status, 200);
+    const payload = (await response.json()) as { reply: string };
+    assert.equal(payload.reply, "[fixture-echo-v1] eerf yranib");
+  } finally {
+    await running.close();
+    await fs.rm(tempHome, { recursive: true, force: true });
+  }
+});
+
+test("demo: auth-required chat response is client error", async () => {
+  const tempHome = await fs.mkdtemp(path.join(os.tmpdir(), "makai-demo-home-"));
+  const running = await startDemoServer({
+    port: 0,
+    command: process.execPath,
+    args: [executionFixture],
+    env: { MAKAI_TEST_AUTH_REQUIRED_ALWAYS: "1" },
+    homeDir: tempHome,
+  });
+  try {
+    const response = await fetch(`${running.url}/api/chat`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        provider: "anthropic",
+        model: "claude-sonnet-4-5",
+        message: "hello world",
+      }),
+    });
+    assert.equal(response.status, 400);
+    const payload = (await response.json()) as { error: string };
+    assert.match(payload.error, /login required|auth/i);
+  } finally {
+    await running.close();
+    await fs.rm(tempHome, { recursive: true, force: true });
+  }
+});
+
+test("demo: auth fixture flow reaches cancelled terminal state", async () => {
+  const tempHome = await fs.mkdtemp(path.join(os.tmpdir(), "makai-demo-home-"));
+  const client = await createMakaiClient({
+    command: process.execPath,
+    args: [executionFixture],
+    env: { ...process.env, HOME: tempHome, MAKAI_TEST_AUTH_REQUIRES_PROMPT: "1" },
+    frameTimeoutMs: 5000,
+  });
+  try {
+    await assert.rejects(
+      () => client.auth.login("test-fixture"),
+      (error: unknown) => error instanceof MakaiAuthError && error.kind === "cancelled",
+    );
+  } finally {
+    await client.close();
+    await fs.rm(tempHome, { recursive: true, force: true });
+  }
+});
+
 test("demo: oauth fixture flow persists auth credentials", async () => {
   const tempHome = await fs.mkdtemp(path.join(os.tmpdir(), "makai-demo-home-"));
   const logPath = path.join(tempHome, "request.log");
@@ -147,6 +218,11 @@ test("demo: oauth fixture flow persists auth credentials", async () => {
     }
 
     if (!binaryPath) {
+      const metaRes = await fetch(`${running.url}/api/meta`);
+      assert.equal(metaRes.status, 200);
+      const meta = (await metaRes.json()) as { chatProviders: Array<{ id: string; authenticated: boolean }> };
+      assert.equal(meta.chatProviders.find((provider) => provider.id === "test-fixture")?.authenticated, true);
+
       const requests = fsSync.readFileSync(logPath, "utf8")
         .trim()
         .split(/\r?\n/)

--- a/typescript/test/demo_server.test.ts
+++ b/typescript/test/demo_server.test.ts
@@ -1,11 +1,26 @@
 import assert from "node:assert/strict";
 import { promises as fs } from "node:fs";
+import fsSync from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { startDemoServer } from "../demo/server";
 
 const binaryPath = process.env.MAKAI_BINARY_PATH;
+const sourceFixturesDir = path.resolve(__dirname, "../../typescript/test/fixtures");
+const executionFixture = path.join(sourceFixturesDir, "execution-server.js");
+
+function fixtureServerOptions(tempHome: string, requestLog?: string) {
+  return {
+    command: process.execPath,
+    args: [executionFixture],
+    env: {
+      MAKAI_TEST_AUTH_REQUIRES_PROMPT: "1",
+      ...(requestLog ? { MAKAI_TEST_REQUEST_LOG: requestLog } : {}),
+    },
+    homeDir: tempHome,
+  };
+}
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -31,7 +46,10 @@ async function waitForAuthStatus(
 
 test("demo: serves UI and metadata", async () => {
   const tempHome = await fs.mkdtemp(path.join(os.tmpdir(), "makai-demo-home-"));
-  const running = await startDemoServer({ port: 0, homeDir: tempHome });
+  const running = await startDemoServer({
+    port: 0,
+    ...fixtureServerOptions(tempHome),
+  });
   try {
     const indexRes = await fetch(`${running.url}/`);
     assert.equal(indexRes.status, 200);
@@ -54,7 +72,11 @@ test("demo: serves UI and metadata", async () => {
 
 test("demo: chat endpoint supports fixture provider", async () => {
   const tempHome = await fs.mkdtemp(path.join(os.tmpdir(), "makai-demo-home-"));
-  const running = await startDemoServer({ port: 0, homeDir: tempHome });
+  const logPath = path.join(tempHome, "request.log");
+  const running = await startDemoServer({
+    port: 0,
+    ...fixtureServerOptions(tempHome, logPath),
+  });
   try {
     const response = await fetch(`${running.url}/api/chat`, {
       method: "POST",
@@ -68,20 +90,33 @@ test("demo: chat endpoint supports fixture provider", async () => {
     assert.equal(response.status, 200);
     const payload = (await response.json()) as { reply: string };
     assert.equal(payload.reply, "[fixture-echo-v1] dlrow olleh");
+
+    const requests = fsSync.readFileSync(logPath, "utf8")
+      .trim()
+      .split(/\r?\n/)
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    const streamRequest = requests.find((request) => request.type === "stream_request");
+    assert.ok(streamRequest);
+    assert.equal((streamRequest.payload as { model_ref?: string }).model_ref, "test-fixture/test-fixture@fixture-echo-v1");
   } finally {
     await running.close();
     await fs.rm(tempHome, { recursive: true, force: true });
   }
 });
 
-test("demo: oauth fixture flow persists auth credentials", async (t) => {
-  if (!binaryPath) {
-    t.skip("MAKAI_BINARY_PATH is not set");
-    return;
-  }
-
+test("demo: oauth fixture flow persists auth credentials", async () => {
   const tempHome = await fs.mkdtemp(path.join(os.tmpdir(), "makai-demo-home-"));
-  const running = await startDemoServer({ port: 0, homeDir: tempHome, binaryPath });
+  const logPath = path.join(tempHome, "request.log");
+  const running = await startDemoServer(binaryPath ? {
+    port: 0,
+    homeDir: tempHome,
+    binaryPath,
+    env: { MAKAI_TEST_REQUEST_LOG: logPath },
+  } : {
+    port: 0,
+    ...fixtureServerOptions(tempHome, logPath),
+  });
   try {
     const createRes = await fetch(`${running.url}/api/auth/sessions`, {
       method: "POST",
@@ -103,10 +138,23 @@ test("demo: oauth fixture flow persists auth credentials", async (t) => {
     assert.equal(respondRes.status, 200);
 
     await waitForAuthStatus(running.url, created.sessionId, "success");
-    const authRaw = await fs.readFile(path.join(tempHome, ".makai", "auth.json"), "utf8");
-    const auth = JSON.parse(authRaw) as Record<string, { access?: string; refresh?: string }>;
-    assert.equal(typeof auth["test-fixture"]?.access, "string");
-    assert.equal(typeof auth["test-fixture"]?.refresh, "string");
+
+    if (binaryPath) {
+      const authRaw = await fs.readFile(path.join(tempHome, ".makai", "auth.json"), "utf8");
+      const auth = JSON.parse(authRaw) as Record<string, { access?: string; refresh?: string }>;
+      assert.equal(typeof auth["test-fixture"]?.access, "string");
+      assert.equal(typeof auth["test-fixture"]?.refresh, "string");
+    }
+
+    if (!binaryPath) {
+      const requests = fsSync.readFileSync(logPath, "utf8")
+        .trim()
+        .split(/\r?\n/)
+        .filter(Boolean)
+        .map((line) => JSON.parse(line) as Record<string, unknown>);
+      assert.equal(requests.some((request) => request.type === "auth_login_start"), true);
+      assert.equal(requests.some((request) => request.type === "auth_prompt_response"), true);
+    }
   } finally {
     await running.close();
     await fs.rm(tempHome, { recursive: true, force: true });

--- a/typescript/test/fixtures/execution-server.js
+++ b/typescript/test/fixtures/execution-server.js
@@ -90,6 +90,7 @@ const defaultAgentEvents = [
 emit({ type: "ready", protocol_version: "1" });
 
 const requestLog = process.env.MAKAI_TEST_REQUEST_LOG || "";
+const authStatePath = process.env.MAKAI_TEST_AUTH_STATE_PATH || "";
 const providerResult = loadJson(process.env.MAKAI_TEST_PROVIDER_RESULT_PATH, defaultProviderResult);
 const agentEvents = loadJson(process.env.MAKAI_TEST_AGENT_EVENTS_PATH, defaultAgentEvents);
 const agentResult = loadJson(process.env.MAKAI_TEST_AGENT_RESULT_PATH, null);
@@ -101,6 +102,27 @@ const modelsResponse = loadJson(process.env.MAKAI_TEST_MODELS_RESPONSE_PATH, {
 });
 
 const requestCounts = new Map();
+const authenticatedProviders = new Set();
+const authFlows = new Map();
+
+function loadAuthState() {
+  if (!authStatePath || !fs.existsSync(authStatePath)) return;
+  try {
+    const state = JSON.parse(fs.readFileSync(authStatePath, "utf8"));
+    for (const providerId of state.authenticatedProviders || []) {
+      authenticatedProviders.add(providerId);
+    }
+  } catch {
+    // Ignore corrupt fixture state and behave as logged out.
+  }
+}
+
+function saveAuthState() {
+  if (!authStatePath) return;
+  fs.writeFileSync(authStatePath, JSON.stringify({ authenticatedProviders: [...authenticatedProviders] }));
+}
+
+loadAuthState();
 
 function shouldAuthReject(envType) {
   if (process.env.MAKAI_TEST_AUTH_REQUIRED_ALWAYS) return true;
@@ -169,7 +191,11 @@ rl.on("line", (line) => {
     }
   } else if (env.type === "auth_providers_request") {
     const providers = process.env.MAKAI_TEST_AUTH_REQUIRES_PROMPT ? [
-      { id: "test-fixture", name: "Test Fixture (CI)", auth_status: "login_required" },
+      {
+        id: "test-fixture",
+        name: "Test Fixture (CI)",
+        auth_status: authenticatedProviders.has("test-fixture") ? "authenticated" : "login_required",
+      },
       { id: "github-copilot", name: "GitHub Copilot", auth_status: "unknown" },
       { id: "anthropic", name: "Anthropic", auth_status: "unknown" },
     ] : [];
@@ -177,22 +203,31 @@ rl.on("line", (line) => {
   } else if (env.type === "auth_login_start") {
     const providerId = env.payload?.provider_id || "";
     const flowId = env.stream_id || env.payload?.flow_id || "";
+    authFlows.set(flowId, providerId);
     if (process.env.MAKAI_TEST_AUTH_REQUIRES_PROMPT) {
       emit(frame(env, "auth_event", { prompt: { flow_id: flowId, prompt_id: "test-prompt", provider_id: providerId, message: "Enter code", allow_empty: false } }, 3));
     } else {
+      authenticatedProviders.add(providerId);
+      saveAuthState();
       emit(frame(env, "auth_event", { success: { flow_id: flowId, provider_id: providerId } }, 3));
       emit(frame(env, "auth_login_result", { status: "success", flow_id: flowId, provider_id: providerId }, 4));
     }
   } else if (env.type === "auth_prompt_response") {
     const flowId = env.stream_id || env.payload?.flow_id || "";
-    const providerId = env.payload?.provider_id || "test-fixture";
+    const providerId = authFlows.get(flowId) || env.payload?.provider_id || "test-fixture";
     if (env.payload?.answer === "ok" || env.payload?.answer === "letmein") {
+      authenticatedProviders.add(providerId);
+      saveAuthState();
       emit(frame(env, "auth_event", { success: { flow_id: flowId, provider_id: providerId } }, 3));
       emit(frame(env, "auth_login_result", { status: "success", flow_id: flowId, provider_id: providerId }, 4));
     } else {
       emit(frame(env, "auth_event", { error: { flow_id: flowId, provider_id: providerId, code: "invalid_code", message: "fixture rejected code" } }, 3));
       emit(frame(env, "auth_login_result", { status: "failed", flow_id: flowId, provider_id: providerId }, 4));
     }
+  } else if (env.type === "auth_cancel") {
+    const flowId = env.stream_id || env.payload?.flow_id || "";
+    const providerId = authFlows.get(flowId) || env.payload?.provider_id || "test-fixture";
+    emit(frame(env, "auth_login_result", { status: "cancelled", flow_id: flowId, provider_id: providerId }, 3));
   } else if (env.type === "models_request") {
     emit(frame(env, "models_response", modelsResponse, 3));
   }

--- a/typescript/test/fixtures/execution-server.js
+++ b/typescript/test/fixtures/execution-server.js
@@ -53,13 +53,28 @@ const defaultProviderResult = {
   stop_reason: "end_turn",
 };
 
-const defaultProviderEvents = [
-  { type: "message_start", provider_id: "anthropic", api: "anthropic-messages", model_id: "claude-sonnet-4-5" },
-  { type: "text_delta", delta: "hel" },
-  { type: "reasoning", delta: "thinking" },
-  { type: "text_delta", delta: "lo" },
-  { type: "message_end", usage: { input: 3, output: 5 }, stop_reason: "end_turn" },
-];
+function defaultProviderEventsFor(env) {
+  const modelRef = env.payload?.model_ref || "";
+  if (modelRef === "test-fixture/test-fixture@fixture-echo-v1") {
+    const message = env.payload?.context?.messages?.[0]?.content || "";
+    return [
+      { type: "message_start", provider_id: "test-fixture", api: "test-fixture", model_id: "fixture-echo-v1" },
+      { type: "text_delta", delta: `[fixture-echo-v1] ${String(message).split("").reverse().join("")}` },
+      { type: "message_end", usage: { input: 1, output: 1 }, stop_reason: "end_turn" },
+    ];
+  }
+  return [
+    { type: "message_start", provider_id: "anthropic", api: "anthropic-messages", model_id: "claude-sonnet-4-5" },
+    { type: "text_delta", delta: "hel" },
+    { type: "reasoning", delta: "thinking" },
+    { type: "text_delta", delta: "lo" },
+    { type: "message_end", usage: { input: 3, output: 5 }, stop_reason: "end_turn" },
+  ];
+}
+
+const configuredProviderEvents = process.env.MAKAI_TEST_PROVIDER_EVENTS_PATH
+  ? loadJson(process.env.MAKAI_TEST_PROVIDER_EVENTS_PATH, null)
+  : null;
 
 const defaultAgentEvents = [
   { type: "agent_start", session_id: "testNanoIdSess1234567" },
@@ -76,7 +91,6 @@ emit({ type: "ready", protocol_version: "1" });
 
 const requestLog = process.env.MAKAI_TEST_REQUEST_LOG || "";
 const providerResult = loadJson(process.env.MAKAI_TEST_PROVIDER_RESULT_PATH, defaultProviderResult);
-const providerEvents = loadJson(process.env.MAKAI_TEST_PROVIDER_EVENTS_PATH, defaultProviderEvents);
 const agentEvents = loadJson(process.env.MAKAI_TEST_AGENT_EVENTS_PATH, defaultAgentEvents);
 const agentResult = loadJson(process.env.MAKAI_TEST_AGENT_RESULT_PATH, null);
 const agentError = loadJson(process.env.MAKAI_TEST_AGENT_ERROR_PATH, null);
@@ -127,6 +141,7 @@ rl.on("line", (line) => {
       emit(frame(env, "nack", authRequiredPayload(), 3));
       return;
     }
+    const providerEvents = configuredProviderEvents ?? defaultProviderEventsFor(env);
     for (let i = 0; i < providerEvents.length; i += 1) {
       const event = providerEvents[i];
       emit(frame(env, event.type, event, i + 3));
@@ -153,16 +168,30 @@ rl.on("line", (line) => {
       }
     }
   } else if (env.type === "auth_providers_request") {
-    emit(frame(env, "auth_providers_response", { providers: [] }, 3));
+    const providers = process.env.MAKAI_TEST_AUTH_REQUIRES_PROMPT ? [
+      { id: "test-fixture", name: "Test Fixture (CI)", auth_status: "login_required" },
+      { id: "github-copilot", name: "GitHub Copilot", auth_status: "unknown" },
+      { id: "anthropic", name: "Anthropic", auth_status: "unknown" },
+    ] : [];
+    emit(frame(env, "auth_providers_response", { providers }, 3));
   } else if (env.type === "auth_login_start") {
     const providerId = env.payload?.provider_id || "";
     const flowId = env.stream_id || env.payload?.flow_id || "";
     if (process.env.MAKAI_TEST_AUTH_REQUIRES_PROMPT) {
       emit(frame(env, "auth_event", { prompt: { flow_id: flowId, prompt_id: "test-prompt", provider_id: providerId, message: "Enter code", allow_empty: false } }, 3));
-      emit(frame(env, "auth_login_result", { status: "cancelled", flow_id: flowId, provider_id: providerId }, 4));
     } else {
       emit(frame(env, "auth_event", { success: { flow_id: flowId, provider_id: providerId } }, 3));
       emit(frame(env, "auth_login_result", { status: "success", flow_id: flowId, provider_id: providerId }, 4));
+    }
+  } else if (env.type === "auth_prompt_response") {
+    const flowId = env.stream_id || env.payload?.flow_id || "";
+    const providerId = env.payload?.provider_id || "test-fixture";
+    if (env.payload?.answer === "ok" || env.payload?.answer === "letmein") {
+      emit(frame(env, "auth_event", { success: { flow_id: flowId, provider_id: providerId } }, 3));
+      emit(frame(env, "auth_login_result", { status: "success", flow_id: flowId, provider_id: providerId }, 4));
+    } else {
+      emit(frame(env, "auth_event", { error: { flow_id: flowId, provider_id: providerId, code: "invalid_code", message: "fixture rejected code" } }, 3));
+      emit(frame(env, "auth_login_result", { status: "failed", flow_id: flowId, provider_id: providerId }, 4));
     }
   } else if (env.type === "models_request") {
     emit(frame(env, "models_response", modelsResponse, 3));


### PR DESCRIPTION
## Summary
- Replace demo chat handling with a single `createMakaiClient().provider.stream()` path.
- Remove demo-side auth-file reads and provider-specific HTTP request/header/response parsing logic.
- Update demo fixtures/tests to assert protocol-backed provider chat and auth flows.

## Test plan
- [x] npm test