### PR TITLE
Add HTTP compatibility abstraction

### DIFF
--- a/zig/build.zig
+++ b/zig/build.zig
@@ -59,6 +59,9 @@ pub fn build(b: *std.Build) void {
         .root_source_file = b.path("src/compat/mod.zig"),
         .target = target,
         .optimize = optimize,
+        .imports = &.{
+            .{ .name = "sse_parser", .module = sse_parser_mod },
+        },
     });
 
     const streaming_json_mod = b.createModule(.{

--- a/zig/src/compat/http.zig
+++ b/zig/src/compat/http.zig
@@ -15,6 +15,9 @@ const default_header_buffer_size = 16 * 1024;
 pub const CompatHttpRequestOptions = struct {
     keep_alive: bool = true,
     header_buffer_size: usize = default_header_buffer_size,
+    /// Defaults to `identity` so SSE streams are not buffered behind gzip. Future
+    /// non-SSE consumers can opt into another value without bypassing this seam.
+    accept_encoding: []const u8 = "identity",
 };
 
 /// Type-erased streaming response body reader.
@@ -126,12 +129,12 @@ pub const CompatHttpClient = struct {
         errdefer self.allocator.free(header_buffer);
 
         // SSE streams must not be gzip-compressed: compression can buffer event
-        // delivery and break incremental parsing. This mirrors provider call
-        // sites that currently override accept-encoding to `identity`.
+        // delivery and break incremental parsing. Default to `identity`, while
+        // allowing non-SSE consumers to opt into another accept-encoding value.
         var request_handle = try self.client.request(method, uri, .{
             .extra_headers = headers,
             .keep_alive = options.keep_alive,
-            .headers = .{ .accept_encoding = .{ .override = "identity" } },
+            .headers = .{ .accept_encoding = .{ .override = options.accept_encoding } },
         });
         errdefer request_handle.deinit();
 
@@ -187,6 +190,7 @@ pub fn responseReader(response: *Response, transfer_buffer: []u8) CompatHttpBody
 pub const CompatHttpMockResponse = struct {
     status_code: CompatHttpStatus,
     header_list: []const CompatHttpHeader,
+    raw_header_bytes: []const u8 = "",
     body: []const u8,
     offset: usize = 0,
     max_chunk_size: usize = std.math.maxInt(usize),
@@ -195,8 +199,26 @@ pub const CompatHttpMockResponse = struct {
         return .{ .status_code = status_code, .header_list = header_list, .body = body };
     }
 
+    pub fn initWithHeaderBytes(
+        status_code: CompatHttpStatus,
+        header_list: []const CompatHttpHeader,
+        raw_header_bytes: []const u8,
+        body: []const u8,
+    ) CompatHttpMockResponse {
+        return .{
+            .status_code = status_code,
+            .header_list = header_list,
+            .raw_header_bytes = raw_header_bytes,
+            .body = body,
+        };
+    }
+
     pub fn status(self: *const CompatHttpMockResponse) CompatHttpStatus {
         return self.status_code;
+    }
+
+    pub fn headerBytes(self: *const CompatHttpMockResponse) []const u8 {
+        return self.raw_header_bytes;
     }
 
     pub fn headers(self: *const CompatHttpMockResponse) []const CompatHttpHeader {
@@ -228,6 +250,10 @@ test "compat http request options default to streaming safe behavior" {
     const options = CompatHttpRequestOptions{};
     try std.testing.expect(options.keep_alive);
     try std.testing.expectEqual(@as(usize, default_header_buffer_size), options.header_buffer_size);
+    try std.testing.expectEqualStrings("identity", options.accept_encoding);
+
+    const gzip_options = CompatHttpRequestOptions{ .accept_encoding = "gzip" };
+    try std.testing.expectEqualStrings("gzip", gzip_options.accept_encoding);
 }
 
 test "compat http mock response exposes status headers and incremental reader" {
@@ -239,6 +265,10 @@ test "compat http mock response exposes status headers and incremental reader" {
 
     try std.testing.expectEqual(CompatHttpStatus.ok, response.status());
     try std.testing.expectEqualStrings("content-type", response.headers()[0].name);
+    try std.testing.expectEqualStrings("", response.headerBytes());
+
+    const raw_response = CompatHttpMockResponse.initWithHeaderBytes(.ok, &headers, "HTTP/1.1 200 OK\r\n", "");
+    try std.testing.expectEqualStrings("HTTP/1.1 200 OK\r\n", raw_response.headerBytes());
 
     var reader = response.reader();
     var buffer: [4]u8 = undefined;

--- a/zig/src/compat/http.zig
+++ b/zig/src/compat/http.zig
@@ -1,78 +1,291 @@
 const std = @import("std");
+const sse_parser = @import("sse_parser");
 
-pub const Method = std.http.Method;
-pub const Headers = std.http.Client.Request.Headers;
-pub const Request = std.http.Client.Request;
-pub const Response = std.http.Client.Response;
-pub const RequestOptions = struct {
-    extra_headers: []const std.http.Header = &.{},
+pub const CompatHttpMethod = std.http.Method;
+pub const CompatHttpHeader = std.http.Header;
+pub const CompatHttpStatus = std.http.Status;
+
+const default_header_buffer_size = 16 * 1024;
+
+/// Request options for the compatibility HTTP seam.
+///
+/// Zig 0.16 mapping: these options remain Makai-owned request metadata. The
+/// implementation will translate them to the future `std.http.Client` request
+/// flow after client construction moves to `std.http.Client{ .io = ... }`.
+pub const CompatHttpRequestOptions = struct {
     keep_alive: bool = true,
+    header_buffer_size: usize = default_header_buffer_size,
 };
 
-/// Thin HTTP client wrapper for the Zig 0.16 I/O migration seam.
+/// Type-erased streaming response body reader.
 ///
-/// Zig 0.16 mapping: construct `std.http.Client` with the Makai-owned default
-/// I/O context (`std.Io.Threaded`/dispatch as required internally) while keeping
-/// `std.Io` out of public signatures. Provider/OAuth rollout will add streaming
-/// response helpers on this boundary without changing provider behavior here.
-pub const HttpClient = struct {
-    client: std.http.Client,
+/// Public APIs intentionally expose only `read`/`readSliceShort` over byte
+/// slices. The Zig 0.15.2 implementation adapts `std.http.Client.Response`'s
+/// reader internally; a later Zig 0.16 implementation can adapt the new I/O
+/// reader shape without leaking `std.Io` into provider or OAuth signatures.
+pub const CompatHttpBodyReader = struct {
+    context: *anyopaque,
+    read_fn: *const fn (context: *anyopaque, buffer: []u8) anyerror!usize,
 
-    pub fn init(allocator: std.mem.Allocator) HttpClient {
-        return .{ .client = .{ .allocator = allocator } };
+    pub fn read(self: CompatHttpBodyReader, buffer: []u8) !usize {
+        return self.read_fn(self.context, buffer);
     }
 
-    pub fn deinit(self: *HttpClient) void {
+    pub fn readSliceShort(self: CompatHttpBodyReader, buffer: []u8) !usize {
+        return self.read(buffer);
+    }
+};
+
+fn stdReaderRead(context: *anyopaque, buffer: []u8) !usize {
+    const reader: *std.Io.Reader = @ptrCast(@alignCast(context));
+    return reader.readSliceShort(buffer);
+}
+
+fn bodyReaderFromStd(reader: *std.Io.Reader) CompatHttpBodyReader {
+    return .{ .context = reader, .read_fn = stdReaderRead };
+}
+
+/// HTTP response wrapper that owns the in-flight request and header storage.
+///
+/// The request must stay alive while callers stream the response body. Keeping it
+/// inside this wrapper preserves the current Zig 0.15.2 lifetime requirements and
+/// gives the Zig 0.16 migration a single place to absorb request/send/receive
+/// state-machine changes.
+pub const CompatHttpResponse = struct {
+    allocator: std.mem.Allocator,
+    request_handle: std.http.Client.Request,
+    response: std.http.Client.Response,
+    header_buffer: []u8,
+
+    pub fn deinit(self: *CompatHttpResponse) void {
+        self.request_handle.deinit();
+        self.allocator.free(self.header_buffer);
+        self.* = undefined;
+    }
+
+    pub fn status(self: *const CompatHttpResponse) CompatHttpStatus {
+        return self.response.head.status;
+    }
+
+    pub fn headerBytes(self: *const CompatHttpResponse) []const u8 {
+        return self.response.head.bytes;
+    }
+
+    pub fn headers(self: *const CompatHttpResponse) std.http.HeaderIterator {
+        return self.response.head.iterateHeaders();
+    }
+
+    pub fn reader(self: *CompatHttpResponse, transfer_buffer: []u8) CompatHttpBodyReader {
+        return bodyReaderFromStd(self.response.reader(transfer_buffer));
+    }
+};
+
+/// Thin HTTP client wrapper for provider/OAuth request creation.
+///
+/// Zig 0.15.2: wraps `std.http.Client{ .allocator = allocator }` and the
+/// `request -> send body -> receive head -> stream body` sequence used by current
+/// providers.
+///
+/// Zig 0.16 mapping: construct `std.http.Client` with the Makai-owned default
+/// I/O context internally (for example `std.http.Client{ .io = ... }`) and
+/// translate this same method to the new request/send/receive flow. Raw `std.Io`
+/// handles must remain private to this module.
+pub const CompatHttpClient = struct {
+    allocator: std.mem.Allocator,
+    client: std.http.Client,
+
+    pub fn init(allocator: std.mem.Allocator) CompatHttpClient {
+        return .{ .allocator = allocator, .client = .{ .allocator = allocator } };
+    }
+
+    pub fn deinit(self: *CompatHttpClient) void {
         self.client.deinit();
         self.* = undefined;
     }
 
-    pub fn openRequest(self: *HttpClient, method: Method, uri: std.Uri, options: RequestOptions) !Request {
-        return self.client.request(method, uri, .{
-            .extra_headers = options.extra_headers,
+    pub fn request(
+        self: *CompatHttpClient,
+        method: CompatHttpMethod,
+        url: []const u8,
+        headers: []const CompatHttpHeader,
+        body: []const u8,
+    ) !CompatHttpResponse {
+        return self.requestWithOptions(method, url, headers, body, .{});
+    }
+
+    pub fn requestWithOptions(
+        self: *CompatHttpClient,
+        method: CompatHttpMethod,
+        url: []const u8,
+        headers: []const CompatHttpHeader,
+        body: []const u8,
+        options: CompatHttpRequestOptions,
+    ) !CompatHttpResponse {
+        const uri = try std.Uri.parse(url);
+        const header_buffer = try self.allocator.alloc(u8, options.header_buffer_size);
+        errdefer self.allocator.free(header_buffer);
+
+        // SSE streams must not be gzip-compressed: compression can buffer event
+        // delivery and break incremental parsing. This mirrors provider call
+        // sites that currently override accept-encoding to `identity`.
+        var request_handle = try self.client.request(method, uri, .{
+            .extra_headers = headers,
             .keep_alive = options.keep_alive,
+            .headers = .{ .accept_encoding = .{ .override = "identity" } },
         });
+        errdefer request_handle.deinit();
+
+        request_handle.transfer_encoding = .{ .content_length = body.len };
+        try request_handle.sendBodyComplete(body);
+
+        const response = try request_handle.receiveHead(header_buffer);
+        return .{
+            .allocator = self.allocator,
+            .request_handle = request_handle,
+            .response = response,
+            .header_buffer = header_buffer,
+        };
     }
 };
 
+/// Backwards-compatible aliases from the initial compatibility skeleton.
+pub const Method = CompatHttpMethod;
+pub const Headers = std.http.Client.Request.Headers;
+pub const Request = std.http.Client.Request;
+pub const Response = std.http.Client.Response;
+pub const RequestOptions = CompatHttpRequestOptions;
+pub const HttpClient = CompatHttpClient;
+pub const ResponseReader = CompatHttpBodyReader;
+
+/// Open a low-level request for call sites that still need to manage the
+/// request state machine directly before they migrate to `CompatHttpClient.request`.
+pub fn openRequest(client: *CompatHttpClient, method: CompatHttpMethod, uri: std.Uri, options: CompatHttpRequestOptions, headers: []const CompatHttpHeader) !Request {
+    return client.client.request(method, uri, .{
+        .extra_headers = headers,
+        .keep_alive = options.keep_alive,
+    });
+}
+
 /// Send a request body and complete the outbound request.
-pub fn sendRequest(request: *Request, body: []const u8) !void {
-    request.transfer_encoding = .{ .content_length = body.len };
-    var body_writer = try request.sendBody(&.{});
-    try body_writer.writer.writeAll(body);
-    try body_writer.end();
+pub fn sendRequest(request_handle: *Request, body: []const u8) !void {
+    request_handle.transfer_encoding = .{ .content_length = body.len };
+    try request_handle.sendBodyComplete(body);
 }
 
 /// Receive the response headers/body metadata for a request.
-pub fn receiveResponse(request: *Request, redirect_buffer: []u8) !Response {
-    return request.receiveHead(redirect_buffer);
+pub fn receiveResponse(request_handle: *Request, header_buffer: []u8) !Response {
+    return request_handle.receiveHead(header_buffer);
 }
 
-/// Reader wrapper for streaming response bodies without exposing raw `std.Io`.
-pub const ResponseReader = struct {
-    inner: *std.Io.Reader,
+/// Return a streaming reader for a response body.
+pub fn responseReader(response: *Response, transfer_buffer: []u8) CompatHttpBodyReader {
+    return bodyReaderFromStd(response.reader(transfer_buffer));
+}
 
-    pub fn read(self: ResponseReader, buffer: []u8) !usize {
-        return self.inner.readSliceShort(buffer);
+/// Mock response for tests and preparatory consumers that need to validate the
+/// abstraction without opening a socket.
+pub const CompatHttpMockResponse = struct {
+    status_code: CompatHttpStatus,
+    header_list: []const CompatHttpHeader,
+    body: []const u8,
+    offset: usize = 0,
+    max_chunk_size: usize = std.math.maxInt(usize),
+
+    pub fn init(status_code: CompatHttpStatus, header_list: []const CompatHttpHeader, body: []const u8) CompatHttpMockResponse {
+        return .{ .status_code = status_code, .header_list = header_list, .body = body };
     }
 
-    pub fn readAll(self: ResponseReader, buffer: []u8) !void {
-        try self.inner.readSliceAll(buffer);
+    pub fn status(self: *const CompatHttpMockResponse) CompatHttpStatus {
+        return self.status_code;
+    }
+
+    pub fn headers(self: *const CompatHttpMockResponse) []const CompatHttpHeader {
+        return self.header_list;
+    }
+
+    pub fn reader(self: *CompatHttpMockResponse) CompatHttpBodyReader {
+        return .{ .context = self, .read_fn = mockRead };
+    }
+
+    fn mockRead(context: *anyopaque, buffer: []u8) !usize {
+        const self: *CompatHttpMockResponse = @ptrCast(@alignCast(context));
+        if (self.offset >= self.body.len) return 0;
+
+        const remaining = self.body.len - self.offset;
+        const n = @min(buffer.len, @min(self.max_chunk_size, remaining));
+        @memcpy(buffer[0..n], self.body[self.offset .. self.offset + n]);
+        self.offset += n;
+        return n;
     }
 };
 
-/// Return a streaming reader for a response body.
-pub fn responseReader(response: *Response, transfer_buf: []u8) ResponseReader {
-    return .{ .inner = response.reader(transfer_buf) };
-}
-
 test "compat http client initializes and deinitializes" {
-    var client = HttpClient.init(std.testing.allocator);
+    var client = CompatHttpClient.init(std.testing.allocator);
     client.deinit();
 }
 
-test "compat http request options default to no extra headers" {
-    const options = RequestOptions{};
-    try std.testing.expectEqual(@as(usize, 0), options.extra_headers.len);
+test "compat http request options default to streaming safe behavior" {
+    const options = CompatHttpRequestOptions{};
     try std.testing.expect(options.keep_alive);
+    try std.testing.expectEqual(@as(usize, default_header_buffer_size), options.header_buffer_size);
+}
+
+test "compat http mock response exposes status headers and incremental reader" {
+    const headers = [_]CompatHttpHeader{
+        .{ .name = "content-type", .value = "text/event-stream" },
+    };
+    var response = CompatHttpMockResponse.init(.ok, &headers, "abcdef");
+    response.max_chunk_size = 2;
+
+    try std.testing.expectEqual(CompatHttpStatus.ok, response.status());
+    try std.testing.expectEqualStrings("content-type", response.headers()[0].name);
+
+    var reader = response.reader();
+    var buffer: [4]u8 = undefined;
+
+    const first = try reader.readSliceShort(&buffer);
+    try std.testing.expectEqual(@as(usize, 2), first);
+    try std.testing.expectEqualStrings("ab", buffer[0..first]);
+
+    const second = try reader.readSliceShort(&buffer);
+    try std.testing.expectEqual(@as(usize, 2), second);
+    try std.testing.expectEqualStrings("cd", buffer[0..second]);
+
+    const third = try reader.readSliceShort(&buffer);
+    try std.testing.expectEqual(@as(usize, 2), third);
+    try std.testing.expectEqualStrings("ef", buffer[0..third]);
+
+    const done = try reader.readSliceShort(&buffer);
+    try std.testing.expectEqual(@as(usize, 0), done);
+}
+
+test "compat http body reader preserves SSE incremental parsing" {
+    const body = "data: first\n\ndata: second\n\n";
+    var response = CompatHttpMockResponse.init(.ok, &.{}, body);
+    response.max_chunk_size = 1;
+    var reader = response.reader();
+
+    var parser = sse_parser.SSEParser.init(std.testing.allocator);
+    defer parser.deinit();
+
+    var read_buffer: [8]u8 = undefined;
+    var event_count: usize = 0;
+    var saw_first = false;
+    var saw_second = false;
+
+    while (true) {
+        const n = try reader.readSliceShort(&read_buffer);
+        if (n == 0) break;
+
+        const events = try parser.feed(read_buffer[0..n]);
+        for (events) |event| {
+            event_count += 1;
+            if (std.mem.eql(u8, event.data, "first")) saw_first = true;
+            if (std.mem.eql(u8, event.data, "second")) saw_second = true;
+        }
+    }
+
+    try std.testing.expectEqual(@as(usize, 2), event_count);
+    try std.testing.expect(saw_first);
+    try std.testing.expect(saw_second);
 }


### PR DESCRIPTION
Part of stack: Zig 0.15.2 → 0.16.0 Migration. PR 6 of 24.

## Summary
- Adds `CompatHttpClient` / `CompatHttpResponse` in `zig/src/compat/http.zig` to centralize provider/OAuth HTTP client creation, request sending, status/header access, and streaming response-body reads.
- Adds a type-erased streaming body reader and mock response test double to validate incremental body consumption without migrating provider call sites yet.
- Documents the expected Zig 0.16 request-flow and `std.http.Client{ .io = ... }` mapping while keeping raw `std.Io` out of public wrapper signatures.

## Test plan
- [x] `cd zig && /tmp/zig-0.15.2/zig build test`