### PR TITLE
Add filesystem and stdio compat helpers

### DIFF
--- a/zig/src/compat/fs.zig
+++ b/zig/src/compat/fs.zig
@@ -84,11 +84,11 @@ fn basename(path: []const u8) []const u8 {
     return std.fs.path.basename(path);
 }
 
-fn tempPath(allocator: std.mem.Allocator, target_path: []const u8) ![]u8 {
+fn tempName(allocator: std.mem.Allocator) ![]u8 {
     return std.fmt.allocPrint(
         allocator,
-        "{s}.tmp.{d}.{x}",
-        .{ target_path, compat_time.nowMillis(), compat_random.randomIntRangeLessThan(u64, std.math.maxInt(u64)) },
+        ".makai-tmp-{d}-{x}",
+        .{ compat_time.nowMillis(), compat_random.randomIntRangeLessThan(u64, std.math.maxInt(u64)) },
     );
 }
 
@@ -112,19 +112,17 @@ fn writeFileFailAfter(dir: Dir, path: []const u8, data: []const u8, mode: std.fs
 }
 
 fn atomicReplaceWithInjectedFailure(allocator: std.mem.Allocator, path: []const u8, data: []const u8, fail_after: ?usize) !void {
-    const tmp_path = try tempPath(allocator, path);
-    defer allocator.free(tmp_path);
-
-    if (std.mem.eql(u8, path, tmp_path)) return error.InvalidAtomicReplacePaths;
-
     const target_dir_path = dirnameOrDot(path);
     const target_name = basename(path);
-    const tmp_name = basename(tmp_path);
+    const tmp_name = try tempName(allocator);
+    defer allocator.free(tmp_name);
 
-    var dir = try getCwd().openDir(target_dir_path, .{ .iterate = true });
+    if (std.mem.eql(u8, target_name, tmp_name)) return error.InvalidAtomicReplacePaths;
+
+    var dir = try getCwd().openDir(target_dir_path, .{});
     defer dir.close();
 
-    const final_mode = if (dir.statFile(target_name)) |stat| stat.mode & 0o777 else |err| switch (err) {
+    const final_mode = if (dir.statFile(target_name)) |stat| stat.mode else |err| switch (err) {
         error.FileNotFound => default_file_mode,
         else => return err,
     };
@@ -258,6 +256,33 @@ test "compat atomic replace preserves existing target mode" {
     try std.testing.expectEqual(@as(std.fs.File.Mode, 0o644), stat.mode & 0o777);
 }
 
+test "compat atomic replace preserves special mode bits" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const path = try makeTmpPath(allocator, tmp, "special-mode.txt");
+    defer allocator.free(path);
+
+    try writeFile(path, "old");
+    var file = try openFile(path, .{ .mode = .write_only });
+    defer file.close();
+    try file.chmod(0o1755);
+
+    try atomicReplace(allocator, path, "new contents");
+
+    const stat = try getCwd().statFile(path);
+    try std.testing.expectEqual(@as(std.fs.File.Mode, 0o1755), stat.mode & 0o7777);
+}
+
+test "compat atomic replace temp basename stays bounded" {
+    const allocator = std.testing.allocator;
+    const name = try tempName(allocator);
+    defer allocator.free(name);
+
+    try std.testing.expect(name.len <= std.fs.max_name_bytes);
+}
+
 test "compat atomic replace cleans temp after partial write failure" {
     const allocator = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});
@@ -279,10 +304,8 @@ test "compat atomic replace cleans temp after partial write failure" {
     var target_dir = try getCwd().openDir(dirnameOrDot(path), .{ .iterate = true });
     defer target_dir.close();
     var iter = target_dir.iterate();
-    const prefix = try std.fmt.allocPrint(allocator, "{s}.tmp.", .{basename(path)});
-    defer allocator.free(prefix);
     while (try iter.next()) |entry| {
-        try std.testing.expect(!std.mem.startsWith(u8, entry.name, prefix));
+        try std.testing.expect(!std.mem.startsWith(u8, entry.name, ".makai-tmp-"));
     }
 }
 

--- a/zig/src/compat/fs.zig
+++ b/zig/src/compat/fs.zig
@@ -3,123 +3,251 @@ const std = @import("std");
 pub const OpenFlags = std.fs.File.OpenFlags;
 pub const CreateFlags = std.fs.File.CreateFlags;
 pub const File = std.fs.File;
+pub const Dir = std.fs.Dir;
+
+pub const default_file_mode: std.fs.File.Mode = 0o600;
+const max_file_bytes = 1024 * 1024;
 
 /// Return the process current working directory handle.
 ///
 /// Zig 0.16 mapping: this remains the stable wrapper for cwd access. Internal
 /// implementation may borrow the Makai default I/O context, but public callers
 /// should not receive or pass raw `std.Io` handles.
-pub fn getCwd() std.fs.Dir {
+pub fn getCwd() Dir {
     return std.fs.cwd();
 }
 
-/// Open a file relative to `dir`.
+/// Open a file from the process current working directory.
 ///
-/// Parameter order follows the migration convention: I/O handle (`dir`) first
-/// for handle-scoped operations, then operation-specific parameters.
-pub fn openFile(dir: std.fs.Dir, path: []const u8, flags: OpenFlags) !File {
-    return dir.openFile(path, flags);
+/// Zig 0.16 mapping: preserve this project-level seam while rerouting the
+/// implementation through the selected Makai filesystem context. The public
+/// signature intentionally exposes `std.fs.File`, not raw `std.Io`.
+pub fn openFile(path: []const u8, flags: OpenFlags) !File {
+    return getCwd().openFile(path, flags);
 }
 
-/// Read a file relative to `dir` into an allocated buffer.
+/// Read a file from the process current working directory into caller-owned
+/// memory. The returned slice is owned by `allocator`.
 ///
-/// Zig 0.16 mapping: preserve allocation ownership and error behavior while
-/// routing file reads through the Makai filesystem wrapper internals.
-pub fn readFileAlloc(allocator: std.mem.Allocator, dir: std.fs.Dir, path: []const u8, max_bytes: usize) ![]u8 {
-    return dir.readFileAlloc(allocator, path, max_bytes);
-}
-
-pub const default_file_mode: std.fs.File.Mode = 0o600;
-
-fn chmodFile(dir: std.fs.Dir, path: []const u8, mode: std.fs.File.Mode) !void {
-    var file = try dir.openFile(path, .{ .mode = .write_only });
+/// Zig 0.16 mapping: keep allocation ownership and error behavior stable while
+/// moving the internals to the future filesystem/I/O context.
+pub fn readFileAlloc(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
+    var file = try openFile(path, .{});
     defer file.close();
-    try file.chmod(mode);
+    return file.readToEndAlloc(allocator, max_file_bytes);
 }
 
-/// Write a file relative to `dir`, replacing existing contents.
+/// Write `data` to `path` from the process current working directory.
 ///
-/// Files are created with restrictive permissions by default because later OAuth
-/// storage migration work may use this wrapper for credential material. Existing
-/// files keep their current mode when opened with truncation on POSIX systems.
-pub fn writeFile(dir: std.fs.Dir, path: []const u8, data: []const u8) !void {
-    var file = try dir.createFile(path, .{ .truncate = true, .mode = default_file_mode });
+/// Files are created with restrictive permissions because this wrapper will be
+/// used by credential storage in a later PR. Existing files are truncated through
+/// the same `std.fs` semantics used today by call sites that directly create
+/// files.
+pub fn writeFile(path: []const u8, data: []const u8) !void {
+    var file = try getCwd().createFile(path, .{ .truncate = true, .mode = default_file_mode });
     defer file.close();
     try file.writeAll(data);
 }
 
-/// Atomically replace `target_path` by writing `data` to `tmp_path` in `dir` and
-/// renaming it over the target.
+/// Create a directory at an absolute path.
 ///
-/// Zig 0.16 mapping: keep the same-directory temporary-file boundary so later
-/// OAuth storage work can preserve same-filesystem rename guarantees and file
-/// mode expectations. This skeleton is intentionally thin; crash-safety policy
-/// hardening belongs to the dedicated filesystem wrapper PR.
-pub fn atomicReplace(dir: std.fs.Dir, target_path: []const u8, tmp_path: []const u8, data: []const u8) !void {
-    if (std.mem.eql(u8, target_path, tmp_path)) return error.InvalidAtomicReplacePaths;
+/// Zig 0.16 mapping: this wraps the current absolute-directory creation API so
+/// later I/O-context plumbing can be localized here.
+pub fn createDir(path: []const u8) !void {
+    try std.fs.makeDirAbsolute(path);
+}
 
-    const target_mode = if (dir.statFile(target_path)) |stat| stat.mode else |err| switch (err) {
-        error.FileNotFound => null,
-        else => return err,
-    };
+fn dirnameOrDot(path: []const u8) []const u8 {
+    return std.fs.path.dirname(path) orelse ".";
+}
+
+fn basename(path: []const u8) []const u8 {
+    return std.fs.path.basename(path);
+}
+
+fn tempPath(allocator: std.mem.Allocator, target_path: []const u8) ![]u8 {
+    return std.fmt.allocPrint(
+        allocator,
+        "{s}.tmp.{d}.{x}",
+        .{ target_path, std.time.milliTimestamp(), std.crypto.random.int(u64) },
+    );
+}
+
+fn chmodPath(path: []const u8, mode: std.fs.File.Mode) !void {
+    var file = try getCwd().openFile(path, .{ .mode = .write_only });
+    defer file.close();
+    try file.chmod(mode);
+}
+
+fn writeFileFailAfter(path: []const u8, data: []const u8, fail_after: ?usize) !void {
+    var file = try getCwd().createFile(path, .{ .truncate = true, .mode = default_file_mode });
+    defer file.close();
+
+    if (fail_after) |limit| {
+        const bytes_to_write = @min(limit, data.len);
+        if (bytes_to_write > 0) try file.writeAll(data[0..bytes_to_write]);
+        return error.InjectedPartialWriteFailure;
+    }
+
+    try file.writeAll(data);
+    try file.sync();
+}
+
+fn atomicReplaceWithInjectedFailure(allocator: std.mem.Allocator, path: []const u8, data: []const u8, fail_after: ?usize) !void {
+    const tmp_path = try tempPath(allocator, path);
+    defer allocator.free(tmp_path);
+
+    if (std.mem.eql(u8, path, tmp_path)) return error.InvalidAtomicReplacePaths;
 
     var cleanup_tmp = true;
-    defer if (cleanup_tmp) dir.deleteFile(tmp_path) catch {};
+    defer if (cleanup_tmp) getCwd().deleteFile(tmp_path) catch {};
 
-    try writeFile(dir, tmp_path, data);
-    if (target_mode) |mode| try chmodFile(dir, tmp_path, mode);
-    try dir.rename(tmp_path, target_path);
+    try writeFileFailAfter(tmp_path, data, fail_after);
+    try chmodPath(tmp_path, default_file_mode);
+    try getCwd().rename(tmp_path, path);
     cleanup_tmp = false;
 }
 
-/// Create a directory and any missing parents relative to `dir`.
-pub fn createDir(dir: std.fs.Dir, path: []const u8) !void {
-    try dir.makePath(path);
+/// Atomically replace `path` with `data`.
+///
+/// The temporary file is created next to the target so `rename` stays on the
+/// same filesystem. The target is not opened or truncated before the rename, so
+/// readers see either the old file or the new complete file. The replacement file
+/// is committed with `0o600` permissions, matching credential-file safety
+/// requirements. Failed writes clean up the temporary file where possible.
+///
+/// Zig 0.16 mapping: keep this same-directory temp-file boundary and public
+/// signature; only the internals should change when std.fs/std.Io APIs move.
+pub fn atomicReplace(path: []const u8, data: []const u8) !void {
+    try atomicReplaceWithInjectedFailure(std.heap.page_allocator, path, data, null);
 }
 
-test "compat filesystem wrappers read write and atomically replace" {
+fn makeTmpPath(allocator: std.mem.Allocator, tmp_dir: std.testing.TmpDir, relative_path: []const u8) ![]u8 {
+    const real = try tmp_dir.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(real);
+    return std.fs.path.join(allocator, &.{ real, relative_path });
+}
+
+fn fileExists(path: []const u8) bool {
+    var file = getCwd().openFile(path, .{}) catch return false;
+    file.close();
+    return true;
+}
+
+test "compat filesystem wrappers read write round trip" {
+    const allocator = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
-    try writeFile(tmp.dir, "compat.txt", "one");
-    const initial = try readFileAlloc(std.testing.allocator, tmp.dir, "compat.txt", 1024);
-    defer std.testing.allocator.free(initial);
-    try std.testing.expectEqualStrings("one", initial);
+    const path = try makeTmpPath(allocator, tmp, "compat.txt");
+    defer allocator.free(path);
 
-    try atomicReplace(tmp.dir, "compat.txt", "compat.txt.tmp", "two");
-    const replaced = try readFileAlloc(std.testing.allocator, tmp.dir, "compat.txt", 1024);
-    defer std.testing.allocator.free(replaced);
-    try std.testing.expectEqualStrings("two", replaced);
+    try writeFile(path, "one");
+    const content = try readFileAlloc(allocator, path);
+    defer allocator.free(content);
 
-    try std.testing.expectError(error.FileNotFound, tmp.dir.openFile("compat.txt.tmp", .{}));
+    try std.testing.expectEqualStrings("one", content);
 }
 
-test "compat atomic replace preserves existing target mode" {
+test "compat filesystem wrappers report missing file errors" {
+    const allocator = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
-    try writeFile(tmp.dir, "mode.txt", "one");
-    try chmodFile(tmp.dir, "mode.txt", 0o640);
+    const path = try makeTmpPath(allocator, tmp, "missing.txt");
+    defer allocator.free(path);
 
-    try atomicReplace(tmp.dir, "mode.txt", "mode.txt.tmp", "two");
-
-    const stat = try tmp.dir.statFile("mode.txt");
-    try std.testing.expectEqual(@as(std.fs.File.Mode, 0o640), stat.mode & 0o777);
+    try std.testing.expectError(error.FileNotFound, openFile(path, .{}));
+    try std.testing.expectError(error.FileNotFound, readFileAlloc(allocator, path));
 }
 
-test "compat filesystem wrappers create directories and open files" {
+test "compat filesystem wrappers create directories" {
+    const allocator = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
-    try createDir(tmp.dir, "nested/path");
-    try writeFile(tmp.dir, "nested/path/file.txt", "data");
+    const dir_path = try makeTmpPath(allocator, tmp, "nested");
+    defer allocator.free(dir_path);
+    const file_path = try makeTmpPath(allocator, tmp, "nested/file.txt");
+    defer allocator.free(file_path);
 
-    var file = try openFile(tmp.dir, "nested/path/file.txt", .{});
-    defer file.close();
+    try createDir(dir_path);
+    try writeFile(file_path, "data");
 
-    var buf: [4]u8 = undefined;
-    const n = try file.readAll(&buf);
-    try std.testing.expectEqualStrings("data", buf[0..n]);
+    const content = try readFileAlloc(allocator, file_path);
+    defer allocator.free(content);
+    try std.testing.expectEqualStrings("data", content);
+}
+
+test "compat atomic replace commits complete data with mode 0600" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const path = try makeTmpPath(allocator, tmp, "atomic.txt");
+    defer allocator.free(path);
+
+    try writeFile(path, "old");
+    try chmodPath(path, 0o644);
+    try atomicReplace(path, "new credential contents");
+
+    const content = try readFileAlloc(allocator, path);
+    defer allocator.free(content);
+    try std.testing.expectEqualStrings("new credential contents", content);
+
+    const stat = try getCwd().statFile(path);
+    try std.testing.expectEqual(@as(std.fs.File.Mode, default_file_mode), stat.mode & 0o777);
+}
+
+test "compat atomic replace cleans temp after partial write failure" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const path = try makeTmpPath(allocator, tmp, "partial.txt");
+    defer allocator.free(path);
+
+    try writeFile(path, "old stable contents");
+    try std.testing.expectError(
+        error.InjectedPartialWriteFailure,
+        atomicReplaceWithInjectedFailure(allocator, path, "new contents", 3),
+    );
+
+    const content = try readFileAlloc(allocator, path);
+    defer allocator.free(content);
+    try std.testing.expectEqualStrings("old stable contents", content);
+
+    const leaked_tmp = try std.fmt.allocPrint(allocator, "{s}.tmp", .{path});
+    defer allocator.free(leaked_tmp);
+    try std.testing.expect(!fileExists(leaked_tmp));
+
+    var target_dir = try getCwd().openDir(dirnameOrDot(path), .{ .iterate = true });
+    defer target_dir.close();
+    var iter = target_dir.iterate();
+    const prefix = try std.fmt.allocPrint(allocator, "{s}.tmp.", .{basename(path)});
+    defer allocator.free(prefix);
+    while (try iter.next()) |entry| {
+        try std.testing.expect(!std.mem.startsWith(u8, entry.name, prefix));
+    }
+}
+
+test "compat atomic replace leaves existing file untouched before successful rename" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const path = try makeTmpPath(allocator, tmp, "unchanged.txt");
+    defer allocator.free(path);
+
+    try writeFile(path, "do not truncate");
+    try std.testing.expectError(
+        error.InjectedPartialWriteFailure,
+        atomicReplaceWithInjectedFailure(allocator, path, "replacement", 0),
+    );
+
+    const content = try readFileAlloc(allocator, path);
+    defer allocator.free(content);
+    try std.testing.expectEqualStrings("do not truncate", content);
 }
 
 test "compat getCwd returns a directory handle" {

--- a/zig/src/compat/fs.zig
+++ b/zig/src/compat/fs.zig
@@ -1,4 +1,6 @@
 const std = @import("std");
+const compat_random = @import("random.zig");
+const compat_time = @import("time.zig");
 
 pub const OpenFlags = std.fs.File.OpenFlags;
 pub const CreateFlags = std.fs.File.CreateFlags;
@@ -6,7 +8,7 @@ pub const File = std.fs.File;
 pub const Dir = std.fs.Dir;
 
 pub const default_file_mode: std.fs.File.Mode = 0o600;
-const max_file_bytes = 1024 * 1024;
+pub const default_max_file_bytes = 1024 * 1024;
 
 /// Return the process current working directory handle.
 ///
@@ -29,12 +31,20 @@ pub fn openFile(path: []const u8, flags: OpenFlags) !File {
 /// Read a file from the process current working directory into caller-owned
 /// memory. The returned slice is owned by `allocator`.
 ///
+/// `max_bytes` preserves the caller-controlled limit from the initial wrapper
+/// skeleton and mirrors `std.fs.File.readToEndAlloc` error behavior.
+///
 /// Zig 0.16 mapping: keep allocation ownership and error behavior stable while
 /// moving the internals to the future filesystem/I/O context.
-pub fn readFileAlloc(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
+pub fn readFileAlloc(allocator: std.mem.Allocator, path: []const u8, max_bytes: usize) ![]u8 {
     var file = try openFile(path, .{});
     defer file.close();
-    return file.readToEndAlloc(allocator, max_file_bytes);
+    return file.readToEndAlloc(allocator, max_bytes);
+}
+
+/// Read a file using the credential/config-sized default cap.
+pub fn readFileAllocDefault(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
+    return readFileAlloc(allocator, path, default_max_file_bytes);
 }
 
 /// Write `data` to `path` from the process current working directory.
@@ -49,12 +59,21 @@ pub fn writeFile(path: []const u8, data: []const u8) !void {
     try file.writeAll(data);
 }
 
-/// Create a directory at an absolute path.
+/// Create a directory path relative to cwd or at an absolute path.
 ///
-/// Zig 0.16 mapping: this wraps the current absolute-directory creation API so
-/// later I/O-context plumbing can be localized here.
+/// This is recursive and idempotent, matching `std.fs.Dir.makePath` behavior so
+/// first-run setup can safely create nested config/cache directories repeatedly.
+///
+/// Zig 0.16 mapping: route through the future filesystem/I/O context while
+/// preserving relative-path support and recursive semantics.
 pub fn createDir(path: []const u8) !void {
-    try std.fs.makeDirAbsolute(path);
+    try getCwd().makePath(path);
+}
+
+/// Explicit alias documenting the recursive semantics expected by later OAuth
+/// storage migration work.
+pub fn createDirAll(path: []const u8) !void {
+    try createDir(path);
 }
 
 fn dirnameOrDot(path: []const u8) []const u8 {
@@ -69,18 +88,16 @@ fn tempPath(allocator: std.mem.Allocator, target_path: []const u8) ![]u8 {
     return std.fmt.allocPrint(
         allocator,
         "{s}.tmp.{d}.{x}",
-        .{ target_path, std.time.milliTimestamp(), std.crypto.random.int(u64) },
+        .{ target_path, compat_time.nowMillis(), compat_random.randomIntRangeLessThan(u64, std.math.maxInt(u64)) },
     );
 }
 
-fn chmodPath(path: []const u8, mode: std.fs.File.Mode) !void {
-    var file = try getCwd().openFile(path, .{ .mode = .write_only });
-    defer file.close();
+fn chmodFile(file: File, mode: std.fs.File.Mode) !void {
     try file.chmod(mode);
 }
 
-fn writeFileFailAfter(path: []const u8, data: []const u8, fail_after: ?usize) !void {
-    var file = try getCwd().createFile(path, .{ .truncate = true, .mode = default_file_mode });
+fn writeFileFailAfter(dir: Dir, path: []const u8, data: []const u8, mode: std.fs.File.Mode, fail_after: ?usize) !void {
+    var file = try dir.createFile(path, .{ .truncate = true, .mode = mode });
     defer file.close();
 
     if (fail_after) |limit| {
@@ -90,6 +107,7 @@ fn writeFileFailAfter(path: []const u8, data: []const u8, fail_after: ?usize) !v
     }
 
     try file.writeAll(data);
+    try chmodFile(file, mode);
     try file.sync();
 }
 
@@ -99,12 +117,23 @@ fn atomicReplaceWithInjectedFailure(allocator: std.mem.Allocator, path: []const 
 
     if (std.mem.eql(u8, path, tmp_path)) return error.InvalidAtomicReplacePaths;
 
-    var cleanup_tmp = true;
-    defer if (cleanup_tmp) getCwd().deleteFile(tmp_path) catch {};
+    const target_dir_path = dirnameOrDot(path);
+    const target_name = basename(path);
+    const tmp_name = basename(tmp_path);
 
-    try writeFileFailAfter(tmp_path, data, fail_after);
-    try chmodPath(tmp_path, default_file_mode);
-    try getCwd().rename(tmp_path, path);
+    var dir = try getCwd().openDir(target_dir_path, .{ .iterate = true });
+    defer dir.close();
+
+    const final_mode = if (dir.statFile(target_name)) |stat| stat.mode & 0o777 else |err| switch (err) {
+        error.FileNotFound => default_file_mode,
+        else => return err,
+    };
+
+    var cleanup_tmp = true;
+    defer if (cleanup_tmp) dir.deleteFile(tmp_name) catch {};
+
+    try writeFileFailAfter(dir, tmp_name, data, final_mode, fail_after);
+    try dir.rename(tmp_name, target_name);
     cleanup_tmp = false;
 }
 
@@ -112,26 +141,20 @@ fn atomicReplaceWithInjectedFailure(allocator: std.mem.Allocator, path: []const 
 ///
 /// The temporary file is created next to the target so `rename` stays on the
 /// same filesystem. The target is not opened or truncated before the rename, so
-/// readers see either the old file or the new complete file. The replacement file
-/// is committed with `0o600` permissions, matching credential-file safety
-/// requirements. Failed writes clean up the temporary file where possible.
+/// readers see either the old file or the new complete file. Existing target
+/// permissions are preserved; new targets use `0o600`, matching credential-file
+/// safety requirements. Failed writes clean up the temporary file where possible.
 ///
 /// Zig 0.16 mapping: keep this same-directory temp-file boundary and public
 /// signature; only the internals should change when std.fs/std.Io APIs move.
-pub fn atomicReplace(path: []const u8, data: []const u8) !void {
-    try atomicReplaceWithInjectedFailure(std.heap.page_allocator, path, data, null);
+pub fn atomicReplace(allocator: std.mem.Allocator, path: []const u8, data: []const u8) !void {
+    try atomicReplaceWithInjectedFailure(allocator, path, data, null);
 }
 
 fn makeTmpPath(allocator: std.mem.Allocator, tmp_dir: std.testing.TmpDir, relative_path: []const u8) ![]u8 {
     const real = try tmp_dir.dir.realpathAlloc(allocator, ".");
     defer allocator.free(real);
     return std.fs.path.join(allocator, &.{ real, relative_path });
-}
-
-fn fileExists(path: []const u8) bool {
-    var file = getCwd().openFile(path, .{}) catch return false;
-    file.close();
-    return true;
 }
 
 test "compat filesystem wrappers read write round trip" {
@@ -143,7 +166,7 @@ test "compat filesystem wrappers read write round trip" {
     defer allocator.free(path);
 
     try writeFile(path, "one");
-    const content = try readFileAlloc(allocator, path);
+    const content = try readFileAlloc(allocator, path, default_max_file_bytes);
     defer allocator.free(content);
 
     try std.testing.expectEqualStrings("one", content);
@@ -158,28 +181,47 @@ test "compat filesystem wrappers report missing file errors" {
     defer allocator.free(path);
 
     try std.testing.expectError(error.FileNotFound, openFile(path, .{}));
-    try std.testing.expectError(error.FileNotFound, readFileAlloc(allocator, path));
+    try std.testing.expectError(error.FileNotFound, readFileAlloc(allocator, path, default_max_file_bytes));
 }
 
-test "compat filesystem wrappers create directories" {
+test "compat filesystem wrappers preserve caller controlled read limits" {
     const allocator = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
-    const dir_path = try makeTmpPath(allocator, tmp, "nested");
+    const path = try makeTmpPath(allocator, tmp, "limited.txt");
+    defer allocator.free(path);
+
+    try writeFile(path, "abcdef");
+    try std.testing.expectError(error.FileTooBig, readFileAlloc(allocator, path, 3));
+
+    const content = try readFileAlloc(allocator, path, 6);
+    defer allocator.free(content);
+    try std.testing.expectEqualStrings("abcdef", content);
+}
+
+test "compat filesystem wrappers create nested directories idempotently" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const dir_path = try makeTmpPath(allocator, tmp, "nested/path");
     defer allocator.free(dir_path);
-    const file_path = try makeTmpPath(allocator, tmp, "nested/file.txt");
+    const file_path = try makeTmpPath(allocator, tmp, "nested/path/file.txt");
     defer allocator.free(file_path);
 
     try createDir(dir_path);
+    try createDir(dir_path);
+    try createDirAll(dir_path);
     try writeFile(file_path, "data");
 
-    const content = try readFileAlloc(allocator, file_path);
+    const content = try readFileAlloc(allocator, file_path, default_max_file_bytes);
     defer allocator.free(content);
     try std.testing.expectEqualStrings("data", content);
 }
 
-test "compat atomic replace commits complete data with mode 0600" {
+
+test "compat atomic replace commits complete data for new file with mode 0600" {
     const allocator = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -187,16 +229,33 @@ test "compat atomic replace commits complete data with mode 0600" {
     const path = try makeTmpPath(allocator, tmp, "atomic.txt");
     defer allocator.free(path);
 
-    try writeFile(path, "old");
-    try chmodPath(path, 0o644);
-    try atomicReplace(path, "new credential contents");
+    try atomicReplace(allocator, path, "new credential contents");
 
-    const content = try readFileAlloc(allocator, path);
+    const content = try readFileAlloc(allocator, path, default_max_file_bytes);
     defer allocator.free(content);
     try std.testing.expectEqualStrings("new credential contents", content);
 
     const stat = try getCwd().statFile(path);
     try std.testing.expectEqual(@as(std.fs.File.Mode, default_file_mode), stat.mode & 0o777);
+}
+
+test "compat atomic replace preserves existing target mode" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const path = try makeTmpPath(allocator, tmp, "mode.txt");
+    defer allocator.free(path);
+
+    try writeFile(path, "old");
+    var file = try openFile(path, .{ .mode = .write_only });
+    defer file.close();
+    try file.chmod(0o644);
+
+    try atomicReplace(allocator, path, "new contents");
+
+    const stat = try getCwd().statFile(path);
+    try std.testing.expectEqual(@as(std.fs.File.Mode, 0o644), stat.mode & 0o777);
 }
 
 test "compat atomic replace cleans temp after partial write failure" {
@@ -213,13 +272,9 @@ test "compat atomic replace cleans temp after partial write failure" {
         atomicReplaceWithInjectedFailure(allocator, path, "new contents", 3),
     );
 
-    const content = try readFileAlloc(allocator, path);
+    const content = try readFileAlloc(allocator, path, default_max_file_bytes);
     defer allocator.free(content);
     try std.testing.expectEqualStrings("old stable contents", content);
-
-    const leaked_tmp = try std.fmt.allocPrint(allocator, "{s}.tmp", .{path});
-    defer allocator.free(leaked_tmp);
-    try std.testing.expect(!fileExists(leaked_tmp));
 
     var target_dir = try getCwd().openDir(dirnameOrDot(path), .{ .iterate = true });
     defer target_dir.close();
@@ -245,7 +300,7 @@ test "compat atomic replace leaves existing file untouched before successful ren
         atomicReplaceWithInjectedFailure(allocator, path, "replacement", 0),
     );
 
-    const content = try readFileAlloc(allocator, path);
+    const content = try readFileAlloc(allocator, path, default_max_file_bytes);
     defer allocator.free(content);
     try std.testing.expectEqualStrings("do not truncate", content);
 }

--- a/zig/src/compat/stdio.zig
+++ b/zig/src/compat/stdio.zig
@@ -1,10 +1,19 @@
 const std = @import("std");
 
+pub const File = std.fs.File;
+pub const FileReader = std.fs.File.Reader;
+pub const FileWriter = std.fs.File.Writer;
+
+pub const default_buffer_size = 4096;
+
+var stdin_reader_buffer: [default_buffer_size]u8 = undefined;
+var stdout_writer_buffer: [default_buffer_size]u8 = undefined;
+
 /// Return the process stdin file handle.
 ///
 /// Zig 0.16 mapping: this will borrow stdin from the Makai default I/O context
 /// or test context, preserving public APIs that avoid raw `std.Io`.
-pub fn stdin() std.fs.File {
+pub fn stdin() File {
     return std.fs.File.stdin();
 }
 
@@ -12,13 +21,58 @@ pub fn stdin() std.fs.File {
 ///
 /// Zig 0.16 mapping: this will borrow stdout from the Makai default I/O context
 /// or test context, preserving public APIs that avoid raw `std.Io`.
-pub fn stdout() std.fs.File {
+pub fn stdout() File {
     return std.fs.File.stdout();
 }
 
-test "compat stdio helpers construct file handles" {
+/// Return a Zig 0.15.2 stdin reader without exposing `std.Io` in the public API.
+///
+/// The returned reader borrows a module-level buffer, matching the process-global
+/// nature of stdin. Future stdio transport call-site migration can use
+/// `fileReader` with caller-owned buffers for testable file-backed readers.
+///
+/// Zig 0.16 mapping: adapt this helper to the selected Makai input context while
+/// preserving caller ownership: stdin itself is borrowed and not closed here.
+pub fn getStdinReader() FileReader {
+    return stdin().reader(&stdin_reader_buffer);
+}
+
+/// Return a Zig 0.15.2 stdout writer without exposing `std.Io` in the public API.
+///
+/// The returned writer borrows a module-level buffer. Callers that write through
+/// it are responsible for flushing according to `std.fs.File.Writer` semantics.
+pub fn getStdoutWriter() FileWriter {
+    return stdout().writer(&stdout_writer_buffer);
+}
+
+/// Return a reader for an explicit file handle using a caller-owned buffer.
+///
+/// Used by future stdio transport and CLI migrations to centralize file reader
+/// construction while keeping `std.Io` out of public signatures.
+pub fn fileReader(file: File, buffer: []u8) FileReader {
+    return file.reader(buffer);
+}
+
+/// Return a writer for an explicit file handle using a caller-owned buffer.
+///
+/// Used by future stdio transport and CLI migrations to centralize file writer
+/// construction while keeping `std.Io` out of public signatures.
+pub fn fileWriter(file: File, buffer: []u8) FileWriter {
+    return file.writer(buffer);
+}
+
+test "compat stdio helpers construct file handles readers and writers" {
     const in = stdin();
     const out = stdout();
-    _ = in;
-    _ = out;
+    var reader = getStdinReader();
+    var writer = getStdoutWriter();
+    var explicit_reader_buf: [default_buffer_size]u8 = undefined;
+    var explicit_writer_buf: [default_buffer_size]u8 = undefined;
+    var explicit_reader = fileReader(in, &explicit_reader_buf);
+    var explicit_writer = fileWriter(out, &explicit_writer_buf);
+
+    _ = &reader;
+    _ = &writer;
+    _ = &explicit_reader;
+    _ = &explicit_writer;
 }

--- a/zig/src/compat/stdio.zig
+++ b/zig/src/compat/stdio.zig
@@ -22,35 +22,44 @@ pub fn stdout() File {
 
 /// Return a Zig 0.15.2 stdin reader using caller-owned buffer storage.
 ///
+/// The reader is initialized in streaming mode so repeated helper construction
+/// continues from the file descriptor's current position instead of resetting to
+/// offset 0 when stdin is redirected from a seekable file.
+///
 /// Zig 0.16 mapping: adapt this helper to the selected Makai input context while
 /// preserving buffer ownership: callers provide the storage and stdin itself is
 /// borrowed, not closed here.
 pub fn getStdinReader(buffer: []u8) FileReader {
-    return stdin().reader(buffer);
+    return stdin().readerStreaming(buffer);
 }
 
 /// Return a Zig 0.15.2 stdout writer using caller-owned buffer storage.
 ///
-/// Callers that write through it are responsible for flushing according to
-/// `std.fs.File.Writer` semantics.
+/// The writer is initialized in streaming mode so repeated helper construction
+/// appends through the file descriptor's current position instead of resetting to
+/// offset 0 when stdout is redirected to a seekable file. Callers that write
+/// through it are responsible for flushing according to `std.fs.File.Writer`
+/// semantics.
 pub fn getStdoutWriter(buffer: []u8) FileWriter {
-    return stdout().writer(buffer);
+    return stdout().writerStreaming(buffer);
 }
 
-/// Return a reader for an explicit file handle using a caller-owned buffer.
+/// Return a streaming reader for an explicit file handle using a caller-owned
+/// buffer.
 ///
 /// Used by future stdio transport and CLI migrations to centralize file reader
 /// construction while keeping `std.Io` out of public signatures.
 pub fn fileReader(file: File, buffer: []u8) FileReader {
-    return file.reader(buffer);
+    return file.readerStreaming(buffer);
 }
 
-/// Return a writer for an explicit file handle using a caller-owned buffer.
+/// Return a streaming writer for an explicit file handle using a caller-owned
+/// buffer.
 ///
 /// Used by future stdio transport and CLI migrations to centralize file writer
 /// construction while keeping `std.Io` out of public signatures.
 pub fn fileWriter(file: File, buffer: []u8) FileWriter {
-    return file.writer(buffer);
+    return file.writerStreaming(buffer);
 }
 
 test "compat stdio helpers construct file handles readers and writers" {

--- a/zig/src/compat/stdio.zig
+++ b/zig/src/compat/stdio.zig
@@ -4,11 +4,6 @@ pub const File = std.fs.File;
 pub const FileReader = std.fs.File.Reader;
 pub const FileWriter = std.fs.File.Writer;
 
-pub const default_buffer_size = 4096;
-
-var stdin_reader_buffer: [default_buffer_size]u8 = undefined;
-var stdout_writer_buffer: [default_buffer_size]u8 = undefined;
-
 /// Return the process stdin file handle.
 ///
 /// Zig 0.16 mapping: this will borrow stdin from the Makai default I/O context
@@ -25,24 +20,21 @@ pub fn stdout() File {
     return std.fs.File.stdout();
 }
 
-/// Return a Zig 0.15.2 stdin reader without exposing `std.Io` in the public API.
-///
-/// The returned reader borrows a module-level buffer, matching the process-global
-/// nature of stdin. Future stdio transport call-site migration can use
-/// `fileReader` with caller-owned buffers for testable file-backed readers.
+/// Return a Zig 0.15.2 stdin reader using caller-owned buffer storage.
 ///
 /// Zig 0.16 mapping: adapt this helper to the selected Makai input context while
-/// preserving caller ownership: stdin itself is borrowed and not closed here.
-pub fn getStdinReader() FileReader {
-    return stdin().reader(&stdin_reader_buffer);
+/// preserving buffer ownership: callers provide the storage and stdin itself is
+/// borrowed, not closed here.
+pub fn getStdinReader(buffer: []u8) FileReader {
+    return stdin().reader(buffer);
 }
 
-/// Return a Zig 0.15.2 stdout writer without exposing `std.Io` in the public API.
+/// Return a Zig 0.15.2 stdout writer using caller-owned buffer storage.
 ///
-/// The returned writer borrows a module-level buffer. Callers that write through
-/// it are responsible for flushing according to `std.fs.File.Writer` semantics.
-pub fn getStdoutWriter() FileWriter {
-    return stdout().writer(&stdout_writer_buffer);
+/// Callers that write through it are responsible for flushing according to
+/// `std.fs.File.Writer` semantics.
+pub fn getStdoutWriter(buffer: []u8) FileWriter {
+    return stdout().writer(buffer);
 }
 
 /// Return a reader for an explicit file handle using a caller-owned buffer.
@@ -64,10 +56,13 @@ pub fn fileWriter(file: File, buffer: []u8) FileWriter {
 test "compat stdio helpers construct file handles readers and writers" {
     const in = stdin();
     const out = stdout();
-    var reader = getStdinReader();
-    var writer = getStdoutWriter();
-    var explicit_reader_buf: [default_buffer_size]u8 = undefined;
-    var explicit_writer_buf: [default_buffer_size]u8 = undefined;
+    var stdin_buf: [4096]u8 = undefined;
+    var stdout_buf: [4096]u8 = undefined;
+    var explicit_reader_buf: [4096]u8 = undefined;
+    var explicit_writer_buf: [4096]u8 = undefined;
+
+    var reader = getStdinReader(&stdin_buf);
+    var writer = getStdoutWriter(&stdout_buf);
     var explicit_reader = fileReader(in, &explicit_reader_buf);
     var explicit_writer = fileWriter(out, &explicit_writer_buf);
 


### PR DESCRIPTION
## Summary
- Add cwd-based filesystem compatibility helpers for open/read/write/createDir and atomic replacement.
- Add stdio/file reader and writer helper seams that avoid public `std.Io` signatures.
- Cover read/write, missing-file, directory creation, and atomic replace safety behavior.

Part of stack: Zig 0.15.2 → 0.16.0 Migration. PR 5 of 24.

## Test plan
- [x] `cd zig && /tmp/zig-0.15.2/zig build test`
- [x] `./scripts/check-zig-patterns.sh`