### PR TITLE
Add Zig I/O compatibility skeleton

### DIFF
--- a/docs/zig-0.16.0-time-sleep-migration-inventory.md
+++ b/docs/zig-0.16.0-time-sleep-migration-inventory.md
@@ -1,0 +1,111 @@
+# Phase 2 Time / Sleep Migration Inventory
+
+This inventory captures every direct call to `std.time.*` and `std.Thread.sleep` in
+`zig/src/` as of Phase 0 work item 3. Phase 0 introduced the wrappers in
+`zig/src/compat/time.zig` (`nowMillis`, `nowSeconds`, `nowNanos`, `monotonicNanos`,
+`sleepNs`, `sleepMs`) and migrated two representative low-risk call sites
+(`zig/src/utils/retry.zig`, `zig/src/protocol/provider/types.zig`).
+
+The remaining call sites listed here are deferred to Phase 2 work item 13
+("Migrate time, sleep, and timestamp call sites through wrappers"). Each
+remaining site must be ported either to the existing wrappers or to a
+follow-up wrapper added in the same PR. After migration, the goal is for the
+only direct `std.time.*` / `std.Thread.sleep` references in `zig/src/` to live
+inside `zig/src/compat/time.zig` itself.
+
+## Summary
+
+- 277 remaining `std.time.{timestamp,milliTimestamp,nanoTimestamp,Timer,Instant}`
+  occurrences across 36 files (excluding the wrapper module itself).
+- 26 remaining `std.Thread.sleep` occurrences across 11 files (excluding the
+  wrapper module itself).
+
+The full breakdown is below. Counts were produced via ripgrep on the
+`add-time-and-sleep-wrappers-on-0-15-2-phase-0-item-3` branch.
+
+## `std.time.{timestamp,milliTimestamp,nanoTimestamp,Timer,Instant}` call sites
+
+### Streaming core
+- `zig/src/event_stream.zig` (2)
+- `zig/src/agent/types.zig` (1)
+- `zig/src/agent/agent.zig` (2)
+- `zig/src/agent/agent_loop.zig` (4)
+- `zig/src/agent/provider_protocol_bridge.zig` (5)
+
+### Protocol layer
+- `zig/src/protocol/provider/server.zig` (62)
+- `zig/src/protocol/provider/client.zig` (26)
+- `zig/src/protocol/provider/envelope.zig` (22)
+- `zig/src/protocol/provider/runtime.zig` (3)
+- `zig/src/protocol/agent/server.zig` (22)
+- `zig/src/protocol/agent/client.zig` (7)
+- `zig/src/protocol/agent/envelope.zig` (5)
+- `zig/src/protocol/auth/server.zig` (15)
+- `zig/src/protocol/auth/envelope.zig` (1)
+- `zig/src/protocol/tool/runtime.zig` (4)
+- `zig/src/protocol/tool/envelope.zig` (2)
+
+### Providers
+- `zig/src/providers/openai_completions_api.zig` (15)
+- `zig/src/providers/openai_responses_api.zig` (12)
+- `zig/src/providers/azure_openai_responses_api.zig` (2)
+- `zig/src/providers/anthropic_messages_api.zig` (3)
+- `zig/src/providers/google_generative_api.zig` (4)
+- `zig/src/providers/google_vertex_api.zig` (4)
+- `zig/src/providers/ollama_api.zig` (5)
+
+### OAuth and auth
+- `zig/src/oauth/mod.zig` (2)
+- `zig/src/oauth/github_copilot.zig` (4)
+- `zig/src/utils/oauth/anthropic.zig` (4)
+- `zig/src/utils/oauth/google.zig` (3)
+- `zig/src/utils/oauth/github_copilot.zig` (5)
+- `zig/src/utils/oauth/storage.zig` (4)
+- `zig/src/utils/oauth/callback_server.zig` (2)
+- `zig/src/utils/oauth/refresh_lock.zig` (4)
+- `zig/src/utils/auth_resolver.zig` (1)
+
+### Utilities and tools
+- `zig/src/utils/aws_sigv4.zig` (1)
+- `zig/src/utils/pre_transform.zig` (1)
+- `zig/src/tools/auth_cli.zig` (3)
+- `zig/src/tools/makai.zig` (8)
+
+## `std.Thread.sleep` call sites
+
+- `zig/src/event_stream.zig` (1)
+- `zig/src/agent/provider_protocol_bridge.zig` (2)
+- `zig/src/protocol/provider/client.zig` (1)
+- `zig/src/protocol/provider/server.zig` (1)
+- `zig/src/transports/in_process.zig` (1)
+- `zig/src/transports/stdio.zig` (1)
+- `zig/src/utils/oauth/refresh_lock.zig` (6)
+- `zig/src/utils/oauth/github_copilot.zig` (2)
+- `zig/src/utils/oauth/callback_server.zig` (1)
+- `zig/src/tools/auth_cli.zig` (2)
+- `zig/src/tools/makai.zig` (8)
+
+## Migration guidance for Phase 2 work item 13
+
+- Wall-clock millisecond timestamps → `compat.time.nowMillis()`.
+- Wall-clock second timestamps → `compat.time.nowSeconds()`.
+- Wall-clock nanosecond timestamps → `compat.time.nowNanos()`.
+- Monotonic durations / deadlines → `compat.time.monotonicNanos()` (do not
+  reuse the wall-clock helpers for elapsed-duration math).
+- Direct nanosecond sleeps → `compat.time.sleepNs(ns)`.
+- Millisecond sleeps → `compat.time.sleepMs(ms)`. The convenience helper
+  saturates to `std.math.maxInt(u64)` instead of overflowing on absurd inputs.
+- Cancellable polling sleeps that already exist (e.g.
+  `zig/src/utils/retry.zig:sleepMs(ms, cancel_token)`) should keep their own
+  shape but call into `compat.time.sleepNs` internally; do **not** reintroduce
+  direct `std.Thread.sleep` once a wrapper is available.
+- `std.time.Timer.start()` and `std.time.Instant.now()` usages should be
+  reviewed individually: most can switch to `compat.time.monotonicNanos()`,
+  but a few keep their own `std.time.Timer` for elapsed-duration math local
+  to a function and may simply gain a `// 0.16: route through default I/O
+  context` comment instead.
+
+After Phase 2 work item 13 lands, the only `std.time.*` and `std.Thread.sleep`
+references in `zig/src/` should live inside `zig/src/compat/time.zig`. A grep
+guardrail for that invariant can be added to `scripts/check-zig-patterns.sh`
+in the same PR.

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -55,6 +55,12 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
 
+    const compat_mod = b.createModule(.{
+        .root_source_file = b.path("src/compat/mod.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
     const streaming_json_mod = b.createModule(.{
         .root_source_file = b.path("src/streaming_json.zig"),
         .target = target,
@@ -726,6 +732,7 @@ pub fn build(b: *std.Build) void {
     const owned_slice_test = b.addTest(.{ .root_module = owned_slice_mod });
     const string_builder_test = b.addTest(.{ .root_module = string_builder_mod });
     const hive_array_test = b.addTest(.{ .root_module = hive_array_mod });
+    const compat_test = b.addTest(.{ .root_module = compat_mod });
 
     const event_stream_test = b.addTest(.{ .root_module = event_stream_mod });
 
@@ -1134,6 +1141,7 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(&b.addRunArtifact(owned_slice_test).step);
     test_step.dependOn(&b.addRunArtifact(string_builder_test).step);
     test_step.dependOn(&b.addRunArtifact(hive_array_test).step);
+    test_step.dependOn(&b.addRunArtifact(compat_test).step);
     test_step.dependOn(&b.addRunArtifact(event_stream_test).step);
     test_step.dependOn(&b.addRunArtifact(streaming_json_test).step);
     test_step.dependOn(&b.addRunArtifact(ai_types_test).step);
@@ -1204,6 +1212,7 @@ pub fn build(b: *std.Build) void {
     test_unit_core_step.dependOn(&b.addRunArtifact(owned_slice_test).step);
     test_unit_core_step.dependOn(&b.addRunArtifact(string_builder_test).step);
     test_unit_core_step.dependOn(&b.addRunArtifact(hive_array_test).step);
+    test_unit_core_step.dependOn(&b.addRunArtifact(compat_test).step);
 
     const test_unit_transport_step = b.step("test-unit-transport", "Run transport layer unit tests");
     test_unit_transport_step.dependOn(&b.addRunArtifact(transport_test).step);

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -160,6 +160,9 @@ pub fn build(b: *std.Build) void {
         .root_source_file = b.path("src/utils/retry.zig"),
         .target = target,
         .optimize = optimize,
+        .imports = &.{
+            .{ .name = "compat", .module = compat_mod },
+        },
     });
 
     const oom_mod = b.createModule(.{
@@ -449,6 +452,7 @@ pub fn build(b: *std.Build) void {
             .{ .name = "ai_types", .module = ai_types_mod },
             .{ .name = "owned_slice", .module = owned_slice_mod },
             .{ .name = "model_catalog_types", .module = protocol_model_catalog_types_mod },
+            .{ .name = "compat", .module = compat_mod },
         },
     });
 

--- a/zig/src/agent/provider_protocol_bridge.zig
+++ b/zig/src/agent/provider_protocol_bridge.zig
@@ -81,9 +81,15 @@ fn streamViaProtocol(
     return out_stream;
 }
 
-fn pushEventBlocking(stream: *event_stream.AssistantMessageEventStream, ev: ai_types.AssistantMessageEvent) !void {
+fn pushEventBlocking(allocator: std.mem.Allocator, stream: *event_stream.AssistantMessageEventStream, ev: ai_types.AssistantMessageEvent) !void {
+    const cloned = try ai_types.cloneAssistantMessageEvent(allocator, ev);
+    errdefer {
+        var cleanup = cloned;
+        ai_types.deinitAssistantMessageEvent(allocator, &cleanup);
+    }
+
     while (true) {
-        stream.push(ev) catch |err| switch (err) {
+        stream.push(cloned) catch |err| switch (err) {
             error.QueueFull => {
                 std.Thread.sleep(1 * std.time.ns_per_ms);
                 continue;
@@ -94,9 +100,9 @@ fn pushEventBlocking(stream: *event_stream.AssistantMessageEventStream, ev: ai_t
     }
 }
 
-fn drainClientEvents(client: *ProtocolClient, out_stream: *event_stream.AssistantMessageEventStream) !void {
+fn drainClientEvents(client: *ProtocolClient, out_stream: *event_stream.AssistantMessageEventStream, allocator: std.mem.Allocator) !void {
     while (client.getEventStream().poll()) |ev| {
-        try pushEventBlocking(out_stream, ev);
+        try pushEventBlocking(allocator, out_stream, ev);
     }
 }
 
@@ -151,7 +157,7 @@ fn runStreamThread(ctx: *StreamThreadContext) void {
             return;
         };
 
-        drainClientEvents(&client, ctx.out_stream) catch |err| {
+        drainClientEvents(&client, ctx.out_stream, ctx.allocator) catch |err| {
             ctx.out_stream.completeWithError(@errorName(err));
             return;
         };
@@ -166,7 +172,7 @@ fn runStreamThread(ctx: *StreamThreadContext) void {
 
     // Final drain after completion.
     _ = runtime.pumpOnce(&client) catch {};
-    drainClientEvents(&client, ctx.out_stream) catch |err| {
+    drainClientEvents(&client, ctx.out_stream, ctx.allocator) catch |err| {
         ctx.out_stream.completeWithError(@errorName(err));
         return;
     };

--- a/zig/src/agent/provider_protocol_bridge.zig
+++ b/zig/src/agent/provider_protocol_bridge.zig
@@ -102,6 +102,8 @@ fn pushEventBlocking(allocator: std.mem.Allocator, stream: *event_stream.Assista
 
 fn drainClientEvents(client: *ProtocolClient, out_stream: *event_stream.AssistantMessageEventStream, allocator: std.mem.Allocator) !void {
     while (client.getEventStream().poll()) |ev| {
+        var owned_ev = ev;
+        defer ai_types.deinitAssistantMessageEvent(allocator, &owned_ev);
         try pushEventBlocking(allocator, out_stream, ev);
     }
 }

--- a/zig/src/compat/fs.zig
+++ b/zig/src/compat/fs.zig
@@ -29,9 +29,15 @@ pub fn readFileAlloc(allocator: std.mem.Allocator, dir: std.fs.Dir, path: []cons
     return dir.readFileAlloc(allocator, path, max_bytes);
 }
 
+pub const default_file_mode: std.fs.File.Mode = 0o600;
+
 /// Write a file relative to `dir`, replacing existing contents.
+///
+/// Files are created with restrictive permissions by default because later OAuth
+/// storage migration work may use this wrapper for credential material. Existing
+/// files keep their current mode when opened with truncation on POSIX systems.
 pub fn writeFile(dir: std.fs.Dir, path: []const u8, data: []const u8) !void {
-    var file = try dir.createFile(path, .{ .truncate = true });
+    var file = try dir.createFile(path, .{ .truncate = true, .mode = default_file_mode });
     defer file.close();
     try file.writeAll(data);
 }
@@ -50,6 +56,10 @@ pub fn atomicReplace(dir: std.fs.Dir, target_path: []const u8, tmp_path: []const
     try writeFile(dir, tmp_path, data);
     try dir.rename(tmp_path, target_path);
     cleanup_tmp = false;
+
+    var replaced = try dir.openFile(target_path, .{ .mode = .write_only });
+    defer replaced.close();
+    try replaced.chmod(default_file_mode);
 }
 
 /// Create a directory and any missing parents relative to `dir`.

--- a/zig/src/compat/fs.zig
+++ b/zig/src/compat/fs.zig
@@ -31,6 +31,12 @@ pub fn readFileAlloc(allocator: std.mem.Allocator, dir: std.fs.Dir, path: []cons
 
 pub const default_file_mode: std.fs.File.Mode = 0o600;
 
+fn chmodFile(dir: std.fs.Dir, path: []const u8, mode: std.fs.File.Mode) !void {
+    var file = try dir.openFile(path, .{ .mode = .write_only });
+    defer file.close();
+    try file.chmod(mode);
+}
+
 /// Write a file relative to `dir`, replacing existing contents.
 ///
 /// Files are created with restrictive permissions by default because later OAuth
@@ -52,10 +58,16 @@ pub fn writeFile(dir: std.fs.Dir, path: []const u8, data: []const u8) !void {
 pub fn atomicReplace(dir: std.fs.Dir, target_path: []const u8, tmp_path: []const u8, data: []const u8) !void {
     if (std.mem.eql(u8, target_path, tmp_path)) return error.InvalidAtomicReplacePaths;
 
+    const target_mode = if (dir.statFile(target_path)) |stat| stat.mode else |err| switch (err) {
+        error.FileNotFound => null,
+        else => return err,
+    };
+
     var cleanup_tmp = true;
     defer if (cleanup_tmp) dir.deleteFile(tmp_path) catch {};
 
     try writeFile(dir, tmp_path, data);
+    if (target_mode) |mode| try chmodFile(dir, tmp_path, mode);
     try dir.rename(tmp_path, target_path);
     cleanup_tmp = false;
 }
@@ -80,6 +92,19 @@ test "compat filesystem wrappers read write and atomically replace" {
     try std.testing.expectEqualStrings("two", replaced);
 
     try std.testing.expectError(error.FileNotFound, tmp.dir.openFile("compat.txt.tmp", .{}));
+}
+
+test "compat atomic replace preserves existing target mode" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeFile(tmp.dir, "mode.txt", "one");
+    try chmodFile(tmp.dir, "mode.txt", 0o640);
+
+    try atomicReplace(tmp.dir, "mode.txt", "mode.txt.tmp", "two");
+
+    const stat = try tmp.dir.statFile("mode.txt");
+    try std.testing.expectEqual(@as(std.fs.File.Mode, 0o640), stat.mode & 0o777);
 }
 
 test "compat filesystem wrappers create directories and open files" {

--- a/zig/src/compat/fs.zig
+++ b/zig/src/compat/fs.zig
@@ -57,8 +57,8 @@ pub fn atomicReplace(dir: std.fs.Dir, target_path: []const u8, tmp_path: []const
 
     var file = try dir.createFile(tmp_path, .{ .truncate = false, .exclusive = true, .mode = default_file_mode });
     cleanup_tmp = true;
-    defer file.close();
     try file.writeAll(data);
+    file.close();
 
     try dir.rename(tmp_path, target_path);
     cleanup_tmp = false;

--- a/zig/src/compat/fs.zig
+++ b/zig/src/compat/fs.zig
@@ -1,0 +1,95 @@
+const std = @import("std");
+
+pub const OpenFlags = std.fs.File.OpenFlags;
+pub const CreateFlags = std.fs.File.CreateFlags;
+pub const File = std.fs.File;
+
+/// Return the process current working directory handle.
+///
+/// Zig 0.16 mapping: this remains the stable wrapper for cwd access. Internal
+/// implementation may borrow the Makai default I/O context, but public callers
+/// should not receive or pass raw `std.Io` handles.
+pub fn getCwd() std.fs.Dir {
+    return std.fs.cwd();
+}
+
+/// Open a file relative to `dir`.
+///
+/// Parameter order follows the migration convention: I/O handle (`dir`) first
+/// for handle-scoped operations, then operation-specific parameters.
+pub fn openFile(dir: std.fs.Dir, path: []const u8, flags: OpenFlags) !File {
+    return dir.openFile(path, flags);
+}
+
+/// Read a file relative to `dir` into an allocated buffer.
+///
+/// Zig 0.16 mapping: preserve allocation ownership and error behavior while
+/// routing file reads through the Makai filesystem wrapper internals.
+pub fn readFileAlloc(allocator: std.mem.Allocator, dir: std.fs.Dir, path: []const u8, max_bytes: usize) ![]u8 {
+    return dir.readFileAlloc(allocator, path, max_bytes);
+}
+
+/// Write a file relative to `dir`, replacing existing contents.
+pub fn writeFile(dir: std.fs.Dir, path: []const u8, data: []const u8) !void {
+    var file = try dir.createFile(path, .{ .truncate = true });
+    defer file.close();
+    try file.writeAll(data);
+}
+
+/// Atomically replace `target_path` by writing `data` to `tmp_path` in `dir` and
+/// renaming it over the target.
+///
+/// Zig 0.16 mapping: keep the same-directory temporary-file boundary so later
+/// OAuth storage work can preserve same-filesystem rename guarantees and file
+/// mode expectations. This skeleton is intentionally thin; crash-safety policy
+/// hardening belongs to the dedicated filesystem wrapper PR.
+pub fn atomicReplace(dir: std.fs.Dir, target_path: []const u8, tmp_path: []const u8, data: []const u8) !void {
+    var cleanup_tmp = true;
+    defer if (cleanup_tmp) dir.deleteFile(tmp_path) catch {};
+
+    try writeFile(dir, tmp_path, data);
+    try dir.rename(tmp_path, target_path);
+    cleanup_tmp = false;
+}
+
+/// Create a directory and any missing parents relative to `dir`.
+pub fn createDir(dir: std.fs.Dir, path: []const u8) !void {
+    try dir.makePath(path);
+}
+
+test "compat filesystem wrappers read write and atomically replace" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeFile(tmp.dir, "compat.txt", "one");
+    const initial = try readFileAlloc(std.testing.allocator, tmp.dir, "compat.txt", 1024);
+    defer std.testing.allocator.free(initial);
+    try std.testing.expectEqualStrings("one", initial);
+
+    try atomicReplace(tmp.dir, "compat.txt", "compat.txt.tmp", "two");
+    const replaced = try readFileAlloc(std.testing.allocator, tmp.dir, "compat.txt", 1024);
+    defer std.testing.allocator.free(replaced);
+    try std.testing.expectEqualStrings("two", replaced);
+
+    try std.testing.expectError(error.FileNotFound, tmp.dir.openFile("compat.txt.tmp", .{}));
+}
+
+test "compat filesystem wrappers create directories and open files" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try createDir(tmp.dir, "nested/path");
+    try writeFile(tmp.dir, "nested/path/file.txt", "data");
+
+    var file = try openFile(tmp.dir, "nested/path/file.txt", .{});
+    defer file.close();
+
+    var buf: [4]u8 = undefined;
+    const n = try file.readAll(&buf);
+    try std.testing.expectEqualStrings("data", buf[0..n]);
+}
+
+test "compat getCwd returns a directory handle" {
+    const cwd = getCwd();
+    _ = cwd;
+}

--- a/zig/src/compat/fs.zig
+++ b/zig/src/compat/fs.zig
@@ -52,13 +52,20 @@ pub fn writeFile(dir: std.fs.Dir, path: []const u8, data: []const u8) !void {
 pub fn atomicReplace(dir: std.fs.Dir, target_path: []const u8, tmp_path: []const u8, data: []const u8) !void {
     if (std.mem.eql(u8, target_path, tmp_path)) return error.InvalidAtomicReplacePaths;
 
+    dir.deleteFile(tmp_path) catch |err| switch (err) {
+        error.FileNotFound => {},
+        else => return err,
+    };
+
     var cleanup_tmp = false;
     defer if (cleanup_tmp) dir.deleteFile(tmp_path) catch {};
 
-    var file = try dir.createFile(tmp_path, .{ .truncate = false, .exclusive = true, .mode = default_file_mode });
-    cleanup_tmp = true;
-    try file.writeAll(data);
-    file.close();
+    {
+        var file = try dir.createFile(tmp_path, .{ .truncate = false, .exclusive = true, .mode = default_file_mode });
+        cleanup_tmp = true;
+        defer file.close();
+        try file.writeAll(data);
+    }
 
     try dir.rename(tmp_path, target_path);
     cleanup_tmp = false;
@@ -103,22 +110,20 @@ test "compat atomic replace re-hardens existing target mode" {
     try std.testing.expectEqual(@as(std.fs.File.Mode, default_file_mode), stat.mode & 0o777);
 }
 
-test "compat atomic replace requires a fresh temporary path" {
+test "compat atomic replace recovers from a stale temporary path" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
     try writeFile(tmp.dir, "target.txt", "target");
     try writeFile(tmp.dir, "target.txt.tmp", "stale");
 
-    try std.testing.expectError(error.PathAlreadyExists, atomicReplace(tmp.dir, "target.txt", "target.txt.tmp", "new"));
+    try atomicReplace(tmp.dir, "target.txt", "target.txt.tmp", "new");
 
     const target = try readFileAlloc(std.testing.allocator, tmp.dir, "target.txt", 1024);
     defer std.testing.allocator.free(target);
-    try std.testing.expectEqualStrings("target", target);
+    try std.testing.expectEqualStrings("new", target);
 
-    const tmp_contents = try readFileAlloc(std.testing.allocator, tmp.dir, "target.txt.tmp", 1024);
-    defer std.testing.allocator.free(tmp_contents);
-    try std.testing.expectEqualStrings("stale", tmp_contents);
+    try std.testing.expectError(error.FileNotFound, tmp.dir.openFile("target.txt.tmp", .{}));
 }
 
 test "compat filesystem wrappers create directories and open files" {

--- a/zig/src/compat/fs.zig
+++ b/zig/src/compat/fs.zig
@@ -50,16 +50,14 @@ pub fn writeFile(dir: std.fs.Dir, path: []const u8, data: []const u8) !void {
 /// mode expectations. This skeleton is intentionally thin; crash-safety policy
 /// hardening belongs to the dedicated filesystem wrapper PR.
 pub fn atomicReplace(dir: std.fs.Dir, target_path: []const u8, tmp_path: []const u8, data: []const u8) !void {
+    if (std.mem.eql(u8, target_path, tmp_path)) return error.InvalidAtomicReplacePaths;
+
     var cleanup_tmp = true;
     defer if (cleanup_tmp) dir.deleteFile(tmp_path) catch {};
 
     try writeFile(dir, tmp_path, data);
     try dir.rename(tmp_path, target_path);
     cleanup_tmp = false;
-
-    var replaced = try dir.openFile(target_path, .{ .mode = .write_only });
-    defer replaced.close();
-    try replaced.chmod(default_file_mode);
 }
 
 /// Create a directory and any missing parents relative to `dir`.

--- a/zig/src/compat/fs.zig
+++ b/zig/src/compat/fs.zig
@@ -31,12 +31,6 @@ pub fn readFileAlloc(allocator: std.mem.Allocator, dir: std.fs.Dir, path: []cons
 
 pub const default_file_mode: std.fs.File.Mode = 0o600;
 
-fn chmodFile(dir: std.fs.Dir, path: []const u8, mode: std.fs.File.Mode) !void {
-    var file = try dir.openFile(path, .{ .mode = .write_only });
-    defer file.close();
-    try file.chmod(mode);
-}
-
 /// Write a file relative to `dir`, replacing existing contents.
 ///
 /// Files are created with restrictive permissions by default because later OAuth
@@ -58,16 +52,14 @@ pub fn writeFile(dir: std.fs.Dir, path: []const u8, data: []const u8) !void {
 pub fn atomicReplace(dir: std.fs.Dir, target_path: []const u8, tmp_path: []const u8, data: []const u8) !void {
     if (std.mem.eql(u8, target_path, tmp_path)) return error.InvalidAtomicReplacePaths;
 
-    const target_mode = if (dir.statFile(target_path)) |stat| stat.mode else |err| switch (err) {
-        error.FileNotFound => null,
-        else => return err,
-    };
-
-    var cleanup_tmp = true;
+    var cleanup_tmp = false;
     defer if (cleanup_tmp) dir.deleteFile(tmp_path) catch {};
 
-    try writeFile(dir, tmp_path, data);
-    if (target_mode) |mode| try chmodFile(dir, tmp_path, mode);
+    var file = try dir.createFile(tmp_path, .{ .truncate = false, .exclusive = true, .mode = default_file_mode });
+    cleanup_tmp = true;
+    defer file.close();
+    try file.writeAll(data);
+
     try dir.rename(tmp_path, target_path);
     cleanup_tmp = false;
 }
@@ -94,17 +86,39 @@ test "compat filesystem wrappers read write and atomically replace" {
     try std.testing.expectError(error.FileNotFound, tmp.dir.openFile("compat.txt.tmp", .{}));
 }
 
-test "compat atomic replace preserves existing target mode" {
+test "compat atomic replace re-hardens existing target mode" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
     try writeFile(tmp.dir, "mode.txt", "one");
-    try chmodFile(tmp.dir, "mode.txt", 0o640);
+    {
+        var file = try tmp.dir.openFile("mode.txt", .{ .mode = .write_only });
+        defer file.close();
+        try file.chmod(0o640);
+    }
 
     try atomicReplace(tmp.dir, "mode.txt", "mode.txt.tmp", "two");
 
     const stat = try tmp.dir.statFile("mode.txt");
-    try std.testing.expectEqual(@as(std.fs.File.Mode, 0o640), stat.mode & 0o777);
+    try std.testing.expectEqual(@as(std.fs.File.Mode, default_file_mode), stat.mode & 0o777);
+}
+
+test "compat atomic replace requires a fresh temporary path" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeFile(tmp.dir, "target.txt", "target");
+    try writeFile(tmp.dir, "target.txt.tmp", "stale");
+
+    try std.testing.expectError(error.PathAlreadyExists, atomicReplace(tmp.dir, "target.txt", "target.txt.tmp", "new"));
+
+    const target = try readFileAlloc(std.testing.allocator, tmp.dir, "target.txt", 1024);
+    defer std.testing.allocator.free(target);
+    try std.testing.expectEqualStrings("target", target);
+
+    const tmp_contents = try readFileAlloc(std.testing.allocator, tmp.dir, "target.txt.tmp", 1024);
+    defer std.testing.allocator.free(tmp_contents);
+    try std.testing.expectEqualStrings("stale", tmp_contents);
 }
 
 test "compat filesystem wrappers create directories and open files" {

--- a/zig/src/compat/http.zig
+++ b/zig/src/compat/http.zig
@@ -1,0 +1,63 @@
+const std = @import("std");
+
+pub const Method = std.http.Method;
+pub const Headers = std.http.Client.Request.Headers;
+pub const Request = std.http.Client.Request;
+pub const Response = std.http.Client.Response;
+pub const RequestOptions = struct {
+    extra_headers: []const std.http.Header = &.{},
+    keep_alive: bool = true,
+};
+
+/// Thin HTTP client wrapper for the Zig 0.16 I/O migration seam.
+///
+/// Zig 0.16 mapping: construct `std.http.Client` with the Makai-owned default
+/// I/O context (`std.Io.Threaded`/dispatch as required internally) while keeping
+/// `std.Io` out of public signatures. Provider/OAuth rollout will add streaming
+/// response helpers on this boundary without changing provider behavior here.
+pub const CompatHttpClient = struct {
+    client: std.http.Client,
+
+    pub fn init(allocator: std.mem.Allocator) CompatHttpClient {
+        return .{ .client = .{ .allocator = allocator } };
+    }
+
+    pub fn deinit(self: *CompatHttpClient) void {
+        self.client.deinit();
+        self.* = undefined;
+    }
+
+    pub fn openRequest(self: *CompatHttpClient, method: Method, uri: std.Uri, options: RequestOptions) !Request {
+        return self.client.request(method, uri, .{
+            .extra_headers = options.extra_headers,
+            .keep_alive = options.keep_alive,
+        });
+    }
+};
+
+/// Send a request body and complete the outbound request.
+pub fn sendRequest(request: *Request, body: []const u8) !void {
+    request.transfer_encoding = .{ .content_length = body.len };
+    try request.sendBodyComplete(body);
+}
+
+/// Receive the response headers/body metadata for a request.
+pub fn receiveResponse(request: *Request, response: *Response) !void {
+    try request.receiveHead(response);
+}
+
+/// Return a streaming reader for a response body.
+pub fn responseReader(response: *Response, transfer_buf: []u8) *std.http.Client.Response.Reader {
+    return response.reader(transfer_buf);
+}
+
+test "compat http client initializes and deinitializes" {
+    var client = CompatHttpClient.init(std.testing.allocator);
+    client.deinit();
+}
+
+test "compat http request options default to no extra headers" {
+    const options = RequestOptions{};
+    try std.testing.expectEqual(@as(usize, 0), options.extra_headers.len);
+    try std.testing.expect(options.keep_alive);
+}

--- a/zig/src/compat/http.zig
+++ b/zig/src/compat/http.zig
@@ -36,18 +36,18 @@ pub const HttpClient = struct {
 };
 
 /// Send a request body and complete the outbound request.
-pub fn sendRequest(request: *Request, body: []const u8) !void {
+pub fn sendRequest(request: *Request, body: []u8) !void {
     request.transfer_encoding = .{ .content_length = body.len };
     try request.sendBodyComplete(body);
 }
 
 /// Receive the response headers/body metadata for a request.
-pub fn receiveResponse(request: *Request, response: *Response) !void {
-    try request.receiveHead(response);
+pub fn receiveResponse(request: *Request, redirect_buffer: []u8) !Response {
+    return request.receiveHead(redirect_buffer);
 }
 
 /// Return a streaming reader for a response body.
-pub fn responseReader(response: *Response, transfer_buf: []u8) *std.http.Client.Response.Reader {
+pub fn responseReader(response: *Response, transfer_buf: []u8) *std.Io.Reader {
     return response.reader(transfer_buf);
 }
 

--- a/zig/src/compat/http.zig
+++ b/zig/src/compat/http.zig
@@ -49,21 +49,23 @@ pub fn receiveResponse(request: *Request, redirect_buffer: []u8) !Response {
 }
 
 /// Reader wrapper for streaming response bodies without exposing raw `std.Io`.
-pub const ResponseReader = struct {
-    inner: *std.Io.Reader,
+pub const ResponseReader = opaque {};
 
-    pub fn read(self: ResponseReader, buffer: []u8) !usize {
-        return self.inner.readSliceShort(buffer);
-    }
+/// Read bytes from a response body reader.
+pub fn readResponse(reader: *ResponseReader, buffer: []u8) !usize {
+    const inner: *std.Io.Reader = @ptrCast(@alignCast(reader));
+    return inner.readSliceShort(buffer);
+}
 
-    pub fn readAll(self: ResponseReader, buffer: []u8) !void {
-        try self.inner.readSliceAll(buffer);
-    }
-};
+/// Read exactly `buffer.len` bytes from a response body reader.
+pub fn readAllResponse(reader: *ResponseReader, buffer: []u8) !void {
+    const inner: *std.Io.Reader = @ptrCast(@alignCast(reader));
+    try inner.readSliceAll(buffer);
+}
 
 /// Return a streaming reader for a response body.
-pub fn responseReader(response: *Response, transfer_buf: []u8) ResponseReader {
-    return .{ .inner = response.reader(transfer_buf) };
+pub fn responseReader(response: *Response, transfer_buf: []u8) *ResponseReader {
+    return @ptrCast(@alignCast(response.reader(transfer_buf)));
 }
 
 test "compat http client initializes and deinitializes" {

--- a/zig/src/compat/http.zig
+++ b/zig/src/compat/http.zig
@@ -15,19 +15,19 @@ pub const RequestOptions = struct {
 /// I/O context (`std.Io.Threaded`/dispatch as required internally) while keeping
 /// `std.Io` out of public signatures. Provider/OAuth rollout will add streaming
 /// response helpers on this boundary without changing provider behavior here.
-pub const CompatHttpClient = struct {
+pub const HttpClient = struct {
     client: std.http.Client,
 
-    pub fn init(allocator: std.mem.Allocator) CompatHttpClient {
+    pub fn init(allocator: std.mem.Allocator) HttpClient {
         return .{ .client = .{ .allocator = allocator } };
     }
 
-    pub fn deinit(self: *CompatHttpClient) void {
+    pub fn deinit(self: *HttpClient) void {
         self.client.deinit();
         self.* = undefined;
     }
 
-    pub fn openRequest(self: *CompatHttpClient, method: Method, uri: std.Uri, options: RequestOptions) !Request {
+    pub fn openRequest(self: *HttpClient, method: Method, uri: std.Uri, options: RequestOptions) !Request {
         return self.client.request(method, uri, .{
             .extra_headers = options.extra_headers,
             .keep_alive = options.keep_alive,
@@ -52,7 +52,7 @@ pub fn responseReader(response: *Response, transfer_buf: []u8) *std.http.Client.
 }
 
 test "compat http client initializes and deinitializes" {
-    var client = CompatHttpClient.init(std.testing.allocator);
+    var client = HttpClient.init(std.testing.allocator);
     client.deinit();
 }
 

--- a/zig/src/compat/http.zig
+++ b/zig/src/compat/http.zig
@@ -36,9 +36,11 @@ pub const HttpClient = struct {
 };
 
 /// Send a request body and complete the outbound request.
-pub fn sendRequest(request: *Request, body: []u8) !void {
+pub fn sendRequest(request: *Request, body: []const u8) !void {
     request.transfer_encoding = .{ .content_length = body.len };
-    try request.sendBodyComplete(body);
+    var body_writer = try request.sendBody(&.{});
+    try body_writer.writer.writeAll(body);
+    try body_writer.end();
 }
 
 /// Receive the response headers/body metadata for a request.
@@ -46,9 +48,22 @@ pub fn receiveResponse(request: *Request, redirect_buffer: []u8) !Response {
     return request.receiveHead(redirect_buffer);
 }
 
+/// Reader wrapper for streaming response bodies without exposing raw `std.Io`.
+pub const ResponseReader = struct {
+    inner: *std.Io.Reader,
+
+    pub fn read(self: ResponseReader, buffer: []u8) !usize {
+        return self.inner.readSliceShort(buffer);
+    }
+
+    pub fn readAll(self: ResponseReader, buffer: []u8) !void {
+        try self.inner.readSliceAll(buffer);
+    }
+};
+
 /// Return a streaming reader for a response body.
-pub fn responseReader(response: *Response, transfer_buf: []u8) *std.Io.Reader {
-    return response.reader(transfer_buf);
+pub fn responseReader(response: *Response, transfer_buf: []u8) ResponseReader {
+    return .{ .inner = response.reader(transfer_buf) };
 }
 
 test "compat http client initializes and deinitializes" {

--- a/zig/src/compat/http.zig
+++ b/zig/src/compat/http.zig
@@ -57,10 +57,10 @@ pub fn readResponse(reader: *ResponseReader, buffer: []u8) !usize {
     return inner.readSliceShort(buffer);
 }
 
-/// Read up to `buffer.len` bytes from a response body reader.
-pub fn readAllResponse(reader: *ResponseReader, buffer: []u8) !usize {
+/// Read exactly `buffer.len` bytes from a response body reader.
+pub fn readAllResponse(reader: *ResponseReader, buffer: []u8) !void {
     const inner: *std.Io.Reader = @ptrCast(@alignCast(reader));
-    return inner.readSliceShort(buffer);
+    try inner.readSliceAll(buffer);
 }
 
 /// Return a streaming reader for a response body.

--- a/zig/src/compat/http.zig
+++ b/zig/src/compat/http.zig
@@ -57,10 +57,10 @@ pub fn readResponse(reader: *ResponseReader, buffer: []u8) !usize {
     return inner.readSliceShort(buffer);
 }
 
-/// Read exactly `buffer.len` bytes from a response body reader.
-pub fn readAllResponse(reader: *ResponseReader, buffer: []u8) !void {
+/// Read up to `buffer.len` bytes from a response body reader.
+pub fn readAllResponse(reader: *ResponseReader, buffer: []u8) !usize {
     const inner: *std.Io.Reader = @ptrCast(@alignCast(reader));
-    try inner.readSliceAll(buffer);
+    return inner.readSliceShort(buffer);
 }
 
 /// Return a streaming reader for a response body.

--- a/zig/src/compat/mod.zig
+++ b/zig/src/compat/mod.zig
@@ -5,6 +5,12 @@
 //! Current implementations are thin Zig 0.15.2-compatible pass-throughs; later
 //! migration PRs will remap internals to Zig 0.16 `std.Io.Threaded`/default
 //! context plumbing without changing these stable names unnecessarily.
+//!
+//! Names intentionally follow the task's stable helper list where it is more
+//! specific than the architecture note's examples (`monotonicNanos`, `sleepNs`,
+//! `getCwd`, `resolveAddress`, `tcpListen`). The examples in the architecture
+//! decision remain guidance; this skeleton records the concrete names that
+//! follow-up PRs will migrate without exposing raw `std.Io`.
 
 pub const time = @import("time.zig");
 pub const random = @import("random.zig");

--- a/zig/src/compat/mod.zig
+++ b/zig/src/compat/mod.zig
@@ -1,0 +1,23 @@
+//! Compatibility seams for the Zig 0.15.2 -> 0.16.0 migration.
+//!
+//! These modules intentionally expose Makai-owned wrapper boundaries, not raw
+//! `std.Io`, matching `docs/zig-0.16.0-io-architecture-decision.md`.
+//! Current implementations are thin Zig 0.15.2-compatible pass-throughs; later
+//! migration PRs will remap internals to Zig 0.16 `std.Io.Threaded`/default
+//! context plumbing without changing these stable names unnecessarily.
+
+pub const time = @import("time.zig");
+pub const random = @import("random.zig");
+pub const fs = @import("fs.zig");
+pub const stdio = @import("stdio.zig");
+pub const http = @import("http.zig");
+pub const net = @import("net.zig");
+
+test {
+    _ = time;
+    _ = random;
+    _ = fs;
+    _ = stdio;
+    _ = http;
+    _ = net;
+}

--- a/zig/src/compat/net.zig
+++ b/zig/src/compat/net.zig
@@ -61,10 +61,11 @@ pub fn tcpConnectAny(list: *const AddressList) !Stream {
 
     var last_err: ?anyerror = null;
     for (list.addrs) |address| {
-        return tcpConnect(address) catch |err| {
+        if (tcpConnect(address)) |stream| {
+            return stream;
+        } else |err| {
             last_err = err;
-            continue;
-        };
+        }
     }
 
     return last_err orelse error.ConnectionRefused;

--- a/zig/src/compat/net.zig
+++ b/zig/src/compat/net.zig
@@ -59,14 +59,15 @@ pub fn resolveAddressList(allocator: std.mem.Allocator, host: []const u8, port: 
 pub fn tcpConnectAny(list: *const AddressList) !Stream {
     if (list.addrs.len == 0) return error.UnknownHostName;
 
+    var last_err: ?anyerror = null;
     for (list.addrs) |address| {
-        return tcpConnect(address) catch |err| switch (err) {
-            error.ConnectionRefused => continue,
-            else => return err,
+        return tcpConnect(address) catch |err| {
+            last_err = err;
+            continue;
         };
     }
 
-    return error.ConnectionRefused;
+    return last_err orelse error.ConnectionRefused;
 }
 
 /// Connect to a TCP host, trying resolved addresses in resolver order.

--- a/zig/src/compat/net.zig
+++ b/zig/src/compat/net.zig
@@ -1,0 +1,66 @@
+const std = @import("std");
+
+pub const Address = std.net.Address;
+pub const Server = std.net.Server;
+
+/// TCP stream wrapper used as the stable Makai networking boundary.
+///
+/// Zig 0.16 mapping: wrap streams produced by Makai default-context networking
+/// helpers. The public wrapper avoids exposing `std.Io` while preserving current
+/// byte-stream read/write/close behavior for transports and OAuth callback code.
+pub const Stream = struct {
+    inner: std.net.Stream,
+
+    pub fn init(inner: std.net.Stream) Stream {
+        return .{ .inner = inner };
+    }
+
+    pub fn read(self: *Stream, buffer: []u8) !usize {
+        return self.inner.read(buffer);
+    }
+
+    pub fn write(self: *Stream, data: []const u8) !usize {
+        return self.inner.write(data);
+    }
+
+    pub fn writeAll(self: *Stream, data: []const u8) !void {
+        try self.inner.writeAll(data);
+    }
+
+    pub fn close(self: *Stream) void {
+        self.inner.close();
+    }
+};
+
+/// Resolve a host/port into an address.
+///
+/// Zig 0.16 mapping: route through the selected Makai default I/O/networking
+/// backend internally while keeping this wrapper signature context/allocator
+/// first and free of raw `std.Io`.
+pub fn resolveAddress(allocator: std.mem.Allocator, host: []const u8, port: u16) !Address {
+    _ = allocator;
+    return std.net.Address.resolveIp(host, port);
+}
+
+/// Connect to a TCP peer.
+pub fn tcpConnect(address: Address) !Stream {
+    return .{ .inner = try std.net.tcpConnectToAddress(address) };
+}
+
+/// Listen for TCP connections on `address`.
+pub fn tcpListen(address: Address, options: Address.ListenOptions) !Server {
+    return address.listen(options);
+}
+
+test "compat networking resolves loopback address" {
+    const address = try resolveAddress(std.testing.allocator, "127.0.0.1", 0);
+    try std.testing.expectEqual(@as(u16, 0), address.getPort());
+}
+
+test "compat networking can listen on loopback" {
+    const address = try resolveAddress(std.testing.allocator, "127.0.0.1", 0);
+    var server = try tcpListen(address, .{ .reuse_address = true });
+    defer server.deinit();
+
+    try std.testing.expect(server.listen_address.getPort() != 0);
+}

--- a/zig/src/compat/net.zig
+++ b/zig/src/compat/net.zig
@@ -55,6 +55,27 @@ pub fn resolveAddressList(allocator: std.mem.Allocator, host: []const u8, port: 
     return std.net.getAddressList(allocator, host, port);
 }
 
+/// Connect to the first reachable TCP peer from a resolved address list.
+pub fn tcpConnectAny(list: *const AddressList) !Stream {
+    if (list.addrs.len == 0) return error.UnknownHostName;
+
+    for (list.addrs) |address| {
+        return tcpConnect(address) catch |err| switch (err) {
+            error.ConnectionRefused => continue,
+            else => return err,
+        };
+    }
+
+    return error.ConnectionRefused;
+}
+
+/// Connect to a TCP host, trying resolved addresses in resolver order.
+pub fn tcpConnectHost(allocator: std.mem.Allocator, host: []const u8, port: u16) !Stream {
+    var list = try resolveAddressList(allocator, host, port);
+    defer list.deinit();
+    return tcpConnectAny(list);
+}
+
 /// Connect to a TCP peer.
 pub fn tcpConnect(address: Address) !Stream {
     return .{ .inner = try std.net.tcpConnectToAddress(address) };

--- a/zig/src/compat/net.zig
+++ b/zig/src/compat/net.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 
 pub const Address = std.net.Address;
+pub const AddressList = std.net.AddressList;
 pub const Server = std.net.Server;
 
 /// TCP stream wrapper used as the stable Makai networking boundary.
@@ -38,12 +39,20 @@ pub const Stream = struct {
 /// backend internally while keeping this wrapper signature context/allocator
 /// first and free of raw `std.Io`.
 ///
-/// `allocator` is intentionally reserved for the future resolver implementation,
-/// which may allocate address lists or context-backed resolver state. The Zig
-/// 0.15.2 pass-through uses `std.net.Address.resolveIp` and does not allocate.
+/// `allocator` owns temporary DNS resolver allocations during this call.
 pub fn resolveAddress(allocator: std.mem.Allocator, host: []const u8, port: u16) !Address {
-    _ = allocator;
-    return std.net.Address.resolveIp(host, port);
+    var list = try std.net.getAddressList(allocator, host, port);
+    defer list.deinit();
+
+    if (list.addrs.len == 0) return error.UnknownHostName;
+    return list.addrs[0];
+}
+
+/// Resolve a host/port into an owned address list.
+///
+/// Callers own the returned list and must call `deinit`.
+pub fn resolveAddressList(allocator: std.mem.Allocator, host: []const u8, port: u16) !*AddressList {
+    return std.net.getAddressList(allocator, host, port);
 }
 
 /// Connect to a TCP peer.

--- a/zig/src/compat/net.zig
+++ b/zig/src/compat/net.zig
@@ -37,6 +37,10 @@ pub const Stream = struct {
 /// Zig 0.16 mapping: route through the selected Makai default I/O/networking
 /// backend internally while keeping this wrapper signature context/allocator
 /// first and free of raw `std.Io`.
+///
+/// `allocator` is intentionally reserved for the future resolver implementation,
+/// which may allocate address lists or context-backed resolver state. The Zig
+/// 0.15.2 pass-through uses `std.net.Address.resolveIp` and does not allocate.
 pub fn resolveAddress(allocator: std.mem.Allocator, host: []const u8, port: u16) !Address {
     _ = allocator;
     return std.net.Address.resolveIp(host, port);

--- a/zig/src/compat/random.zig
+++ b/zig/src/compat/random.zig
@@ -1,0 +1,37 @@
+const std = @import("std");
+
+/// Fill `buf` with security-sensitive random bytes.
+///
+/// Zig 0.16 mapping: route to the Makai default context's secure entropy source
+/// (`io.randomSecure` or equivalent) per the architecture decision. OAuth
+/// PKCE/state, credential material, and protocol-sensitive nonces should prefer
+/// this helper.
+pub fn secureBytes(buf: []u8) void {
+    std.crypto.random.bytes(buf);
+}
+
+/// Fill `buf` with ordinary random bytes.
+///
+/// Zig 0.16 mapping: route to the Makai default context's non-secure random
+/// source (`io.random`/test deterministic source where appropriate). Do not use
+/// this for credentials, PKCE, OAuth state, or other security-sensitive values.
+pub fn randomBytes(buf: []u8) void {
+    std.crypto.random.bytes(buf);
+}
+
+test "compat random helpers fill requested buffers" {
+    var secure: [16]u8 = [_]u8{0} ** 16;
+    var ordinary: [16]u8 = [_]u8{0} ** 16;
+
+    secureBytes(&secure);
+    randomBytes(&ordinary);
+
+    try std.testing.expect(!std.mem.eql(u8, &secure, &([_]u8{0} ** 16)));
+    try std.testing.expect(!std.mem.eql(u8, &ordinary, &([_]u8{0} ** 16)));
+}
+
+test "compat random helpers accept empty buffers" {
+    var empty: [0]u8 = .{};
+    secureBytes(&empty);
+    randomBytes(&empty);
+}

--- a/zig/src/compat/random.zig
+++ b/zig/src/compat/random.zig
@@ -12,9 +12,13 @@ pub fn secureBytes(buf: []u8) void {
 
 /// Fill `buf` with ordinary random bytes.
 ///
+/// Zig 0.15.2 note: this is currently equivalent to `secureBytes`; both use
+/// `std.crypto.random.bytes` until the Zig 0.16 I/O context exists.
+///
 /// Zig 0.16 mapping: route to the Makai default context's non-secure random
-/// source (`io.random`/test deterministic source where appropriate). Do not use
-/// this for credentials, PKCE, OAuth state, or other security-sensitive values.
+/// source (`io.random`/test deterministic source where appropriate), diverging
+/// from `secureBytes`. After that remap, do not use this for credentials, PKCE,
+/// OAuth state, or other security-sensitive values.
 pub fn randomBytes(buf: []u8) void {
     std.crypto.random.bytes(buf);
 }

--- a/zig/src/compat/stdio.zig
+++ b/zig/src/compat/stdio.zig
@@ -4,7 +4,7 @@ const std = @import("std");
 ///
 /// Zig 0.16 mapping: this will borrow stdin from the Makai default I/O context
 /// or test context, preserving public APIs that avoid raw `std.Io`.
-pub fn getStdinReader() std.fs.File {
+pub fn stdin() std.fs.File {
     return std.fs.File.stdin();
 }
 
@@ -12,13 +12,13 @@ pub fn getStdinReader() std.fs.File {
 ///
 /// Zig 0.16 mapping: this will borrow stdout from the Makai default I/O context
 /// or test context, preserving public APIs that avoid raw `std.Io`.
-pub fn getStdoutWriter() std.fs.File {
+pub fn stdout() std.fs.File {
     return std.fs.File.stdout();
 }
 
 test "compat stdio helpers construct file handles" {
-    const stdin = getStdinReader();
-    const stdout = getStdoutWriter();
-    _ = stdin;
-    _ = stdout;
+    const in = stdin();
+    const out = stdout();
+    _ = in;
+    _ = out;
 }

--- a/zig/src/compat/stdio.zig
+++ b/zig/src/compat/stdio.zig
@@ -1,0 +1,24 @@
+const std = @import("std");
+
+/// Return the process stdin file handle.
+///
+/// Zig 0.16 mapping: this will borrow stdin from the Makai default I/O context
+/// or test context, preserving public APIs that avoid raw `std.Io`.
+pub fn getStdinReader() std.fs.File {
+    return std.fs.File.stdin();
+}
+
+/// Return the process stdout file handle.
+///
+/// Zig 0.16 mapping: this will borrow stdout from the Makai default I/O context
+/// or test context, preserving public APIs that avoid raw `std.Io`.
+pub fn getStdoutWriter() std.fs.File {
+    return std.fs.File.stdout();
+}
+
+test "compat stdio helpers construct file handles" {
+    const stdin = getStdinReader();
+    const stdout = getStdoutWriter();
+    _ = stdin;
+    _ = stdout;
+}

--- a/zig/src/compat/time.zig
+++ b/zig/src/compat/time.zig
@@ -25,12 +25,24 @@ pub fn nowNanos() i128 {
     return std.time.nanoTimestamp();
 }
 
+var monotonic_timer: ?std.time.Timer = null;
+var monotonic_mutex: std.Thread.Mutex = .{};
+
 /// Monotonic nanoseconds suitable for durations and deadlines.
 ///
+/// Zig 0.15.2 mapping: use a process-wide `std.time.Timer` so readings share a
+/// stable monotonic origin and can be subtracted for elapsed-duration math.
 /// Zig 0.16 mapping: move to the chosen `std.Io.Threaded`/default-context
 /// monotonic clock internally while keeping raw `std.Io` out of this API.
 pub fn monotonicNanos() u64 {
-    return @intCast(std.time.nanoTimestamp());
+    monotonic_mutex.lock();
+    defer monotonic_mutex.unlock();
+
+    if (monotonic_timer == null) {
+        monotonic_timer = std.time.Timer.start() catch return 0;
+    }
+
+    return monotonic_timer.?.read();
 }
 
 /// Sleep for a number of nanoseconds.

--- a/zig/src/compat/time.zig
+++ b/zig/src/compat/time.zig
@@ -1,0 +1,59 @@
+const std = @import("std");
+
+/// Wall-clock milliseconds since the Unix epoch.
+///
+/// Zig 0.16 mapping: this remains a wall-clock timestamp helper, backed by the
+/// Makai default I/O context/clock selected in the architecture decision rather
+/// than exposing `std.Io` in the public signature.
+pub fn nowMillis() i64 {
+    return std.time.milliTimestamp();
+}
+
+/// Wall-clock seconds since the Unix epoch.
+///
+/// Zig 0.16 mapping: preserve wall-clock semantics while moving the internal
+/// source to the default Makai context clock.
+pub fn nowSeconds() i64 {
+    return std.time.timestamp();
+}
+
+/// Wall-clock nanoseconds since the Unix epoch.
+///
+/// Zig 0.16 mapping: preserve timestamp semantics separately from monotonic
+/// timing; use the context-backed timestamp source internally.
+pub fn nowNanos() i128 {
+    return std.time.nanoTimestamp();
+}
+
+/// Monotonic nanoseconds suitable for durations and deadlines.
+///
+/// Zig 0.16 mapping: move to the chosen `std.Io.Threaded`/default-context
+/// monotonic clock internally while keeping raw `std.Io` out of this API.
+pub fn monotonicNanos() u64 {
+    return @intCast(std.time.nanoTimestamp());
+}
+
+/// Sleep for a number of nanoseconds.
+///
+/// Zig 0.16 mapping: route through the Makai default I/O context timeout/sleep
+/// primitive while keeping this public helper stable.
+pub fn sleepNs(ns: u64) void {
+    std.Thread.sleep(ns);
+}
+
+/// Sleep for a number of milliseconds.
+pub fn sleepMs(ms: u64) void {
+    sleepNs(ms * std.time.ns_per_ms);
+}
+
+test "compat time helpers return plausible timestamps" {
+    try std.testing.expect(nowMillis() > 0);
+    try std.testing.expect(nowSeconds() > 0);
+    try std.testing.expect(nowNanos() > 0);
+    try std.testing.expect(monotonicNanos() > 0);
+}
+
+test "compat sleep helpers accept zero duration" {
+    sleepNs(0);
+    sleepMs(0);
+}

--- a/zig/src/compat/time.zig
+++ b/zig/src/compat/time.zig
@@ -30,8 +30,7 @@ pub fn nowNanos() i128 {
 /// Zig 0.16 mapping: move to the chosen `std.Io.Threaded`/default-context
 /// monotonic clock internally while keeping raw `std.Io` out of this API.
 pub fn monotonicNanos() u64 {
-    var timer = std.time.Timer.start() catch return 0;
-    return timer.read();
+    return @intCast(std.time.nanoTimestamp());
 }
 
 /// Sleep for a number of nanoseconds.

--- a/zig/src/compat/time.zig
+++ b/zig/src/compat/time.zig
@@ -55,14 +55,14 @@ pub fn sleepNs(ns: u64) void {
 
 /// Sleep for a number of milliseconds.
 pub fn sleepMs(ms: u64) void {
-    sleepNs(ms * std.time.ns_per_ms);
+    sleepNs(std.math.mul(u64, ms, std.time.ns_per_ms) catch std.math.maxInt(u64));
 }
 
 test "compat time helpers return plausible timestamps" {
     try std.testing.expect(nowMillis() > 0);
     try std.testing.expect(nowSeconds() > 0);
     try std.testing.expect(nowNanos() > 0);
-    try std.testing.expect(monotonicNanos() > 0);
+    _ = monotonicNanos();
 }
 
 test "compat sleep helpers accept zero duration" {

--- a/zig/src/compat/time.zig
+++ b/zig/src/compat/time.zig
@@ -2,27 +2,29 @@ const std = @import("std");
 
 /// Wall-clock milliseconds since the Unix epoch.
 ///
-/// Zig 0.16 mapping: this remains a wall-clock timestamp helper, backed by the
-/// Makai default I/O context/clock selected in the architecture decision rather
-/// than exposing `std.Io` in the public signature.
+/// 0.15.2: wraps `std.time.milliTimestamp()`.
+/// 0.16: use `std.Io.Timestamp.now` through the Makai default context while
+/// keeping raw `std.Io` out of this public signature.
 pub fn nowMillis() i64 {
     return std.time.milliTimestamp();
 }
 
 /// Wall-clock seconds since the Unix epoch.
 ///
-/// Zig 0.16 mapping: preserve wall-clock semantics while moving the internal
-/// source to the default Makai context clock.
+/// 0.15.2: wraps `std.time.timestamp()`.
+/// 0.16: use `std.Io.Timestamp.now` through the Makai default context while
+/// preserving wall-clock semantics.
 pub fn nowSeconds() i64 {
     return std.time.timestamp();
 }
 
 /// Wall-clock nanoseconds since the Unix epoch.
 ///
-/// Zig 0.16 mapping: preserve timestamp semantics separately from monotonic
-/// timing; use the context-backed timestamp source internally.
-pub fn nowNanos() i128 {
-    return std.time.nanoTimestamp();
+/// 0.15.2: wraps `std.time.nanoTimestamp()`.
+/// 0.16: use `std.Io.Timestamp.now` through the Makai default context and keep
+/// this separate from monotonic-duration measurements.
+pub fn nowNanos() i64 {
+    return @intCast(std.time.nanoTimestamp());
 }
 
 var monotonic_timer: ?std.time.Timer = null;
@@ -30,10 +32,10 @@ var monotonic_mutex: std.Thread.Mutex = .{};
 
 /// Monotonic nanoseconds suitable for durations and deadlines.
 ///
-/// Zig 0.15.2 mapping: use a process-wide `std.time.Timer` so readings share a
-/// stable monotonic origin and can be subtracted for elapsed-duration math.
-/// Zig 0.16 mapping: move to the chosen `std.Io.Threaded`/default-context
-/// monotonic clock internally while keeping raw `std.Io` out of this API.
+/// 0.15.2: use a process-wide `std.time.Timer` so readings share a stable
+/// monotonic origin and can be subtracted for elapsed-duration math.
+/// 0.16: use `std.Io.Clock`/the chosen default-context monotonic clock
+/// internally while keeping raw `std.Io` out of this API.
 pub fn monotonicNanos() u64 {
     monotonic_mutex.lock();
     defer monotonic_mutex.unlock();
@@ -47,8 +49,9 @@ pub fn monotonicNanos() u64 {
 
 /// Sleep for a number of nanoseconds.
 ///
-/// Zig 0.16 mapping: route through the Makai default I/O context timeout/sleep
-/// primitive while keeping this public helper stable.
+/// 0.15.2: wraps `std.Thread.sleep`.
+/// 0.16: route through the Makai default I/O context timeout/sleep primitive
+/// while keeping this public helper stable.
 pub fn sleepNs(ns: u64) void {
     std.Thread.sleep(ns);
 }
@@ -58,11 +61,48 @@ pub fn sleepMs(ms: u64) void {
     sleepNs(std.math.mul(u64, ms, std.time.ns_per_ms) catch std.math.maxInt(u64));
 }
 
-test "compat time helpers return plausible timestamps" {
-    try std.testing.expect(nowMillis() > 0);
-    try std.testing.expect(nowSeconds() > 0);
-    try std.testing.expect(nowNanos() > 0);
-    _ = monotonicNanos();
+test "compat time helpers return expected public types" {
+    const millis: i64 = nowMillis();
+    const seconds: i64 = nowSeconds();
+    const nanos: i64 = nowNanos();
+    const monotonic: u64 = monotonicNanos();
+
+    _ = millis;
+    _ = seconds;
+    _ = nanos;
+    _ = monotonic;
+}
+
+test "compat time helpers return plausible wall-clock timestamps" {
+    const seconds = nowSeconds();
+    const millis = nowMillis();
+    const nanos = nowNanos();
+
+    try std.testing.expect(seconds > 0);
+    try std.testing.expect(millis > 0);
+    try std.testing.expect(nanos > 0);
+    try std.testing.expect(@divTrunc(millis, std.time.ms_per_s) >= seconds - 1);
+    try std.testing.expect(@divTrunc(nanos, std.time.ns_per_s) >= seconds - 1);
+}
+
+test "compat monotonic nanoseconds are nondecreasing" {
+    const before = monotonicNanos();
+    sleepNs(1);
+    const after = monotonicNanos();
+
+    try std.testing.expect(after >= before);
+}
+
+test "compat sleep helpers bound short sleeps" {
+    const start_ns = monotonicNanos();
+    sleepNs(1 * std.time.ns_per_ms);
+    const elapsed_ns = monotonicNanos() - start_ns;
+
+    // Only assert the lower bound: `sleepNs` must wait at least the requested
+    // duration. Avoid an absolute upper bound here because scheduler pauses on
+    // loaded or virtualized CI runners can legitimately exceed any tight
+    // ceiling without indicating a defect in the wrapper.
+    try std.testing.expect(elapsed_ns >= 1 * std.time.ns_per_ms);
 }
 
 test "compat sleep helpers accept zero duration" {

--- a/zig/src/compat/time.zig
+++ b/zig/src/compat/time.zig
@@ -30,7 +30,8 @@ pub fn nowNanos() i128 {
 /// Zig 0.16 mapping: move to the chosen `std.Io.Threaded`/default-context
 /// monotonic clock internally while keeping raw `std.Io` out of this API.
 pub fn monotonicNanos() u64 {
-    return @intCast(std.time.nanoTimestamp());
+    var timer = std.time.Timer.start() catch return 0;
+    return timer.read();
 }
 
 /// Sleep for a number of nanoseconds.

--- a/zig/src/compat/time.zig
+++ b/zig/src/compat/time.zig
@@ -34,12 +34,12 @@ var monotonic_mutex: std.Thread.Mutex = .{};
 /// stable monotonic origin and can be subtracted for elapsed-duration math.
 /// Zig 0.16 mapping: move to the chosen `std.Io.Threaded`/default-context
 /// monotonic clock internally while keeping raw `std.Io` out of this API.
-pub fn monotonicNanos() u64 {
+pub fn monotonicNanos() !u64 {
     monotonic_mutex.lock();
     defer monotonic_mutex.unlock();
 
     if (monotonic_timer == null) {
-        monotonic_timer = std.time.Timer.start() catch return 0;
+        monotonic_timer = try std.time.Timer.start();
     }
 
     return monotonic_timer.?.read();
@@ -62,7 +62,7 @@ test "compat time helpers return plausible timestamps" {
     try std.testing.expect(nowMillis() > 0);
     try std.testing.expect(nowSeconds() > 0);
     try std.testing.expect(nowNanos() > 0);
-    _ = monotonicNanos();
+    _ = try monotonicNanos();
 }
 
 test "compat sleep helpers accept zero duration" {

--- a/zig/src/protocol/provider/types.zig
+++ b/zig/src/protocol/provider/types.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const ai_types = @import("ai_types");
 const owned_slice_mod = @import("owned_slice");
 const model_catalog_types = @import("model_catalog_types");
+const compat = @import("compat");
 
 pub const OwnedSlice = owned_slice_mod.OwnedSlice;
 pub const PROTOCOL_VERSION: u8 = 1;
@@ -90,7 +91,7 @@ fn ulidDecode(c: u8) ?u5 {
 pub fn generateUlid() Ulid {
     var ulid: Ulid = undefined;
 
-    const now_ms: u64 = @intCast(@max(std.time.milliTimestamp(), 0));
+    const now_ms: u64 = @intCast(@max(compat.time.nowMillis(), 0));
     ulid[0] = @intCast((now_ms >> 40) & 0xff);
     ulid[1] = @intCast((now_ms >> 32) & 0xff);
     ulid[2] = @intCast((now_ms >> 24) & 0xff);
@@ -445,7 +446,7 @@ test "generateSessionId produces 21-character alphanumeric NanoID" {
 
 test "generateUlid produces valid ULID" {
     const ulid = generateUlid();
-    const now_ms: u64 = @intCast(@max(std.time.milliTimestamp(), 0));
+    const now_ms: u64 = @intCast(@max(compat.time.nowMillis(), 0));
     const ulid_ms = (@as(u64, ulid[0]) << 40) |
         (@as(u64, ulid[1]) << 32) |
         (@as(u64, ulid[2]) << 24) |
@@ -542,7 +543,7 @@ test "Envelope with ping payload" {
         .stream_id = ulid,
         .message_id = generateUlid(),
         .sequence = 1,
-        .timestamp = std.time.milliTimestamp(),
+        .timestamp = compat.time.nowMillis(),
         .payload = .ping,
     };
 

--- a/zig/src/utils/oauth/refresh_lock.zig
+++ b/zig/src/utils/oauth/refresh_lock.zig
@@ -481,6 +481,15 @@ pub const RefreshLock = struct {
 // ===========================================================================
 
 const testing = std.testing;
+const waiter_spin_limit = 10_000;
+
+fn waitForRefCount(lock: *RefreshLock, provider: []const u8, expected: usize) !void {
+    var attempts: usize = 0;
+    while (lock.refCountForTesting(provider, null) < expected) : (attempts += 1) {
+        if (attempts >= waiter_spin_limit) return error.WaiterRefCountTimeout;
+        std.Thread.sleep(1 * std.time.ns_per_ms);
+    }
+}
 
 fn expectAcquired(result: RefreshLock.AcquireResult) !u64 {
     return switch (result) {
@@ -633,9 +642,7 @@ test "concurrent requests for same provider trigger only one refresh" {
         t.* = try std.Thread.spawn(.{}, concurrentWorker, .{&ctx});
     }
 
-    while (lock.refCountForTesting("test-provider", null) < num_waiters + 1) {
-        std.Thread.sleep(1 * std.time.ns_per_ms);
-    }
+    try waitForRefCount(&lock, "test-provider", num_waiters + 1);
     lock.complete("test-provider", null, first_gen, null);
 
     for (&threads) |t| {
@@ -673,9 +680,7 @@ test "all waiting requests succeed after a single shared refresh completes" {
         t.* = try std.Thread.spawn(.{}, concurrentWorker, .{&ctx});
     }
 
-    while (lock.refCountForTesting("prov-ok", null) < num_waiters + 1) {
-        std.Thread.sleep(1 * std.time.ns_per_ms);
-    }
+    try waitForRefCount(&lock, "prov-ok", num_waiters + 1);
     lock.complete("prov-ok", null, first_gen, null);
 
     for (&threads) |t| {

--- a/zig/src/utils/oauth/refresh_lock.zig
+++ b/zig/src/utils/oauth/refresh_lock.zig
@@ -461,6 +461,19 @@ pub const RefreshLock = struct {
         }
         return count;
     }
+
+    fn refCountForTesting(self: *RefreshLock, provider_id: []const u8, user_id: ?[]const u8) usize {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+
+        var iter = self.entries.iterator();
+        while (iter.next()) |hashmap_entry| {
+            if (keyMatches(hashmap_entry.key_ptr.*, provider_id, user_id)) {
+                return hashmap_entry.value_ptr.*.ref_count;
+            }
+        }
+        return 0;
+    }
 };
 
 // ===========================================================================
@@ -620,8 +633,9 @@ test "concurrent requests for same provider trigger only one refresh" {
         t.* = try std.Thread.spawn(.{}, concurrentWorker, .{&ctx});
     }
 
-    // Hold the lock a moment so waiters actually block.
-    std.Thread.sleep(10 * std.time.ns_per_ms);
+    while (lock.refCountForTesting("test-provider", null) < num_waiters + 1) {
+        std.Thread.sleep(1 * std.time.ns_per_ms);
+    }
     lock.complete("test-provider", null, first_gen, null);
 
     for (&threads) |t| {
@@ -659,8 +673,9 @@ test "all waiting requests succeed after a single shared refresh completes" {
         t.* = try std.Thread.spawn(.{}, concurrentWorker, .{&ctx});
     }
 
-    // Complete with success.
-    std.Thread.sleep(5 * std.time.ns_per_ms);
+    while (lock.refCountForTesting("prov-ok", null) < num_waiters + 1) {
+        std.Thread.sleep(1 * std.time.ns_per_ms);
+    }
     lock.complete("prov-ok", null, first_gen, null);
 
     for (&threads) |t| {

--- a/zig/src/utils/retry.zig
+++ b/zig/src/utils/retry.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const compat = @import("compat");
 
 /// Retry configuration
 pub const RetryConfig = struct {
@@ -21,7 +22,7 @@ pub const RetryConfig = struct {
 
         // Apply jitter if factor > 0
         if (self.jitter_factor > 0) {
-            const seed = @as(u64, @intCast(std.time.nanoTimestamp()));
+            const seed = @as(u64, @intCast(compat.time.nowNanos()));
             var prng = std.Random.DefaultPrng.init(seed);
             const rand = prng.random().float(f32);
             // jitter_mult ranges from (1 - jitter_factor) to (1 + jitter_factor)
@@ -76,7 +77,7 @@ pub fn extractRetryDelayFromHeader(header_value: ?[]const u8) ?u64 {
     // Try parsing as HTTP date (RFC 1123)
     // Format: "Wed, 21 Oct 2015 07:28:00 GMT"
     if (parseHttpDate(trimmed)) |timestamp_ms| {
-        const now_ms = @as(u64, @intCast(std.time.timestamp())) * 1000;
+        const now_ms = @as(u64, @intCast(compat.time.nowSeconds())) * 1000;
         if (timestamp_ms > now_ms) {
             return timestamp_ms - now_ms;
         }
@@ -379,7 +380,7 @@ pub fn isRetryableError(error_text: []const u8) bool {
 /// Returns false if cancelled, true if completed normally.
 pub fn sleepMs(ms: u64, cancel_token: ?*const std.atomic.Value(bool)) bool {
     const check_interval_ms: u64 = 100;
-    const ns_per_ms: u64 = 1_000_000;
+    const ns_per_ms: u64 = std.time.ns_per_ms;
     var remaining: u64 = ms;
 
     while (remaining > 0) {
@@ -391,7 +392,7 @@ pub fn sleepMs(ms: u64, cancel_token: ?*const std.atomic.Value(bool)) bool {
         }
 
         const sleep_time = @min(remaining, check_interval_ms);
-        std.Thread.sleep(sleep_time * ns_per_ms);
+        compat.time.sleepNs(sleep_time * ns_per_ms);
         remaining -= sleep_time;
     }
 
@@ -592,24 +593,24 @@ test "indexOfCaseInsensitive finds substrings correctly" {
 }
 
 test "sleepMs completes normally without cancel token" {
-    const ns_per_ms: i128 = 1_000_000;
-    const start = std.time.nanoTimestamp();
+    const ns_per_ms: u64 = std.time.ns_per_ms;
+    const start = compat.time.monotonicNanos();
     const completed = sleepMs(50, null);
-    const elapsed = std.time.nanoTimestamp() - start;
+    const elapsed = compat.time.monotonicNanos() - start;
 
     try std.testing.expect(completed);
     try std.testing.expect(elapsed >= 50 * ns_per_ms);
 }
 
 test "sleepMs respects cancel token" {
-    const ns_per_ms: u64 = 1_000_000;
+    const ns_per_ms: u64 = std.time.ns_per_ms;
     var cancelled = std.atomic.Value(bool).init(false);
 
     // Start a timer to cancel after 10ms
     const ThreadCtx = struct {
         cancel_token: *std.atomic.Value(bool),
         fn run(self: *@This()) void {
-            std.Thread.sleep(10 * ns_per_ms);
+            compat.time.sleepNs(10 * ns_per_ms);
             self.cancel_token.store(true, .release);
         }
     };


### PR DESCRIPTION
## Summary
- Add `zig/src/compat` module with thin Zig 0.15.2 wrapper boundaries for time/sleep, random, filesystem/stdio, HTTP, and networking.
- Document the planned Zig 0.16 mapping in each wrapper per the accepted Makai-owned I/O architecture decision.
- Wire the compat module into `zig/build.zig` and the core/full test steps with smoke coverage.

Part of stack: Zig 0.15.2 → 0.16.0 Migration. PR 2 of 24.

## Test plan
- [x] `cd zig && /tmp/zig-x86_64-macos-0.15.2/zig build test-unit-core`
- [x] `cd zig && /tmp/zig-x86_64-macos-0.15.2/zig build test`
- [x] `./scripts/check-zig-patterns.sh`

## Notes
- The system `zig` on this runner is 0.16.0, so Zig 0.15.2 validation used a downloaded local toolchain at `/tmp/zig-x86_64-macos-0.15.2/zig`.
- A system `zig build test-unit-core` run with Zig 0.16.0 fails on pre-existing migration issues outside this PR (for example `std.Thread.Mutex`, `std.time.*Timestamp`, and `std.http.Client` API drift), which is expected before the compiler-switch work item.