### PR TITLE
Add compat random wrappers

### DIFF
--- a/zig/build.zig
+++ b/zig/build.zig
@@ -817,6 +817,7 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
             .imports = &.{
                 .{ .name = "pkce", .module = oauth_pkce_mod },
+                .{ .name = "compat", .module = compat_mod },
             },
         }),
     });

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -114,6 +114,9 @@ pub fn build(b: *std.Build) void {
         .root_source_file = b.path("src/utils/oauth/pkce.zig"),
         .target = target,
         .optimize = optimize,
+        .imports = &.{
+            .{ .name = "compat", .module = compat_mod },
+        },
     });
 
     const oauth_anthropic_mod = b.createModule(.{
@@ -203,6 +206,9 @@ pub fn build(b: *std.Build) void {
         .root_source_file = b.path("src/oauth/pkce.zig"),
         .target = target,
         .optimize = optimize,
+        .imports = &.{
+            .{ .name = "compat", .module = compat_mod },
+        },
     });
 
     const openai_completions_api_mod = b.createModule(.{
@@ -390,6 +396,7 @@ pub fn build(b: *std.Build) void {
         .imports = &.{
             .{ .name = "transport", .module = transport_mod },
             .{ .name = "ai_types", .module = ai_types_mod },
+            .{ .name = "compat", .module = compat_mod },
         },
     });
 
@@ -799,6 +806,7 @@ pub fn build(b: *std.Build) void {
     const ollama_api_test = b.addTest(.{ .root_module = ollama_api_mod });
 
     const oauth_pkce_test = b.addTest(.{ .root_module = oauth_pkce_mod });
+    const oauth_utils_pkce_test = b.addTest(.{ .root_module = oauth_utils_pkce_mod });
 
     const refresh_lock_test = b.addTest(.{ .root_module = refresh_lock_mod });
 
@@ -1184,6 +1192,7 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(&b.addRunArtifact(google_vertex_api_test).step);
     test_step.dependOn(&b.addRunArtifact(ollama_api_test).step);
     test_step.dependOn(&b.addRunArtifact(oauth_pkce_test).step);
+    test_step.dependOn(&b.addRunArtifact(oauth_utils_pkce_test).step);
     test_step.dependOn(&b.addRunArtifact(refresh_lock_test).step);
     test_step.dependOn(&b.addRunArtifact(oauth_test).step);
     test_step.dependOn(&b.addRunArtifact(agent_types_test).step);
@@ -1265,6 +1274,7 @@ pub fn build(b: *std.Build) void {
     const test_unit_utils_step = b.step("test-unit-utils", "Run utils/oauth unit tests");
     test_unit_utils_step.dependOn(&b.addRunArtifact(github_copilot_test).step);
     test_unit_utils_step.dependOn(&b.addRunArtifact(oauth_pkce_test).step);
+    test_unit_utils_step.dependOn(&b.addRunArtifact(oauth_utils_pkce_test).step);
     test_unit_utils_step.dependOn(&b.addRunArtifact(refresh_lock_test).step);
     test_unit_utils_step.dependOn(&b.addRunArtifact(oauth_test).step);
     test_unit_utils_step.dependOn(&b.addRunArtifact(overflow_test).step);

--- a/zig/src/compat/random.zig
+++ b/zig/src/compat/random.zig
@@ -1,41 +1,126 @@
 const std = @import("std");
 
+/// Deterministic byte source for tests that need stable random-dependent output.
+pub const DeterministicSource = struct {
+    prng: std.Random.DefaultPrng,
+
+    pub fn init(seed: u64) DeterministicSource {
+        return .{ .prng = std.Random.DefaultPrng.init(seed) };
+    }
+
+    pub fn bytes(self: *DeterministicSource, buf: []u8) void {
+        self.prng.random().bytes(buf);
+    }
+
+    pub fn allocBytes(self: *DeterministicSource, allocator: std.mem.Allocator, len: usize) ![]u8 {
+        const buf = try allocator.alloc(u8, len);
+        self.bytes(buf);
+        return buf;
+    }
+};
+
 /// Fill `buf` with security-sensitive random bytes.
 ///
-/// Zig 0.16 mapping: route to the Makai default context's secure entropy source
-/// (`io.randomSecure` or equivalent) per the architecture decision. OAuth
-/// PKCE/state, credential material, and protocol-sensitive nonces should prefer
-/// this helper.
-pub fn secureBytes(buf: []u8) void {
+/// 0.15.2: wraps `std.crypto.random.bytes`.
+/// 0.16: use `io.randomSecure` through the Makai default context while keeping
+/// raw `std.Io` out of this public signature. OAuth PKCE/state, credential
+/// material, and protocol-sensitive nonces should prefer this helper.
+pub fn fillSecureBytes(buf: []u8) void {
     std.crypto.random.bytes(buf);
 }
 
 /// Fill `buf` with ordinary random bytes.
 ///
-/// Zig 0.15.2 note: this is currently equivalent to `secureBytes`; both use
+/// 0.15.2: this is currently equivalent to `fillSecureBytes`; both use
 /// `std.crypto.random.bytes` until the Zig 0.16 I/O context exists.
 ///
-/// Zig 0.16 mapping: route to the Makai default context's non-secure random
-/// source (`io.random`/test deterministic source where appropriate), diverging
-/// from `secureBytes`. After that remap, do not use this for credentials, PKCE,
+/// 0.16: use `io.random` through the Makai default context and keep this
+/// separate from `fillSecureBytes`. Do not use this for credentials, PKCE,
 /// OAuth state, or other security-sensitive values.
-pub fn randomBytes(buf: []u8) void {
+pub fn fillRandomBytes(buf: []u8) void {
     std.crypto.random.bytes(buf);
 }
 
-test "compat random helpers fill requested buffers" {
-    var secure: [16]u8 = [_]u8{0} ** 16;
-    var ordinary: [16]u8 = [_]u8{0} ** 16;
+/// Allocate and fill security-sensitive random bytes.
+///
+/// 0.16: use `io.randomSecure` through the Makai default context.
+pub fn secureBytes(allocator: std.mem.Allocator, len: usize) ![]u8 {
+    const buf = try allocator.alloc(u8, len);
+    fillSecureBytes(buf);
+    return buf;
+}
 
-    secureBytes(&secure);
-    randomBytes(&ordinary);
+/// Allocate and fill ordinary random bytes for non-security identifiers.
+///
+/// 0.16: use `io.random` through the Makai default context.
+pub fn randomBytes(allocator: std.mem.Allocator, len: usize) ![]u8 {
+    const buf = try allocator.alloc(u8, len);
+    fillRandomBytes(buf);
+    return buf;
+}
 
-    try std.testing.expect(!std.mem.eql(u8, &secure, &([_]u8{0} ** 16)));
-    try std.testing.expect(!std.mem.eql(u8, &ordinary, &([_]u8{0} ** 16)));
+fn isAllZero(bytes: []const u8) bool {
+    for (bytes) |byte| {
+        if (byte != 0) return false;
+    }
+    return true;
+}
+
+test "compat random helpers allocate requested lengths" {
+    const secure = try secureBytes(std.testing.allocator, 32);
+    defer std.testing.allocator.free(secure);
+    const ordinary = try randomBytes(std.testing.allocator, 17);
+    defer std.testing.allocator.free(ordinary);
+
+    try std.testing.expectEqual(@as(usize, 32), secure.len);
+    try std.testing.expectEqual(@as(usize, 17), ordinary.len);
+}
+
+test "compat random helpers generate non-empty bytes" {
+    const secure = try secureBytes(std.testing.allocator, 32);
+    defer std.testing.allocator.free(secure);
+    const ordinary = try randomBytes(std.testing.allocator, 32);
+    defer std.testing.allocator.free(ordinary);
+
+    try std.testing.expect(!isAllZero(secure));
+    try std.testing.expect(!isAllZero(ordinary));
+}
+
+test "compat random helpers have basic uniqueness" {
+    const first = try secureBytes(std.testing.allocator, 32);
+    defer std.testing.allocator.free(first);
+    const second = try secureBytes(std.testing.allocator, 32);
+    defer std.testing.allocator.free(second);
+
+    try std.testing.expect(!std.mem.eql(u8, first, second));
+}
+
+test "compat deterministic random source is reproducible" {
+    var first_source = DeterministicSource.init(0x1234_5678);
+    var second_source = DeterministicSource.init(0x1234_5678);
+    var different_source = DeterministicSource.init(0x8765_4321);
+
+    const first = try first_source.allocBytes(std.testing.allocator, 32);
+    defer std.testing.allocator.free(first);
+    const second = try second_source.allocBytes(std.testing.allocator, 32);
+    defer std.testing.allocator.free(second);
+    const different = try different_source.allocBytes(std.testing.allocator, 32);
+    defer std.testing.allocator.free(different);
+
+    try std.testing.expectEqualSlices(u8, first, second);
+    try std.testing.expect(!std.mem.eql(u8, first, different));
 }
 
 test "compat random helpers accept empty buffers" {
     var empty: [0]u8 = .{};
-    secureBytes(&empty);
-    randomBytes(&empty);
+    fillSecureBytes(&empty);
+    fillRandomBytes(&empty);
+
+    const secure = try secureBytes(std.testing.allocator, 0);
+    defer std.testing.allocator.free(secure);
+    const ordinary = try randomBytes(std.testing.allocator, 0);
+    defer std.testing.allocator.free(ordinary);
+
+    try std.testing.expectEqual(@as(usize, 0), secure.len);
+    try std.testing.expectEqual(@as(usize, 0), ordinary.len);
 }

--- a/zig/src/compat/random.zig
+++ b/zig/src/compat/random.zig
@@ -59,6 +59,25 @@ pub fn randomBytes(allocator: std.mem.Allocator, len: usize) ![]u8 {
     return buf;
 }
 
+/// Return a secure random integer in `[0, upper_bound)` without modulo bias.
+///
+/// 0.15.2: delegates to `std.crypto.random.intRangeLessThan`, which uses
+/// rejection sampling. 0.16: use `io.randomSecure` through the Makai default
+/// context and preserve rejection-sampling semantics.
+pub fn secureIntRangeLessThan(comptime T: type, upper_bound: T) T {
+    return std.crypto.random.intRangeLessThan(T, 0, upper_bound);
+}
+
+/// Return an ordinary random integer in `[0, upper_bound)` without modulo bias.
+///
+/// 0.15.2: this is currently equivalent to `secureIntRangeLessThan`; both use
+/// `std.crypto.random.intRangeLessThan` until the Zig 0.16 I/O context exists.
+/// 0.16: use `io.random` through the Makai default context and preserve
+/// rejection-sampling semantics.
+pub fn randomIntRangeLessThan(comptime T: type, upper_bound: T) T {
+    return std.crypto.random.intRangeLessThan(T, 0, upper_bound);
+}
+
 fn isAllZero(bytes: []const u8) bool {
     for (bytes) |byte| {
         if (byte != 0) return false;
@@ -93,6 +112,20 @@ test "compat random helpers have basic uniqueness" {
     defer std.testing.allocator.free(second);
 
     try std.testing.expect(!std.mem.eql(u8, first, second));
+}
+
+test "compat random range helpers respect upper bound" {
+    for (0..128) |_| {
+        const secure_value = secureIntRangeLessThan(usize, 62);
+        const ordinary_value = randomIntRangeLessThan(usize, 62);
+        try std.testing.expect(secure_value < 62);
+        try std.testing.expect(ordinary_value < 62);
+    }
+}
+
+test "compat random range helpers accept a single value range" {
+    try std.testing.expectEqual(@as(usize, 0), secureIntRangeLessThan(usize, 1));
+    try std.testing.expectEqual(@as(usize, 0), randomIntRangeLessThan(usize, 1));
 }
 
 test "compat deterministic random source is reproducible" {

--- a/zig/src/oauth/pkce.zig
+++ b/zig/src/oauth/pkce.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const compat = @import("compat");
 
 /// PKCE pair containing verifier and challenge
 pub const PKCEPair = struct {
@@ -7,11 +8,15 @@ pub const PKCEPair = struct {
 };
 
 /// Generate a PKCE verifier and challenge pair.
-/// Uses crypto.random for secure random bytes.
+/// Uses compat secure random bytes for verifier material.
 pub fn generatePKCE() PKCEPair {
-    // 1. Generate 32 random bytes
+    return generatePKCEWithRandom(compat.random.fillSecureBytes);
+}
+
+fn generatePKCEWithRandom(fill_random: fn ([]u8) void) PKCEPair {
+    // 1. Generate 32 secure random bytes
     var random_bytes: [32]u8 = undefined;
-    std.crypto.random.bytes(&random_bytes);
+    fill_random(&random_bytes);
 
     // 2. Base64URL encode -> verifier (43 chars)
     var verifier: [43]u8 = undefined;
@@ -44,6 +49,12 @@ fn base64URLEncode(input: []const u8, output: []u8) usize {
     return encoded_len;
 }
 
+fn fillTestPkceBytes(buf: []u8) void {
+    for (buf, 0..) |*byte, i| {
+        byte.* = @intCast(i);
+    }
+}
+
 test "generatePKCE produces valid pair" {
     const pair = generatePKCE();
 
@@ -74,6 +85,15 @@ test "generatePKCE creates unique verifiers" {
     // Should be different
     try std.testing.expect(!std.mem.eql(u8, &pair1.verifier, &pair2.verifier));
     try std.testing.expect(!std.mem.eql(u8, &pair1.challenge, &pair2.challenge));
+}
+
+test "generatePKCEWithRandom is deterministic for test seam" {
+    const pair1 = generatePKCEWithRandom(fillTestPkceBytes);
+    const pair2 = generatePKCEWithRandom(fillTestPkceBytes);
+
+    try std.testing.expectEqualSlices(u8, &pair1.verifier, &pair2.verifier);
+    try std.testing.expectEqualSlices(u8, &pair1.challenge, &pair2.challenge);
+    try std.testing.expectEqualStrings("AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8", &pair1.verifier);
 }
 
 test "base64URLEncode produces correct output" {

--- a/zig/src/protocol/provider/types.zig
+++ b/zig/src/protocol/provider/types.zig
@@ -30,10 +30,7 @@ pub const SessionId = [SESSION_ID_LENGTH]u8;
 pub fn generateSessionId() SessionId {
     var session_id: SessionId = undefined;
     for (&session_id) |*byte| {
-        var random_index: [2]u8 = undefined;
-        compat.random.fillRandomBytes(&random_index);
-        const raw_index = std.mem.readInt(u16, &random_index, .little);
-        const idx = raw_index % SESSION_ID_ALPHABET.len;
+        const idx = compat.random.secureIntRangeLessThan(usize, SESSION_ID_ALPHABET.len);
         byte.* = SESSION_ID_ALPHABET[idx];
     }
     return session_id;
@@ -101,7 +98,7 @@ pub fn generateUlid() Ulid {
     ulid[3] = @intCast((now_ms >> 16) & 0xff);
     ulid[4] = @intCast((now_ms >> 8) & 0xff);
     ulid[5] = @intCast(now_ms & 0xff);
-    compat.random.fillRandomBytes(ulid[6..16]);
+    compat.random.fillSecureBytes(ulid[6..16]);
 
     return ulid;
 }

--- a/zig/src/protocol/provider/types.zig
+++ b/zig/src/protocol/provider/types.zig
@@ -30,7 +30,10 @@ pub const SessionId = [SESSION_ID_LENGTH]u8;
 pub fn generateSessionId() SessionId {
     var session_id: SessionId = undefined;
     for (&session_id) |*byte| {
-        const idx = std.crypto.random.intRangeLessThan(usize, 0, SESSION_ID_ALPHABET.len);
+        var random_index: [2]u8 = undefined;
+        compat.random.fillRandomBytes(&random_index);
+        const raw_index = std.mem.readInt(u16, &random_index, .little);
+        const idx = raw_index % SESSION_ID_ALPHABET.len;
         byte.* = SESSION_ID_ALPHABET[idx];
     }
     return session_id;
@@ -98,7 +101,7 @@ pub fn generateUlid() Ulid {
     ulid[3] = @intCast((now_ms >> 16) & 0xff);
     ulid[4] = @intCast((now_ms >> 8) & 0xff);
     ulid[5] = @intCast(now_ms & 0xff);
-    std.crypto.random.bytes(ulid[6..16]);
+    compat.random.fillRandomBytes(ulid[6..16]);
 
     return ulid;
 }

--- a/zig/src/transports/websocket.zig
+++ b/zig/src/transports/websocket.zig
@@ -7,6 +7,7 @@
 const std = @import("std");
 const transport = @import("transport");
 const ai_types = @import("ai_types");
+const compat = @import("compat");
 
 pub const WebSocketClient = struct {
     allocator: std.mem.Allocator,
@@ -447,7 +448,7 @@ pub fn encodeFrame(frame: Frame, allocator: std.mem.Allocator) ![]u8 {
     if (frame.masked) {
         // Generate random mask
         var mask: [4]u8 = undefined;
-        std.crypto.random.bytes(&mask);
+        compat.random.fillSecureBytes(&mask);
 
         // Write mask
         buffer[offset..][0..4].* = mask;
@@ -543,7 +544,7 @@ fn performHandshake(
 
     // Generate random 16-byte nonce and base64 encode
     var nonce: [16]u8 = undefined;
-    std.crypto.random.bytes(&nonce);
+    compat.random.fillSecureBytes(&nonce);
 
     // Base64 encode the nonce
     const encoder = std.base64.standard.Encoder;

--- a/zig/src/utils/oauth/pkce.zig
+++ b/zig/src/utils/oauth/pkce.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const compat = @import("compat");
 
 /// PKCE challenge pair (verifier and challenge)
 pub const PKCEChallenge = struct {
@@ -14,9 +15,13 @@ pub const PKCEChallenge = struct {
 /// Generate PKCE challenge pair
 /// Returns base64url(random_32_bytes) as verifier and base64url(SHA256(verifier)) as challenge
 pub fn generate(allocator: std.mem.Allocator) !PKCEChallenge {
-    // 1. Generate 32 random bytes
+    return generateWithRandom(allocator, compat.random.fillSecureBytes);
+}
+
+fn generateWithRandom(allocator: std.mem.Allocator, fill_random: fn ([]u8) void) !PKCEChallenge {
+    // 1. Generate 32 secure random bytes
     var random_bytes: [32]u8 = undefined;
-    std.crypto.random.bytes(&random_bytes);
+    fill_random(&random_bytes);
 
     // 2. Base64url encode → verifier
     const verifier = try base64urlEncode(allocator, &random_bytes);
@@ -40,6 +45,12 @@ fn base64urlEncode(allocator: std.mem.Allocator, data: []const u8) ![]const u8 {
     const encoded = try allocator.alloc(u8, encoded_len);
     _ = encoder.encode(encoded, data);
     return encoded;
+}
+
+fn fillTestPkceBytes(buf: []u8) void {
+    for (buf, 0..) |*byte, i| {
+        byte.* = @intCast(i);
+    }
 }
 
 test "generate - returns valid PKCE challenge" {
@@ -71,6 +82,18 @@ test "generate - creates unique verifiers" {
     // Should be different
     try std.testing.expect(!std.mem.eql(u8, challenge1.verifier, challenge2.verifier));
     try std.testing.expect(!std.mem.eql(u8, challenge1.challenge, challenge2.challenge));
+}
+
+test "generateWithRandom - is deterministic for test seam" {
+    const challenge1 = try generateWithRandom(std.testing.allocator, fillTestPkceBytes);
+    defer challenge1.deinit(std.testing.allocator);
+
+    const challenge2 = try generateWithRandom(std.testing.allocator, fillTestPkceBytes);
+    defer challenge2.deinit(std.testing.allocator);
+
+    try std.testing.expectEqualStrings(challenge1.verifier, challenge2.verifier);
+    try std.testing.expectEqualStrings(challenge1.challenge, challenge2.challenge);
+    try std.testing.expectEqualStrings("AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8", challenge1.verifier);
 }
 
 test "base64urlEncode - encodes correctly" {


### PR DESCRIPTION
## Summary
- Add compat random helper boundaries for secure vs ordinary random byte generation, plus a deterministic test source.
- Route PKCE verifier generation, WebSocket masks/nonces, and provider protocol IDs through the compat random seam.
- Add deterministic PKCE seam tests and include the utils PKCE module in the build test graph.

Part of stack: Zig 0.15.2 → 0.16.0 Migration. PR 4 of 24.

## Test plan
- [x] ./scripts/check-zig-patterns.sh
- [x] cd zig && /tmp/zig-x86_64-macos-0.15.2/zig build test-unit-utils
- [x] cd zig && /tmp/zig-x86_64-macos-0.15.2/zig build test-unit-protocol
- [x] cd zig && /tmp/zig-x86_64-macos-0.15.2/zig build test-unit-transport
- [x] cd zig && /tmp/zig-x86_64-macos-0.15.2/zig build test

Note: the default `zig` on this runner is 0.16.0 and fails current 0.15.2-targeted code before this PR's changes; tests were run with the local Zig 0.15.2 binary.