### PR TITLE
Plan Zig 0.16 migration tasks

### DIFF
--- a/docs/zig-0.16.0-migration-plan.md
+++ b/docs/zig-0.16.0-migration-plan.md
@@ -6,48 +6,69 @@ Target: Makai `zig/` codebase and CI, migrating from Zig 0.15.2 to Zig 0.16.0
 
 ## Goal summary
 
-Migrate Makai from Zig 0.15.2 to Zig 0.16.0 while preserving current provider, protocol, transport, OAuth, agent-loop, and CLI behavior. The migration should be delivered as a staged sequence of reviewable PRs: first add compatibility seams and focused regression tests that still compile on 0.15.2, then switch the compiler/dependency baseline, then complete the core/std, I/O, provider/OAuth, transport, and validation work on 0.16.0. The initial objective is compile/test parity and minimal architectural churn, not a full redesign around evented I/O or a libxev-backed `std.Io` adapter.
+Migrate Makai from Zig 0.15.2 to Zig 0.16.0 while preserving current provider, protocol, transport, OAuth, agent-loop, and CLI behavior. The migration should be delivered as a staged sequence of reviewable PRs: first make a prerequisite I/O architecture decision, then add compatibility seams and focused regression tests that still compile on 0.15.2, then land a first green compiler/dependency baseline, then complete the core/std, I/O, provider/OAuth, transport, and validation work on 0.16.0. The initial objective is compile/test parity and controlled architectural churn, not a full redesign around evented I/O or a libxev-backed `std.Io` adapter.
 
 ## Design decisions and rationale
 
-1. **Use a staged migration instead of one large rewrite.**  
-   The impact assessment identifies high-volume mechanical changes and high-risk I/O/concurrency changes. Splitting wrapper/test preparation from the compiler switch keeps early PRs reviewable and reduces the amount of behavior change that lands at the Zig 0.16.0 sync point.
+1. **Make the `std.Io` backend and ownership model an explicit prerequisite.**  
+   The wrapper APIs cannot be designed responsibly while the default backend and I/O lifecycle ownership are unresolved. The binding default for dispatch is: Phase 0 wrappers MUST NOT expose `std.Io` in public API signatures; public constructors and entry points should use Makai-owned context/default-I/O patterns, while internal helpers may accept explicit I/O handles where needed. Work item 1 must document where CLI, tests, providers, OAuth flows, and transports obtain their I/O handles within that default.
 
-2. **Make the compiler switch the hard synchronization point.**  
-   All Phase 0 work must compile and pass on Zig 0.15.2. After the Phase 1 compiler/dependency switch lands, all follow-up work should target Zig 0.16.0 only.
+2. **Use a staged migration instead of one large rewrite.**  
+   The impact assessment identifies high-volume mechanical changes and high-risk I/O/concurrency changes. Splitting architecture, wrapper/test preparation, compiler switch, and subsystem migration keeps PRs reviewable and prevents unrelated concerns from being coupled.
 
-3. **Prefer project-level compatibility seams over ad hoc call-site rewrites.**  
-   Introduce central wrappers for time, sleep, random, filesystem/stdio, HTTP client construction/request flows, and networking. This avoids duplicating 0.16-specific decisions across providers, OAuth flows, transports, and CLI code.
+3. **Make Phase 1 a first green Zig 0.16 baseline PR.**  
+   This plan chooses a mergeable baseline PR with minimum compile-restoring fixes over an unmerged integration checkpoint with stacked red PRs. The Phase 1 PR should update toolchain/dependency metadata, verify libxev, and apply only the minimum source changes needed to produce an agreed green Zig 0.16 build/test subset; remaining issues become follow-up tasks.
 
-4. **Use the simplest supported `std.Io` backend for initial parity.**  
+4. **Prefer project-level compatibility seams over ad hoc call-site rewrites.**  
+   Introduce central wrappers for time, sleep, random, filesystem/stdio, HTTP client construction/request flows, and networking. The wrappers should reflect the prerequisite architecture decision and avoid duplicating 0.16-specific decisions across providers, OAuth flows, transports, and CLI code.
+
+5. **Use the simplest supported `std.Io` backend for initial parity.**  
    Do not depend on libxev implementing `std.Io`; the research notes that upstream libxev issue #219 is still open. The initial migration should choose a standard Zig 0.16 backend with networking support, then defer evented/libxev integration to a later project.
 
-5. **Preserve public behavior before redesigning APIs.**  
-   Threading explicit `std.Io` through every public API may be the long-term direction, but the first migration should minimize downstream churn. Where API changes are unavoidable, isolate them behind constructors/context objects and document them in the relevant implementation PR.
+6. **Preserve public behavior before redesigning APIs.**  
+   Public API churn should be limited to what the architecture decision and compiler require. The migration does not need to preserve Zig 0.15.2 source compatibility after Phase 1, but it must preserve documented Makai behavior where possible and provide migration notes for any public API signature changes. Where API changes are unavoidable, isolate them behind constructors/context objects and document them in the relevant implementation PR.
 
-6. **Treat provider HTTP streaming and `EventStream` synchronization as the highest-risk areas.**  
-   Provider/OAuth HTTP request flow changes and futex/mutex/condition migration can introduce subtle runtime failures even after compilation succeeds. These work items require focused regression tests and careful review.
+7. **Treat provider HTTP streaming and core stream synchronization as separate high-risk tracks.**  
+   Provider/OAuth HTTP request flow changes and futex/mutex/condition migration can introduce subtle runtime failures even after compilation succeeds. Core `EventStream`/`stream` synchronization, auth/OAuth synchronization, shared HTTP abstraction, and provider-family rollout should each be reviewed in separate PRs.
 
 ## Phased PR sequence
 
+### Phase -1 — Architecture prerequisite
+
+Purpose: decide the foundational `std.Io` backend, ownership, and API model before wrappers encode accidental architecture.
+
+#### Work item 1 — Decide Zig 0.16 I/O architecture and ownership model
+
+Priority: **urgent**
+
+Make the default `std.Io` backend and lifecycle ownership model an up-front architecture decision. Use the binding default that Phase 0 wrappers MUST NOT expose `std.Io` in public API signatures; public constructors use Makai-owned context/default-I/O patterns, while internal helpers may accept explicit I/O handles when the implementation requires them. Document where the default I/O instance is created for CLI runs, tests, providers, OAuth flows, transports, and protocol/agent runtime paths.
+
+Suggested scope for one PR:
+- Add an architecture note or design section that records the backend, ownership, and context/default-I/O decision and rationale.
+- Identify public API signatures expected to change, stay stable, or receive transitional overloads; do not promise Zig 0.15.2 source compatibility after Phase 1.
+- Define wrapper naming conventions and parameter order, including allocator/context first, explicit internal I/O handle second when present, then operation-specific parameters, to reduce review friction on dependent PRs.
+- Confirm the selected backend supports the networking paths needed for HTTP providers, OAuth callback server, and WebSocket transport.
+
+Depends on: none.
+
 ### Phase 0 — Preparation wrappers and regression tests on Zig 0.15.2
 
-Purpose: create compatibility seams and tests while the codebase still builds on the current toolchain. Phase 0 tasks should be done in parallel where they touch separate layers.
+Purpose: create compatibility seams and tests while the codebase still builds on the current toolchain. Phase 0 tasks can be done in parallel after work item 1 where they touch separate layers.
 
-#### Work item 1 — Add I/O compatibility design skeleton
+#### Work item 2 — Add I/O compatibility design skeleton
 
 Priority: **high**
 
-Create a small `zig/src/utils` or `zig/src/compat` module that defines the intended wrapper boundaries for time, sleep, random, filesystem/stdio, HTTP, and networking. In the first PR, keep implementations thin and Zig 0.15.2-compatible, with comments documenting the planned Zig 0.16 mapping. Add the module to `zig/build.zig` imports and expose only stable helper functions/types needed by follow-up PRs.
+Create a small `zig/src/utils` or `zig/src/compat` module that defines the intended wrapper boundaries for time, sleep, random, filesystem/stdio, HTTP, and networking. In the first PR, keep implementations thin and Zig 0.15.2-compatible, with comments documenting the planned Zig 0.16 mapping based on work item 1. Add the module to `zig/build.zig` imports and expose only stable helper functions/types needed by follow-up PRs.
 
 Suggested scope for one PR:
 - Add the compatibility module and build wiring.
 - Add smoke tests for helper construction and no-op/basic behavior.
 - Do not migrate all call sites yet.
 
-Depends on: none.
+Depends on: work item 1.
 
-#### Work item 2 — Add time and sleep wrappers on 0.15.2
+#### Work item 3 — Add time and sleep wrappers on 0.15.2
 
 Priority: **high**
 
@@ -58,9 +79,9 @@ Suggested scope for one PR:
 - Migrate representative low-risk call sites only.
 - Record remaining direct timestamp/sleep call sites for later PRs.
 
-Depends on: work item 1.
+Depends on: work item 2.
 
-#### Work item 3 — Add random/secure-random wrappers on 0.15.2
+#### Work item 4 — Add random/secure-random wrappers on 0.15.2
 
 Priority: **high**
 
@@ -71,48 +92,48 @@ Suggested scope for one PR:
 - Add unit tests for length, non-empty generation, and deterministic test behavior.
 - Migrate one low-risk ID generation path only if straightforward.
 
-Depends on: work item 1.
+Depends on: work item 2.
 
-#### Work item 4 — Add filesystem and stdio helper layer on 0.15.2
+#### Work item 5 — Add filesystem and stdio helper layer on 0.15.2
 
 Priority: **high**
 
-Add wrappers around cwd/open/read/write/atomic rename, stdin/stdout access, and file reader/writer operations used by OAuth storage, stdio transport, and CLI tooling. The wrapper should preserve current ownership and error behavior, especially around credential storage and atomic file replacement. Avoid changing provider behavior in this PR.
+Add wrappers around cwd/open/read/write/atomic rename, stdin/stdout access, and file reader/writer operations used by OAuth storage, stdio transport, and CLI tooling. The wrapper should preserve current ownership and error behavior while keeping OAuth storage migration separate from stdio/CLI migration later. Avoid changing provider behavior in this PR.
 
 Suggested scope for one PR:
 - Implement wrappers with 0.15.2 `std.fs`/`std.io` APIs.
 - Add tests for read/write, missing file behavior, directory creation, and atomic replace semantics.
-- Migrate OAuth storage only if the PR remains small; otherwise leave migration for work item 14.
+- Do not migrate OAuth storage, stdio transport, and CLI file I/O together; leave those for separate post-switch PRs.
 
-Depends on: work item 1.
+Depends on: work item 2.
 
-#### Work item 5 — Add HTTP client/request abstraction on 0.15.2
+#### Work item 6 — Add HTTP client/request abstraction on 0.15.2
 
 Priority: **high**
 
-Define a thin project abstraction for provider/OAuth HTTP client creation and response-body streaming. It should hide the future Zig 0.16 `std.http.Client{ .io = ... }` construction and request/send/receive API differences while preserving streaming SSE behavior. Start with one provider or test double so the abstraction shape is proven before all providers move.
+Define a thin project abstraction for provider/OAuth HTTP client creation and response-body streaming. It should hide the future Zig 0.16 `std.http.Client{ .io = ... }` construction and request/send/receive API differences while preserving streaming SSE behavior. Start with a test double or mock consumer; production provider rollout is explicitly split after the Zig 0.16 abstraction is proven.
 
 Suggested scope for one PR:
 - Add HTTP abstraction interfaces/helpers backed by current `std.http.Client`.
 - Add tests with local/mock response behavior where feasible.
-- Migrate at most one low-risk HTTP consumer to validate the shape.
+- Avoid migrating all providers in this preparatory PR.
 
-Depends on: work item 1.
+Depends on: work item 2.
 
-#### Work item 6 — Add networking helper layer on 0.15.2
+#### Work item 7 — Add networking helper layer on 0.15.2
 
 Priority: **normal**
 
-Create wrappers for TCP connect, address resolution, listen/accept, and stream read/write paths used by WebSocket transport and OAuth callback server. Keep the 0.15.2 implementation backed by `std.net`. This sets up a contained Zig 0.16 migration to `std.Io.net` later.
+Create wrappers for TCP connect, address resolution, listen/accept, and stream read/write paths used by WebSocket transport and OAuth callback server. Keep the 0.15.2 implementation backed by `std.net`. This sets up contained Zig 0.16 migrations for WebSocket and OAuth callback networking without coupling either to filesystem/stdin/stdout work.
 
 Suggested scope for one PR:
 - Add connect/listen/stream wrapper types or helper functions.
 - Add loopback tests where possible without external services.
-- Avoid a full WebSocket/callback-server migration until after wrappers are reviewed.
+- Avoid full WebSocket/callback-server migration until after wrappers are reviewed.
 
-Depends on: work item 1.
+Depends on: work item 2.
 
-#### Work item 7 — Add focused regression tests for concurrency, parsing, protocol, and storage
+#### Work item 8 — Add focused regression tests for concurrency, parsing, protocol, and storage
 
 Priority: **high**
 
@@ -123,30 +144,33 @@ Suggested scope for one PR:
 - Keep tests in the existing grouped test structure.
 - Do not add external provider E2E coverage.
 
-Depends on: none; can run in parallel with wrapper tasks.
+Depends on: work item 1; can run in parallel with wrapper tasks.
 
 ### Phase 1 — Dependency and compiler switch
 
-Purpose: move the branch to Zig 0.16.0 and establish the new baseline. This is the critical sync point; no further work should assume Zig 0.15.2 compatibility after it lands.
+Purpose: move the branch to Zig 0.16.0 with a mergeable green baseline. After this PR lands, no further work should assume Zig 0.15.2 compatibility.
 
-#### Work item 8 — Switch CI/build metadata to Zig 0.16.0 and verify libxev
+Branch strategy: Phase 0 PRs may land directly on `main` while `main` still targets Zig 0.15.2. Phase 1 should be a normal PR to `main` that switches `main` to Zig 0.16.0 with the agreed green baseline. After Phase 1 merges, follow-up migration PRs are short-lived branches targeting `main`; avoid a long-lived feature branch unless Phase 1 is explicitly re-planned as a red integration checkpoint.
+
+#### Work item 9 — Switch to a first green Zig 0.16 baseline PR
 
 Priority: **urgent**
 
-Update `zig/build.zig.zon` `.version` to `0.16.0`, select and pin a libxev commit/release that builds with Zig 0.16.0, refresh the dependency hash, and update CI setup-zig versions. Run the smallest build/test steps needed to prove dependency resolution and capture first-pass compile failures. This PR is expected to require minimal source fixes only when necessary to keep the tree buildable enough for downstream migration PRs.
+Update `zig/build.zig.zon` `.version` to `0.16.0`, select and pin a libxev commit/release that builds with Zig 0.16.0, refresh the dependency hash, and update CI setup-zig versions. Apply only minimum compile-restoring source fixes needed for the agreed baseline test subset to pass; do not use an unmerged red integration branch as the normal path. Capture the remaining compile/test inventory and assign it to follow-up tasks.
 
 Suggested scope for one PR:
 - Update `build.zig.zon`, CI Zig versions, and any docs/scripts that hard-code 0.15.2.
 - Verify libxev with Zig 0.16.0 and record the chosen pin rationale.
-- Commit a compile-error inventory if not everything is fixed in the same PR.
+- Apply minimal fixes needed for a green baseline, such as build metadata/API adjustments that unblock the build graph.
+- Document the exact baseline command set that passed.
 
-Depends on: work items 1-7, or an explicit decision to skip incomplete Phase 0 coverage.
+Depends on: work items 1-8, or an explicit decision to accept reduced pre-switch coverage.
 
 ### Phase 2 — Core/std migration on Zig 0.16.0
 
-Purpose: resolve compiler errors and behavior changes in core shared code before provider and transport work.
+Purpose: resolve compiler errors and behavior changes in core shared code before provider and transport rollout.
 
-#### Work item 9 — Migrate `std.mem.indexOf*` call sites to `std.mem.find*`
+#### Work item 10 — Migrate `std.mem.indexOf*` call sites to `std.mem.find*`
 
 Priority: **high**
 
@@ -157,22 +181,36 @@ Suggested scope for one PR:
 - Run relevant grouped unit tests once compilation reaches those modules.
 - Avoid unrelated `ArrayList` or I/O changes.
 
-Depends on: work item 8.
+Depends on: work item 9.
 
-#### Work item 10 — Migrate `EventStream` and synchronization primitives
+#### Work item 11 — Migrate core EventStream and stream synchronization
 
 Priority: **high**
 
-Port `std.Thread.Futex`, `Mutex`, `Condition`, and `ResetEvent` usage to Zig 0.16-compatible `std.Io.*` primitives or equivalent constructs. Start with `EventStream` because it is central to provider streaming and protocol clients, then update agent/auth refresh synchronization. Use the Phase 0 regression tests to validate wait, timeout, wake, completion, and error behavior.
+Port synchronization in `zig/src/event_stream.zig` and `zig/src/stream.zig` from `std.Thread.Futex` and related primitives to Zig 0.16-compatible `std.Io.*` primitives or equivalent constructs. Keep this PR focused on central streaming semantics only, because `EventStream` is shared by providers, protocol clients, and agent paths. Use the Phase 0 regression tests to validate wait, timeout, wake, completion, polling, and error behavior.
 
 Suggested scope for one PR:
-- Migrate `zig/src/event_stream.zig`, `zig/src/stream.zig`, `zig/src/agent/agent.zig`, `zig/src/protocol/auth/server.zig`, and `zig/src/utils/oauth/refresh_lock.zig` if tightly coupled.
-- Run `zig build test-unit-core`, auth/protocol-related tests, and any new stress tests.
-- Document any semantic differences in timeout or wake behavior.
+- Migrate `zig/src/event_stream.zig` and `zig/src/stream.zig`.
+- Run `zig build test-unit-core` and any new stream stress tests.
+- Preserve existing error messages and error types for stream completion/error paths unless a compiler-enforced change is documented.
+- Document semantic differences in timeout or wake behavior.
 
-Depends on: work items 7 and 8.
+Depends on: work items 8 and 9.
 
-#### Work item 11 — Migrate time, sleep, and timestamp call sites through wrappers
+#### Work item 12 — Migrate agent/auth/OAuth synchronization
+
+Priority: **high**
+
+Port synchronization in `zig/src/agent/agent.zig`, `zig/src/protocol/auth/server.zig`, and `zig/src/utils/oauth/refresh_lock.zig` separately from core EventStream work. This isolates auth/agent coordination review from lock-free stream review. Validate refresh coordination, auth protocol locking, and agent event completion behavior.
+
+Suggested scope for one PR:
+- Migrate agent reset events and auth/OAuth mutex/condition usage.
+- Run relevant agent, protocol/auth, and utils tests.
+- Confirm no provider auth logic leaks into the auth-agnostic agent layer.
+
+Depends on: work items 8, 9, and 11.
+
+#### Work item 13 — Migrate time, sleep, and timestamp call sites through wrappers
 
 Priority: **high**
 
@@ -183,9 +221,9 @@ Suggested scope for one PR:
 - Migrate all remaining production call sites and tests.
 - Run core, protocol, provider, utils, and agent unit groups as applicable.
 
-Depends on: work items 2 and 8; may depend on work item 10 if wrappers use migrated sync primitives.
+Depends on: work items 3 and 9; may depend on work item 11 if wrappers use migrated stream timing primitives.
 
-#### Work item 12 — Migrate random and protocol/OAuth ID generation
+#### Work item 14 — Migrate random and protocol/OAuth ID generation
 
 Priority: **high**
 
@@ -196,9 +234,9 @@ Suggested scope for one PR:
 - Migrate all `std.crypto.random` call sites identified in the assessment.
 - Add or update tests to distinguish deterministic test mode from secure production mode.
 
-Depends on: work items 3 and 8.
+Depends on: work items 4 and 9.
 
-#### Work item 13 — Migrate ArrayList, formatting, custom JSON writer, and std.json drift
+#### Work item 15 — Migrate ArrayList, formatting, custom JSON writer, and std.json drift
 
 Priority: **high**
 
@@ -209,39 +247,81 @@ Suggested scope for one PR:
 - Update `zig/src/json/writer.zig`, `zig/src/utils/streaming_json.zig`, and related envelope/provider request code.
 - Run protocol/provider/utils unit groups to cover serialization.
 
-Depends on: work item 8; can run after or in parallel with work item 9 if merge conflicts are managed.
+Depends on: work item 9; can run after or in parallel with work item 10 if merge conflicts are managed.
 
 ### Phase 3 — I/O stack migration on Zig 0.16.0
 
-Purpose: migrate filesystem, stdio, HTTP, and networking consumers once core helpers are ready.
+Purpose: migrate filesystem, stdio, HTTP, and networking consumers through the reviewed wrappers and architecture model.
 
-#### Work item 14 — Migrate filesystem, stdio transport, OAuth storage, and CLI file I/O
+#### Work item 16 — Migrate OAuth credential storage filesystem operations
 
 Priority: **high**
 
-Port filesystem and stdio helpers to Zig 0.16 `std.Io.Dir`, `std.Io.File`, and writer/reader APIs, then migrate OAuth storage, stdio transport, and CLI file operations. Preserve atomic credential-file replacement behavior and current error handling. Keep user-data safety as the review focus.
+Port OAuth credential storage to Zig 0.16 filesystem helpers as a standalone user-data-focused PR. Preserve atomic credential-file replacement behavior, directory creation, missing-file handling, permission expectations, and current error behavior. Keep stdio transport and CLI file I/O out of this PR so user-data safety receives focused review.
 
 Suggested scope for one PR:
-- Update wrappers and migrate `zig/src/utils/oauth/storage.zig`, `zig/src/transports/stdio.zig`, and targeted CLI file I/O.
-- Run utils, transport, and CLI-related tests.
+- Migrate `zig/src/utils/oauth/storage.zig` through filesystem helpers.
+- Run OAuth storage and utils tests.
+- Preserve existing storage error messages and error types unless a compiler-enforced change is documented.
 - Include manual notes for credential storage rollback/backup behavior if relevant.
 
-Depends on: work items 4, 8, 11, and 13.
+Depends on: work items 5, 9, 13, 14, and 15.
 
-#### Work item 15 — Migrate provider HTTP streaming implementations
+#### Work item 17 — Migrate stdio transport and CLI file I/O
+
+Priority: **high**
+
+Port stdio transport and CLI file operations to Zig 0.16 filesystem/stdio helpers separately from OAuth credential storage. This keeps transport/CLI review focused on byte I/O and user interaction rather than credential safety. Preserve current stdin/stdout semantics and CLI harness behavior.
+
+Suggested scope for one PR:
+- Migrate `zig/src/transports/stdio.zig` and targeted `zig/src/tools/makai.zig` file/stdio call sites.
+- Run transport and CLI-related tests.
+- Validate CLI output formatting, exit codes, and auth-flow prompts remain unchanged except where explicitly documented.
+- Avoid changes to OAuth storage.
+
+Depends on: work items 5, 9, 13, and 15.
+
+#### Work item 18 — Migrate shared HTTP abstraction and one proving provider
 
 Priority: **urgent**
 
-Port all provider streaming implementations from the old `std.http.Client` construction/response reader flow to Zig 0.16's `std.Io`-aware HTTP request flow. Maintain incremental SSE parsing and cancellation semantics. Providers include Anthropic, OpenAI Completions, OpenAI Responses, Azure OpenAI Responses, Google Generative, Google Vertex, and Ollama.
+Port the shared HTTP abstraction to Zig 0.16's `std.Io`-aware HTTP request/response flow and migrate exactly one representative streaming provider as a proving provider. The proving provider should exercise request bodies, response head handling, incremental body reads, SSE parsing, cancellation, and provider error-body handling. Do not migrate all provider families until this PR establishes the abstraction shape.
 
-Suggested scope for one PR, or split by provider family if too large:
+Suggested scope for one PR:
 - Update shared HTTP abstraction for Zig 0.16.
-- Migrate provider files in cohesive groups.
-- Run provider unit tests and mock/non-secret tests; do not require external provider E2E.
+- Migrate one representative provider, preferably one with SSE streaming and nontrivial request/error handling.
+- Run provider unit tests and mock/non-secret tests for that provider.
+- Preserve existing provider error messages and error types unless a compiler-enforced change is documented.
 
-Depends on: work items 5, 8, 11, 12, and 13.
+Depends on: work items 6, 9, 13, 14, and 15.
 
-#### Work item 16 — Migrate OAuth HTTP flows and callback networking
+#### Work item 19 — Migrate remaining OpenAI/Azure provider HTTP implementations
+
+Priority: **high**
+
+Migrate OpenAI Completions, OpenAI Responses, and Azure OpenAI Responses providers through the proven shared HTTP abstraction. Keep request JSON and response parsing changes limited to what Zig 0.16 requires. Preserve cancellation, usage accounting, tool-call delta handling, and error-body handling.
+
+Suggested scope for one PR:
+- Migrate OpenAI and Azure provider HTTP call sites.
+- Run provider unit tests and mock/non-secret tests.
+- Avoid changing Anthropic/Google/Ollama in the same PR unless required by shared test fixtures.
+
+Depends on: work item 18.
+
+#### Work item 20 — Migrate remaining Anthropic/Google/Ollama provider HTTP implementations
+
+Priority: **high**
+
+Migrate Anthropic Messages, Google Generative, Google Vertex, and Ollama providers through the proven shared HTTP abstraction. Preserve streaming, SSE parsing, cancellation, extended thinking blocks, provider-specific request options, and provider-specific error handling. Keep this separate from the OpenAI/Azure migration to keep provider-family review manageable.
+
+Suggested scope for one PR:
+- Migrate Anthropic, Google, and Ollama provider HTTP call sites.
+- Run provider unit tests and mock/non-secret tests.
+- Do not require external provider E2E.
+
+Depends on: work item 18; can run in parallel with work item 19 if shared abstraction is stable.
+
+#### Work item 21 — Migrate OAuth HTTP flows and callback networking
 
 Priority: **high**
 
@@ -252,9 +332,9 @@ Suggested scope for one PR:
 - Run utils/auth/OAuth tests and mock callback-server tests.
 - Avoid external login E2E unless explicitly configured.
 
-Depends on: work items 5, 6, 12, and 14; may run partly in parallel with work item 15 if shared HTTP abstractions are stable.
+Depends on: work items 6, 7, 14, 16, and 18. It does not depend on stdio transport/CLI migration.
 
-#### Work item 17 — Migrate WebSocket transport networking
+#### Work item 22 — Migrate WebSocket transport networking
 
 Priority: **normal**
 
@@ -265,13 +345,13 @@ Suggested scope for one PR:
 - Run transport unit tests and WebSocket-specific regression tests.
 - Document any unsupported `std.Io` backend/networking caveats.
 
-Depends on: work items 6, 12, and 14.
+Depends on: work items 7 and 14. It does not depend on filesystem/stdio/OAuth storage migration.
 
 ### Phase 4 — Validation and stabilization
 
 Purpose: prove Zig 0.16 parity and prepare the migration series for merge.
 
-#### Work item 18 — Full unit and mock E2E validation on Zig 0.16.0
+#### Work item 23 — Full unit and mock E2E validation on Zig 0.16.0
 
 Priority: **urgent**
 
@@ -280,74 +360,92 @@ Run and stabilize all grouped unit tests plus mock-based protocol E2E tests on Z
 Suggested scope for one PR:
 - Run `zig build test-unit-core`, `test-unit-transport`, `test-unit-protocol`, `test-unit-providers`, `test-unit-utils`, `test-unit-agent`, and current split agent groups if CI still uses them.
 - Run `zig build test-e2e-protocol`.
+- Validate CLI output formatting, exit codes, and auth-flow prompts remain unchanged after the full migration.
 - Fix only validation failures and test harness drift.
 
-Depends on: work items 9-17.
+Depends on: work items 10-22.
 
-#### Work item 19 — Documentation, migration notes, and cleanup
+#### Work item 24 — Documentation, migration notes, and cleanup
 
 Priority: **normal**
 
-Update developer documentation, build instructions, CI comments, and migration notes to reflect Zig 0.16.0. Remove transitional TODOs or dead compatibility paths that are no longer needed after the switch. Keep any deliberate wrappers that provide ongoing abstraction value.
+Update developer documentation, build instructions, CI comments, changelog/release notes, and downstream migration notes to reflect Zig 0.16.0. Remove transitional TODOs or dead compatibility paths that are no longer needed after the switch. Keep any deliberate wrappers that provide ongoing abstraction value.
 
 Suggested scope for one PR:
-- Update `CLAUDE.md`, README/build docs if present, and relevant internal docs.
+- Update `CLAUDE.md`, including changing the build requirement from Zig 0.15.2 to Zig 0.16.0.
+- Add a changelog or release-notes entry for the Zig version upgrade.
+- Add a downstream migration guide for consumers depending on Makai public types and constructors.
+- Update README/build docs if present and relevant internal docs.
 - Remove obsolete 0.15.2-only comments or code paths.
 - Confirm pattern guardrails and docs references are current.
 
-Depends on: work item 18.
+Depends on: work item 23.
 
 ## Dependency graph
 
-- Work item 1 is the base for wrapper work items 2-6.
-- Work item 7 can run in parallel with work items 1-6.
-- Work item 8 depends on completion of work items 1-7 unless the team explicitly accepts reduced pre-switch coverage.
-- Work item 9 depends on work item 8.
-- Work item 10 depends on work items 7 and 8.
-- Work item 11 depends on work items 2 and 8, and may depend on work item 10.
-- Work item 12 depends on work items 3 and 8.
-- Work item 13 depends on work item 8, and can run after or in parallel with work item 9 with conflict coordination.
-- Work item 14 depends on work items 4, 8, 11, and 13.
-- Work item 15 depends on work items 5, 8, 11, 12, and 13.
-- Work item 16 depends on work items 5, 6, 12, and 14.
-- Work item 17 depends on work items 6, 12, and 14.
-- Work item 18 depends on work items 9-17.
+- Work item 1 is the prerequisite for work items 2-8.
+- Work item 2 is the base for wrapper work items 3-7.
+- Work item 8 can run in parallel with wrapper tasks after work item 1.
+- Work item 9 depends on completion of work items 1-8 unless the team explicitly accepts reduced pre-switch coverage.
+- Work item 10 depends on work item 9.
+- Work item 11 depends on work items 8 and 9.
+- Work item 12 depends on work items 8, 9, and 11.
+- Work item 13 depends on work items 3 and 9, and may depend on work item 11 if wrapper tests require migrated stream timing semantics.
+- Work item 14 depends on work items 4 and 9.
+- Work item 15 depends on work item 9, and can run after or in parallel with work item 10 with conflict coordination.
+- Work item 16 depends on work items 5, 9, 13, 14, and 15.
+- Work item 17 depends on work items 5, 9, 13, and 15. It does not depend on work item 16.
+- Work item 18 depends on work items 6, 9, 13, 14, and 15.
 - Work item 19 depends on work item 18.
+- Work item 20 depends on work item 18 and can run in parallel with work item 19 if shared helpers are stable.
+- Work item 21 depends on work items 6, 7, 14, 16, and 18. It does not depend on work item 17.
+- Work item 22 depends on work items 7 and 14. It does not depend on work items 16 or 17.
+- Work item 23 depends on work items 10-22.
+- Work item 24 depends on work item 23.
 
 ## Risk mitigations
 
-1. **Compile error inventory after Phase 1.**  
-   Capture first-pass Zig 0.16 compile failures and use them to validate or adjust the planned task boundaries before assigning later PRs.
+1. **Architecture decision before wrappers.**  
+   Default backend, I/O ownership, and context-vs-explicit-io decisions must be recorded first so wrapper PRs do not encode conflicting assumptions.
 
-2. **Regression tests before semantic rewrites.**  
-   EventStream synchronization, OAuth storage, HTTP streaming, SSE parsing, protocol envelopes, and WebSocket framing should have tests in place before their migration PRs.
+2. **First green baseline instead of red stacked migration.**  
+   The Phase 1 compiler switch should be mergeable and green for an agreed baseline command set. If that proves impossible, explicitly revisit the strategy rather than silently creating a long-lived red integration branch.
 
-3. **Security-sensitive randomness review.**  
+3. **Compile error inventory after Phase 1.**  
+   Capture first-pass Zig 0.16 compile failures and use them to validate or adjust later task boundaries before assigning subsystem PRs.
+
+4. **Regression tests before semantic rewrites.**  
+   EventStream synchronization, auth/OAuth locks, OAuth storage, HTTP streaming, SSE parsing, protocol envelopes, and WebSocket framing should have tests in place before their migration PRs.
+
+5. **Security-sensitive randomness review.**  
    Treat OAuth PKCE/state, WebSocket masks/nonces, and protocol IDs as explicit review points. Do not silently downgrade secure entropy to deterministic or weak randomness.
 
-4. **Keep libxev independent of initial `std.Io` decisions.**  
+6. **Keep libxev independent of initial `std.Io` decisions.**  
    Verify libxev builds with Zig 0.16.0, but do not block the initial migration on libxev implementing `std.Io`.
 
-5. **Provider migration by shared abstraction.**  
-   Migrate providers through a shared HTTP abstraction to prevent seven separate ad hoc request-flow implementations.
+7. **Provider migration by proving provider and provider families.**  
+   First port the shared HTTP abstraction and one proving provider, then migrate remaining provider families in separate PRs. This prevents seven independent ad hoc request-flow migrations and avoids one oversized provider PR.
 
-6. **No external E2E requirement for migration validation.**  
+8. **No external E2E requirement for migration validation.**  
    Use grouped unit tests and mock E2E protocol tests as the acceptance gate. External provider E2E remains out of scope unless separately requested.
 
-7. **Minimize public API churn.**  
-   Prefer context/default-I/O ownership patterns over forcing every caller to pass `std.Io` unless compiler or architecture constraints require it.
+9. **Minimize public API churn.**  
+   Prefer the architecture-approved context/default-I/O ownership pattern over forcing every caller to pass `std.Io` unless compiler or design constraints require it.
 
 ## Rollback strategy
 
 - **Before Phase 1:** each Phase 0 PR is independently revertible because it should compile on Zig 0.15.2 and preserve behavior through thin wrappers/tests.
-- **At Phase 1:** if libxev or the compiler switch blocks progress, revert the compiler/dependency PR and continue improving Phase 0 wrappers/tests on 0.15.2.
+- **At Phase 1:** if libxev or the compiler switch cannot produce the agreed first green baseline, revert the compiler/dependency PR and continue improving Phase 0 wrappers/tests on 0.15.2. Do not merge a red Zig 0.16 baseline without explicitly changing this plan.
 - **After Phase 1:** rollback should revert to the last green Zig 0.16 migration PR rather than partially restoring Zig 0.15.2 APIs. Keep each post-switch PR narrow enough to revert independently.
-- **For user-data paths:** OAuth storage migration PRs must preserve existing files and atomic write behavior. If a regression is found, revert the storage migration PR and keep the wrapper interface stable while fixing implementation details.
-- **For provider regressions:** provider HTTP migration can be split by provider family if needed; revert only the affected provider family PR while preserving shared abstraction fixes.
+- **For core stream synchronization:** if core `EventStream` semantics regress, revert work item 11 independently without reverting auth/OAuth synchronization work that has not yet landed.
+- **For auth/OAuth synchronization:** if refresh coordination or auth locks regress, revert work item 12 independently from core stream synchronization.
+- **For user-data paths:** OAuth storage migration is isolated in work item 16. If a regression is found, revert that PR and keep stdio/CLI migration separate.
+- **For provider regressions:** the proving-provider PR can be reverted independently from later provider-family PRs. Later regressions should revert only the affected provider-family PR while preserving shared abstraction fixes where safe.
 
 ## Out of scope
 
-- Full evented-I/O redesign of Makai's public APIs.
+- Full evented-I/O redesign of Makai's public APIs beyond the explicit architecture decision required for this migration.
+- Preserving Zig 0.15.2 source compatibility after Phase 1; public API changes are allowed when documented in migration notes.
 - Implementing or maintaining a libxev-to-`std.Io` adapter.
 - Waiting for libxev issue #219 before starting the compiler migration.
 - Adding new providers, transports, OAuth providers, or agent features.
@@ -357,10 +455,6 @@ Depends on: work item 18.
 
 ## Open questions
 
-1. Which Zig 0.16 `std.Io` backend should be the default for CLI, tests, providers, and networking-heavy flows?
-2. Should public provider/agent APIs accept explicit `std.Io`, or should Makai introduce a context object that owns the default I/O instance?
-3. Should `EventStream` remain futex/atomic-based using `std.Io.Futex`, or should it be redesigned around higher-level `std.Io` primitives after parity is achieved?
-4. Which libxev commit/release should be pinned for Zig 0.16.0, and what evidence is sufficient to accept it?
-5. Are downstream users relying on Zig 0.15.2 source compatibility after the compiler switch, or can public API signatures change with a migration note?
-6. Does Zig 0.16.0 preserve `std.time.milliTimestamp`/`nanoTimestamp`, or should all usage move immediately to wrapper implementations backed by `std.Io.Timestamp`/`Io.Clock`?
-7. Should provider HTTP migration be one PR for all providers or split by provider family after the shared abstraction lands?
+1. Which libxev commit/release should be pinned for Zig 0.16.0, and what evidence is sufficient to accept it?
+2. Does Zig 0.16.0 preserve `std.time.milliTimestamp`/`nanoTimestamp`, or should all usage move immediately to wrapper implementations backed by `std.Io.Timestamp`/`Io.Clock`?
+3. Which provider should be selected as the proving provider for the shared HTTP abstraction PR?

--- a/docs/zig-0.16.0-migration-plan.md
+++ b/docs/zig-0.16.0-migration-plan.md
@@ -90,7 +90,7 @@ Create random helpers that distinguish security-sensitive randomness from ordina
 Suggested scope for one PR:
 - Add `secureBytes`, `randomBytes`, and test/deterministic source helpers if needed.
 - Add unit tests for length, non-empty generation, and deterministic test behavior.
-- Add a guardrail to `scripts/check-zig-patterns.sh` that fails production code using `std.crypto.random` directly after wrapper adoption and that forbids security-sensitive call sites from using non-secure helper names.
+- Add non-failing inventory/reporting support for random usage if useful, but do **not** make `scripts/check-zig-patterns.sh` fail on direct `std.crypto.random` in Phase 0 because most call sites intentionally migrate later.
 - Migrate one low-risk ID generation path only if straightforward.
 
 Depends on: work item 2.
@@ -173,7 +173,9 @@ Suggested scope for one PR:
 - Update CI Zig versions and any docs/scripts that hard-code 0.15.2.
 - Update `zig/build.zig.zon` to Zig 0.16.0 and remove the libxev dependency entry.
 - Record the dependency audit in the PR: no `b.dependency("libxev")`, `@import("xev")`, or `@import("libxev")` call sites exist.
-- Apply enough build/source fixes for `zig build test-unit-core` and `zig build test-unit-utils` to pass on Zig 0.16.0 at minimum; add temporary internal stubs only if they are explicitly documented and covered by follow-up work items.
+- Apply enough build/source fixes for all required PR CI jobs to pass on Zig 0.16.0, including the current unit-test matrix (`test-unit-core`, `test-unit-transport`, `test-unit-protocol`, `test-unit-providers`, `test-unit-utils`, `test-unit-agent-types`, `test-unit-agent-loop`, `test-unit-agent-mod`, `test-unit-agent-bridge`, `test-unit-agent-unit`, `test-unit-agent-chain`) and TS SDK E2E (`npm run test:sdk`) if it remains required by CI.
+- If CI is updated to include `test-unit-makai-cli`, include it in the Phase 1 baseline gate as well.
+- Add temporary internal stubs only if they are explicitly documented and covered by follow-up work items.
 - Document the exact baseline command set that passed and keep GitHub CI green for that baseline.
 
 Depends on: work items 1-8. If any Phase 0 coverage is incomplete, the Phase 1 PR must explicitly list the missing coverage, explain the accepted risk, and identify the follow-up task that closes it; it still must not leave `main` red.
@@ -244,7 +246,7 @@ Update random wrappers to use Zig 0.16 `io.random`, `io.randomSecure`, or `std.R
 Suggested scope for one PR:
 - Update wrapper implementation for Zig 0.16.
 - Migrate all `std.crypto.random` call sites identified in the assessment.
-- Extend the `scripts/check-zig-patterns.sh` guardrail from work item 4 so production code cannot reintroduce direct `std.crypto.random` usage and security-sensitive paths cannot use `io.random`/non-secure wrappers instead of `io.randomSecure`/secure wrappers.
+- After all intended random call sites in this work item are migrated, add or enable the failing `scripts/check-zig-patterns.sh` guardrail so production code cannot reintroduce direct `std.crypto.random` usage and security-sensitive paths cannot use `io.random`/non-secure wrappers instead of `io.randomSecure`/secure wrappers.
 - Add or update tests to distinguish deterministic test mode from secure production mode.
 
 Depends on: work items 4 and 9.
@@ -373,8 +375,9 @@ Priority: **urgent**
 Run and stabilize all grouped unit tests plus mock-based protocol E2E tests on Zig 0.16.0. Per standing instruction, do not add or require external provider E2E testing in this phase. Capture CI status, fix flakes, and update any CI timeouts only with evidence.
 
 Suggested scope for one PR:
-- Run `zig build test-unit-core`, `test-unit-transport`, `test-unit-protocol`, `test-unit-providers`, `test-unit-utils`, `test-unit-agent`, and current split agent groups if CI still uses them.
+- Run `zig build test-unit-core`, `test-unit-transport`, `test-unit-protocol`, `test-unit-providers`, `test-unit-utils`, `test-unit-makai-cli`, `test-unit-agent`, and all split agent groups (`test-unit-agent-types`, `test-unit-agent-loop`, `test-unit-agent-mod`, `test-unit-agent-bridge`, `test-unit-agent-unit`, `test-unit-agent-chain`).
 - Run `zig build test-e2e-protocol`.
+- Run required CI-level TS SDK validation (`npm run test:sdk`) if it remains part of required PR CI.
 - Validate CLI output formatting, exit codes, and auth-flow prompts remain unchanged after the full migration.
 - Fix only validation failures and test harness drift.
 
@@ -478,7 +481,7 @@ Depends on: work item 23.
 | libxev dependency posture | Decided | 9 | Remove libxev in Phase 1; current scan shows no active source/build usage beyond `build.zig.zon`. |
 | Zig 0.15.2 source compatibility after Phase 1 | Decided | 9 | Not required after compiler switch; public API changes must be documented in migration notes. |
 | Provider HTTP rollout shape | Decided | 18 | Shared abstraction + one proving provider, then OpenAI/Azure, then Anthropic/Google/Ollama. |
-| Secure randomness enforcement | Decided | 4 | Add/extend `check-zig-patterns.sh` guardrails so secure paths cannot use non-secure entropy directly. |
+| Secure randomness enforcement | Decided | 14 | Phase 0 may add non-failing inventory only; enable failing `check-zig-patterns.sh` guardrails after random call sites migrate in work item 14. |
 
 ## Open questions
 

--- a/docs/zig-0.16.0-migration-plan.md
+++ b/docs/zig-0.16.0-migration-plan.md
@@ -90,6 +90,7 @@ Create random helpers that distinguish security-sensitive randomness from ordina
 Suggested scope for one PR:
 - Add `secureBytes`, `randomBytes`, and test/deterministic source helpers if needed.
 - Add unit tests for length, non-empty generation, and deterministic test behavior.
+- Add a guardrail to `scripts/check-zig-patterns.sh` that fails production code using `std.crypto.random` directly after wrapper adoption and that forbids security-sensitive call sites from using non-secure helper names.
 - Migrate one low-risk ID generation path only if straightforward.
 
 Depends on: work item 2.
@@ -103,6 +104,7 @@ Add wrappers around cwd/open/read/write/atomic rename, stdin/stdout access, and 
 Suggested scope for one PR:
 - Implement wrappers with 0.15.2 `std.fs`/`std.io` APIs.
 - Add tests for read/write, missing file behavior, directory creation, and atomic replace semantics.
+- Acceptance criteria for atomic replacement helpers: temp file is created in the target directory for same-filesystem rename, final credential file mode is or remains `0o600`, partially written temp files are cleaned up on failure where possible, and existing files are not truncated before rename succeeds.
 - Do not migrate OAuth storage, stdio transport, and CLI file I/O together; leave those for separate post-switch PRs.
 
 Depends on: work item 2.
@@ -137,11 +139,20 @@ Depends on: work item 2.
 
 Priority: **high**
 
-Strengthen tests before changing core behavior. Add or expand tests for `EventStream.wait`, `pollBatch`, completion and error paths, OAuth refresh lock coordination, OAuth storage atomic writes, WebSocket frame parsing/masking, provider SSE parsing, and protocol envelope JSON round trips. These tests should run under Zig 0.15.2 and become the safety net for post-switch changes.
+Strengthen tests before changing core behavior. These tests should run under Zig 0.15.2 and become the safety net for post-switch changes. The PR must enumerate each scenario by name in test descriptions so later migration PRs can cite the exact coverage.
+
+Required scenarios and acceptance gate:
+- EventStream/core stream: `completion_after_error_is_stable`, `double_completion_is_idempotent_or_errors_predictably`, `wait_timeout_returns_without_event`, `multi_producer_stress_preserves_events`, and `completion_memory_ordering_visibility`.
+- OAuth storage: call the production `saveToFile` path directly, assert credential file mode `0o600` where the platform supports it, test same-directory temp/rename behavior as a crash-safety surrogate, and verify temp-file cleanup after injected write/rename failure.
+- WebSocket: verify masking-key XOR output byte-for-byte and continuation-frame reassembly across fragmented frames.
+- SSE parser/provider input: stress 1-byte incremental reads and inject provider error bodies through the parser/error path.
+- Provider cancellation: add cancellation-boundary tests for providers without coverage, at least Anthropic, Ollama, Azure, and Vertex, and cover cancellation before request, during connect/setup where mockable, during headers, between SSE events, and mid-event.
+- Retry/time: cover zero-timeout, very-large-timeout, integer-overflow, and retry budget exhaustion edge cases.
 
 Suggested scope for one PR:
 - Add focused unit tests only; avoid production behavior changes except test-only helpers.
 - Keep tests in the existing grouped test structure.
+- Measurable gate: all newly named scenarios must be present and passing in their grouped unit steps on Zig 0.15.2 before Phase 1 dispatch.
 - Do not add external provider E2E coverage.
 
 Depends on: work item 1; can run in parallel with wrapper tasks.
@@ -150,21 +161,21 @@ Depends on: work item 1; can run in parallel with wrapper tasks.
 
 Purpose: move the branch to Zig 0.16.0 with a mergeable green baseline. After this PR lands, no further work should assume Zig 0.15.2 compatibility.
 
-Branch strategy: Phase 0 PRs may land directly on `main` while `main` still targets Zig 0.15.2. Phase 1 should be a normal PR to `main` that switches `main` to Zig 0.16.0 with the agreed green baseline. After Phase 1 merges, follow-up migration PRs are short-lived branches targeting `main`; avoid a long-lived feature branch unless Phase 1 is explicitly re-planned as a red integration checkpoint.
+Branch strategy: Phase 0 PRs may land directly on `main` while `main` still targets Zig 0.15.2. This plan uses the main-branch path, not a long-lived integration branch: Phase 1 must be a normal PR to `main` that switches `main` to Zig 0.16.0 and keeps CI green for the agreed baseline. After Phase 1 merges, follow-up migration PRs are short-lived branches targeting `main`; if the team chooses an integration branch instead, this plan must be revised before dispatch.
 
 #### Work item 9 — Switch to a first green Zig 0.16 baseline PR
 
 Priority: **urgent**
 
-Update `zig/build.zig.zon` `.version` to `0.16.0`, select and pin a libxev commit/release that builds with Zig 0.16.0, refresh the dependency hash, and update CI setup-zig versions. Apply only minimum compile-restoring source fixes needed for the agreed baseline test subset to pass; do not use an unmerged red integration branch as the normal path. Capture the remaining compile/test inventory and assign it to follow-up tasks.
+Update `zig/build.zig.zon` `.version` to `0.16.0`, select and pin a libxev commit/release that builds with Zig 0.16.0, refresh the dependency hash, and update CI setup-zig versions. Apply enough compile-restoring source fixes or temporary internal stubs for the agreed baseline test subset to pass; do not merge a red PR to `main` and do not use an unmerged red integration branch as the normal path. Capture the remaining compile/test inventory and assign it to follow-up tasks.
 
 Suggested scope for one PR:
 - Update `build.zig.zon`, CI Zig versions, and any docs/scripts that hard-code 0.15.2.
 - Verify libxev with Zig 0.16.0 and record the chosen pin rationale.
-- Apply minimal fixes needed for a green baseline, such as build metadata/API adjustments that unblock the build graph.
-- Document the exact baseline command set that passed.
+- Apply enough build/source fixes for `zig build test-unit-core` and `zig build test-unit-utils` to pass on Zig 0.16.0 at minimum; add temporary internal stubs only if they are explicitly documented and covered by follow-up work items.
+- Document the exact baseline command set that passed and keep GitHub CI green for that baseline.
 
-Depends on: work items 1-8, or an explicit decision to accept reduced pre-switch coverage.
+Depends on: work items 1-8. If any Phase 0 coverage is incomplete, the Phase 1 PR must explicitly list the missing coverage, explain the accepted risk, and identify the follow-up task that closes it; it still must not leave `main` red.
 
 ### Phase 2 — Core/std migration on Zig 0.16.0
 
@@ -232,6 +243,7 @@ Update random wrappers to use Zig 0.16 `io.random`, `io.randomSecure`, or `std.R
 Suggested scope for one PR:
 - Update wrapper implementation for Zig 0.16.
 - Migrate all `std.crypto.random` call sites identified in the assessment.
+- Extend the `scripts/check-zig-patterns.sh` guardrail from work item 4 so production code cannot reintroduce direct `std.crypto.random` usage and security-sensitive paths cannot use `io.random`/non-secure wrappers instead of `io.randomSecure`/secure wrappers.
 - Add or update tests to distinguish deterministic test mode from secure production mode.
 
 Depends on: work items 4 and 9.
@@ -262,6 +274,7 @@ Port OAuth credential storage to Zig 0.16 filesystem helpers as a standalone use
 Suggested scope for one PR:
 - Migrate `zig/src/utils/oauth/storage.zig` through filesystem helpers.
 - Run OAuth storage and utils tests.
+- Acceptance criteria: temp files are created in the target directory to preserve same-filesystem rename guarantees, final credential file mode is or remains `0o600` where supported, failed writes/renames do not truncate the existing credential file, and temporary files are cleaned up on failure where possible.
 - Preserve existing storage error messages and error types unless a compiler-enforced change is documented.
 - Include manual notes for credential storage rollback/backup behavior if relevant.
 
@@ -290,6 +303,7 @@ Port the shared HTTP abstraction to Zig 0.16's `std.Io`-aware HTTP request/respo
 Suggested scope for one PR:
 - Update shared HTTP abstraction for Zig 0.16.
 - Migrate one representative provider, preferably one with SSE streaming and nontrivial request/error handling.
+- Add HTTP/SSE cancellation tests for cancel during connect/setup, during response headers, between SSE events, and mid-event payload; use mocks where real network timing is not deterministic.
 - Run provider unit tests and mock/non-secret tests for that provider.
 - Preserve existing provider error messages and error types unless a compiler-enforced change is documented.
 
@@ -386,7 +400,7 @@ Depends on: work item 23.
 - Work item 1 is the prerequisite for work items 2-8.
 - Work item 2 is the base for wrapper work items 3-7.
 - Work item 8 can run in parallel with wrapper tasks after work item 1.
-- Work item 9 depends on completion of work items 1-8 unless the team explicitly accepts reduced pre-switch coverage.
+- Work item 9 depends on completion of work items 1-8. If any Phase 0 coverage is incomplete, the Phase 1 PR must explicitly list the missing coverage, explain the accepted risk, identify the follow-up task that closes it, and still keep `main` green.
 - Work item 10 depends on work item 9.
 - Work item 11 depends on work items 8 and 9.
 - Work item 12 depends on work items 8, 9, and 11.
@@ -453,8 +467,18 @@ Depends on: work item 23.
 - Broad performance optimization beyond preserving current behavior and avoiding obvious regressions.
 - Changes to GitHub repository rules, admin bypass, or direct changes to the local root repo outside required sync operations.
 
+## Decision log
+
+| Decision | Status for dispatch | Earliest blocked work item | Notes |
+|---|---|---:|---|
+| Default `std.Io` backend and ownership model | Binding default set; final backend selection recorded in work item 1 | 1 | Phase 0 wrappers MUST NOT expose `std.Io` in public APIs; public constructors use Makai context/default-I/O patterns, internal helpers may accept explicit handles. |
+| Branch strategy | Decided | 9 | Use main-branch path with a first green Zig 0.16 PR; no long-lived integration branch unless this plan is revised. |
+| Zig 0.15.2 source compatibility after Phase 1 | Decided | 9 | Not required after compiler switch; public API changes must be documented in migration notes. |
+| Provider HTTP rollout shape | Decided | 18 | Shared abstraction + one proving provider, then OpenAI/Azure, then Anthropic/Google/Ollama. |
+| Secure randomness enforcement | Decided | 4 | Add/extend `check-zig-patterns.sh` guardrails so secure paths cannot use non-secure entropy directly. |
+
 ## Open questions
 
-1. Which libxev commit/release should be pinned for Zig 0.16.0, and what evidence is sufficient to accept it?
-2. Does Zig 0.16.0 preserve `std.time.milliTimestamp`/`nanoTimestamp`, or should all usage move immediately to wrapper implementations backed by `std.Io.Timestamp`/`Io.Clock`?
-3. Which provider should be selected as the proving provider for the shared HTTP abstraction PR?
+1. Which libxev commit/release should be pinned for Zig 0.16.0, and what evidence is sufficient to accept it? Earliest blocked work item: **9**.
+2. Does Zig 0.16.0 preserve `std.time.milliTimestamp`/`nanoTimestamp`, or should all usage move immediately to wrapper implementations backed by `std.Io.Timestamp`/`Io.Clock`? Earliest blocked work item: **13**.
+3. Which provider should be selected as the proving provider for the shared HTTP abstraction PR? Earliest blocked work item: **18**.

--- a/docs/zig-0.16.0-migration-plan.md
+++ b/docs/zig-0.16.0-migration-plan.md
@@ -1,0 +1,366 @@
+# Zig 0.15.2 → 0.16.0 Migration Plan
+
+Date: 2026-05-07  
+Source research: [`docs/zig-0.16.0-upgrade-impact-assessment.md`](./zig-0.16.0-upgrade-impact-assessment.md)  
+Target: Makai `zig/` codebase and CI, migrating from Zig 0.15.2 to Zig 0.16.0
+
+## Goal summary
+
+Migrate Makai from Zig 0.15.2 to Zig 0.16.0 while preserving current provider, protocol, transport, OAuth, agent-loop, and CLI behavior. The migration should be delivered as a staged sequence of reviewable PRs: first add compatibility seams and focused regression tests that still compile on 0.15.2, then switch the compiler/dependency baseline, then complete the core/std, I/O, provider/OAuth, transport, and validation work on 0.16.0. The initial objective is compile/test parity and minimal architectural churn, not a full redesign around evented I/O or a libxev-backed `std.Io` adapter.
+
+## Design decisions and rationale
+
+1. **Use a staged migration instead of one large rewrite.**  
+   The impact assessment identifies high-volume mechanical changes and high-risk I/O/concurrency changes. Splitting wrapper/test preparation from the compiler switch keeps early PRs reviewable and reduces the amount of behavior change that lands at the Zig 0.16.0 sync point.
+
+2. **Make the compiler switch the hard synchronization point.**  
+   All Phase 0 work must compile and pass on Zig 0.15.2. After the Phase 1 compiler/dependency switch lands, all follow-up work should target Zig 0.16.0 only.
+
+3. **Prefer project-level compatibility seams over ad hoc call-site rewrites.**  
+   Introduce central wrappers for time, sleep, random, filesystem/stdio, HTTP client construction/request flows, and networking. This avoids duplicating 0.16-specific decisions across providers, OAuth flows, transports, and CLI code.
+
+4. **Use the simplest supported `std.Io` backend for initial parity.**  
+   Do not depend on libxev implementing `std.Io`; the research notes that upstream libxev issue #219 is still open. The initial migration should choose a standard Zig 0.16 backend with networking support, then defer evented/libxev integration to a later project.
+
+5. **Preserve public behavior before redesigning APIs.**  
+   Threading explicit `std.Io` through every public API may be the long-term direction, but the first migration should minimize downstream churn. Where API changes are unavoidable, isolate them behind constructors/context objects and document them in the relevant implementation PR.
+
+6. **Treat provider HTTP streaming and `EventStream` synchronization as the highest-risk areas.**  
+   Provider/OAuth HTTP request flow changes and futex/mutex/condition migration can introduce subtle runtime failures even after compilation succeeds. These work items require focused regression tests and careful review.
+
+## Phased PR sequence
+
+### Phase 0 — Preparation wrappers and regression tests on Zig 0.15.2
+
+Purpose: create compatibility seams and tests while the codebase still builds on the current toolchain. Phase 0 tasks should be done in parallel where they touch separate layers.
+
+#### Work item 1 — Add I/O compatibility design skeleton
+
+Priority: **high**
+
+Create a small `zig/src/utils` or `zig/src/compat` module that defines the intended wrapper boundaries for time, sleep, random, filesystem/stdio, HTTP, and networking. In the first PR, keep implementations thin and Zig 0.15.2-compatible, with comments documenting the planned Zig 0.16 mapping. Add the module to `zig/build.zig` imports and expose only stable helper functions/types needed by follow-up PRs.
+
+Suggested scope for one PR:
+- Add the compatibility module and build wiring.
+- Add smoke tests for helper construction and no-op/basic behavior.
+- Do not migrate all call sites yet.
+
+Depends on: none.
+
+#### Work item 2 — Add time and sleep wrappers on 0.15.2
+
+Priority: **high**
+
+Introduce project helpers for `nowMillis`, `nowSeconds`, `nowNanos`/monotonic time, and `sleepNs` backed by current `std.time` and `std.Thread.sleep` APIs. Update a narrow set of central call sites, such as retry utilities and protocol timestamps, to validate ergonomics without destabilizing the full tree. These wrappers become the single place to remap `std.time.timestamp`, `milliTimestamp`, `nanoTimestamp`, and `Io.Clock` behavior after the compiler switch.
+
+Suggested scope for one PR:
+- Implement wrappers and tests on Zig 0.15.2.
+- Migrate representative low-risk call sites only.
+- Record remaining direct timestamp/sleep call sites for later PRs.
+
+Depends on: work item 1.
+
+#### Work item 3 — Add random/secure-random wrappers on 0.15.2
+
+Priority: **high**
+
+Create random helpers that distinguish security-sensitive randomness from ordinary IDs. Use them for PKCE verifiers, OAuth state, WebSocket nonce/masks, protocol IDs, and storage temporary-name generation in follow-up PRs. In Phase 0, implement wrappers using `std.crypto.random` and add deterministic test seams where possible.
+
+Suggested scope for one PR:
+- Add `secureBytes`, `randomBytes`, and test/deterministic source helpers if needed.
+- Add unit tests for length, non-empty generation, and deterministic test behavior.
+- Migrate one low-risk ID generation path only if straightforward.
+
+Depends on: work item 1.
+
+#### Work item 4 — Add filesystem and stdio helper layer on 0.15.2
+
+Priority: **high**
+
+Add wrappers around cwd/open/read/write/atomic rename, stdin/stdout access, and file reader/writer operations used by OAuth storage, stdio transport, and CLI tooling. The wrapper should preserve current ownership and error behavior, especially around credential storage and atomic file replacement. Avoid changing provider behavior in this PR.
+
+Suggested scope for one PR:
+- Implement wrappers with 0.15.2 `std.fs`/`std.io` APIs.
+- Add tests for read/write, missing file behavior, directory creation, and atomic replace semantics.
+- Migrate OAuth storage only if the PR remains small; otherwise leave migration for work item 14.
+
+Depends on: work item 1.
+
+#### Work item 5 — Add HTTP client/request abstraction on 0.15.2
+
+Priority: **high**
+
+Define a thin project abstraction for provider/OAuth HTTP client creation and response-body streaming. It should hide the future Zig 0.16 `std.http.Client{ .io = ... }` construction and request/send/receive API differences while preserving streaming SSE behavior. Start with one provider or test double so the abstraction shape is proven before all providers move.
+
+Suggested scope for one PR:
+- Add HTTP abstraction interfaces/helpers backed by current `std.http.Client`.
+- Add tests with local/mock response behavior where feasible.
+- Migrate at most one low-risk HTTP consumer to validate the shape.
+
+Depends on: work item 1.
+
+#### Work item 6 — Add networking helper layer on 0.15.2
+
+Priority: **normal**
+
+Create wrappers for TCP connect, address resolution, listen/accept, and stream read/write paths used by WebSocket transport and OAuth callback server. Keep the 0.15.2 implementation backed by `std.net`. This sets up a contained Zig 0.16 migration to `std.Io.net` later.
+
+Suggested scope for one PR:
+- Add connect/listen/stream wrapper types or helper functions.
+- Add loopback tests where possible without external services.
+- Avoid a full WebSocket/callback-server migration until after wrappers are reviewed.
+
+Depends on: work item 1.
+
+#### Work item 7 — Add focused regression tests for concurrency, parsing, protocol, and storage
+
+Priority: **high**
+
+Strengthen tests before changing core behavior. Add or expand tests for `EventStream.wait`, `pollBatch`, completion and error paths, OAuth refresh lock coordination, OAuth storage atomic writes, WebSocket frame parsing/masking, provider SSE parsing, and protocol envelope JSON round trips. These tests should run under Zig 0.15.2 and become the safety net for post-switch changes.
+
+Suggested scope for one PR:
+- Add focused unit tests only; avoid production behavior changes except test-only helpers.
+- Keep tests in the existing grouped test structure.
+- Do not add external provider E2E coverage.
+
+Depends on: none; can run in parallel with wrapper tasks.
+
+### Phase 1 — Dependency and compiler switch
+
+Purpose: move the branch to Zig 0.16.0 and establish the new baseline. This is the critical sync point; no further work should assume Zig 0.15.2 compatibility after it lands.
+
+#### Work item 8 — Switch CI/build metadata to Zig 0.16.0 and verify libxev
+
+Priority: **urgent**
+
+Update `zig/build.zig.zon` `.version` to `0.16.0`, select and pin a libxev commit/release that builds with Zig 0.16.0, refresh the dependency hash, and update CI setup-zig versions. Run the smallest build/test steps needed to prove dependency resolution and capture first-pass compile failures. This PR is expected to require minimal source fixes only when necessary to keep the tree buildable enough for downstream migration PRs.
+
+Suggested scope for one PR:
+- Update `build.zig.zon`, CI Zig versions, and any docs/scripts that hard-code 0.15.2.
+- Verify libxev with Zig 0.16.0 and record the chosen pin rationale.
+- Commit a compile-error inventory if not everything is fixed in the same PR.
+
+Depends on: work items 1-7, or an explicit decision to skip incomplete Phase 0 coverage.
+
+### Phase 2 — Core/std migration on Zig 0.16.0
+
+Purpose: resolve compiler errors and behavior changes in core shared code before provider and transport work.
+
+#### Work item 9 — Migrate `std.mem.indexOf*` call sites to `std.mem.find*`
+
+Priority: **high**
+
+Replace `std.mem.indexOf`, `indexOfScalar`, `indexOfAny`, and `indexOfPos` usages with the correct Zig 0.16 `std.mem.find*` family. This is high-volume but mostly mechanical and should happen before deeper I/O work so mechanical errors do not obscure complex failures. Verify exact scalar, positional, and any/none replacement names against Zig 0.16.0.
+
+Suggested scope for one PR:
+- Migrate all production and test call sites in `zig/**/*.zig`.
+- Run relevant grouped unit tests once compilation reaches those modules.
+- Avoid unrelated `ArrayList` or I/O changes.
+
+Depends on: work item 8.
+
+#### Work item 10 — Migrate `EventStream` and synchronization primitives
+
+Priority: **high**
+
+Port `std.Thread.Futex`, `Mutex`, `Condition`, and `ResetEvent` usage to Zig 0.16-compatible `std.Io.*` primitives or equivalent constructs. Start with `EventStream` because it is central to provider streaming and protocol clients, then update agent/auth refresh synchronization. Use the Phase 0 regression tests to validate wait, timeout, wake, completion, and error behavior.
+
+Suggested scope for one PR:
+- Migrate `zig/src/event_stream.zig`, `zig/src/stream.zig`, `zig/src/agent/agent.zig`, `zig/src/protocol/auth/server.zig`, and `zig/src/utils/oauth/refresh_lock.zig` if tightly coupled.
+- Run `zig build test-unit-core`, auth/protocol-related tests, and any new stress tests.
+- Document any semantic differences in timeout or wake behavior.
+
+Depends on: work items 7 and 8.
+
+#### Work item 11 — Migrate time, sleep, and timestamp call sites through wrappers
+
+Priority: **high**
+
+Convert remaining direct `std.time.timestamp`, `milliTimestamp`, `nanoTimestamp`, and `std.Thread.sleep` call sites to the project wrapper API. Remap wrapper implementations to Zig 0.16 `std.Io.Timestamp`, `Io.Clock`, `Duration`, and timeout facilities as appropriate. Preserve wall-clock vs monotonic-time semantics explicitly.
+
+Suggested scope for one PR:
+- Update wrapper implementation for Zig 0.16.
+- Migrate all remaining production call sites and tests.
+- Run core, protocol, provider, utils, and agent unit groups as applicable.
+
+Depends on: work items 2 and 8; may depend on work item 10 if wrappers use migrated sync primitives.
+
+#### Work item 12 — Migrate random and protocol/OAuth ID generation
+
+Priority: **high**
+
+Update random wrappers to use Zig 0.16 `io.random`, `io.randomSecure`, or `std.Random.IoSource` as appropriate. Migrate PKCE, OAuth state, WebSocket masks/nonces, protocol ID generation, and storage temporary names through these wrappers. Treat OAuth and security-sensitive call sites as requiring explicit secure entropy.
+
+Suggested scope for one PR:
+- Update wrapper implementation for Zig 0.16.
+- Migrate all `std.crypto.random` call sites identified in the assessment.
+- Add or update tests to distinguish deterministic test mode from secure production mode.
+
+Depends on: work items 3 and 8.
+
+#### Work item 13 — Migrate ArrayList, formatting, custom JSON writer, and std.json drift
+
+Priority: **high**
+
+Fix container and writer-related compile errors after the compiler switch. Verify whether Makai's `std.ArrayList` patterns still compile or need unmanaged-style allocator parameters, then migrate affected call sites consistently. Port `std.fmt.format` usage in the custom JSON writer and protocol envelope code to Zig 0.16 writer/print APIs, and fix any `std.json` parse/stringify drift.
+
+Suggested scope for one PR:
+- Convert only compile-confirmed ArrayList breakages; avoid speculative churn.
+- Update `zig/src/json/writer.zig`, `zig/src/utils/streaming_json.zig`, and related envelope/provider request code.
+- Run protocol/provider/utils unit groups to cover serialization.
+
+Depends on: work item 8; can run after or in parallel with work item 9 if merge conflicts are managed.
+
+### Phase 3 — I/O stack migration on Zig 0.16.0
+
+Purpose: migrate filesystem, stdio, HTTP, and networking consumers once core helpers are ready.
+
+#### Work item 14 — Migrate filesystem, stdio transport, OAuth storage, and CLI file I/O
+
+Priority: **high**
+
+Port filesystem and stdio helpers to Zig 0.16 `std.Io.Dir`, `std.Io.File`, and writer/reader APIs, then migrate OAuth storage, stdio transport, and CLI file operations. Preserve atomic credential-file replacement behavior and current error handling. Keep user-data safety as the review focus.
+
+Suggested scope for one PR:
+- Update wrappers and migrate `zig/src/utils/oauth/storage.zig`, `zig/src/transports/stdio.zig`, and targeted CLI file I/O.
+- Run utils, transport, and CLI-related tests.
+- Include manual notes for credential storage rollback/backup behavior if relevant.
+
+Depends on: work items 4, 8, 11, and 13.
+
+#### Work item 15 — Migrate provider HTTP streaming implementations
+
+Priority: **urgent**
+
+Port all provider streaming implementations from the old `std.http.Client` construction/response reader flow to Zig 0.16's `std.Io`-aware HTTP request flow. Maintain incremental SSE parsing and cancellation semantics. Providers include Anthropic, OpenAI Completions, OpenAI Responses, Azure OpenAI Responses, Google Generative, Google Vertex, and Ollama.
+
+Suggested scope for one PR, or split by provider family if too large:
+- Update shared HTTP abstraction for Zig 0.16.
+- Migrate provider files in cohesive groups.
+- Run provider unit tests and mock/non-secret tests; do not require external provider E2E.
+
+Depends on: work items 5, 8, 11, 12, and 13.
+
+#### Work item 16 — Migrate OAuth HTTP flows and callback networking
+
+Priority: **high**
+
+Port OAuth HTTP clients and callback-server networking to Zig 0.16 `std.Io` APIs. Cover GitHub Copilot, Anthropic, Google, and OpenAI Codex OAuth paths, including response-body reading limits and secure state/PKCE generation. Preserve auth-boundary guidance: provider/OAuth layers own credentials; agent logic remains auth-agnostic.
+
+Suggested scope for one PR:
+- Migrate OAuth HTTP helpers and callback server.
+- Run utils/auth/OAuth tests and mock callback-server tests.
+- Avoid external login E2E unless explicitly configured.
+
+Depends on: work items 5, 6, 12, and 14; may run partly in parallel with work item 15 if shared HTTP abstractions are stable.
+
+#### Work item 17 — Migrate WebSocket transport networking
+
+Priority: **normal**
+
+Port WebSocket connection setup, stream read/write, nonce/mask generation, and network error handling to Zig 0.16 networking APIs. Preserve frame parsing behavior and existing transport interfaces. Validate with loopback or mock tests rather than external endpoints.
+
+Suggested scope for one PR:
+- Migrate `zig/src/transports/websocket.zig` through networking/random wrappers.
+- Run transport unit tests and WebSocket-specific regression tests.
+- Document any unsupported `std.Io` backend/networking caveats.
+
+Depends on: work items 6, 12, and 14.
+
+### Phase 4 — Validation and stabilization
+
+Purpose: prove Zig 0.16 parity and prepare the migration series for merge.
+
+#### Work item 18 — Full unit and mock E2E validation on Zig 0.16.0
+
+Priority: **urgent**
+
+Run and stabilize all grouped unit tests plus mock-based protocol E2E tests on Zig 0.16.0. Per standing instruction, do not add or require external provider E2E testing in this phase. Capture CI status, fix flakes, and update any CI timeouts only with evidence.
+
+Suggested scope for one PR:
+- Run `zig build test-unit-core`, `test-unit-transport`, `test-unit-protocol`, `test-unit-providers`, `test-unit-utils`, `test-unit-agent`, and current split agent groups if CI still uses them.
+- Run `zig build test-e2e-protocol`.
+- Fix only validation failures and test harness drift.
+
+Depends on: work items 9-17.
+
+#### Work item 19 — Documentation, migration notes, and cleanup
+
+Priority: **normal**
+
+Update developer documentation, build instructions, CI comments, and migration notes to reflect Zig 0.16.0. Remove transitional TODOs or dead compatibility paths that are no longer needed after the switch. Keep any deliberate wrappers that provide ongoing abstraction value.
+
+Suggested scope for one PR:
+- Update `CLAUDE.md`, README/build docs if present, and relevant internal docs.
+- Remove obsolete 0.15.2-only comments or code paths.
+- Confirm pattern guardrails and docs references are current.
+
+Depends on: work item 18.
+
+## Dependency graph
+
+- Work item 1 is the base for wrapper work items 2-6.
+- Work item 7 can run in parallel with work items 1-6.
+- Work item 8 depends on completion of work items 1-7 unless the team explicitly accepts reduced pre-switch coverage.
+- Work item 9 depends on work item 8.
+- Work item 10 depends on work items 7 and 8.
+- Work item 11 depends on work items 2 and 8, and may depend on work item 10.
+- Work item 12 depends on work items 3 and 8.
+- Work item 13 depends on work item 8, and can run after or in parallel with work item 9 with conflict coordination.
+- Work item 14 depends on work items 4, 8, 11, and 13.
+- Work item 15 depends on work items 5, 8, 11, 12, and 13.
+- Work item 16 depends on work items 5, 6, 12, and 14.
+- Work item 17 depends on work items 6, 12, and 14.
+- Work item 18 depends on work items 9-17.
+- Work item 19 depends on work item 18.
+
+## Risk mitigations
+
+1. **Compile error inventory after Phase 1.**  
+   Capture first-pass Zig 0.16 compile failures and use them to validate or adjust the planned task boundaries before assigning later PRs.
+
+2. **Regression tests before semantic rewrites.**  
+   EventStream synchronization, OAuth storage, HTTP streaming, SSE parsing, protocol envelopes, and WebSocket framing should have tests in place before their migration PRs.
+
+3. **Security-sensitive randomness review.**  
+   Treat OAuth PKCE/state, WebSocket masks/nonces, and protocol IDs as explicit review points. Do not silently downgrade secure entropy to deterministic or weak randomness.
+
+4. **Keep libxev independent of initial `std.Io` decisions.**  
+   Verify libxev builds with Zig 0.16.0, but do not block the initial migration on libxev implementing `std.Io`.
+
+5. **Provider migration by shared abstraction.**  
+   Migrate providers through a shared HTTP abstraction to prevent seven separate ad hoc request-flow implementations.
+
+6. **No external E2E requirement for migration validation.**  
+   Use grouped unit tests and mock E2E protocol tests as the acceptance gate. External provider E2E remains out of scope unless separately requested.
+
+7. **Minimize public API churn.**  
+   Prefer context/default-I/O ownership patterns over forcing every caller to pass `std.Io` unless compiler or architecture constraints require it.
+
+## Rollback strategy
+
+- **Before Phase 1:** each Phase 0 PR is independently revertible because it should compile on Zig 0.15.2 and preserve behavior through thin wrappers/tests.
+- **At Phase 1:** if libxev or the compiler switch blocks progress, revert the compiler/dependency PR and continue improving Phase 0 wrappers/tests on 0.15.2.
+- **After Phase 1:** rollback should revert to the last green Zig 0.16 migration PR rather than partially restoring Zig 0.15.2 APIs. Keep each post-switch PR narrow enough to revert independently.
+- **For user-data paths:** OAuth storage migration PRs must preserve existing files and atomic write behavior. If a regression is found, revert the storage migration PR and keep the wrapper interface stable while fixing implementation details.
+- **For provider regressions:** provider HTTP migration can be split by provider family if needed; revert only the affected provider family PR while preserving shared abstraction fixes.
+
+## Out of scope
+
+- Full evented-I/O redesign of Makai's public APIs.
+- Implementing or maintaining a libxev-to-`std.Io` adapter.
+- Waiting for libxev issue #219 before starting the compiler migration.
+- Adding new providers, transports, OAuth providers, or agent features.
+- External provider E2E stabilization or new secret-dependent tests.
+- Broad performance optimization beyond preserving current behavior and avoiding obvious regressions.
+- Changes to GitHub repository rules, admin bypass, or direct changes to the local root repo outside required sync operations.
+
+## Open questions
+
+1. Which Zig 0.16 `std.Io` backend should be the default for CLI, tests, providers, and networking-heavy flows?
+2. Should public provider/agent APIs accept explicit `std.Io`, or should Makai introduce a context object that owns the default I/O instance?
+3. Should `EventStream` remain futex/atomic-based using `std.Io.Futex`, or should it be redesigned around higher-level `std.Io` primitives after parity is achieved?
+4. Which libxev commit/release should be pinned for Zig 0.16.0, and what evidence is sufficient to accept it?
+5. Are downstream users relying on Zig 0.15.2 source compatibility after the compiler switch, or can public API signatures change with a migration note?
+6. Does Zig 0.16.0 preserve `std.time.milliTimestamp`/`nanoTimestamp`, or should all usage move immediately to wrapper implementations backed by `std.Io.Timestamp`/`Io.Clock`?
+7. Should provider HTTP migration be one PR for all providers or split by provider family after the shared abstraction lands?

--- a/docs/zig-0.16.0-migration-plan.md
+++ b/docs/zig-0.16.0-migration-plan.md
@@ -17,13 +17,13 @@ Migrate Makai from Zig 0.15.2 to Zig 0.16.0 while preserving current provider, p
    The impact assessment identifies high-volume mechanical changes and high-risk I/O/concurrency changes. Splitting architecture, wrapper/test preparation, compiler switch, and subsystem migration keeps PRs reviewable and prevents unrelated concerns from being coupled.
 
 3. **Make Phase 1 a first green Zig 0.16 baseline PR.**  
-   This plan chooses a mergeable baseline PR with minimum compile-restoring fixes over an unmerged integration checkpoint with stacked red PRs. The Phase 1 PR should update toolchain metadata, audit the currently declared but apparently unused libxev dependency, and apply only the minimum source changes needed to produce an agreed green Zig 0.16 build/test subset; remaining issues become follow-up tasks.
+   This plan chooses a mergeable baseline PR with minimum compile-restoring fixes over an unmerged integration checkpoint with stacked red PRs. The Phase 1 PR should update toolchain metadata, remove the currently unused libxev dependency declaration, and apply only the minimum source changes needed to produce an agreed green Zig 0.16 build/test subset; remaining issues become follow-up tasks.
 
 4. **Prefer project-level compatibility seams over ad hoc call-site rewrites.**  
    Introduce central wrappers for time, sleep, random, filesystem/stdio, HTTP client construction/request flows, and networking. The wrappers should reflect the prerequisite architecture decision and avoid duplicating 0.16-specific decisions across providers, OAuth flows, transports, and CLI code.
 
 5. **Use the simplest supported `std.Io` backend for initial parity.**  
-   Do not depend on libxev implementing `std.Io`; a fresh repo scan found no active Makai source/build usage beyond the `build.zig.zon` declaration. The initial migration should choose a standard Zig 0.16 backend with networking support, then handle libxev as dependency cleanup: remove it if the audit confirms it is unused, or update the pin only if a real user is identified.
+   Do not depend on libxev implementing `std.Io`; a fresh repo scan found no active Makai source/build usage beyond the `build.zig.zon` declaration. The initial migration should choose a standard Zig 0.16 backend with networking support and remove libxev from `build.zig.zon` during Phase 1.
 
 6. **Preserve public behavior before redesigning APIs.**  
    Public API churn should be limited to what the architecture decision and compiler require. The migration does not need to preserve Zig 0.15.2 source compatibility after Phase 1, but it must preserve documented Makai behavior where possible and provide migration notes for any public API signature changes. Where API changes are unavoidable, isolate them behind constructors/context objects and document them in the relevant implementation PR.
@@ -163,16 +163,16 @@ Purpose: move the branch to Zig 0.16.0 with a mergeable green baseline. After th
 
 Branch strategy: Phase 0 PRs may land directly on `main` while `main` still targets Zig 0.15.2. This plan uses the main-branch path, not a long-lived integration branch: Phase 1 must be a normal PR to `main` that switches `main` to Zig 0.16.0 and keeps CI green for the agreed baseline. After Phase 1 merges, follow-up migration PRs are short-lived branches targeting `main`; if the team chooses an integration branch instead, this plan must be revised before dispatch.
 
-#### Work item 9 — Switch to a first green Zig 0.16 baseline PR and resolve unused libxev declaration
+#### Work item 9 — Switch to a first green Zig 0.16 baseline PR and remove libxev
 
 Priority: **urgent**
 
-Update `zig/build.zig.zon` `.version` to `0.16.0`, update CI setup-zig versions, and resolve the currently declared libxev dependency. A repo scan found `libxev` only in `zig/build.zig.zon` and documentation; `zig/build.zig` does not call `b.dependency("libxev", ...)`, add an xev module, or expose an xev import, and source files do not import `xev`/`libxev`. Therefore the preferred Phase 1 action is to remove the unused libxev declaration; if a hidden or future consumer is identified during the audit, update the pin to a Zig 0.16-compatible upstream commit instead and document the consumer.
+Update `zig/build.zig.zon` `.version` to `0.16.0`, update CI setup-zig versions, and remove the unused libxev dependency declaration. A repo scan found `libxev` only in `zig/build.zig.zon` and documentation; `zig/build.zig` does not call `b.dependency("libxev", ...)`, add an xev module, or expose an xev import, and source files do not import `xev`/`libxev`. Therefore Phase 1 must remove libxev from `build.zig.zon` rather than update/pin it.
 
 Suggested scope for one PR:
 - Update CI Zig versions and any docs/scripts that hard-code 0.15.2.
-- Update `zig/build.zig.zon` to Zig 0.16.0 and either remove unused libxev or update/pin it only with a documented active consumer.
-- If removing libxev, prove no `b.dependency("libxev")`, `@import("xev")`, or `@import("libxev")` call sites exist, and record that audit in the PR.
+- Update `zig/build.zig.zon` to Zig 0.16.0 and remove the libxev dependency entry.
+- Record the dependency audit in the PR: no `b.dependency("libxev")`, `@import("xev")`, or `@import("libxev")` call sites exist.
 - Apply enough build/source fixes for `zig build test-unit-core` and `zig build test-unit-utils` to pass on Zig 0.16.0 at minimum; add temporary internal stubs only if they are explicitly documented and covered by follow-up work items.
 - Document the exact baseline command set that passed and keep GitHub CI green for that baseline.
 
@@ -435,8 +435,8 @@ Depends on: work item 23.
 5. **Security-sensitive randomness review.**  
    Treat OAuth PKCE/state, WebSocket masks/nonces, and protocol IDs as explicit review points. Do not silently downgrade secure entropy to deterministic or weak randomness.
 
-6. **Treat libxev as dependency cleanup, not an initial `std.Io` backend.**  
-   The current codebase appears not to use libxev beyond the package declaration. Prefer removing the unused dependency in Phase 1; if the audit finds a real consumer, update it to a Zig 0.16-compatible commit but keep it independent of the initial `std.Io` backend decision.
+6. **Remove libxev instead of treating it as an initial `std.Io` backend.**  
+   The current codebase does not use libxev beyond the package declaration. Remove the unused dependency in Phase 1 and keep the initial `std.Io` backend decision independent of libxev.
 
 7. **Provider migration by proving provider and provider families.**  
    First port the shared HTTP abstraction and one proving provider, then migrate remaining provider families in separate PRs. This prevents seven independent ad hoc request-flow migrations and avoids one oversized provider PR.
@@ -450,7 +450,7 @@ Depends on: work item 23.
 ## Rollback strategy
 
 - **Before Phase 1:** each Phase 0 PR is independently revertible because it should compile on Zig 0.15.2 and preserve behavior through thin wrappers/tests.
-- **At Phase 1:** if the compiler switch or libxev dependency-audit decision cannot produce the agreed first green baseline, revert the compiler/dependency PR and continue improving Phase 0 wrappers/tests on 0.15.2. Do not merge a red Zig 0.16 baseline without explicitly changing this plan.
+- **At Phase 1:** if the compiler switch or libxev removal cannot produce the agreed first green baseline, revert the compiler/dependency PR and continue improving Phase 0 wrappers/tests on 0.15.2. Do not merge a red Zig 0.16 baseline without explicitly changing this plan.
 - **After Phase 1:** rollback should revert to the last green Zig 0.16 migration PR rather than partially restoring Zig 0.15.2 APIs. Keep each post-switch PR narrow enough to revert independently.
 - **For core stream synchronization:** if core `EventStream` semantics regress, revert work item 11 independently without reverting auth/OAuth synchronization work that has not yet landed.
 - **For auth/OAuth synchronization:** if refresh coordination or auth locks regress, revert work item 12 independently from core stream synchronization.
@@ -463,7 +463,7 @@ Depends on: work item 23.
 - Preserving Zig 0.15.2 source compatibility after Phase 1; public API changes are allowed when documented in migration notes.
 - Implementing or maintaining a libxev-to-`std.Io` adapter.
 - Waiting for libxev issue #219 before starting the compiler migration.
-- Keeping libxev solely because it is declared today; Phase 1 should remove it if the dependency audit confirms it is unused.
+- Keeping libxev solely because it is declared today; Phase 1 removes it because the dependency audit found no active source/build usage.
 - Adding new providers, transports, OAuth providers, or agent features.
 - External provider E2E stabilization or new secret-dependent tests.
 - Broad performance optimization beyond preserving current behavior and avoiding obvious regressions.
@@ -475,7 +475,7 @@ Depends on: work item 23.
 |---|---|---:|---|
 | Default `std.Io` backend and ownership model | Binding default set; final backend selection recorded in work item 1 | 1 | Phase 0 wrappers MUST NOT expose `std.Io` in public APIs; public constructors use Makai context/default-I/O patterns, internal helpers may accept explicit handles. |
 | Branch strategy | Decided | 9 | Use main-branch path with a first green Zig 0.16 PR; no long-lived integration branch unless this plan is revised. |
-| libxev dependency posture | Decided pending audit confirmation | 9 | Current scan shows no active source/build usage beyond `build.zig.zon`; prefer removal in Phase 1 unless an active consumer is found. |
+| libxev dependency posture | Decided | 9 | Remove libxev in Phase 1; current scan shows no active source/build usage beyond `build.zig.zon`. |
 | Zig 0.15.2 source compatibility after Phase 1 | Decided | 9 | Not required after compiler switch; public API changes must be documented in migration notes. |
 | Provider HTTP rollout shape | Decided | 18 | Shared abstraction + one proving provider, then OpenAI/Azure, then Anthropic/Google/Ollama. |
 | Secure randomness enforcement | Decided | 4 | Add/extend `check-zig-patterns.sh` guardrails so secure paths cannot use non-secure entropy directly. |

--- a/docs/zig-0.16.0-migration-plan.md
+++ b/docs/zig-0.16.0-migration-plan.md
@@ -85,7 +85,7 @@ Depends on: work item 2.
 
 Priority: **high**
 
-Create random helpers that distinguish security-sensitive randomness from ordinary IDs. Use them for PKCE verifiers, OAuth state, WebSocket nonce/masks, protocol IDs, and storage temporary-name generation in follow-up PRs. In Phase 0, implement wrappers using `std.crypto.random` and add deterministic test seams where possible.
+Create random helpers that distinguish security-sensitive randomness from ordinary IDs. Use them for both PKCE verifier modules (`zig/src/oauth/pkce.zig` and `zig/src/utils/oauth/pkce.zig`), OAuth state, WebSocket nonce/masks, protocol IDs, and storage temporary-name generation in follow-up PRs. In Phase 0, implement wrappers using `std.crypto.random`, add deterministic test seams where possible, and note that the two PKCE modules should either share the secure helper or be deduplicated in a follow-up to avoid divergent verifier entropy behavior.
 
 Suggested scope for one PR:
 - Add `secureBytes`, `randomBytes`, and test/deterministic source helpers if needed.
@@ -233,6 +233,7 @@ Convert remaining direct `std.time.timestamp`, `milliTimestamp`, `nanoTimestamp`
 Suggested scope for one PR:
 - Update wrapper implementation for Zig 0.16.
 - Migrate all remaining production call sites and tests.
+- Verify OAuth token-expiry arithmetic produces identical results on Zig 0.16.0 for representative seconds/milliseconds inputs, including boundary values used by refresh scheduling.
 - Run core, protocol, provider, utils, and agent unit groups as applicable.
 
 Depends on: work items 3 and 9; may depend on work item 11 if wrappers use migrated stream timing primitives.
@@ -241,11 +242,11 @@ Depends on: work items 3 and 9; may depend on work item 11 if wrappers use migra
 
 Priority: **high**
 
-Update random wrappers to use Zig 0.16 `io.random`, `io.randomSecure`, or `std.Random.IoSource` as appropriate. Migrate PKCE, OAuth state, WebSocket masks/nonces, protocol ID generation, and storage temporary names through these wrappers. Treat OAuth and security-sensitive call sites as requiring explicit secure entropy.
+Update random wrappers to use Zig 0.16 `io.random`, `io.randomSecure`, or `std.Random.IoSource` as appropriate. Migrate both PKCE verifier modules (`zig/src/oauth/pkce.zig:14` and `zig/src/utils/oauth/pkce.zig:19`), OAuth state, WebSocket masks/nonces, protocol ID generation, and storage temporary names through these wrappers. Treat OAuth and security-sensitive call sites as requiring explicit secure entropy, and either deduplicate the two PKCE paths or document why both remain separate while sharing the same secure helper.
 
 Suggested scope for one PR:
 - Update wrapper implementation for Zig 0.16.
-- Migrate all `std.crypto.random` call sites identified in the assessment.
+- Migrate all `std.crypto.random` call sites identified in the assessment, explicitly including `zig/src/oauth/pkce.zig` and `zig/src/utils/oauth/pkce.zig`.
 - After all intended random call sites in this work item are migrated, add or enable the failing `scripts/check-zig-patterns.sh` guardrail so production code cannot reintroduce direct `std.crypto.random` usage and security-sensitive paths cannot use `io.random`/non-secure wrappers instead of `io.randomSecure`/secure wrappers.
 - Add or update tests to distinguish deterministic test mode from secure production mode.
 
@@ -277,8 +278,9 @@ Port OAuth credential storage to Zig 0.16 filesystem helpers as a standalone use
 Suggested scope for one PR:
 - Migrate `zig/src/utils/oauth/storage.zig` through filesystem helpers.
 - Run OAuth storage and utils tests.
-- Acceptance criteria: temp files are created in the target directory to preserve same-filesystem rename guarantees, final credential file mode is or remains `0o600` where supported, failed writes/renames do not truncate the existing credential file, and temporary files are cleaned up on failure where possible.
+- Acceptance criteria: temp files are created in the target directory to preserve same-filesystem rename guarantees, final credential file mode is or remains `0o600` where supported, failed writes/renames do not truncate the existing credential file, temporary files are cleaned up on failure where possible, and startup/load code cleans up stale orphaned `.tmp.*` files left by crashed writes where safe.
 - Preserve existing storage error messages and error types unless a compiler-enforced change is documented.
+- Address credential memory zeroing for `Credentials.deinit()` and `ProviderAuth.deinit()` if practical while touching storage; otherwise file a named security-debt follow-up and document that sensitive token/key slices are still freed without zeroing.
 - Include manual notes for credential storage rollback/backup behavior if relevant.
 
 Depends on: work items 5, 9, 13, 14, and 15.
@@ -307,6 +309,7 @@ Suggested scope for one PR:
 - Update shared HTTP abstraction for Zig 0.16.
 - Migrate one representative provider, preferably one with SSE streaming and nontrivial request/error handling.
 - Add HTTP/SSE cancellation tests for cancel during connect/setup, during response headers, between SSE events, and mid-event payload; use mocks where real network timing is not deterministic.
+- Preserve auth-header construction and forwarding semantics exactly, including API key, bearer token, OAuth, and provider-specific header names/values.
 - Run provider unit tests and mock/non-secret tests for that provider.
 - Preserve existing provider error messages and error types unless a compiler-enforced change is documented.
 
@@ -360,6 +363,8 @@ Port WebSocket connection setup, stream read/write, nonce/mask generation, and n
 Suggested scope for one PR:
 - Migrate `zig/src/transports/websocket.zig` through networking/random wrappers.
 - Run transport unit tests and WebSocket-specific regression tests.
+- Add or explicitly defer full `Sec-WebSocket-Accept` value verification; current behavior only checks header existence, so the PR must either fix it or document the known limitation.
+- Document that `wss://` TLS remains unsupported post-migration unless the PR explicitly adds TLS support.
 - Document any unsupported `std.Io` backend/networking caveats.
 
 Depends on: work items 7 and 14. It does not depend on filesystem/stdio/OAuth storage migration.
@@ -481,7 +486,8 @@ Depends on: work item 23.
 | libxev dependency posture | Decided | 9 | Remove libxev in Phase 1; current scan shows no active source/build usage beyond `build.zig.zon`. |
 | Zig 0.15.2 source compatibility after Phase 1 | Decided | 9 | Not required after compiler switch; public API changes must be documented in migration notes. |
 | Provider HTTP rollout shape | Decided | 18 | Shared abstraction + one proving provider, then OpenAI/Azure, then Anthropic/Google/Ollama. |
-| Secure randomness enforcement | Decided | 14 | Phase 0 may add non-failing inventory only; enable failing `check-zig-patterns.sh` guardrails after random call sites migrate in work item 14. |
+| Secure randomness enforcement | Decided | 14 | Phase 0 may add non-failing inventory only; enable failing `check-zig-patterns.sh` guardrails after random call sites migrate in work item 14. Both PKCE modules must migrate to secure entropy. |
+| Credential memory zeroing | Known security debt; address or explicitly defer | 16 | `Credentials.deinit()` and `ProviderAuth.deinit()` currently free sensitive slices without zeroing; work item 16 must either fix this while touching storage or file a named follow-up. |
 
 ## Open questions
 

--- a/docs/zig-0.16.0-migration-plan.md
+++ b/docs/zig-0.16.0-migration-plan.md
@@ -17,13 +17,13 @@ Migrate Makai from Zig 0.15.2 to Zig 0.16.0 while preserving current provider, p
    The impact assessment identifies high-volume mechanical changes and high-risk I/O/concurrency changes. Splitting architecture, wrapper/test preparation, compiler switch, and subsystem migration keeps PRs reviewable and prevents unrelated concerns from being coupled.
 
 3. **Make Phase 1 a first green Zig 0.16 baseline PR.**  
-   This plan chooses a mergeable baseline PR with minimum compile-restoring fixes over an unmerged integration checkpoint with stacked red PRs. The Phase 1 PR should update toolchain/dependency metadata, verify libxev, and apply only the minimum source changes needed to produce an agreed green Zig 0.16 build/test subset; remaining issues become follow-up tasks.
+   This plan chooses a mergeable baseline PR with minimum compile-restoring fixes over an unmerged integration checkpoint with stacked red PRs. The Phase 1 PR should update toolchain metadata, audit the currently declared but apparently unused libxev dependency, and apply only the minimum source changes needed to produce an agreed green Zig 0.16 build/test subset; remaining issues become follow-up tasks.
 
 4. **Prefer project-level compatibility seams over ad hoc call-site rewrites.**  
    Introduce central wrappers for time, sleep, random, filesystem/stdio, HTTP client construction/request flows, and networking. The wrappers should reflect the prerequisite architecture decision and avoid duplicating 0.16-specific decisions across providers, OAuth flows, transports, and CLI code.
 
 5. **Use the simplest supported `std.Io` backend for initial parity.**  
-   Do not depend on libxev implementing `std.Io`; the research notes that upstream libxev issue #219 is still open. The initial migration should choose a standard Zig 0.16 backend with networking support, then defer evented/libxev integration to a later project.
+   Do not depend on libxev implementing `std.Io`; a fresh repo scan found no active Makai source/build usage beyond the `build.zig.zon` declaration. The initial migration should choose a standard Zig 0.16 backend with networking support, then handle libxev as dependency cleanup: remove it if the audit confirms it is unused, or update the pin only if a real user is identified.
 
 6. **Preserve public behavior before redesigning APIs.**  
    Public API churn should be limited to what the architecture decision and compiler require. The migration does not need to preserve Zig 0.15.2 source compatibility after Phase 1, but it must preserve documented Makai behavior where possible and provide migration notes for any public API signature changes. Where API changes are unavoidable, isolate them behind constructors/context objects and document them in the relevant implementation PR.
@@ -163,15 +163,16 @@ Purpose: move the branch to Zig 0.16.0 with a mergeable green baseline. After th
 
 Branch strategy: Phase 0 PRs may land directly on `main` while `main` still targets Zig 0.15.2. This plan uses the main-branch path, not a long-lived integration branch: Phase 1 must be a normal PR to `main` that switches `main` to Zig 0.16.0 and keeps CI green for the agreed baseline. After Phase 1 merges, follow-up migration PRs are short-lived branches targeting `main`; if the team chooses an integration branch instead, this plan must be revised before dispatch.
 
-#### Work item 9 — Switch to a first green Zig 0.16 baseline PR
+#### Work item 9 — Switch to a first green Zig 0.16 baseline PR and resolve unused libxev declaration
 
 Priority: **urgent**
 
-Update `zig/build.zig.zon` `.version` to `0.16.0`, select and pin a libxev commit/release that builds with Zig 0.16.0, refresh the dependency hash, and update CI setup-zig versions. Apply enough compile-restoring source fixes or temporary internal stubs for the agreed baseline test subset to pass; do not merge a red PR to `main` and do not use an unmerged red integration branch as the normal path. Capture the remaining compile/test inventory and assign it to follow-up tasks.
+Update `zig/build.zig.zon` `.version` to `0.16.0`, update CI setup-zig versions, and resolve the currently declared libxev dependency. A repo scan found `libxev` only in `zig/build.zig.zon` and documentation; `zig/build.zig` does not call `b.dependency("libxev", ...)`, add an xev module, or expose an xev import, and source files do not import `xev`/`libxev`. Therefore the preferred Phase 1 action is to remove the unused libxev declaration; if a hidden or future consumer is identified during the audit, update the pin to a Zig 0.16-compatible upstream commit instead and document the consumer.
 
 Suggested scope for one PR:
-- Update `build.zig.zon`, CI Zig versions, and any docs/scripts that hard-code 0.15.2.
-- Verify libxev with Zig 0.16.0 and record the chosen pin rationale.
+- Update CI Zig versions and any docs/scripts that hard-code 0.15.2.
+- Update `zig/build.zig.zon` to Zig 0.16.0 and either remove unused libxev or update/pin it only with a documented active consumer.
+- If removing libxev, prove no `b.dependency("libxev")`, `@import("xev")`, or `@import("libxev")` call sites exist, and record that audit in the PR.
 - Apply enough build/source fixes for `zig build test-unit-core` and `zig build test-unit-utils` to pass on Zig 0.16.0 at minimum; add temporary internal stubs only if they are explicitly documented and covered by follow-up work items.
 - Document the exact baseline command set that passed and keep GitHub CI green for that baseline.
 
@@ -434,8 +435,8 @@ Depends on: work item 23.
 5. **Security-sensitive randomness review.**  
    Treat OAuth PKCE/state, WebSocket masks/nonces, and protocol IDs as explicit review points. Do not silently downgrade secure entropy to deterministic or weak randomness.
 
-6. **Keep libxev independent of initial `std.Io` decisions.**  
-   Verify libxev builds with Zig 0.16.0, but do not block the initial migration on libxev implementing `std.Io`.
+6. **Treat libxev as dependency cleanup, not an initial `std.Io` backend.**  
+   The current codebase appears not to use libxev beyond the package declaration. Prefer removing the unused dependency in Phase 1; if the audit finds a real consumer, update it to a Zig 0.16-compatible commit but keep it independent of the initial `std.Io` backend decision.
 
 7. **Provider migration by proving provider and provider families.**  
    First port the shared HTTP abstraction and one proving provider, then migrate remaining provider families in separate PRs. This prevents seven independent ad hoc request-flow migrations and avoids one oversized provider PR.
@@ -449,7 +450,7 @@ Depends on: work item 23.
 ## Rollback strategy
 
 - **Before Phase 1:** each Phase 0 PR is independently revertible because it should compile on Zig 0.15.2 and preserve behavior through thin wrappers/tests.
-- **At Phase 1:** if libxev or the compiler switch cannot produce the agreed first green baseline, revert the compiler/dependency PR and continue improving Phase 0 wrappers/tests on 0.15.2. Do not merge a red Zig 0.16 baseline without explicitly changing this plan.
+- **At Phase 1:** if the compiler switch or libxev dependency-audit decision cannot produce the agreed first green baseline, revert the compiler/dependency PR and continue improving Phase 0 wrappers/tests on 0.15.2. Do not merge a red Zig 0.16 baseline without explicitly changing this plan.
 - **After Phase 1:** rollback should revert to the last green Zig 0.16 migration PR rather than partially restoring Zig 0.15.2 APIs. Keep each post-switch PR narrow enough to revert independently.
 - **For core stream synchronization:** if core `EventStream` semantics regress, revert work item 11 independently without reverting auth/OAuth synchronization work that has not yet landed.
 - **For auth/OAuth synchronization:** if refresh coordination or auth locks regress, revert work item 12 independently from core stream synchronization.
@@ -462,6 +463,7 @@ Depends on: work item 23.
 - Preserving Zig 0.15.2 source compatibility after Phase 1; public API changes are allowed when documented in migration notes.
 - Implementing or maintaining a libxev-to-`std.Io` adapter.
 - Waiting for libxev issue #219 before starting the compiler migration.
+- Keeping libxev solely because it is declared today; Phase 1 should remove it if the dependency audit confirms it is unused.
 - Adding new providers, transports, OAuth providers, or agent features.
 - External provider E2E stabilization or new secret-dependent tests.
 - Broad performance optimization beyond preserving current behavior and avoiding obvious regressions.
@@ -473,12 +475,12 @@ Depends on: work item 23.
 |---|---|---:|---|
 | Default `std.Io` backend and ownership model | Binding default set; final backend selection recorded in work item 1 | 1 | Phase 0 wrappers MUST NOT expose `std.Io` in public APIs; public constructors use Makai context/default-I/O patterns, internal helpers may accept explicit handles. |
 | Branch strategy | Decided | 9 | Use main-branch path with a first green Zig 0.16 PR; no long-lived integration branch unless this plan is revised. |
+| libxev dependency posture | Decided pending audit confirmation | 9 | Current scan shows no active source/build usage beyond `build.zig.zon`; prefer removal in Phase 1 unless an active consumer is found. |
 | Zig 0.15.2 source compatibility after Phase 1 | Decided | 9 | Not required after compiler switch; public API changes must be documented in migration notes. |
 | Provider HTTP rollout shape | Decided | 18 | Shared abstraction + one proving provider, then OpenAI/Azure, then Anthropic/Google/Ollama. |
 | Secure randomness enforcement | Decided | 4 | Add/extend `check-zig-patterns.sh` guardrails so secure paths cannot use non-secure entropy directly. |
 
 ## Open questions
 
-1. Which libxev commit/release should be pinned for Zig 0.16.0, and what evidence is sufficient to accept it? Earliest blocked work item: **9**.
-2. Does Zig 0.16.0 preserve `std.time.milliTimestamp`/`nanoTimestamp`, or should all usage move immediately to wrapper implementations backed by `std.Io.Timestamp`/`Io.Clock`? Earliest blocked work item: **13**.
-3. Which provider should be selected as the proving provider for the shared HTTP abstraction PR? Earliest blocked work item: **18**.
+1. Does Zig 0.16.0 preserve `std.time.milliTimestamp`/`nanoTimestamp`, or should all usage move immediately to wrapper implementations backed by `std.Io.Timestamp`/`Io.Clock`? Earliest blocked work item: **13**.
+2. Which provider should be selected as the proving provider for the shared HTTP abstraction PR? Earliest blocked work item: **18**.

--- a/plan.md
+++ b/plan.md
@@ -2,106 +2,132 @@
 
 ## Goal summary
 
-Deliver a concrete, reviewable implementation plan for migrating Makai from Zig 0.15.2 to Zig 0.16.0 based on the approved impact assessment in `docs/zig-0.16.0-upgrade-impact-assessment.md`. The migration should proceed through preparation wrappers/tests on Zig 0.15.2, a compiler/dependency synchronization point, core/std fixes, I/O/provider/OAuth/transport migration, and final Zig 0.16 validation. The primary deliverable is `docs/zig-0.16.0-migration-plan.md`, which decomposes the work into single-PR implementation tasks with dependency ordering, risk mitigations, rollback strategy, and open questions.
+Deliver a concrete, reviewable implementation plan for migrating Makai from Zig 0.15.2 to Zig 0.16.0 based on the approved impact assessment in `docs/zig-0.16.0-upgrade-impact-assessment.md`. The migration proceeds through an explicit architecture-decision prerequisite, preparation wrappers/tests on Zig 0.15.2, a green compiler/dependency baseline PR, core/std fixes, I/O/provider/OAuth/transport migration, and final Zig 0.16 validation. The primary implementation deliverable is `docs/zig-0.16.0-migration-plan.md`, which decomposes the work into single-PR tasks with dependency ordering, risk mitigations, rollback strategy, and remaining clarification points.
 
 ## Work items
 
-1. **Add I/O compatibility design skeleton**  
-   Priority: **high**  
-   Create the base compatibility module and build wiring for time, sleep, random, filesystem/stdio, HTTP, and networking seams. Keep it Zig 0.15.2-compatible and document how each seam should map to Zig 0.16 `std.Io`. This creates a shared foundation for parallel Phase 0 wrapper PRs.
+1. **Decide Zig 0.16 I/O architecture and ownership model**  
+   Priority: **urgent**  
+   Make the default `std.Io` backend and ownership model an up-front architecture decision before wrapper work starts. The binding default for dispatch is that Phase 0 wrappers MUST NOT expose `std.Io` in public API signatures; public constructors use Makai-owned context/default-I/O patterns, while internal helpers may accept explicit I/O handles when needed. Document wrapper naming conventions and parameter order so dependent PRs are consistent.
 
-2. **Add time and sleep wrappers on Zig 0.15.2**  
+2. **Add I/O compatibility design skeleton**  
    Priority: **high**  
-   Introduce helpers for wall-clock timestamps, monotonic time, and sleeping using the current `std.time` and `std.Thread.sleep` APIs. Migrate only representative low-risk call sites initially. These wrappers become the post-switch location for `std.Io.Timestamp`, `Io.Clock`, `Duration`, and timeout behavior.
+   Create the base compatibility module and build wiring for time, sleep, random, filesystem/stdio, HTTP, and networking seams. Keep it Zig 0.15.2-compatible and document how each seam should map to the architecture decision from work item 1. This creates a shared foundation for parallel Phase 0 wrapper PRs.
 
-3. **Add random and secure-random wrappers on Zig 0.15.2**  
+3. **Add time and sleep wrappers on Zig 0.15.2**  
+   Priority: **high**  
+   Introduce helpers for wall-clock timestamps, monotonic time, and sleeping using current `std.time` and `std.Thread.sleep` APIs. Migrate representative low-risk call sites only. These wrappers become the post-switch location for `std.Io.Timestamp`, `Io.Clock`, `Duration`, and timeout behavior.
+
+4. **Add random and secure-random wrappers on Zig 0.15.2**  
    Priority: **high**  
    Add helpers that distinguish security-sensitive entropy from ordinary random bytes. The wrappers should support later migration of PKCE, OAuth state, WebSocket nonce/masks, protocol IDs, and storage temporary names. Include deterministic test seams where practical.
 
-4. **Add filesystem and stdio helper layer on Zig 0.15.2**  
+5. **Add filesystem and stdio helper layer on Zig 0.15.2**  
    Priority: **high**  
-   Add wrappers around cwd/open/read/write/atomic rename, stdin/stdout, and file reader/writer operations. The initial implementation should use 0.15.2 `std.fs`/`std.io` while preserving existing OAuth credential-storage semantics. Include tests for read/write, missing files, directory creation, and atomic replacement.
+   Add wrappers around cwd/open/read/write/atomic rename, stdin/stdout, and file reader/writer operations. The initial implementation should use 0.15.2 `std.fs`/`std.io` while preserving existing behavior. Include tests for read/write, missing files, directory creation, and atomic replacement.
 
-5. **Add HTTP client/request abstraction on Zig 0.15.2**  
+6. **Add HTTP client/request abstraction on Zig 0.15.2**  
    Priority: **high**  
-   Define a thin abstraction over provider/OAuth HTTP client creation, request sending, response body reading, and streaming. The goal is to hide Zig 0.16 `std.http.Client{ .io = ... }` and new request-flow changes behind one project API. Validate the shape with a test double or one low-risk HTTP consumer.
+   Define a thin abstraction over provider/OAuth HTTP client creation, request sending, response body reading, and streaming. The goal is to hide Zig 0.16 `std.http.Client{ .io = ... }` and new request-flow changes behind one project API. Validate the shape with a test double; production provider rollout is split into later PRs.
 
-6. **Add networking helper layer on Zig 0.15.2**  
+7. **Add networking helper layer on Zig 0.15.2**  
    Priority: **normal**  
    Create wrappers for TCP connect, address resolution, listen/accept, and stream read/write operations used by WebSocket transport and OAuth callback server. Keep the implementation backed by `std.net` until the compiler switch. Add loopback or unit tests that do not depend on external services.
 
-7. **Add focused regression tests before semantic migration**  
+8. **Add focused regression tests before semantic migration**  
    Priority: **high**  
-   Expand tests for `EventStream` wait/poll/complete/error behavior, auth refresh locking, OAuth storage atomic writes, WebSocket frame parsing/masking, SSE parsing, and protocol envelope JSON. These tests should run on Zig 0.15.2 and become the safety net for post-switch changes. Avoid external provider E2E tests.
+   Expand tests for core EventStream/stream behavior, auth/OAuth refresh locking, OAuth storage atomic writes, WebSocket frame parsing/masking, SSE parsing, and protocol envelope JSON. These tests should run on Zig 0.15.2 and become the safety net for post-switch changes. Avoid external provider E2E tests.
 
-8. **Switch CI/build metadata to Zig 0.16.0 and verify libxev**  
+9. **Switch to a first green Zig 0.16 baseline PR**  
    Priority: **urgent**  
-   Update `zig/build.zig.zon`, select and hash a Zig 0.16-compatible libxev pin, and update CI Zig versions. Run initial Zig 0.16 build/test steps to prove dependency resolution and collect first-pass compile errors. This is the hard sync point after which remaining work targets Zig 0.16.0 only.
+   Update `zig/build.zig.zon`, select and hash a Zig 0.16-compatible libxev pin, update CI Zig versions, and apply only minimum compile-restoring source fixes needed for the baseline to compile and pass an agreed smoke/unit subset. This plan chooses a first green baseline PR rather than an unmerged integration checkpoint, so downstream migration PRs are based on mergeable Zig 0.16 code. Phase 0 PRs may land on `main` while it still targets 0.15.2; after this PR merges, follow-up migration work should use short-lived branches targeting Zig 0.16 `main` rather than a long-lived feature branch.
 
-9. **Migrate `std.mem.indexOf*` call sites to `std.mem.find*`**  
-   Priority: **high**  
-   Replace all `std.mem.indexOf`, `indexOfScalar`, `indexOfAny`, and `indexOfPos` usages with the correct Zig 0.16 `find` family. This high-volume mechanical work should be isolated to reduce noise in deeper I/O PRs. Verify exact replacement names against Zig 0.16.0.
-
-10. **Migrate `EventStream` and synchronization primitives**  
+10. **Migrate `std.mem.indexOf*` call sites to `std.mem.find*`**  
     Priority: **high**  
-    Port `std.Thread.Futex`, `Mutex`, `Condition`, and `ResetEvent` usage to Zig 0.16-compatible `std.Io.*` primitives or suitable equivalents. Start with `EventStream`, then update agent/auth refresh synchronization. Use the regression tests from work item 7 to validate wake, timeout, completion, and error semantics.
+    Replace all `std.mem.indexOf`, `indexOfScalar`, `indexOfAny`, and `indexOfPos` usages with the correct Zig 0.16 `find` family. This high-volume mechanical work should be isolated to reduce noise in deeper I/O PRs. Verify exact replacement names against Zig 0.16.0.
 
-11. **Migrate time, sleep, and timestamp call sites through wrappers**  
+11. **Migrate core EventStream and stream synchronization**  
+    Priority: **high**  
+    Port synchronization in `zig/src/event_stream.zig` and `zig/src/stream.zig` from `std.Thread.Futex`/related primitives to Zig 0.16-compatible `std.Io.*` primitives or suitable equivalents. Keep this PR focused on central streaming semantics only. Use the regression tests from work item 8 to validate wake, timeout, completion, polling, and error behavior, and preserve existing stream error messages/error types unless a compiler-enforced change is documented.
+
+12. **Migrate agent/auth/OAuth synchronization**  
+    Priority: **high**  
+    Port synchronization in `zig/src/agent/agent.zig`, `zig/src/protocol/auth/server.zig`, and `zig/src/utils/oauth/refresh_lock.zig` separately from core EventStream work. This isolates auth/agent coordination review from lock-free stream review. Validate refresh coordination, auth protocol locking, and agent event completion behavior.
+
+13. **Migrate time, sleep, and timestamp call sites through wrappers**  
     Priority: **high**  
     Convert remaining direct timestamp and sleep calls to the project wrapper API. Update wrapper implementations to use the chosen Zig 0.16 `std.Io` time primitives. Preserve wall-clock versus monotonic semantics explicitly.
 
-12. **Migrate random and protocol/OAuth ID generation**  
+14. **Migrate random and protocol/OAuth ID generation**  
     Priority: **high**  
     Update random wrappers to use Zig 0.16 `io.random`, `io.randomSecure`, or `std.Random.IoSource` as appropriate. Migrate PKCE, OAuth state, WebSocket masks/nonces, protocol IDs, and storage temporary names. Treat secure entropy call sites as explicit security review points.
 
-13. **Migrate ArrayList, formatting, custom JSON writer, and std.json drift**  
+15. **Migrate ArrayList, formatting, custom JSON writer, and std.json drift**  
     Priority: **high**  
     Fix container and writer API compile errors after the compiler switch. Convert only compile-confirmed `std.ArrayList` breakages and migrate `std.fmt.format` uses in the custom JSON writer/protocol envelope code. Validate `std.json` parse/stringify APIs through protocol/provider/utils tests.
 
-14. **Migrate filesystem, stdio transport, OAuth storage, and CLI file I/O**  
+16. **Migrate OAuth credential storage filesystem operations**  
     Priority: **high**  
-    Port filesystem and stdio helpers to Zig 0.16 `std.Io.Dir`, `std.Io.File`, and reader/writer APIs. Migrate OAuth storage, stdio transport, and targeted CLI file I/O through the helpers. Preserve atomic credential-storage behavior and current error handling.
+    Port OAuth credential storage to Zig 0.16 filesystem helpers as its own user-data-focused PR. Preserve atomic replacement, directory creation, missing-file behavior, permissions expectations, rollback/backup safety, and existing storage error messages/error types unless a compiler-enforced change is documented. Keep stdio transport and CLI file I/O out of this PR.
 
-15. **Migrate provider HTTP streaming implementations**  
+17. **Migrate stdio transport and CLI file I/O**  
+    Priority: **high**  
+    Port stdio transport and CLI file operations to Zig 0.16 filesystem/stdio helpers. Keep this separate from OAuth credential storage so transport/CLI review does not obscure user-data safety. Validate transport and CLI-related unit tests, plus CLI output formatting, exit codes, and auth-flow prompts.
+
+18. **Migrate shared HTTP abstraction and one proving provider**  
     Priority: **urgent**  
-    Port Anthropic, OpenAI Completions, OpenAI Responses, Azure OpenAI Responses, Google Generative, Google Vertex, and Ollama providers to the Zig 0.16 HTTP flow. Preserve incremental SSE parsing and cancellation behavior. Use the shared HTTP abstraction rather than separate ad hoc provider implementations.
+    Port the shared HTTP abstraction to Zig 0.16's `std.Io`-aware request/response flow and migrate exactly one representative streaming provider as the proving provider. The proving provider should exercise request bodies, response head handling, incremental body reads, SSE parsing, cancellation, and provider error-body handling. Preserve existing provider error messages/error types unless a compiler-enforced change is documented; do not migrate all provider families until this PR establishes the abstraction shape.
 
-16. **Migrate OAuth HTTP flows and callback networking**  
+19. **Migrate remaining OpenAI/Azure provider HTTP implementations**  
+    Priority: **high**  
+    Migrate OpenAI Completions, OpenAI Responses, and Azure OpenAI Responses providers through the proven shared HTTP abstraction. Keep request/response formatting changes limited to what Zig 0.16 requires. Run provider unit tests and mock/non-secret tests.
+
+20. **Migrate remaining Anthropic/Google/Ollama provider HTTP implementations**  
+    Priority: **high**  
+    Migrate Anthropic Messages, Google Generative, Google Vertex, and Ollama providers through the proven shared HTTP abstraction. Preserve streaming, SSE parsing, cancellation, thinking blocks, and provider-specific error handling. Run provider unit tests and mock/non-secret tests.
+
+21. **Migrate OAuth HTTP flows and callback networking**  
     Priority: **high**  
     Port GitHub Copilot, Anthropic, Google, and OpenAI Codex OAuth HTTP paths plus callback-server networking to Zig 0.16 APIs. Preserve credential ownership boundaries and response-body limits. Validate with utility/auth tests and mock callback-server tests, not external login E2E.
 
-17. **Migrate WebSocket transport networking**  
+22. **Migrate WebSocket transport networking**  
     Priority: **normal**  
     Port WebSocket connection setup, stream read/write, nonce/mask generation, and network error handling through the networking/random wrappers. Preserve frame parsing and existing transport interfaces. Validate with loopback or mock transport tests.
 
-18. **Run full unit and mock E2E validation on Zig 0.16.0**  
+23. **Run full unit and mock E2E validation on Zig 0.16.0**  
     Priority: **urgent**  
-    Run all grouped unit test steps plus mock-based protocol E2E on Zig 0.16.0. Stabilize failures and CI timing without adding external provider E2E requirements. This is the acceptance gate for compile/test parity.
+    Run all grouped unit test steps plus mock-based protocol E2E on Zig 0.16.0. Stabilize failures and CI timing without adding external provider E2E requirements. Validate CLI output formatting, exit codes, and auth-flow prompts as part of the acceptance gate for compile/test parity.
 
-19. **Update documentation, migration notes, and cleanup transitional code**  
+24. **Update documentation, migration notes, and cleanup transitional code**  
     Priority: **normal**  
-    Update developer docs and build instructions to reflect Zig 0.16.0. Remove obsolete Zig 0.15.2-only comments or dead compatibility paths while preserving wrappers that remain useful. Confirm pattern guardrails and CI references are current.
+    Update developer docs, build instructions, changelog/release notes, and downstream migration notes to reflect Zig 0.16.0. Specifically update `CLAUDE.md` from "Requires Zig 0.15.2" to "Requires Zig 0.16.0" and add guidance for consumers depending on Makai public types/constructors. Remove obsolete Zig 0.15.2-only comments or dead compatibility paths while preserving wrappers that remain useful.
 
 ## Dependencies
 
-- Work item 1 is the base for work items 2, 3, 4, 5, and 6.
-- Work item 7 can run in parallel with work items 1-6.
-- Work item 8 depends on work items 1-7, unless the team explicitly accepts reduced pre-switch coverage.
-- Work item 9 depends on work item 8.
-- Work item 10 depends on work items 7 and 8.
-- Work item 11 depends on work items 2 and 8, and may depend on work item 10 if synchronization primitives affect wrapper implementation.
-- Work item 12 depends on work items 3 and 8.
-- Work item 13 depends on work item 8 and can run after or in parallel with work item 9 with conflict coordination.
-- Work item 14 depends on work items 4, 8, 11, and 13.
-- Work item 15 depends on work items 5, 8, 11, 12, and 13.
-- Work item 16 depends on work items 5, 6, 12, and 14.
-- Work item 17 depends on work items 6, 12, and 14.
-- Work item 18 depends on work items 9-17.
+- Work item 1 is the prerequisite for work items 2-7.
+- Work item 2 is the base for work items 3-7.
+- Work item 8 can run in parallel with work items 2-7 after work item 1 is decided.
+- Work item 9 depends on work items 1-8.
+- Work item 10 depends on work item 9.
+- Work item 11 depends on work items 8 and 9.
+- Work item 12 depends on work items 8, 9, and 11.
+- Work item 13 depends on work items 3 and 9, and may depend on work item 11 if shared timing primitives affect tests.
+- Work item 14 depends on work items 4 and 9.
+- Work item 15 depends on work item 9 and can run after or in parallel with work item 10 with conflict coordination.
+- Work item 16 depends on work items 5, 9, 13, 14, and 15.
+- Work item 17 depends on work items 5, 9, 13, and 15; it does not depend on OAuth credential storage.
+- Work item 18 depends on work items 6, 9, 13, 14, and 15.
 - Work item 19 depends on work item 18.
+- Work item 20 depends on work item 18 and can run in parallel with work item 19 if shared provider helpers are stable.
+- Work item 21 depends on work items 6, 7, 14, 16, and 18.
+- Work item 22 depends on work items 7 and 14; it does not depend on filesystem/stdio/OAuth storage migration.
+- Work item 23 depends on work items 10-22.
+- Work item 24 depends on work item 23.
 
 ## Out of scope
 
-- Full evented-I/O redesign of Makai's public APIs.
+- Full evented-I/O redesign of Makai's public APIs beyond the explicit architecture decision required for this migration.
+- Preserving Zig 0.15.2 source compatibility after Phase 1; public API changes are allowed when documented in migration notes.
 - Building or maintaining a libxev-to-`std.Io` adapter.
 - Waiting for upstream libxev `std.Io` support before the initial migration.
 - Adding new providers, transports, OAuth flows, or agent features.
@@ -111,9 +137,6 @@ Deliver a concrete, reviewable implementation plan for migrating Makai from Zig 
 
 ## Open questions
 
-1. Which Zig 0.16 `std.Io` backend should Makai use by default for CLI, tests, providers, and networking flows?
-2. Should public APIs accept explicit `std.Io`, or should Makai introduce context objects that own default I/O instances?
-3. Should `EventStream` remain futex/atomic-based after migration, or should a follow-up redesign use higher-level `std.Io` primitives?
-4. Which libxev commit or release should be selected as the Zig 0.16-compatible pin, and what verification is required?
-5. Are downstream users expected to retain Zig 0.15.2 source compatibility after the compiler switch?
-6. Should provider HTTP migration be one large provider PR or split by provider family after the shared abstraction lands?
+1. Which libxev commit or release should be selected as the Zig 0.16-compatible pin, and what verification is required?
+2. Does Zig 0.16.0 preserve `std.time.milliTimestamp`/`nanoTimestamp`, or should all usage move immediately to wrapper implementations backed by `std.Io.Timestamp`/`Io.Clock`?
+3. Which provider should serve as the proving provider for the shared HTTP abstraction PR?

--- a/plan.md
+++ b/plan.md
@@ -38,9 +38,9 @@ Deliver a concrete, reviewable implementation plan for migrating Makai from Zig 
    Priority: **high**  
    Expand named tests for EventStream completion-after-error, double-completion, timeout, multi-producer stress, and memory ordering; OAuth storage production `saveToFile`, `0o600` mode, same-directory temp rename, and cleanup; WebSocket masking-key XOR and continuation reassembly; SSE 1-byte incremental reads and error-body injection; provider cancellation across pre-request, connect/setup, headers, between events, and mid-event; and retry/time zero-timeout, large-timeout, overflow, and budget exhaustion. These tests must run on Zig 0.15.2 and become the measurable gate before Phase 1 dispatch. Avoid external provider E2E tests.
 
-9. **Switch to a first green Zig 0.16 baseline PR and resolve unused libxev declaration**  
+9. **Switch to a first green Zig 0.16 baseline PR and remove libxev**  
    Priority: **urgent**  
-   Update Zig/CI metadata and resolve the currently declared libxev dependency. A repo scan found `libxev` only in `zig/build.zig.zon` and docs; `zig/build.zig` does not call `b.dependency("libxev", ...)`, and source files do not import `xev`/`libxev`. Prefer removing the unused declaration in Phase 1; only update/pin libxev to a Zig 0.16-compatible commit if the audit identifies an active consumer. Apply enough compile-restoring fixes for `zig build test-unit-core` and `zig build test-unit-utils` to pass on Zig 0.16 at minimum.
+   Update Zig/CI metadata and remove the currently declared libxev dependency. A repo scan found `libxev` only in `zig/build.zig.zon` and docs; `zig/build.zig` does not call `b.dependency("libxev", ...)`, and source files do not import `xev`/`libxev`. Phase 1 must remove the unused declaration rather than update/pin it. Apply enough compile-restoring fixes for `zig build test-unit-core` and `zig build test-unit-utils` to pass on Zig 0.16 at minimum.
 
 10. **Migrate `std.mem.indexOf*` call sites to `std.mem.find*`**  
     Priority: **high**  
@@ -130,7 +130,7 @@ Deliver a concrete, reviewable implementation plan for migrating Makai from Zig 
 - Preserving Zig 0.15.2 source compatibility after Phase 1; public API changes are allowed when documented in migration notes.
 - Building or maintaining a libxev-to-`std.Io` adapter.
 - Waiting for upstream libxev `std.Io` support before the initial migration.
-- Keeping libxev solely because it is declared today; Phase 1 should remove it if the dependency audit confirms it is unused.
+- Keeping libxev solely because it is declared today; Phase 1 removes it because the dependency audit found no active source/build usage.
 - Adding new providers, transports, OAuth flows, or agent features.
 - External provider E2E stabilization or new secret-dependent tests.
 - Broad performance optimization unrelated to compile/test parity.
@@ -142,7 +142,7 @@ Deliver a concrete, reviewable implementation plan for migrating Makai from Zig 
 |---|---|---:|---|
 | Default `std.Io` backend and ownership model | Binding default set; final backend selection recorded in work item 1 | 1 | Phase 0 wrappers MUST NOT expose `std.Io` in public APIs; public constructors use Makai context/default-I/O patterns, internal helpers may accept explicit handles. |
 | Branch strategy | Decided | 9 | Use main-branch path with a first green Zig 0.16 PR; no long-lived integration branch unless this plan is revised. |
-| libxev dependency posture | Decided pending audit confirmation | 9 | Current scan shows no active source/build usage beyond `build.zig.zon`; prefer removal in Phase 1 unless an active consumer is found. |
+| libxev dependency posture | Decided | 9 | Remove libxev in Phase 1; current scan shows no active source/build usage beyond `build.zig.zon`. |
 | Zig 0.15.2 source compatibility after Phase 1 | Decided | 9 | Not required after compiler switch; public API changes must be documented in migration notes. |
 | Provider HTTP rollout shape | Decided | 18 | Shared abstraction + one proving provider, then OpenAI/Azure, then Anthropic/Google/Ollama. |
 | Secure randomness enforcement | Decided | 4 | Add/extend `check-zig-patterns.sh` guardrails so secure paths cannot use non-secure entropy directly. |

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,119 @@
+# Plan: Zig 0.15.2 → 0.16.0 Migration Decomposition
+
+## Goal summary
+
+Deliver a concrete, reviewable implementation plan for migrating Makai from Zig 0.15.2 to Zig 0.16.0 based on the approved impact assessment in `docs/zig-0.16.0-upgrade-impact-assessment.md`. The migration should proceed through preparation wrappers/tests on Zig 0.15.2, a compiler/dependency synchronization point, core/std fixes, I/O/provider/OAuth/transport migration, and final Zig 0.16 validation. The primary deliverable is `docs/zig-0.16.0-migration-plan.md`, which decomposes the work into single-PR implementation tasks with dependency ordering, risk mitigations, rollback strategy, and open questions.
+
+## Work items
+
+1. **Add I/O compatibility design skeleton**  
+   Priority: **high**  
+   Create the base compatibility module and build wiring for time, sleep, random, filesystem/stdio, HTTP, and networking seams. Keep it Zig 0.15.2-compatible and document how each seam should map to Zig 0.16 `std.Io`. This creates a shared foundation for parallel Phase 0 wrapper PRs.
+
+2. **Add time and sleep wrappers on Zig 0.15.2**  
+   Priority: **high**  
+   Introduce helpers for wall-clock timestamps, monotonic time, and sleeping using the current `std.time` and `std.Thread.sleep` APIs. Migrate only representative low-risk call sites initially. These wrappers become the post-switch location for `std.Io.Timestamp`, `Io.Clock`, `Duration`, and timeout behavior.
+
+3. **Add random and secure-random wrappers on Zig 0.15.2**  
+   Priority: **high**  
+   Add helpers that distinguish security-sensitive entropy from ordinary random bytes. The wrappers should support later migration of PKCE, OAuth state, WebSocket nonce/masks, protocol IDs, and storage temporary names. Include deterministic test seams where practical.
+
+4. **Add filesystem and stdio helper layer on Zig 0.15.2**  
+   Priority: **high**  
+   Add wrappers around cwd/open/read/write/atomic rename, stdin/stdout, and file reader/writer operations. The initial implementation should use 0.15.2 `std.fs`/`std.io` while preserving existing OAuth credential-storage semantics. Include tests for read/write, missing files, directory creation, and atomic replacement.
+
+5. **Add HTTP client/request abstraction on Zig 0.15.2**  
+   Priority: **high**  
+   Define a thin abstraction over provider/OAuth HTTP client creation, request sending, response body reading, and streaming. The goal is to hide Zig 0.16 `std.http.Client{ .io = ... }` and new request-flow changes behind one project API. Validate the shape with a test double or one low-risk HTTP consumer.
+
+6. **Add networking helper layer on Zig 0.15.2**  
+   Priority: **normal**  
+   Create wrappers for TCP connect, address resolution, listen/accept, and stream read/write operations used by WebSocket transport and OAuth callback server. Keep the implementation backed by `std.net` until the compiler switch. Add loopback or unit tests that do not depend on external services.
+
+7. **Add focused regression tests before semantic migration**  
+   Priority: **high**  
+   Expand tests for `EventStream` wait/poll/complete/error behavior, auth refresh locking, OAuth storage atomic writes, WebSocket frame parsing/masking, SSE parsing, and protocol envelope JSON. These tests should run on Zig 0.15.2 and become the safety net for post-switch changes. Avoid external provider E2E tests.
+
+8. **Switch CI/build metadata to Zig 0.16.0 and verify libxev**  
+   Priority: **urgent**  
+   Update `zig/build.zig.zon`, select and hash a Zig 0.16-compatible libxev pin, and update CI Zig versions. Run initial Zig 0.16 build/test steps to prove dependency resolution and collect first-pass compile errors. This is the hard sync point after which remaining work targets Zig 0.16.0 only.
+
+9. **Migrate `std.mem.indexOf*` call sites to `std.mem.find*`**  
+   Priority: **high**  
+   Replace all `std.mem.indexOf`, `indexOfScalar`, `indexOfAny`, and `indexOfPos` usages with the correct Zig 0.16 `find` family. This high-volume mechanical work should be isolated to reduce noise in deeper I/O PRs. Verify exact replacement names against Zig 0.16.0.
+
+10. **Migrate `EventStream` and synchronization primitives**  
+    Priority: **high**  
+    Port `std.Thread.Futex`, `Mutex`, `Condition`, and `ResetEvent` usage to Zig 0.16-compatible `std.Io.*` primitives or suitable equivalents. Start with `EventStream`, then update agent/auth refresh synchronization. Use the regression tests from work item 7 to validate wake, timeout, completion, and error semantics.
+
+11. **Migrate time, sleep, and timestamp call sites through wrappers**  
+    Priority: **high**  
+    Convert remaining direct timestamp and sleep calls to the project wrapper API. Update wrapper implementations to use the chosen Zig 0.16 `std.Io` time primitives. Preserve wall-clock versus monotonic semantics explicitly.
+
+12. **Migrate random and protocol/OAuth ID generation**  
+    Priority: **high**  
+    Update random wrappers to use Zig 0.16 `io.random`, `io.randomSecure`, or `std.Random.IoSource` as appropriate. Migrate PKCE, OAuth state, WebSocket masks/nonces, protocol IDs, and storage temporary names. Treat secure entropy call sites as explicit security review points.
+
+13. **Migrate ArrayList, formatting, custom JSON writer, and std.json drift**  
+    Priority: **high**  
+    Fix container and writer API compile errors after the compiler switch. Convert only compile-confirmed `std.ArrayList` breakages and migrate `std.fmt.format` uses in the custom JSON writer/protocol envelope code. Validate `std.json` parse/stringify APIs through protocol/provider/utils tests.
+
+14. **Migrate filesystem, stdio transport, OAuth storage, and CLI file I/O**  
+    Priority: **high**  
+    Port filesystem and stdio helpers to Zig 0.16 `std.Io.Dir`, `std.Io.File`, and reader/writer APIs. Migrate OAuth storage, stdio transport, and targeted CLI file I/O through the helpers. Preserve atomic credential-storage behavior and current error handling.
+
+15. **Migrate provider HTTP streaming implementations**  
+    Priority: **urgent**  
+    Port Anthropic, OpenAI Completions, OpenAI Responses, Azure OpenAI Responses, Google Generative, Google Vertex, and Ollama providers to the Zig 0.16 HTTP flow. Preserve incremental SSE parsing and cancellation behavior. Use the shared HTTP abstraction rather than separate ad hoc provider implementations.
+
+16. **Migrate OAuth HTTP flows and callback networking**  
+    Priority: **high**  
+    Port GitHub Copilot, Anthropic, Google, and OpenAI Codex OAuth HTTP paths plus callback-server networking to Zig 0.16 APIs. Preserve credential ownership boundaries and response-body limits. Validate with utility/auth tests and mock callback-server tests, not external login E2E.
+
+17. **Migrate WebSocket transport networking**  
+    Priority: **normal**  
+    Port WebSocket connection setup, stream read/write, nonce/mask generation, and network error handling through the networking/random wrappers. Preserve frame parsing and existing transport interfaces. Validate with loopback or mock transport tests.
+
+18. **Run full unit and mock E2E validation on Zig 0.16.0**  
+    Priority: **urgent**  
+    Run all grouped unit test steps plus mock-based protocol E2E on Zig 0.16.0. Stabilize failures and CI timing without adding external provider E2E requirements. This is the acceptance gate for compile/test parity.
+
+19. **Update documentation, migration notes, and cleanup transitional code**  
+    Priority: **normal**  
+    Update developer docs and build instructions to reflect Zig 0.16.0. Remove obsolete Zig 0.15.2-only comments or dead compatibility paths while preserving wrappers that remain useful. Confirm pattern guardrails and CI references are current.
+
+## Dependencies
+
+- Work item 1 is the base for work items 2, 3, 4, 5, and 6.
+- Work item 7 can run in parallel with work items 1-6.
+- Work item 8 depends on work items 1-7, unless the team explicitly accepts reduced pre-switch coverage.
+- Work item 9 depends on work item 8.
+- Work item 10 depends on work items 7 and 8.
+- Work item 11 depends on work items 2 and 8, and may depend on work item 10 if synchronization primitives affect wrapper implementation.
+- Work item 12 depends on work items 3 and 8.
+- Work item 13 depends on work item 8 and can run after or in parallel with work item 9 with conflict coordination.
+- Work item 14 depends on work items 4, 8, 11, and 13.
+- Work item 15 depends on work items 5, 8, 11, 12, and 13.
+- Work item 16 depends on work items 5, 6, 12, and 14.
+- Work item 17 depends on work items 6, 12, and 14.
+- Work item 18 depends on work items 9-17.
+- Work item 19 depends on work item 18.
+
+## Out of scope
+
+- Full evented-I/O redesign of Makai's public APIs.
+- Building or maintaining a libxev-to-`std.Io` adapter.
+- Waiting for upstream libxev `std.Io` support before the initial migration.
+- Adding new providers, transports, OAuth flows, or agent features.
+- External provider E2E stabilization or new secret-dependent tests.
+- Broad performance optimization unrelated to compile/test parity.
+- Changes to GitHub repository rules, admin bypass, or direct local-root modifications beyond instructed sync operations.
+
+## Open questions
+
+1. Which Zig 0.16 `std.Io` backend should Makai use by default for CLI, tests, providers, and networking flows?
+2. Should public APIs accept explicit `std.Io`, or should Makai introduce context objects that own default I/O instances?
+3. Should `EventStream` remain futex/atomic-based after migration, or should a follow-up redesign use higher-level `std.Io` primitives?
+4. Which libxev commit or release should be selected as the Zig 0.16-compatible pin, and what verification is required?
+5. Are downstream users expected to retain Zig 0.15.2 source compatibility after the compiler switch?
+6. Should provider HTTP migration be one large provider PR or split by provider family after the shared abstraction lands?

--- a/plan.md
+++ b/plan.md
@@ -38,9 +38,9 @@ Deliver a concrete, reviewable implementation plan for migrating Makai from Zig 
    Priority: **high**  
    Expand named tests for EventStream completion-after-error, double-completion, timeout, multi-producer stress, and memory ordering; OAuth storage production `saveToFile`, `0o600` mode, same-directory temp rename, and cleanup; WebSocket masking-key XOR and continuation reassembly; SSE 1-byte incremental reads and error-body injection; provider cancellation across pre-request, connect/setup, headers, between events, and mid-event; and retry/time zero-timeout, large-timeout, overflow, and budget exhaustion. These tests must run on Zig 0.15.2 and become the measurable gate before Phase 1 dispatch. Avoid external provider E2E tests.
 
-9. **Switch to a first green Zig 0.16 baseline PR**  
+9. **Switch to a first green Zig 0.16 baseline PR and resolve unused libxev declaration**  
    Priority: **urgent**  
-   Update `zig/build.zig.zon`, select and hash a Zig 0.16-compatible libxev pin, update CI Zig versions, and apply enough compile-restoring source fixes or documented temporary internal stubs for `zig build test-unit-core` and `zig build test-unit-utils` to pass on Zig 0.16 at minimum. This plan chooses a main-branch first green baseline PR rather than an unmerged integration checkpoint; Phase 0 PRs may land on `main` while it still targets 0.15.2, and after this PR merges, follow-up migration work should use short-lived branches targeting Zig 0.16 `main`.
+   Update Zig/CI metadata and resolve the currently declared libxev dependency. A repo scan found `libxev` only in `zig/build.zig.zon` and docs; `zig/build.zig` does not call `b.dependency("libxev", ...)`, and source files do not import `xev`/`libxev`. Prefer removing the unused declaration in Phase 1; only update/pin libxev to a Zig 0.16-compatible commit if the audit identifies an active consumer. Apply enough compile-restoring fixes for `zig build test-unit-core` and `zig build test-unit-utils` to pass on Zig 0.16 at minimum.
 
 10. **Migrate `std.mem.indexOf*` call sites to `std.mem.find*`**  
     Priority: **high**  
@@ -130,6 +130,7 @@ Deliver a concrete, reviewable implementation plan for migrating Makai from Zig 
 - Preserving Zig 0.15.2 source compatibility after Phase 1; public API changes are allowed when documented in migration notes.
 - Building or maintaining a libxev-to-`std.Io` adapter.
 - Waiting for upstream libxev `std.Io` support before the initial migration.
+- Keeping libxev solely because it is declared today; Phase 1 should remove it if the dependency audit confirms it is unused.
 - Adding new providers, transports, OAuth flows, or agent features.
 - External provider E2E stabilization or new secret-dependent tests.
 - Broad performance optimization unrelated to compile/test parity.
@@ -141,12 +142,12 @@ Deliver a concrete, reviewable implementation plan for migrating Makai from Zig 
 |---|---|---:|---|
 | Default `std.Io` backend and ownership model | Binding default set; final backend selection recorded in work item 1 | 1 | Phase 0 wrappers MUST NOT expose `std.Io` in public APIs; public constructors use Makai context/default-I/O patterns, internal helpers may accept explicit handles. |
 | Branch strategy | Decided | 9 | Use main-branch path with a first green Zig 0.16 PR; no long-lived integration branch unless this plan is revised. |
+| libxev dependency posture | Decided pending audit confirmation | 9 | Current scan shows no active source/build usage beyond `build.zig.zon`; prefer removal in Phase 1 unless an active consumer is found. |
 | Zig 0.15.2 source compatibility after Phase 1 | Decided | 9 | Not required after compiler switch; public API changes must be documented in migration notes. |
 | Provider HTTP rollout shape | Decided | 18 | Shared abstraction + one proving provider, then OpenAI/Azure, then Anthropic/Google/Ollama. |
 | Secure randomness enforcement | Decided | 4 | Add/extend `check-zig-patterns.sh` guardrails so secure paths cannot use non-secure entropy directly. |
 
 ## Open questions
 
-1. Which libxev commit or release should be selected as the Zig 0.16-compatible pin, and what verification is required? Earliest blocked work item: **9**.
-2. Does Zig 0.16.0 preserve `std.time.milliTimestamp`/`nanoTimestamp`, or should all usage move immediately to wrapper implementations backed by `std.Io.Timestamp`/`Io.Clock`? Earliest blocked work item: **13**.
-3. Which provider should serve as the proving provider for the shared HTTP abstraction PR? Earliest blocked work item: **18**.
+1. Does Zig 0.16.0 preserve `std.time.milliTimestamp`/`nanoTimestamp`, or should all usage move immediately to wrapper implementations backed by `std.Io.Timestamp`/`Io.Clock`? Earliest blocked work item: **13**.
+2. Which provider should serve as the proving provider for the shared HTTP abstraction PR? Earliest blocked work item: **18**.

--- a/plan.md
+++ b/plan.md
@@ -20,11 +20,11 @@ Deliver a concrete, reviewable implementation plan for migrating Makai from Zig 
 
 4. **Add random and secure-random wrappers on Zig 0.15.2**  
    Priority: **high**  
-   Add helpers that distinguish security-sensitive entropy from ordinary random bytes. The wrappers should support later migration of PKCE, OAuth state, WebSocket nonce/masks, protocol IDs, and storage temporary names. Include deterministic test seams where practical.
+   Add helpers that distinguish security-sensitive entropy from ordinary random bytes. The wrappers should support later migration of PKCE, OAuth state, WebSocket nonce/masks, protocol IDs, and storage temporary names. Add a `scripts/check-zig-patterns.sh` guardrail that prevents direct production `std.crypto.random` use after wrapper adoption and forbids security-sensitive call sites from using non-secure helper names.
 
 5. **Add filesystem and stdio helper layer on Zig 0.15.2**  
    Priority: **high**  
-   Add wrappers around cwd/open/read/write/atomic rename, stdin/stdout, and file reader/writer operations. The initial implementation should use 0.15.2 `std.fs`/`std.io` while preserving existing behavior. Include tests for read/write, missing files, directory creation, and atomic replacement.
+   Add wrappers around cwd/open/read/write/atomic rename, stdin/stdout, and file reader/writer operations. The initial implementation should use 0.15.2 `std.fs`/`std.io` while preserving existing behavior. Atomic replacement acceptance criteria include same-directory temp files for same-filesystem rename, final `0o600` credential-file mode where supported, no truncation before successful rename, and temp-file cleanup on failure where possible.
 
 6. **Add HTTP client/request abstraction on Zig 0.15.2**  
    Priority: **high**  
@@ -36,11 +36,11 @@ Deliver a concrete, reviewable implementation plan for migrating Makai from Zig 
 
 8. **Add focused regression tests before semantic migration**  
    Priority: **high**  
-   Expand tests for core EventStream/stream behavior, auth/OAuth refresh locking, OAuth storage atomic writes, WebSocket frame parsing/masking, SSE parsing, and protocol envelope JSON. These tests should run on Zig 0.15.2 and become the safety net for post-switch changes. Avoid external provider E2E tests.
+   Expand named tests for EventStream completion-after-error, double-completion, timeout, multi-producer stress, and memory ordering; OAuth storage production `saveToFile`, `0o600` mode, same-directory temp rename, and cleanup; WebSocket masking-key XOR and continuation reassembly; SSE 1-byte incremental reads and error-body injection; provider cancellation across pre-request, connect/setup, headers, between events, and mid-event; and retry/time zero-timeout, large-timeout, overflow, and budget exhaustion. These tests must run on Zig 0.15.2 and become the measurable gate before Phase 1 dispatch. Avoid external provider E2E tests.
 
 9. **Switch to a first green Zig 0.16 baseline PR**  
    Priority: **urgent**  
-   Update `zig/build.zig.zon`, select and hash a Zig 0.16-compatible libxev pin, update CI Zig versions, and apply only minimum compile-restoring source fixes needed for the baseline to compile and pass an agreed smoke/unit subset. This plan chooses a first green baseline PR rather than an unmerged integration checkpoint, so downstream migration PRs are based on mergeable Zig 0.16 code. Phase 0 PRs may land on `main` while it still targets 0.15.2; after this PR merges, follow-up migration work should use short-lived branches targeting Zig 0.16 `main` rather than a long-lived feature branch.
+   Update `zig/build.zig.zon`, select and hash a Zig 0.16-compatible libxev pin, update CI Zig versions, and apply enough compile-restoring source fixes or documented temporary internal stubs for `zig build test-unit-core` and `zig build test-unit-utils` to pass on Zig 0.16 at minimum. This plan chooses a main-branch first green baseline PR rather than an unmerged integration checkpoint; Phase 0 PRs may land on `main` while it still targets 0.15.2, and after this PR merges, follow-up migration work should use short-lived branches targeting Zig 0.16 `main`.
 
 10. **Migrate `std.mem.indexOf*` call sites to `std.mem.find*`**  
     Priority: **high**  
@@ -60,7 +60,7 @@ Deliver a concrete, reviewable implementation plan for migrating Makai from Zig 
 
 14. **Migrate random and protocol/OAuth ID generation**  
     Priority: **high**  
-    Update random wrappers to use Zig 0.16 `io.random`, `io.randomSecure`, or `std.Random.IoSource` as appropriate. Migrate PKCE, OAuth state, WebSocket masks/nonces, protocol IDs, and storage temporary names. Treat secure entropy call sites as explicit security review points.
+    Update random wrappers to use Zig 0.16 `io.random`, `io.randomSecure`, or `std.Random.IoSource` as appropriate. Migrate PKCE, OAuth state, WebSocket masks/nonces, protocol IDs, and storage temporary names. Extend the pattern guardrail so production code cannot reintroduce direct `std.crypto.random` usage and security-sensitive paths cannot use `io.random`/non-secure wrappers instead of secure entropy.
 
 15. **Migrate ArrayList, formatting, custom JSON writer, and std.json drift**  
     Priority: **high**  
@@ -76,7 +76,7 @@ Deliver a concrete, reviewable implementation plan for migrating Makai from Zig 
 
 18. **Migrate shared HTTP abstraction and one proving provider**  
     Priority: **urgent**  
-    Port the shared HTTP abstraction to Zig 0.16's `std.Io`-aware request/response flow and migrate exactly one representative streaming provider as the proving provider. The proving provider should exercise request bodies, response head handling, incremental body reads, SSE parsing, cancellation, and provider error-body handling. Preserve existing provider error messages/error types unless a compiler-enforced change is documented; do not migrate all provider families until this PR establishes the abstraction shape.
+    Port the shared HTTP abstraction to Zig 0.16's `std.Io`-aware request/response flow and migrate exactly one representative streaming provider as the proving provider. The proving provider should exercise request bodies, response head handling, incremental body reads, SSE parsing, provider error-body handling, and cancellation during connect/setup, headers, between SSE events, and mid-event payload. Preserve existing provider error messages/error types unless a compiler-enforced change is documented; do not migrate all provider families until this PR establishes the abstraction shape.
 
 19. **Migrate remaining OpenAI/Azure provider HTTP implementations**  
     Priority: **high**  
@@ -135,8 +135,18 @@ Deliver a concrete, reviewable implementation plan for migrating Makai from Zig 
 - Broad performance optimization unrelated to compile/test parity.
 - Changes to GitHub repository rules, admin bypass, or direct local-root modifications beyond instructed sync operations.
 
+## Decision log
+
+| Decision | Status for dispatch | Earliest blocked work item | Notes |
+|---|---|---:|---|
+| Default `std.Io` backend and ownership model | Binding default set; final backend selection recorded in work item 1 | 1 | Phase 0 wrappers MUST NOT expose `std.Io` in public APIs; public constructors use Makai context/default-I/O patterns, internal helpers may accept explicit handles. |
+| Branch strategy | Decided | 9 | Use main-branch path with a first green Zig 0.16 PR; no long-lived integration branch unless this plan is revised. |
+| Zig 0.15.2 source compatibility after Phase 1 | Decided | 9 | Not required after compiler switch; public API changes must be documented in migration notes. |
+| Provider HTTP rollout shape | Decided | 18 | Shared abstraction + one proving provider, then OpenAI/Azure, then Anthropic/Google/Ollama. |
+| Secure randomness enforcement | Decided | 4 | Add/extend `check-zig-patterns.sh` guardrails so secure paths cannot use non-secure entropy directly. |
+
 ## Open questions
 
-1. Which libxev commit or release should be selected as the Zig 0.16-compatible pin, and what verification is required?
-2. Does Zig 0.16.0 preserve `std.time.milliTimestamp`/`nanoTimestamp`, or should all usage move immediately to wrapper implementations backed by `std.Io.Timestamp`/`Io.Clock`?
-3. Which provider should serve as the proving provider for the shared HTTP abstraction PR?
+1. Which libxev commit or release should be selected as the Zig 0.16-compatible pin, and what verification is required? Earliest blocked work item: **9**.
+2. Does Zig 0.16.0 preserve `std.time.milliTimestamp`/`nanoTimestamp`, or should all usage move immediately to wrapper implementations backed by `std.Io.Timestamp`/`Io.Clock`? Earliest blocked work item: **13**.
+3. Which provider should serve as the proving provider for the shared HTTP abstraction PR? Earliest blocked work item: **18**.

--- a/plan.md
+++ b/plan.md
@@ -20,7 +20,7 @@ Deliver a concrete, reviewable implementation plan for migrating Makai from Zig 
 
 4. **Add random and secure-random wrappers on Zig 0.15.2**  
    Priority: **high**  
-   Add helpers that distinguish security-sensitive entropy from ordinary random bytes. The wrappers should support later migration of PKCE, OAuth state, WebSocket nonce/masks, protocol IDs, and storage temporary names. Phase 0 may add non-failing inventory/reporting for direct `std.crypto.random` usage, but must not make `check-zig-patterns.sh` fail until the bulk call-site migration in work item 14.
+   Add helpers that distinguish security-sensitive entropy from ordinary random bytes. The wrappers should support later migration of both PKCE modules (`zig/src/oauth/pkce.zig` and `zig/src/utils/oauth/pkce.zig`), OAuth state, WebSocket nonce/masks, protocol IDs, and storage temporary names. Phase 0 may add non-failing inventory/reporting for direct `std.crypto.random` usage, but must not make `check-zig-patterns.sh` fail until the bulk call-site migration in work item 14.
 
 5. **Add filesystem and stdio helper layer on Zig 0.15.2**  
    Priority: **high**  
@@ -56,11 +56,11 @@ Deliver a concrete, reviewable implementation plan for migrating Makai from Zig 
 
 13. **Migrate time, sleep, and timestamp call sites through wrappers**  
     Priority: **high**  
-    Convert remaining direct timestamp and sleep calls to the project wrapper API. Update wrapper implementations to use the chosen Zig 0.16 `std.Io` time primitives. Preserve wall-clock versus monotonic semantics explicitly.
+    Convert remaining direct timestamp and sleep calls to the project wrapper API. Update wrapper implementations to use the chosen Zig 0.16 `std.Io` time primitives. Preserve wall-clock versus monotonic semantics explicitly and verify OAuth token-expiry arithmetic remains identical on Zig 0.16 for representative and boundary inputs.
 
 14. **Migrate random and protocol/OAuth ID generation**  
     Priority: **high**  
-    Update random wrappers to use Zig 0.16 `io.random`, `io.randomSecure`, or `std.Random.IoSource` as appropriate. Migrate PKCE, OAuth state, WebSocket masks/nonces, protocol IDs, and storage temporary names. After these call sites migrate, enable the failing pattern guardrail so production code cannot reintroduce direct `std.crypto.random` usage and security-sensitive paths cannot use `io.random`/non-secure wrappers instead of secure entropy.
+    Update random wrappers to use Zig 0.16 `io.random`, `io.randomSecure`, or `std.Random.IoSource` as appropriate. Migrate both PKCE modules (`zig/src/oauth/pkce.zig:14` and `zig/src/utils/oauth/pkce.zig:19`), OAuth state, WebSocket masks/nonces, protocol IDs, and storage temporary names; deduplicate PKCE helper logic or document why both paths remain separate while sharing secure entropy. After these call sites migrate, enable the failing pattern guardrail so production code cannot reintroduce direct `std.crypto.random` usage and security-sensitive paths cannot use `io.random`/non-secure wrappers instead of secure entropy.
 
 15. **Migrate ArrayList, formatting, custom JSON writer, and std.json drift**  
     Priority: **high**  
@@ -68,7 +68,7 @@ Deliver a concrete, reviewable implementation plan for migrating Makai from Zig 
 
 16. **Migrate OAuth credential storage filesystem operations**  
     Priority: **high**  
-    Port OAuth credential storage to Zig 0.16 filesystem helpers as its own user-data-focused PR. Preserve atomic replacement, directory creation, missing-file behavior, permissions expectations, rollback/backup safety, and existing storage error messages/error types unless a compiler-enforced change is documented. Keep stdio transport and CLI file I/O out of this PR.
+    Port OAuth credential storage to Zig 0.16 filesystem helpers as its own user-data-focused PR. Preserve atomic replacement, directory creation, missing-file behavior, permissions expectations, rollback/backup safety, startup cleanup of stale orphaned `.tmp.*` files where safe, and existing storage error messages/error types unless a compiler-enforced change is documented. Address credential memory zeroing for `Credentials.deinit()` and `ProviderAuth.deinit()` if practical while touching storage; otherwise file a named security-debt follow-up documenting that sensitive slices are still freed without zeroing.
 
 17. **Migrate stdio transport and CLI file I/O**  
     Priority: **high**  
@@ -76,7 +76,7 @@ Deliver a concrete, reviewable implementation plan for migrating Makai from Zig 
 
 18. **Migrate shared HTTP abstraction and one proving provider**  
     Priority: **urgent**  
-    Port the shared HTTP abstraction to Zig 0.16's `std.Io`-aware request/response flow and migrate exactly one representative streaming provider as the proving provider. The proving provider should exercise request bodies, response head handling, incremental body reads, SSE parsing, provider error-body handling, and cancellation during connect/setup, headers, between SSE events, and mid-event payload. Preserve existing provider error messages/error types unless a compiler-enforced change is documented; do not migrate all provider families until this PR establishes the abstraction shape.
+    Port the shared HTTP abstraction to Zig 0.16's `std.Io`-aware request/response flow and migrate exactly one representative streaming provider as the proving provider. The proving provider should exercise request bodies, response head handling, incremental body reads, SSE parsing, provider error-body handling, and cancellation during connect/setup, headers, between SSE events, and mid-event payload. Preserve auth-header construction/forwarding semantics for API keys, bearer tokens, OAuth tokens, and provider-specific headers, and preserve existing provider error messages/error types unless a compiler-enforced change is documented.
 
 19. **Migrate remaining OpenAI/Azure provider HTTP implementations**  
     Priority: **high**  
@@ -92,7 +92,7 @@ Deliver a concrete, reviewable implementation plan for migrating Makai from Zig 
 
 22. **Migrate WebSocket transport networking**  
     Priority: **normal**  
-    Port WebSocket connection setup, stream read/write, nonce/mask generation, and network error handling through the networking/random wrappers. Preserve frame parsing and existing transport interfaces. Validate with loopback or mock transport tests.
+    Port WebSocket connection setup, stream read/write, nonce/mask generation, and network error handling through the networking/random wrappers. Preserve frame parsing and existing transport interfaces. Add or explicitly defer full `Sec-WebSocket-Accept` value verification, since current behavior only checks header existence, and document that `wss://` TLS remains unsupported post-migration unless the PR adds TLS support.
 
 23. **Run full unit and mock E2E validation on Zig 0.16.0**  
     Priority: **urgent**  
@@ -145,7 +145,8 @@ Deliver a concrete, reviewable implementation plan for migrating Makai from Zig 
 | libxev dependency posture | Decided | 9 | Remove libxev in Phase 1; current scan shows no active source/build usage beyond `build.zig.zon`. |
 | Zig 0.15.2 source compatibility after Phase 1 | Decided | 9 | Not required after compiler switch; public API changes must be documented in migration notes. |
 | Provider HTTP rollout shape | Decided | 18 | Shared abstraction + one proving provider, then OpenAI/Azure, then Anthropic/Google/Ollama. |
-| Secure randomness enforcement | Decided | 14 | Phase 0 may add non-failing inventory only; enable failing `check-zig-patterns.sh` guardrails after random call sites migrate in work item 14. |
+| Secure randomness enforcement | Decided | 14 | Phase 0 may add non-failing inventory only; enable failing `check-zig-patterns.sh` guardrails after random call sites migrate in work item 14. Both PKCE modules must migrate to secure entropy. |
+| Credential memory zeroing | Known security debt; address or explicitly defer | 16 | `Credentials.deinit()` and `ProviderAuth.deinit()` currently free sensitive slices without zeroing; work item 16 must either fix this while touching storage or file a named follow-up. |
 
 ## Open questions
 

--- a/plan.md
+++ b/plan.md
@@ -20,7 +20,7 @@ Deliver a concrete, reviewable implementation plan for migrating Makai from Zig 
 
 4. **Add random and secure-random wrappers on Zig 0.15.2**  
    Priority: **high**  
-   Add helpers that distinguish security-sensitive entropy from ordinary random bytes. The wrappers should support later migration of PKCE, OAuth state, WebSocket nonce/masks, protocol IDs, and storage temporary names. Add a `scripts/check-zig-patterns.sh` guardrail that prevents direct production `std.crypto.random` use after wrapper adoption and forbids security-sensitive call sites from using non-secure helper names.
+   Add helpers that distinguish security-sensitive entropy from ordinary random bytes. The wrappers should support later migration of PKCE, OAuth state, WebSocket nonce/masks, protocol IDs, and storage temporary names. Phase 0 may add non-failing inventory/reporting for direct `std.crypto.random` usage, but must not make `check-zig-patterns.sh` fail until the bulk call-site migration in work item 14.
 
 5. **Add filesystem and stdio helper layer on Zig 0.15.2**  
    Priority: **high**  
@@ -40,7 +40,7 @@ Deliver a concrete, reviewable implementation plan for migrating Makai from Zig 
 
 9. **Switch to a first green Zig 0.16 baseline PR and remove libxev**  
    Priority: **urgent**  
-   Update Zig/CI metadata and remove the currently declared libxev dependency. A repo scan found `libxev` only in `zig/build.zig.zon` and docs; `zig/build.zig` does not call `b.dependency("libxev", ...)`, and source files do not import `xev`/`libxev`. Phase 1 must remove the unused declaration rather than update/pin it. Apply enough compile-restoring fixes for `zig build test-unit-core` and `zig build test-unit-utils` to pass on Zig 0.16 at minimum.
+   Update Zig/CI metadata and remove the currently declared libxev dependency. A repo scan found `libxev` only in `zig/build.zig.zon` and docs; `zig/build.zig` does not call `b.dependency("libxev", ...)`, and source files do not import `xev`/`libxev`. Phase 1 must remove the unused declaration rather than update/pin it. Apply enough compile-restoring fixes for all required PR CI jobs to pass, including the current unit-test matrix and TS SDK E2E; include `test-unit-makai-cli` too if CI adds it.
 
 10. **Migrate `std.mem.indexOf*` call sites to `std.mem.find*`**  
     Priority: **high**  
@@ -60,7 +60,7 @@ Deliver a concrete, reviewable implementation plan for migrating Makai from Zig 
 
 14. **Migrate random and protocol/OAuth ID generation**  
     Priority: **high**  
-    Update random wrappers to use Zig 0.16 `io.random`, `io.randomSecure`, or `std.Random.IoSource` as appropriate. Migrate PKCE, OAuth state, WebSocket masks/nonces, protocol IDs, and storage temporary names. Extend the pattern guardrail so production code cannot reintroduce direct `std.crypto.random` usage and security-sensitive paths cannot use `io.random`/non-secure wrappers instead of secure entropy.
+    Update random wrappers to use Zig 0.16 `io.random`, `io.randomSecure`, or `std.Random.IoSource` as appropriate. Migrate PKCE, OAuth state, WebSocket masks/nonces, protocol IDs, and storage temporary names. After these call sites migrate, enable the failing pattern guardrail so production code cannot reintroduce direct `std.crypto.random` usage and security-sensitive paths cannot use `io.random`/non-secure wrappers instead of secure entropy.
 
 15. **Migrate ArrayList, formatting, custom JSON writer, and std.json drift**  
     Priority: **high**  
@@ -96,7 +96,7 @@ Deliver a concrete, reviewable implementation plan for migrating Makai from Zig 
 
 23. **Run full unit and mock E2E validation on Zig 0.16.0**  
     Priority: **urgent**  
-    Run all grouped unit test steps plus mock-based protocol E2E on Zig 0.16.0. Stabilize failures and CI timing without adding external provider E2E requirements. Validate CLI output formatting, exit codes, and auth-flow prompts as part of the acceptance gate for compile/test parity.
+    Run all grouped unit test steps, including `test-unit-makai-cli`, plus mock-based protocol E2E on Zig 0.16.0. Run required CI-level TS SDK validation if still required by PR CI. Stabilize failures and CI timing without adding external provider E2E requirements, and validate CLI output formatting, exit codes, and auth-flow prompts as part of the acceptance gate for compile/test parity.
 
 24. **Update documentation, migration notes, and cleanup transitional code**  
     Priority: **normal**  
@@ -145,7 +145,7 @@ Deliver a concrete, reviewable implementation plan for migrating Makai from Zig 
 | libxev dependency posture | Decided | 9 | Remove libxev in Phase 1; current scan shows no active source/build usage beyond `build.zig.zon`. |
 | Zig 0.15.2 source compatibility after Phase 1 | Decided | 9 | Not required after compiler switch; public API changes must be documented in migration notes. |
 | Provider HTTP rollout shape | Decided | 18 | Shared abstraction + one proving provider, then OpenAI/Azure, then Anthropic/Google/Ollama. |
-| Secure randomness enforcement | Decided | 4 | Add/extend `check-zig-patterns.sh` guardrails so secure paths cannot use non-secure entropy directly. |
+| Secure randomness enforcement | Decided | 14 | Phase 0 may add non-failing inventory only; enable failing `check-zig-patterns.sh` guardrails after random call sites migrate in work item 14. |
 
 ## Open questions
 


### PR DESCRIPTION
## Summary
- Add `docs/zig-0.16.0-migration-plan.md` with a phased Zig 0.15.2 → 0.16.0 migration strategy.
- Decompose the migration into single-PR implementation tasks with priorities and dependency ordering.
- Include risk mitigations, rollback strategy, out-of-scope items, and open questions for dispatch/review.

## Test plan
- [x] Documentation-only planning change; no code tests required.
- [x] Read approved impact assessment before drafting the plan.