### PR TITLE
Add compat time and sleep wrappers on 0.15.2

### DIFF
--- a/docs/zig-0.16.0-time-sleep-migration-inventory.md
+++ b/docs/zig-0.16.0-time-sleep-migration-inventory.md
@@ -1,0 +1,111 @@
+# Phase 2 Time / Sleep Migration Inventory
+
+This inventory captures every direct call to `std.time.*` and `std.Thread.sleep` in
+`zig/src/` as of Phase 0 work item 3. Phase 0 introduced the wrappers in
+`zig/src/compat/time.zig` (`nowMillis`, `nowSeconds`, `nowNanos`, `monotonicNanos`,
+`sleepNs`, `sleepMs`) and migrated two representative low-risk call sites
+(`zig/src/utils/retry.zig`, `zig/src/protocol/provider/types.zig`).
+
+The remaining call sites listed here are deferred to Phase 2 work item 13
+("Migrate time, sleep, and timestamp call sites through wrappers"). Each
+remaining site must be ported either to the existing wrappers or to a
+follow-up wrapper added in the same PR. After migration, the goal is for the
+only direct `std.time.*` / `std.Thread.sleep` references in `zig/src/` to live
+inside `zig/src/compat/time.zig` itself.
+
+## Summary
+
+- 277 remaining `std.time.{timestamp,milliTimestamp,nanoTimestamp,Timer,Instant}`
+  occurrences across 36 files (excluding the wrapper module itself).
+- 26 remaining `std.Thread.sleep` occurrences across 11 files (excluding the
+  wrapper module itself).
+
+The full breakdown is below. Counts were produced via ripgrep on the
+`add-time-and-sleep-wrappers-on-0-15-2-phase-0-item-3` branch.
+
+## `std.time.{timestamp,milliTimestamp,nanoTimestamp,Timer,Instant}` call sites
+
+### Streaming core
+- `zig/src/event_stream.zig` (2)
+- `zig/src/agent/types.zig` (1)
+- `zig/src/agent/agent.zig` (2)
+- `zig/src/agent/agent_loop.zig` (4)
+- `zig/src/agent/provider_protocol_bridge.zig` (5)
+
+### Protocol layer
+- `zig/src/protocol/provider/server.zig` (62)
+- `zig/src/protocol/provider/client.zig` (26)
+- `zig/src/protocol/provider/envelope.zig` (22)
+- `zig/src/protocol/provider/runtime.zig` (3)
+- `zig/src/protocol/agent/server.zig` (22)
+- `zig/src/protocol/agent/client.zig` (7)
+- `zig/src/protocol/agent/envelope.zig` (5)
+- `zig/src/protocol/auth/server.zig` (15)
+- `zig/src/protocol/auth/envelope.zig` (1)
+- `zig/src/protocol/tool/runtime.zig` (4)
+- `zig/src/protocol/tool/envelope.zig` (2)
+
+### Providers
+- `zig/src/providers/openai_completions_api.zig` (15)
+- `zig/src/providers/openai_responses_api.zig` (12)
+- `zig/src/providers/azure_openai_responses_api.zig` (2)
+- `zig/src/providers/anthropic_messages_api.zig` (3)
+- `zig/src/providers/google_generative_api.zig` (4)
+- `zig/src/providers/google_vertex_api.zig` (4)
+- `zig/src/providers/ollama_api.zig` (5)
+
+### OAuth and auth
+- `zig/src/oauth/mod.zig` (2)
+- `zig/src/oauth/github_copilot.zig` (4)
+- `zig/src/utils/oauth/anthropic.zig` (4)
+- `zig/src/utils/oauth/google.zig` (3)
+- `zig/src/utils/oauth/github_copilot.zig` (5)
+- `zig/src/utils/oauth/storage.zig` (4)
+- `zig/src/utils/oauth/callback_server.zig` (2)
+- `zig/src/utils/oauth/refresh_lock.zig` (4)
+- `zig/src/utils/auth_resolver.zig` (1)
+
+### Utilities and tools
+- `zig/src/utils/aws_sigv4.zig` (1)
+- `zig/src/utils/pre_transform.zig` (1)
+- `zig/src/tools/auth_cli.zig` (3)
+- `zig/src/tools/makai.zig` (8)
+
+## `std.Thread.sleep` call sites
+
+- `zig/src/event_stream.zig` (1)
+- `zig/src/agent/provider_protocol_bridge.zig` (2)
+- `zig/src/protocol/provider/client.zig` (1)
+- `zig/src/protocol/provider/server.zig` (1)
+- `zig/src/transports/in_process.zig` (1)
+- `zig/src/transports/stdio.zig` (1)
+- `zig/src/utils/oauth/refresh_lock.zig` (6)
+- `zig/src/utils/oauth/github_copilot.zig` (2)
+- `zig/src/utils/oauth/callback_server.zig` (1)
+- `zig/src/tools/auth_cli.zig` (2)
+- `zig/src/tools/makai.zig` (8)
+
+## Migration guidance for Phase 2 work item 13
+
+- Wall-clock millisecond timestamps → `compat.time.nowMillis()`.
+- Wall-clock second timestamps → `compat.time.nowSeconds()`.
+- Wall-clock nanosecond timestamps → `compat.time.nowNanos()`.
+- Monotonic durations / deadlines → `compat.time.monotonicNanos()` (do not
+  reuse the wall-clock helpers for elapsed-duration math).
+- Direct nanosecond sleeps → `compat.time.sleepNs(ns)`.
+- Millisecond sleeps → `compat.time.sleepMs(ms)`. The convenience helper
+  saturates to `std.math.maxInt(u64)` instead of overflowing on absurd inputs.
+- Cancellable polling sleeps that already exist (e.g.
+  `zig/src/utils/retry.zig:sleepMs(ms, cancel_token)`) should keep their own
+  shape but call into `compat.time.sleepNs` internally; do **not** reintroduce
+  direct `std.Thread.sleep` once a wrapper is available.
+- `std.time.Timer.start()` and `std.time.Instant.now()` usages should be
+  reviewed individually: most can switch to `compat.time.monotonicNanos()`,
+  but a few keep their own `std.time.Timer` for elapsed-duration math local
+  to a function and may simply gain a `// 0.16: route through default I/O
+  context` comment instead.
+
+After Phase 2 work item 13 lands, the only `std.time.*` and `std.Thread.sleep`
+references in `zig/src/` should live inside `zig/src/compat/time.zig`. A grep
+guardrail for that invariant can be added to `scripts/check-zig-patterns.sh`
+in the same PR.

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -160,6 +160,9 @@ pub fn build(b: *std.Build) void {
         .root_source_file = b.path("src/utils/retry.zig"),
         .target = target,
         .optimize = optimize,
+        .imports = &.{
+            .{ .name = "compat", .module = compat_mod },
+        },
     });
 
     const oom_mod = b.createModule(.{
@@ -449,6 +452,7 @@ pub fn build(b: *std.Build) void {
             .{ .name = "ai_types", .module = ai_types_mod },
             .{ .name = "owned_slice", .module = owned_slice_mod },
             .{ .name = "model_catalog_types", .module = protocol_model_catalog_types_mod },
+            .{ .name = "compat", .module = compat_mod },
         },
     });
 

--- a/zig/src/compat/time.zig
+++ b/zig/src/compat/time.zig
@@ -2,27 +2,29 @@ const std = @import("std");
 
 /// Wall-clock milliseconds since the Unix epoch.
 ///
-/// Zig 0.16 mapping: this remains a wall-clock timestamp helper, backed by the
-/// Makai default I/O context/clock selected in the architecture decision rather
-/// than exposing `std.Io` in the public signature.
+/// 0.15.2: wraps `std.time.milliTimestamp()`.
+/// 0.16: use `std.Io.Timestamp.now` through the Makai default context while
+/// keeping raw `std.Io` out of this public signature.
 pub fn nowMillis() i64 {
     return std.time.milliTimestamp();
 }
 
 /// Wall-clock seconds since the Unix epoch.
 ///
-/// Zig 0.16 mapping: preserve wall-clock semantics while moving the internal
-/// source to the default Makai context clock.
+/// 0.15.2: wraps `std.time.timestamp()`.
+/// 0.16: use `std.Io.Timestamp.now` through the Makai default context while
+/// preserving wall-clock semantics.
 pub fn nowSeconds() i64 {
     return std.time.timestamp();
 }
 
 /// Wall-clock nanoseconds since the Unix epoch.
 ///
-/// Zig 0.16 mapping: preserve timestamp semantics separately from monotonic
-/// timing; use the context-backed timestamp source internally.
-pub fn nowNanos() i128 {
-    return std.time.nanoTimestamp();
+/// 0.15.2: wraps `std.time.nanoTimestamp()`.
+/// 0.16: use `std.Io.Timestamp.now` through the Makai default context and keep
+/// this separate from monotonic-duration measurements.
+pub fn nowNanos() i64 {
+    return @intCast(std.time.nanoTimestamp());
 }
 
 var monotonic_timer: ?std.time.Timer = null;
@@ -30,10 +32,10 @@ var monotonic_mutex: std.Thread.Mutex = .{};
 
 /// Monotonic nanoseconds suitable for durations and deadlines.
 ///
-/// Zig 0.15.2 mapping: use a process-wide `std.time.Timer` so readings share a
-/// stable monotonic origin and can be subtracted for elapsed-duration math.
-/// Zig 0.16 mapping: move to the chosen `std.Io.Threaded`/default-context
-/// monotonic clock internally while keeping raw `std.Io` out of this API.
+/// 0.15.2: use a process-wide `std.time.Timer` so readings share a stable
+/// monotonic origin and can be subtracted for elapsed-duration math.
+/// 0.16: use `std.Io.Clock`/the chosen default-context monotonic clock
+/// internally while keeping raw `std.Io` out of this API.
 pub fn monotonicNanos() u64 {
     monotonic_mutex.lock();
     defer monotonic_mutex.unlock();
@@ -47,8 +49,9 @@ pub fn monotonicNanos() u64 {
 
 /// Sleep for a number of nanoseconds.
 ///
-/// Zig 0.16 mapping: route through the Makai default I/O context timeout/sleep
-/// primitive while keeping this public helper stable.
+/// 0.15.2: wraps `std.Thread.sleep`.
+/// 0.16: route through the Makai default I/O context timeout/sleep primitive
+/// while keeping this public helper stable.
 pub fn sleepNs(ns: u64) void {
     std.Thread.sleep(ns);
 }
@@ -58,11 +61,45 @@ pub fn sleepMs(ms: u64) void {
     sleepNs(std.math.mul(u64, ms, std.time.ns_per_ms) catch std.math.maxInt(u64));
 }
 
-test "compat time helpers return plausible timestamps" {
-    try std.testing.expect(nowMillis() > 0);
-    try std.testing.expect(nowSeconds() > 0);
-    try std.testing.expect(nowNanos() > 0);
-    _ = monotonicNanos();
+test "compat time helpers return expected public types" {
+    const millis: i64 = nowMillis();
+    const seconds: i64 = nowSeconds();
+    const nanos: i64 = nowNanos();
+    const monotonic: u64 = monotonicNanos();
+
+    _ = millis;
+    _ = seconds;
+    _ = nanos;
+    _ = monotonic;
+}
+
+test "compat time helpers return plausible wall-clock timestamps" {
+    const seconds = nowSeconds();
+    const millis = nowMillis();
+    const nanos = nowNanos();
+
+    try std.testing.expect(seconds > 0);
+    try std.testing.expect(millis > 0);
+    try std.testing.expect(nanos > 0);
+    try std.testing.expect(@divTrunc(millis, std.time.ms_per_s) >= seconds - 1);
+    try std.testing.expect(@divTrunc(nanos, std.time.ns_per_s) >= seconds - 1);
+}
+
+test "compat monotonic nanoseconds are nondecreasing" {
+    const before = monotonicNanos();
+    sleepNs(1);
+    const after = monotonicNanos();
+
+    try std.testing.expect(after >= before);
+}
+
+test "compat sleep helpers bound short sleeps" {
+    const start_ns = monotonicNanos();
+    sleepNs(1 * std.time.ns_per_ms);
+    const elapsed_ns = monotonicNanos() - start_ns;
+
+    try std.testing.expect(elapsed_ns >= 1 * std.time.ns_per_ms);
+    try std.testing.expect(elapsed_ns < 250 * std.time.ns_per_ms);
 }
 
 test "compat sleep helpers accept zero duration" {

--- a/zig/src/compat/time.zig
+++ b/zig/src/compat/time.zig
@@ -98,8 +98,11 @@ test "compat sleep helpers bound short sleeps" {
     sleepNs(1 * std.time.ns_per_ms);
     const elapsed_ns = monotonicNanos() - start_ns;
 
+    // Only assert the lower bound: `sleepNs` must wait at least the requested
+    // duration. Avoid an absolute upper bound here because scheduler pauses on
+    // loaded or virtualized CI runners can legitimately exceed any tight
+    // ceiling without indicating a defect in the wrapper.
     try std.testing.expect(elapsed_ns >= 1 * std.time.ns_per_ms);
-    try std.testing.expect(elapsed_ns < 250 * std.time.ns_per_ms);
 }
 
 test "compat sleep helpers accept zero duration" {

--- a/zig/src/protocol/provider/types.zig
+++ b/zig/src/protocol/provider/types.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const ai_types = @import("ai_types");
 const owned_slice_mod = @import("owned_slice");
 const model_catalog_types = @import("model_catalog_types");
+const compat = @import("compat");
 
 pub const OwnedSlice = owned_slice_mod.OwnedSlice;
 pub const PROTOCOL_VERSION: u8 = 1;
@@ -90,7 +91,7 @@ fn ulidDecode(c: u8) ?u5 {
 pub fn generateUlid() Ulid {
     var ulid: Ulid = undefined;
 
-    const now_ms: u64 = @intCast(@max(std.time.milliTimestamp(), 0));
+    const now_ms: u64 = @intCast(@max(compat.time.nowMillis(), 0));
     ulid[0] = @intCast((now_ms >> 40) & 0xff);
     ulid[1] = @intCast((now_ms >> 32) & 0xff);
     ulid[2] = @intCast((now_ms >> 24) & 0xff);
@@ -445,7 +446,7 @@ test "generateSessionId produces 21-character alphanumeric NanoID" {
 
 test "generateUlid produces valid ULID" {
     const ulid = generateUlid();
-    const now_ms: u64 = @intCast(@max(std.time.milliTimestamp(), 0));
+    const now_ms: u64 = @intCast(@max(compat.time.nowMillis(), 0));
     const ulid_ms = (@as(u64, ulid[0]) << 40) |
         (@as(u64, ulid[1]) << 32) |
         (@as(u64, ulid[2]) << 24) |
@@ -542,7 +543,7 @@ test "Envelope with ping payload" {
         .stream_id = ulid,
         .message_id = generateUlid(),
         .sequence = 1,
-        .timestamp = std.time.milliTimestamp(),
+        .timestamp = compat.time.nowMillis(),
         .payload = .ping,
     };
 

--- a/zig/src/utils/retry.zig
+++ b/zig/src/utils/retry.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const compat = @import("compat");
 
 /// Retry configuration
 pub const RetryConfig = struct {
@@ -21,7 +22,7 @@ pub const RetryConfig = struct {
 
         // Apply jitter if factor > 0
         if (self.jitter_factor > 0) {
-            const seed = @as(u64, @intCast(std.time.nanoTimestamp()));
+            const seed = @as(u64, @intCast(compat.time.nowNanos()));
             var prng = std.Random.DefaultPrng.init(seed);
             const rand = prng.random().float(f32);
             // jitter_mult ranges from (1 - jitter_factor) to (1 + jitter_factor)
@@ -76,7 +77,7 @@ pub fn extractRetryDelayFromHeader(header_value: ?[]const u8) ?u64 {
     // Try parsing as HTTP date (RFC 1123)
     // Format: "Wed, 21 Oct 2015 07:28:00 GMT"
     if (parseHttpDate(trimmed)) |timestamp_ms| {
-        const now_ms = @as(u64, @intCast(std.time.timestamp())) * 1000;
+        const now_ms = @as(u64, @intCast(compat.time.nowSeconds())) * 1000;
         if (timestamp_ms > now_ms) {
             return timestamp_ms - now_ms;
         }
@@ -379,7 +380,7 @@ pub fn isRetryableError(error_text: []const u8) bool {
 /// Returns false if cancelled, true if completed normally.
 pub fn sleepMs(ms: u64, cancel_token: ?*const std.atomic.Value(bool)) bool {
     const check_interval_ms: u64 = 100;
-    const ns_per_ms: u64 = 1_000_000;
+    const ns_per_ms: u64 = std.time.ns_per_ms;
     var remaining: u64 = ms;
 
     while (remaining > 0) {
@@ -391,7 +392,7 @@ pub fn sleepMs(ms: u64, cancel_token: ?*const std.atomic.Value(bool)) bool {
         }
 
         const sleep_time = @min(remaining, check_interval_ms);
-        std.Thread.sleep(sleep_time * ns_per_ms);
+        compat.time.sleepNs(sleep_time * ns_per_ms);
         remaining -= sleep_time;
     }
 
@@ -592,24 +593,24 @@ test "indexOfCaseInsensitive finds substrings correctly" {
 }
 
 test "sleepMs completes normally without cancel token" {
-    const ns_per_ms: i128 = 1_000_000;
-    const start = std.time.nanoTimestamp();
+    const ns_per_ms: u64 = std.time.ns_per_ms;
+    const start = compat.time.monotonicNanos();
     const completed = sleepMs(50, null);
-    const elapsed = std.time.nanoTimestamp() - start;
+    const elapsed = compat.time.monotonicNanos() - start;
 
     try std.testing.expect(completed);
     try std.testing.expect(elapsed >= 50 * ns_per_ms);
 }
 
 test "sleepMs respects cancel token" {
-    const ns_per_ms: u64 = 1_000_000;
+    const ns_per_ms: u64 = std.time.ns_per_ms;
     var cancelled = std.atomic.Value(bool).init(false);
 
     // Start a timer to cancel after 10ms
     const ThreadCtx = struct {
         cancel_token: *std.atomic.Value(bool),
         fn run(self: *@This()) void {
-            std.Thread.sleep(10 * ns_per_ms);
+            compat.time.sleepNs(10 * ns_per_ms);
             self.cancel_token.store(true, .release);
         }
     };


### PR DESCRIPTION
Part of stack: Zig 0.15.2 → 0.16.0 Migration. PR 3 of 24.

## Summary
- Implement real `std.time` / `std.Thread.sleep` wrappers in `zig/src/compat/time.zig` (`nowMillis`, `nowSeconds`, `nowNanos`, `monotonicNanos`, `sleepNs`, `sleepMs`) with 0.16 migration comments and no `std.Io` in their public signatures.
- Migrate two representative low-risk call sites: `zig/src/utils/retry.zig` (jitter seeding, Retry-After parsing, cancellable polling sleep) and `zig/src/protocol/provider/types.zig` (ULID timestamp generation, envelope timestamp tests).
- Add unit tests covering return types, plausible wall-clock values, monotonic non-decreasing behavior, sleep duration bounds, and zero-duration sleeps.
- Record the remaining 277 `std.time.*` and 26 `std.Thread.sleep` call sites in `docs/zig-0.16.0-time-sleep-migration-inventory.md` so Phase 2 work item 13 can migrate them without rediscovering the inventory.

## Acceptance criteria
- Time/sleep wrappers compile and pass tests on Zig 0.15.2.
- `retry.zig` and protocol types migrated to use the wrappers.
- All existing tests continue to pass.
- Remaining call sites documented for Phase 2 migration.

## Constraints honored
- Compiles on Zig 0.15.2 (verified locally with `/usr/local/opt/zig@0.15/bin/zig build test` and `test-unit-utils` / `test-unit-protocol`).
- Only two low-risk central call sites migrated; the 279+ remaining sites are catalogued for Phase 2.
- Wall-clock and monotonic helpers are kept distinct (`std.time.Timer` backs `monotonicNanos`).
- Public wrapper signatures expose only Zig primitive types — no `std.Io` leakage.

## Test plan
- [x] `cd zig && /usr/local/opt/zig@0.15/bin/zig build test` (all unit groups)
- [x] `cd zig && /usr/local/opt/zig@0.15/bin/zig build test-unit-utils`
- [x] `cd zig && /usr/local/opt/zig@0.15/bin/zig build test-unit-protocol`
- [x] `./scripts/check-zig-patterns.sh`