### PR TITLE
Add Zig I/O compatibility skeleton

### DIFF
--- a/zig/build.zig
+++ b/zig/build.zig
@@ -55,6 +55,12 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
 
+    const compat_mod = b.createModule(.{
+        .root_source_file = b.path("src/compat/mod.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
     const streaming_json_mod = b.createModule(.{
         .root_source_file = b.path("src/streaming_json.zig"),
         .target = target,
@@ -726,6 +732,7 @@ pub fn build(b: *std.Build) void {
     const owned_slice_test = b.addTest(.{ .root_module = owned_slice_mod });
     const string_builder_test = b.addTest(.{ .root_module = string_builder_mod });
     const hive_array_test = b.addTest(.{ .root_module = hive_array_mod });
+    const compat_test = b.addTest(.{ .root_module = compat_mod });
 
     const event_stream_test = b.addTest(.{ .root_module = event_stream_mod });
 
@@ -1134,6 +1141,7 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(&b.addRunArtifact(owned_slice_test).step);
     test_step.dependOn(&b.addRunArtifact(string_builder_test).step);
     test_step.dependOn(&b.addRunArtifact(hive_array_test).step);
+    test_step.dependOn(&b.addRunArtifact(compat_test).step);
     test_step.dependOn(&b.addRunArtifact(event_stream_test).step);
     test_step.dependOn(&b.addRunArtifact(streaming_json_test).step);
     test_step.dependOn(&b.addRunArtifact(ai_types_test).step);
@@ -1204,6 +1212,7 @@ pub fn build(b: *std.Build) void {
     test_unit_core_step.dependOn(&b.addRunArtifact(owned_slice_test).step);
     test_unit_core_step.dependOn(&b.addRunArtifact(string_builder_test).step);
     test_unit_core_step.dependOn(&b.addRunArtifact(hive_array_test).step);
+    test_unit_core_step.dependOn(&b.addRunArtifact(compat_test).step);
 
     const test_unit_transport_step = b.step("test-unit-transport", "Run transport layer unit tests");
     test_unit_transport_step.dependOn(&b.addRunArtifact(transport_test).step);

--- a/zig/src/compat/fs.zig
+++ b/zig/src/compat/fs.zig
@@ -29,9 +29,15 @@ pub fn readFileAlloc(allocator: std.mem.Allocator, dir: std.fs.Dir, path: []cons
     return dir.readFileAlloc(allocator, path, max_bytes);
 }
 
+pub const default_file_mode: std.fs.File.Mode = 0o600;
+
 /// Write a file relative to `dir`, replacing existing contents.
+///
+/// Files are created with restrictive permissions by default because later OAuth
+/// storage migration work may use this wrapper for credential material. Existing
+/// files keep their current mode when opened with truncation on POSIX systems.
 pub fn writeFile(dir: std.fs.Dir, path: []const u8, data: []const u8) !void {
-    var file = try dir.createFile(path, .{ .truncate = true });
+    var file = try dir.createFile(path, .{ .truncate = true, .mode = default_file_mode });
     defer file.close();
     try file.writeAll(data);
 }
@@ -50,6 +56,10 @@ pub fn atomicReplace(dir: std.fs.Dir, target_path: []const u8, tmp_path: []const
     try writeFile(dir, tmp_path, data);
     try dir.rename(tmp_path, target_path);
     cleanup_tmp = false;
+
+    var replaced = try dir.openFile(target_path, .{ .mode = .write_only });
+    defer replaced.close();
+    try replaced.chmod(default_file_mode);
 }
 
 /// Create a directory and any missing parents relative to `dir`.

--- a/zig/src/compat/fs.zig
+++ b/zig/src/compat/fs.zig
@@ -31,6 +31,12 @@ pub fn readFileAlloc(allocator: std.mem.Allocator, dir: std.fs.Dir, path: []cons
 
 pub const default_file_mode: std.fs.File.Mode = 0o600;
 
+fn chmodFile(dir: std.fs.Dir, path: []const u8, mode: std.fs.File.Mode) !void {
+    var file = try dir.openFile(path, .{ .mode = .write_only });
+    defer file.close();
+    try file.chmod(mode);
+}
+
 /// Write a file relative to `dir`, replacing existing contents.
 ///
 /// Files are created with restrictive permissions by default because later OAuth
@@ -52,10 +58,16 @@ pub fn writeFile(dir: std.fs.Dir, path: []const u8, data: []const u8) !void {
 pub fn atomicReplace(dir: std.fs.Dir, target_path: []const u8, tmp_path: []const u8, data: []const u8) !void {
     if (std.mem.eql(u8, target_path, tmp_path)) return error.InvalidAtomicReplacePaths;
 
+    const target_mode = if (dir.statFile(target_path)) |stat| stat.mode else |err| switch (err) {
+        error.FileNotFound => null,
+        else => return err,
+    };
+
     var cleanup_tmp = true;
     defer if (cleanup_tmp) dir.deleteFile(tmp_path) catch {};
 
     try writeFile(dir, tmp_path, data);
+    if (target_mode) |mode| try chmodFile(dir, tmp_path, mode);
     try dir.rename(tmp_path, target_path);
     cleanup_tmp = false;
 }
@@ -80,6 +92,19 @@ test "compat filesystem wrappers read write and atomically replace" {
     try std.testing.expectEqualStrings("two", replaced);
 
     try std.testing.expectError(error.FileNotFound, tmp.dir.openFile("compat.txt.tmp", .{}));
+}
+
+test "compat atomic replace preserves existing target mode" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeFile(tmp.dir, "mode.txt", "one");
+    try chmodFile(tmp.dir, "mode.txt", 0o640);
+
+    try atomicReplace(tmp.dir, "mode.txt", "mode.txt.tmp", "two");
+
+    const stat = try tmp.dir.statFile("mode.txt");
+    try std.testing.expectEqual(@as(std.fs.File.Mode, 0o640), stat.mode & 0o777);
 }
 
 test "compat filesystem wrappers create directories and open files" {

--- a/zig/src/compat/fs.zig
+++ b/zig/src/compat/fs.zig
@@ -1,0 +1,95 @@
+const std = @import("std");
+
+pub const OpenFlags = std.fs.File.OpenFlags;
+pub const CreateFlags = std.fs.File.CreateFlags;
+pub const File = std.fs.File;
+
+/// Return the process current working directory handle.
+///
+/// Zig 0.16 mapping: this remains the stable wrapper for cwd access. Internal
+/// implementation may borrow the Makai default I/O context, but public callers
+/// should not receive or pass raw `std.Io` handles.
+pub fn getCwd() std.fs.Dir {
+    return std.fs.cwd();
+}
+
+/// Open a file relative to `dir`.
+///
+/// Parameter order follows the migration convention: I/O handle (`dir`) first
+/// for handle-scoped operations, then operation-specific parameters.
+pub fn openFile(dir: std.fs.Dir, path: []const u8, flags: OpenFlags) !File {
+    return dir.openFile(path, flags);
+}
+
+/// Read a file relative to `dir` into an allocated buffer.
+///
+/// Zig 0.16 mapping: preserve allocation ownership and error behavior while
+/// routing file reads through the Makai filesystem wrapper internals.
+pub fn readFileAlloc(allocator: std.mem.Allocator, dir: std.fs.Dir, path: []const u8, max_bytes: usize) ![]u8 {
+    return dir.readFileAlloc(allocator, path, max_bytes);
+}
+
+/// Write a file relative to `dir`, replacing existing contents.
+pub fn writeFile(dir: std.fs.Dir, path: []const u8, data: []const u8) !void {
+    var file = try dir.createFile(path, .{ .truncate = true });
+    defer file.close();
+    try file.writeAll(data);
+}
+
+/// Atomically replace `target_path` by writing `data` to `tmp_path` in `dir` and
+/// renaming it over the target.
+///
+/// Zig 0.16 mapping: keep the same-directory temporary-file boundary so later
+/// OAuth storage work can preserve same-filesystem rename guarantees and file
+/// mode expectations. This skeleton is intentionally thin; crash-safety policy
+/// hardening belongs to the dedicated filesystem wrapper PR.
+pub fn atomicReplace(dir: std.fs.Dir, target_path: []const u8, tmp_path: []const u8, data: []const u8) !void {
+    var cleanup_tmp = true;
+    defer if (cleanup_tmp) dir.deleteFile(tmp_path) catch {};
+
+    try writeFile(dir, tmp_path, data);
+    try dir.rename(tmp_path, target_path);
+    cleanup_tmp = false;
+}
+
+/// Create a directory and any missing parents relative to `dir`.
+pub fn createDir(dir: std.fs.Dir, path: []const u8) !void {
+    try dir.makePath(path);
+}
+
+test "compat filesystem wrappers read write and atomically replace" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeFile(tmp.dir, "compat.txt", "one");
+    const initial = try readFileAlloc(std.testing.allocator, tmp.dir, "compat.txt", 1024);
+    defer std.testing.allocator.free(initial);
+    try std.testing.expectEqualStrings("one", initial);
+
+    try atomicReplace(tmp.dir, "compat.txt", "compat.txt.tmp", "two");
+    const replaced = try readFileAlloc(std.testing.allocator, tmp.dir, "compat.txt", 1024);
+    defer std.testing.allocator.free(replaced);
+    try std.testing.expectEqualStrings("two", replaced);
+
+    try std.testing.expectError(error.FileNotFound, tmp.dir.openFile("compat.txt.tmp", .{}));
+}
+
+test "compat filesystem wrappers create directories and open files" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try createDir(tmp.dir, "nested/path");
+    try writeFile(tmp.dir, "nested/path/file.txt", "data");
+
+    var file = try openFile(tmp.dir, "nested/path/file.txt", .{});
+    defer file.close();
+
+    var buf: [4]u8 = undefined;
+    const n = try file.readAll(&buf);
+    try std.testing.expectEqualStrings("data", buf[0..n]);
+}
+
+test "compat getCwd returns a directory handle" {
+    const cwd = getCwd();
+    _ = cwd;
+}

--- a/zig/src/compat/fs.zig
+++ b/zig/src/compat/fs.zig
@@ -50,16 +50,14 @@ pub fn writeFile(dir: std.fs.Dir, path: []const u8, data: []const u8) !void {
 /// mode expectations. This skeleton is intentionally thin; crash-safety policy
 /// hardening belongs to the dedicated filesystem wrapper PR.
 pub fn atomicReplace(dir: std.fs.Dir, target_path: []const u8, tmp_path: []const u8, data: []const u8) !void {
+    if (std.mem.eql(u8, target_path, tmp_path)) return error.InvalidAtomicReplacePaths;
+
     var cleanup_tmp = true;
     defer if (cleanup_tmp) dir.deleteFile(tmp_path) catch {};
 
     try writeFile(dir, tmp_path, data);
     try dir.rename(tmp_path, target_path);
     cleanup_tmp = false;
-
-    var replaced = try dir.openFile(target_path, .{ .mode = .write_only });
-    defer replaced.close();
-    try replaced.chmod(default_file_mode);
 }
 
 /// Create a directory and any missing parents relative to `dir`.

--- a/zig/src/compat/fs.zig
+++ b/zig/src/compat/fs.zig
@@ -31,12 +31,6 @@ pub fn readFileAlloc(allocator: std.mem.Allocator, dir: std.fs.Dir, path: []cons
 
 pub const default_file_mode: std.fs.File.Mode = 0o600;
 
-fn chmodFile(dir: std.fs.Dir, path: []const u8, mode: std.fs.File.Mode) !void {
-    var file = try dir.openFile(path, .{ .mode = .write_only });
-    defer file.close();
-    try file.chmod(mode);
-}
-
 /// Write a file relative to `dir`, replacing existing contents.
 ///
 /// Files are created with restrictive permissions by default because later OAuth
@@ -58,16 +52,14 @@ pub fn writeFile(dir: std.fs.Dir, path: []const u8, data: []const u8) !void {
 pub fn atomicReplace(dir: std.fs.Dir, target_path: []const u8, tmp_path: []const u8, data: []const u8) !void {
     if (std.mem.eql(u8, target_path, tmp_path)) return error.InvalidAtomicReplacePaths;
 
-    const target_mode = if (dir.statFile(target_path)) |stat| stat.mode else |err| switch (err) {
-        error.FileNotFound => null,
-        else => return err,
-    };
-
-    var cleanup_tmp = true;
+    var cleanup_tmp = false;
     defer if (cleanup_tmp) dir.deleteFile(tmp_path) catch {};
 
-    try writeFile(dir, tmp_path, data);
-    if (target_mode) |mode| try chmodFile(dir, tmp_path, mode);
+    var file = try dir.createFile(tmp_path, .{ .truncate = false, .exclusive = true, .mode = default_file_mode });
+    cleanup_tmp = true;
+    defer file.close();
+    try file.writeAll(data);
+
     try dir.rename(tmp_path, target_path);
     cleanup_tmp = false;
 }
@@ -94,17 +86,39 @@ test "compat filesystem wrappers read write and atomically replace" {
     try std.testing.expectError(error.FileNotFound, tmp.dir.openFile("compat.txt.tmp", .{}));
 }
 
-test "compat atomic replace preserves existing target mode" {
+test "compat atomic replace re-hardens existing target mode" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
     try writeFile(tmp.dir, "mode.txt", "one");
-    try chmodFile(tmp.dir, "mode.txt", 0o640);
+    {
+        var file = try tmp.dir.openFile("mode.txt", .{ .mode = .write_only });
+        defer file.close();
+        try file.chmod(0o640);
+    }
 
     try atomicReplace(tmp.dir, "mode.txt", "mode.txt.tmp", "two");
 
     const stat = try tmp.dir.statFile("mode.txt");
-    try std.testing.expectEqual(@as(std.fs.File.Mode, 0o640), stat.mode & 0o777);
+    try std.testing.expectEqual(@as(std.fs.File.Mode, default_file_mode), stat.mode & 0o777);
+}
+
+test "compat atomic replace requires a fresh temporary path" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeFile(tmp.dir, "target.txt", "target");
+    try writeFile(tmp.dir, "target.txt.tmp", "stale");
+
+    try std.testing.expectError(error.PathAlreadyExists, atomicReplace(tmp.dir, "target.txt", "target.txt.tmp", "new"));
+
+    const target = try readFileAlloc(std.testing.allocator, tmp.dir, "target.txt", 1024);
+    defer std.testing.allocator.free(target);
+    try std.testing.expectEqualStrings("target", target);
+
+    const tmp_contents = try readFileAlloc(std.testing.allocator, tmp.dir, "target.txt.tmp", 1024);
+    defer std.testing.allocator.free(tmp_contents);
+    try std.testing.expectEqualStrings("stale", tmp_contents);
 }
 
 test "compat filesystem wrappers create directories and open files" {

--- a/zig/src/compat/http.zig
+++ b/zig/src/compat/http.zig
@@ -1,0 +1,63 @@
+const std = @import("std");
+
+pub const Method = std.http.Method;
+pub const Headers = std.http.Client.Request.Headers;
+pub const Request = std.http.Client.Request;
+pub const Response = std.http.Client.Response;
+pub const RequestOptions = struct {
+    extra_headers: []const std.http.Header = &.{},
+    keep_alive: bool = true,
+};
+
+/// Thin HTTP client wrapper for the Zig 0.16 I/O migration seam.
+///
+/// Zig 0.16 mapping: construct `std.http.Client` with the Makai-owned default
+/// I/O context (`std.Io.Threaded`/dispatch as required internally) while keeping
+/// `std.Io` out of public signatures. Provider/OAuth rollout will add streaming
+/// response helpers on this boundary without changing provider behavior here.
+pub const CompatHttpClient = struct {
+    client: std.http.Client,
+
+    pub fn init(allocator: std.mem.Allocator) CompatHttpClient {
+        return .{ .client = .{ .allocator = allocator } };
+    }
+
+    pub fn deinit(self: *CompatHttpClient) void {
+        self.client.deinit();
+        self.* = undefined;
+    }
+
+    pub fn openRequest(self: *CompatHttpClient, method: Method, uri: std.Uri, options: RequestOptions) !Request {
+        return self.client.request(method, uri, .{
+            .extra_headers = options.extra_headers,
+            .keep_alive = options.keep_alive,
+        });
+    }
+};
+
+/// Send a request body and complete the outbound request.
+pub fn sendRequest(request: *Request, body: []const u8) !void {
+    request.transfer_encoding = .{ .content_length = body.len };
+    try request.sendBodyComplete(body);
+}
+
+/// Receive the response headers/body metadata for a request.
+pub fn receiveResponse(request: *Request, response: *Response) !void {
+    try request.receiveHead(response);
+}
+
+/// Return a streaming reader for a response body.
+pub fn responseReader(response: *Response, transfer_buf: []u8) *std.http.Client.Response.Reader {
+    return response.reader(transfer_buf);
+}
+
+test "compat http client initializes and deinitializes" {
+    var client = CompatHttpClient.init(std.testing.allocator);
+    client.deinit();
+}
+
+test "compat http request options default to no extra headers" {
+    const options = RequestOptions{};
+    try std.testing.expectEqual(@as(usize, 0), options.extra_headers.len);
+    try std.testing.expect(options.keep_alive);
+}

--- a/zig/src/compat/http.zig
+++ b/zig/src/compat/http.zig
@@ -36,18 +36,18 @@ pub const HttpClient = struct {
 };
 
 /// Send a request body and complete the outbound request.
-pub fn sendRequest(request: *Request, body: []const u8) !void {
+pub fn sendRequest(request: *Request, body: []u8) !void {
     request.transfer_encoding = .{ .content_length = body.len };
     try request.sendBodyComplete(body);
 }
 
 /// Receive the response headers/body metadata for a request.
-pub fn receiveResponse(request: *Request, response: *Response) !void {
-    try request.receiveHead(response);
+pub fn receiveResponse(request: *Request, redirect_buffer: []u8) !Response {
+    return request.receiveHead(redirect_buffer);
 }
 
 /// Return a streaming reader for a response body.
-pub fn responseReader(response: *Response, transfer_buf: []u8) *std.http.Client.Response.Reader {
+pub fn responseReader(response: *Response, transfer_buf: []u8) *std.Io.Reader {
     return response.reader(transfer_buf);
 }
 

--- a/zig/src/compat/http.zig
+++ b/zig/src/compat/http.zig
@@ -49,21 +49,23 @@ pub fn receiveResponse(request: *Request, redirect_buffer: []u8) !Response {
 }
 
 /// Reader wrapper for streaming response bodies without exposing raw `std.Io`.
-pub const ResponseReader = struct {
-    inner: *std.Io.Reader,
+pub const ResponseReader = opaque {};
 
-    pub fn read(self: ResponseReader, buffer: []u8) !usize {
-        return self.inner.readSliceShort(buffer);
-    }
+/// Read bytes from a response body reader.
+pub fn readResponse(reader: *ResponseReader, buffer: []u8) !usize {
+    const inner: *std.Io.Reader = @ptrCast(@alignCast(reader));
+    return inner.readSliceShort(buffer);
+}
 
-    pub fn readAll(self: ResponseReader, buffer: []u8) !void {
-        try self.inner.readSliceAll(buffer);
-    }
-};
+/// Read exactly `buffer.len` bytes from a response body reader.
+pub fn readAllResponse(reader: *ResponseReader, buffer: []u8) !void {
+    const inner: *std.Io.Reader = @ptrCast(@alignCast(reader));
+    try inner.readSliceAll(buffer);
+}
 
 /// Return a streaming reader for a response body.
-pub fn responseReader(response: *Response, transfer_buf: []u8) ResponseReader {
-    return .{ .inner = response.reader(transfer_buf) };
+pub fn responseReader(response: *Response, transfer_buf: []u8) *ResponseReader {
+    return @ptrCast(@alignCast(response.reader(transfer_buf)));
 }
 
 test "compat http client initializes and deinitializes" {

--- a/zig/src/compat/http.zig
+++ b/zig/src/compat/http.zig
@@ -15,19 +15,19 @@ pub const RequestOptions = struct {
 /// I/O context (`std.Io.Threaded`/dispatch as required internally) while keeping
 /// `std.Io` out of public signatures. Provider/OAuth rollout will add streaming
 /// response helpers on this boundary without changing provider behavior here.
-pub const CompatHttpClient = struct {
+pub const HttpClient = struct {
     client: std.http.Client,
 
-    pub fn init(allocator: std.mem.Allocator) CompatHttpClient {
+    pub fn init(allocator: std.mem.Allocator) HttpClient {
         return .{ .client = .{ .allocator = allocator } };
     }
 
-    pub fn deinit(self: *CompatHttpClient) void {
+    pub fn deinit(self: *HttpClient) void {
         self.client.deinit();
         self.* = undefined;
     }
 
-    pub fn openRequest(self: *CompatHttpClient, method: Method, uri: std.Uri, options: RequestOptions) !Request {
+    pub fn openRequest(self: *HttpClient, method: Method, uri: std.Uri, options: RequestOptions) !Request {
         return self.client.request(method, uri, .{
             .extra_headers = options.extra_headers,
             .keep_alive = options.keep_alive,
@@ -52,7 +52,7 @@ pub fn responseReader(response: *Response, transfer_buf: []u8) *std.http.Client.
 }
 
 test "compat http client initializes and deinitializes" {
-    var client = CompatHttpClient.init(std.testing.allocator);
+    var client = HttpClient.init(std.testing.allocator);
     client.deinit();
 }
 

--- a/zig/src/compat/http.zig
+++ b/zig/src/compat/http.zig
@@ -36,9 +36,11 @@ pub const HttpClient = struct {
 };
 
 /// Send a request body and complete the outbound request.
-pub fn sendRequest(request: *Request, body: []u8) !void {
+pub fn sendRequest(request: *Request, body: []const u8) !void {
     request.transfer_encoding = .{ .content_length = body.len };
-    try request.sendBodyComplete(body);
+    var body_writer = try request.sendBody(&.{});
+    try body_writer.writer.writeAll(body);
+    try body_writer.end();
 }
 
 /// Receive the response headers/body metadata for a request.
@@ -46,9 +48,22 @@ pub fn receiveResponse(request: *Request, redirect_buffer: []u8) !Response {
     return request.receiveHead(redirect_buffer);
 }
 
+/// Reader wrapper for streaming response bodies without exposing raw `std.Io`.
+pub const ResponseReader = struct {
+    inner: *std.Io.Reader,
+
+    pub fn read(self: ResponseReader, buffer: []u8) !usize {
+        return self.inner.readSliceShort(buffer);
+    }
+
+    pub fn readAll(self: ResponseReader, buffer: []u8) !void {
+        try self.inner.readSliceAll(buffer);
+    }
+};
+
 /// Return a streaming reader for a response body.
-pub fn responseReader(response: *Response, transfer_buf: []u8) *std.Io.Reader {
-    return response.reader(transfer_buf);
+pub fn responseReader(response: *Response, transfer_buf: []u8) ResponseReader {
+    return .{ .inner = response.reader(transfer_buf) };
 }
 
 test "compat http client initializes and deinitializes" {

--- a/zig/src/compat/mod.zig
+++ b/zig/src/compat/mod.zig
@@ -5,6 +5,12 @@
 //! Current implementations are thin Zig 0.15.2-compatible pass-throughs; later
 //! migration PRs will remap internals to Zig 0.16 `std.Io.Threaded`/default
 //! context plumbing without changing these stable names unnecessarily.
+//!
+//! Names intentionally follow the task's stable helper list where it is more
+//! specific than the architecture note's examples (`monotonicNanos`, `sleepNs`,
+//! `getCwd`, `resolveAddress`, `tcpListen`). The examples in the architecture
+//! decision remain guidance; this skeleton records the concrete names that
+//! follow-up PRs will migrate without exposing raw `std.Io`.
 
 pub const time = @import("time.zig");
 pub const random = @import("random.zig");

--- a/zig/src/compat/mod.zig
+++ b/zig/src/compat/mod.zig
@@ -1,0 +1,23 @@
+//! Compatibility seams for the Zig 0.15.2 -> 0.16.0 migration.
+//!
+//! These modules intentionally expose Makai-owned wrapper boundaries, not raw
+//! `std.Io`, matching `docs/zig-0.16.0-io-architecture-decision.md`.
+//! Current implementations are thin Zig 0.15.2-compatible pass-throughs; later
+//! migration PRs will remap internals to Zig 0.16 `std.Io.Threaded`/default
+//! context plumbing without changing these stable names unnecessarily.
+
+pub const time = @import("time.zig");
+pub const random = @import("random.zig");
+pub const fs = @import("fs.zig");
+pub const stdio = @import("stdio.zig");
+pub const http = @import("http.zig");
+pub const net = @import("net.zig");
+
+test {
+    _ = time;
+    _ = random;
+    _ = fs;
+    _ = stdio;
+    _ = http;
+    _ = net;
+}

--- a/zig/src/compat/net.zig
+++ b/zig/src/compat/net.zig
@@ -1,0 +1,66 @@
+const std = @import("std");
+
+pub const Address = std.net.Address;
+pub const Server = std.net.Server;
+
+/// TCP stream wrapper used as the stable Makai networking boundary.
+///
+/// Zig 0.16 mapping: wrap streams produced by Makai default-context networking
+/// helpers. The public wrapper avoids exposing `std.Io` while preserving current
+/// byte-stream read/write/close behavior for transports and OAuth callback code.
+pub const Stream = struct {
+    inner: std.net.Stream,
+
+    pub fn init(inner: std.net.Stream) Stream {
+        return .{ .inner = inner };
+    }
+
+    pub fn read(self: *Stream, buffer: []u8) !usize {
+        return self.inner.read(buffer);
+    }
+
+    pub fn write(self: *Stream, data: []const u8) !usize {
+        return self.inner.write(data);
+    }
+
+    pub fn writeAll(self: *Stream, data: []const u8) !void {
+        try self.inner.writeAll(data);
+    }
+
+    pub fn close(self: *Stream) void {
+        self.inner.close();
+    }
+};
+
+/// Resolve a host/port into an address.
+///
+/// Zig 0.16 mapping: route through the selected Makai default I/O/networking
+/// backend internally while keeping this wrapper signature context/allocator
+/// first and free of raw `std.Io`.
+pub fn resolveAddress(allocator: std.mem.Allocator, host: []const u8, port: u16) !Address {
+    _ = allocator;
+    return std.net.Address.resolveIp(host, port);
+}
+
+/// Connect to a TCP peer.
+pub fn tcpConnect(address: Address) !Stream {
+    return .{ .inner = try std.net.tcpConnectToAddress(address) };
+}
+
+/// Listen for TCP connections on `address`.
+pub fn tcpListen(address: Address, options: Address.ListenOptions) !Server {
+    return address.listen(options);
+}
+
+test "compat networking resolves loopback address" {
+    const address = try resolveAddress(std.testing.allocator, "127.0.0.1", 0);
+    try std.testing.expectEqual(@as(u16, 0), address.getPort());
+}
+
+test "compat networking can listen on loopback" {
+    const address = try resolveAddress(std.testing.allocator, "127.0.0.1", 0);
+    var server = try tcpListen(address, .{ .reuse_address = true });
+    defer server.deinit();
+
+    try std.testing.expect(server.listen_address.getPort() != 0);
+}

--- a/zig/src/compat/net.zig
+++ b/zig/src/compat/net.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 
 pub const Address = std.net.Address;
+pub const AddressList = std.net.AddressList;
 pub const Server = std.net.Server;
 
 /// TCP stream wrapper used as the stable Makai networking boundary.
@@ -38,12 +39,20 @@ pub const Stream = struct {
 /// backend internally while keeping this wrapper signature context/allocator
 /// first and free of raw `std.Io`.
 ///
-/// `allocator` is intentionally reserved for the future resolver implementation,
-/// which may allocate address lists or context-backed resolver state. The Zig
-/// 0.15.2 pass-through uses `std.net.Address.resolveIp` and does not allocate.
+/// `allocator` owns temporary DNS resolver allocations during this call.
 pub fn resolveAddress(allocator: std.mem.Allocator, host: []const u8, port: u16) !Address {
-    _ = allocator;
-    return std.net.Address.resolveIp(host, port);
+    var list = try std.net.getAddressList(allocator, host, port);
+    defer list.deinit();
+
+    if (list.addrs.len == 0) return error.UnknownHostName;
+    return list.addrs[0];
+}
+
+/// Resolve a host/port into an owned address list.
+///
+/// Callers own the returned list and must call `deinit`.
+pub fn resolveAddressList(allocator: std.mem.Allocator, host: []const u8, port: u16) !*AddressList {
+    return std.net.getAddressList(allocator, host, port);
 }
 
 /// Connect to a TCP peer.

--- a/zig/src/compat/net.zig
+++ b/zig/src/compat/net.zig
@@ -37,6 +37,10 @@ pub const Stream = struct {
 /// Zig 0.16 mapping: route through the selected Makai default I/O/networking
 /// backend internally while keeping this wrapper signature context/allocator
 /// first and free of raw `std.Io`.
+///
+/// `allocator` is intentionally reserved for the future resolver implementation,
+/// which may allocate address lists or context-backed resolver state. The Zig
+/// 0.15.2 pass-through uses `std.net.Address.resolveIp` and does not allocate.
 pub fn resolveAddress(allocator: std.mem.Allocator, host: []const u8, port: u16) !Address {
     _ = allocator;
     return std.net.Address.resolveIp(host, port);

--- a/zig/src/compat/random.zig
+++ b/zig/src/compat/random.zig
@@ -1,0 +1,37 @@
+const std = @import("std");
+
+/// Fill `buf` with security-sensitive random bytes.
+///
+/// Zig 0.16 mapping: route to the Makai default context's secure entropy source
+/// (`io.randomSecure` or equivalent) per the architecture decision. OAuth
+/// PKCE/state, credential material, and protocol-sensitive nonces should prefer
+/// this helper.
+pub fn secureBytes(buf: []u8) void {
+    std.crypto.random.bytes(buf);
+}
+
+/// Fill `buf` with ordinary random bytes.
+///
+/// Zig 0.16 mapping: route to the Makai default context's non-secure random
+/// source (`io.random`/test deterministic source where appropriate). Do not use
+/// this for credentials, PKCE, OAuth state, or other security-sensitive values.
+pub fn randomBytes(buf: []u8) void {
+    std.crypto.random.bytes(buf);
+}
+
+test "compat random helpers fill requested buffers" {
+    var secure: [16]u8 = [_]u8{0} ** 16;
+    var ordinary: [16]u8 = [_]u8{0} ** 16;
+
+    secureBytes(&secure);
+    randomBytes(&ordinary);
+
+    try std.testing.expect(!std.mem.eql(u8, &secure, &([_]u8{0} ** 16)));
+    try std.testing.expect(!std.mem.eql(u8, &ordinary, &([_]u8{0} ** 16)));
+}
+
+test "compat random helpers accept empty buffers" {
+    var empty: [0]u8 = .{};
+    secureBytes(&empty);
+    randomBytes(&empty);
+}

--- a/zig/src/compat/random.zig
+++ b/zig/src/compat/random.zig
@@ -12,9 +12,13 @@ pub fn secureBytes(buf: []u8) void {
 
 /// Fill `buf` with ordinary random bytes.
 ///
+/// Zig 0.15.2 note: this is currently equivalent to `secureBytes`; both use
+/// `std.crypto.random.bytes` until the Zig 0.16 I/O context exists.
+///
 /// Zig 0.16 mapping: route to the Makai default context's non-secure random
-/// source (`io.random`/test deterministic source where appropriate). Do not use
-/// this for credentials, PKCE, OAuth state, or other security-sensitive values.
+/// source (`io.random`/test deterministic source where appropriate), diverging
+/// from `secureBytes`. After that remap, do not use this for credentials, PKCE,
+/// OAuth state, or other security-sensitive values.
 pub fn randomBytes(buf: []u8) void {
     std.crypto.random.bytes(buf);
 }

--- a/zig/src/compat/stdio.zig
+++ b/zig/src/compat/stdio.zig
@@ -4,7 +4,7 @@ const std = @import("std");
 ///
 /// Zig 0.16 mapping: this will borrow stdin from the Makai default I/O context
 /// or test context, preserving public APIs that avoid raw `std.Io`.
-pub fn getStdinReader() std.fs.File {
+pub fn stdin() std.fs.File {
     return std.fs.File.stdin();
 }
 
@@ -12,13 +12,13 @@ pub fn getStdinReader() std.fs.File {
 ///
 /// Zig 0.16 mapping: this will borrow stdout from the Makai default I/O context
 /// or test context, preserving public APIs that avoid raw `std.Io`.
-pub fn getStdoutWriter() std.fs.File {
+pub fn stdout() std.fs.File {
     return std.fs.File.stdout();
 }
 
 test "compat stdio helpers construct file handles" {
-    const stdin = getStdinReader();
-    const stdout = getStdoutWriter();
-    _ = stdin;
-    _ = stdout;
+    const in = stdin();
+    const out = stdout();
+    _ = in;
+    _ = out;
 }

--- a/zig/src/compat/stdio.zig
+++ b/zig/src/compat/stdio.zig
@@ -1,0 +1,24 @@
+const std = @import("std");
+
+/// Return the process stdin file handle.
+///
+/// Zig 0.16 mapping: this will borrow stdin from the Makai default I/O context
+/// or test context, preserving public APIs that avoid raw `std.Io`.
+pub fn getStdinReader() std.fs.File {
+    return std.fs.File.stdin();
+}
+
+/// Return the process stdout file handle.
+///
+/// Zig 0.16 mapping: this will borrow stdout from the Makai default I/O context
+/// or test context, preserving public APIs that avoid raw `std.Io`.
+pub fn getStdoutWriter() std.fs.File {
+    return std.fs.File.stdout();
+}
+
+test "compat stdio helpers construct file handles" {
+    const stdin = getStdinReader();
+    const stdout = getStdoutWriter();
+    _ = stdin;
+    _ = stdout;
+}

--- a/zig/src/compat/time.zig
+++ b/zig/src/compat/time.zig
@@ -25,12 +25,24 @@ pub fn nowNanos() i128 {
     return std.time.nanoTimestamp();
 }
 
+var monotonic_timer: ?std.time.Timer = null;
+var monotonic_mutex: std.Thread.Mutex = .{};
+
 /// Monotonic nanoseconds suitable for durations and deadlines.
 ///
+/// Zig 0.15.2 mapping: use a process-wide `std.time.Timer` so readings share a
+/// stable monotonic origin and can be subtracted for elapsed-duration math.
 /// Zig 0.16 mapping: move to the chosen `std.Io.Threaded`/default-context
 /// monotonic clock internally while keeping raw `std.Io` out of this API.
 pub fn monotonicNanos() u64 {
-    return @intCast(std.time.nanoTimestamp());
+    monotonic_mutex.lock();
+    defer monotonic_mutex.unlock();
+
+    if (monotonic_timer == null) {
+        monotonic_timer = std.time.Timer.start() catch return 0;
+    }
+
+    return monotonic_timer.?.read();
 }
 
 /// Sleep for a number of nanoseconds.

--- a/zig/src/compat/time.zig
+++ b/zig/src/compat/time.zig
@@ -1,0 +1,59 @@
+const std = @import("std");
+
+/// Wall-clock milliseconds since the Unix epoch.
+///
+/// Zig 0.16 mapping: this remains a wall-clock timestamp helper, backed by the
+/// Makai default I/O context/clock selected in the architecture decision rather
+/// than exposing `std.Io` in the public signature.
+pub fn nowMillis() i64 {
+    return std.time.milliTimestamp();
+}
+
+/// Wall-clock seconds since the Unix epoch.
+///
+/// Zig 0.16 mapping: preserve wall-clock semantics while moving the internal
+/// source to the default Makai context clock.
+pub fn nowSeconds() i64 {
+    return std.time.timestamp();
+}
+
+/// Wall-clock nanoseconds since the Unix epoch.
+///
+/// Zig 0.16 mapping: preserve timestamp semantics separately from monotonic
+/// timing; use the context-backed timestamp source internally.
+pub fn nowNanos() i128 {
+    return std.time.nanoTimestamp();
+}
+
+/// Monotonic nanoseconds suitable for durations and deadlines.
+///
+/// Zig 0.16 mapping: move to the chosen `std.Io.Threaded`/default-context
+/// monotonic clock internally while keeping raw `std.Io` out of this API.
+pub fn monotonicNanos() u64 {
+    return @intCast(std.time.nanoTimestamp());
+}
+
+/// Sleep for a number of nanoseconds.
+///
+/// Zig 0.16 mapping: route through the Makai default I/O context timeout/sleep
+/// primitive while keeping this public helper stable.
+pub fn sleepNs(ns: u64) void {
+    std.Thread.sleep(ns);
+}
+
+/// Sleep for a number of milliseconds.
+pub fn sleepMs(ms: u64) void {
+    sleepNs(ms * std.time.ns_per_ms);
+}
+
+test "compat time helpers return plausible timestamps" {
+    try std.testing.expect(nowMillis() > 0);
+    try std.testing.expect(nowSeconds() > 0);
+    try std.testing.expect(nowNanos() > 0);
+    try std.testing.expect(monotonicNanos() > 0);
+}
+
+test "compat sleep helpers accept zero duration" {
+    sleepNs(0);
+    sleepMs(0);
+}

--- a/zig/src/compat/time.zig
+++ b/zig/src/compat/time.zig
@@ -30,8 +30,7 @@ pub fn nowNanos() i128 {
 /// Zig 0.16 mapping: move to the chosen `std.Io.Threaded`/default-context
 /// monotonic clock internally while keeping raw `std.Io` out of this API.
 pub fn monotonicNanos() u64 {
-    var timer = std.time.Timer.start() catch return 0;
-    return timer.read();
+    return @intCast(std.time.nanoTimestamp());
 }
 
 /// Sleep for a number of nanoseconds.

--- a/zig/src/compat/time.zig
+++ b/zig/src/compat/time.zig
@@ -55,14 +55,14 @@ pub fn sleepNs(ns: u64) void {
 
 /// Sleep for a number of milliseconds.
 pub fn sleepMs(ms: u64) void {
-    sleepNs(ms * std.time.ns_per_ms);
+    sleepNs(std.math.mul(u64, ms, std.time.ns_per_ms) catch std.math.maxInt(u64));
 }
 
 test "compat time helpers return plausible timestamps" {
     try std.testing.expect(nowMillis() > 0);
     try std.testing.expect(nowSeconds() > 0);
     try std.testing.expect(nowNanos() > 0);
-    try std.testing.expect(monotonicNanos() > 0);
+    _ = monotonicNanos();
 }
 
 test "compat sleep helpers accept zero duration" {

--- a/zig/src/compat/time.zig
+++ b/zig/src/compat/time.zig
@@ -30,7 +30,8 @@ pub fn nowNanos() i128 {
 /// Zig 0.16 mapping: move to the chosen `std.Io.Threaded`/default-context
 /// monotonic clock internally while keeping raw `std.Io` out of this API.
 pub fn monotonicNanos() u64 {
-    return @intCast(std.time.nanoTimestamp());
+    var timer = std.time.Timer.start() catch return 0;
+    return timer.read();
 }
 
 /// Sleep for a number of nanoseconds.

--- a/zig/src/compat/time.zig
+++ b/zig/src/compat/time.zig
@@ -34,12 +34,12 @@ var monotonic_mutex: std.Thread.Mutex = .{};
 /// stable monotonic origin and can be subtracted for elapsed-duration math.
 /// Zig 0.16 mapping: move to the chosen `std.Io.Threaded`/default-context
 /// monotonic clock internally while keeping raw `std.Io` out of this API.
-pub fn monotonicNanos() u64 {
+pub fn monotonicNanos() !u64 {
     monotonic_mutex.lock();
     defer monotonic_mutex.unlock();
 
     if (monotonic_timer == null) {
-        monotonic_timer = std.time.Timer.start() catch return 0;
+        monotonic_timer = try std.time.Timer.start();
     }
 
     return monotonic_timer.?.read();
@@ -62,7 +62,7 @@ test "compat time helpers return plausible timestamps" {
     try std.testing.expect(nowMillis() > 0);
     try std.testing.expect(nowSeconds() > 0);
     try std.testing.expect(nowNanos() > 0);
-    _ = monotonicNanos();
+    _ = try monotonicNanos();
 }
 
 test "compat sleep helpers accept zero duration" {


### PR DESCRIPTION
## Summary
- Add a Zig 0.15.2-compatible `compat` module with stable wrapper seams for time, random, filesystem/stdio, HTTP, and networking.
- Wire the compat module into the Zig build and unit test steps without migrating existing call sites.
- Document the Zig 0.16 mapping intent while keeping raw `std.Io` out of public compat signatures.

Part of stack: Zig 0.15.2 → 0.16.0 Migration. PR 2 of 24.

## Test plan
- [x] `/tmp/zig-x86_64-macos-0.15.2/zig build test-unit-core`
- [x] `/tmp/zig-x86_64-macos-0.15.2/zig build test`
- [x] `./scripts/check-zig-patterns.sh`