### PR TITLE
Add networking compatibility wrappers

### DIFF
--- a/zig/src/compat/net.zig
+++ b/zig/src/compat/net.zig
@@ -167,11 +167,12 @@ test "compat networking loopback connect read write round trip" {
     var server = try tcpListen(address, .{ .reuse_address = true });
     defer server.deinit();
 
+    var client = try tcpConnect(server.listenAddress());
+    errdefer client.close();
+
     var context = LoopbackServerContext{ .server = &server };
     const thread = try std.Thread.spawn(.{}, loopbackServerThread, .{&context});
     defer thread.join();
-
-    var client = try tcpConnect(server.listenAddress());
     defer client.close();
 
     try client.writeAll("ping");

--- a/zig/src/compat/net.zig
+++ b/zig/src/compat/net.zig
@@ -2,13 +2,14 @@ const std = @import("std");
 
 pub const Address = std.net.Address;
 pub const AddressList = std.net.AddressList;
-pub const Server = std.net.Server;
+pub const ListenOptions = Address.ListenOptions;
 
 /// TCP stream wrapper used as the stable Makai networking boundary.
 ///
-/// Zig 0.16 mapping: wrap streams produced by Makai default-context networking
-/// helpers. The public wrapper avoids exposing `std.Io` while preserving current
-/// byte-stream read/write/close behavior for transports and OAuth callback code.
+/// Zig 0.15.2: owns a `std.net.Stream` and forwards byte reads/writes.
+/// 0.16: use streams produced by Makai default-context networking helpers
+/// (`std.Io.net.tcpConnect` internally) without exposing raw `std.Io` in this
+/// public wrapper API.
 pub const Stream = struct {
     inner: std.net.Stream,
 
@@ -33,22 +34,50 @@ pub const Stream = struct {
     }
 };
 
-/// Resolve a host/port into an address.
-///
-/// Zig 0.16 mapping: route through the selected Makai default I/O/networking
-/// backend internally while keeping this wrapper signature context/allocator
-/// first and free of raw `std.Io`.
-///
-/// `allocator` owns temporary DNS resolver allocations during this call.
-pub fn resolveAddress(allocator: std.mem.Allocator, host: []const u8, port: u16) !Address {
-    var list = try std.net.getAddressList(allocator, host, port);
-    defer list.deinit();
+/// Accepted TCP connection returned by `Server.accept`.
+pub const Connection = struct {
+    stream: Stream,
+    address: Address,
+};
 
-    if (list.addrs.len == 0) return error.UnknownHostName;
-    return list.addrs[0];
+/// TCP listener wrapper used by OAuth callback and transport networking paths.
+///
+/// Zig 0.15.2: owns a `std.net.Server`. 0.16: use Makai's selected networking
+/// backend internally while preserving this listen/accept shape.
+pub const Server = struct {
+    inner: std.net.Server,
+
+    pub fn init(inner: std.net.Server) Server {
+        return .{ .inner = inner };
+    }
+
+    pub fn listenAddress(self: *const Server) Address {
+        return self.inner.listen_address;
+    }
+
+    pub fn accept(self: *Server) !Connection {
+        const connection = try self.inner.accept();
+        return .{
+            .stream = Stream.init(connection.stream),
+            .address = connection.address,
+        };
+    }
+
+    pub fn deinit(self: *Server) void {
+        self.inner.deinit();
+    }
+};
+
+/// Resolve an IPv4/IPv6 string host and port into an address.
+///
+/// Zig 0.15.2: wraps `std.net.Address.resolveIp`.
+/// 0.16: keep this public signature and route through the selected Makai
+/// networking context internally.
+pub fn resolveAddress(host: []const u8, port: u16) !Address {
+    return std.net.Address.resolveIp(host, port);
 }
 
-/// Resolve a host/port into an owned address list.
+/// Resolve a host/port into an owned address list for DNS-style consumers.
 ///
 /// Callers own the returned list and must call `deinit`.
 pub fn resolveAddressList(allocator: std.mem.Allocator, host: []const u8, port: u16) !*AddressList {
@@ -56,24 +85,80 @@ pub fn resolveAddressList(allocator: std.mem.Allocator, host: []const u8, port: 
 }
 
 /// Connect to a TCP peer.
+///
+/// Zig 0.15.2: wraps `std.net.tcpConnectToAddress`.
+/// 0.16: use std.Io.net.tcpConnect internally.
 pub fn tcpConnect(address: Address) !Stream {
-    return .{ .inner = try std.net.tcpConnectToAddress(address) };
+    return Stream.init(try std.net.tcpConnectToAddress(address));
 }
 
 /// Listen for TCP connections on `address`.
-pub fn tcpListen(address: Address, options: Address.ListenOptions) !Server {
-    return address.listen(options);
+///
+/// Zig 0.15.2: wraps `std.net.Address.listen`.
+/// 0.16: use std.Io.net.tcpListen internally.
+pub fn tcpListen(address: Address, options: ListenOptions) !Server {
+    return Server.init(try address.listen(options));
+}
+
+const LoopbackServerContext = struct {
+    server: *Server,
+    result: anyerror!void = {},
+};
+
+fn loopbackServerThread(context: *LoopbackServerContext) void {
+    var connection = context.server.accept() catch |err| {
+        context.result = err;
+        return;
+    };
+    defer connection.stream.close();
+
+    var buffer: [32]u8 = undefined;
+    const bytes_read = connection.stream.read(&buffer) catch |err| {
+        context.result = err;
+        return;
+    };
+
+    if (!std.mem.eql(u8, buffer[0..bytes_read], "ping")) {
+        context.result = error.UnexpectedRequest;
+        return;
+    }
+
+    connection.stream.writeAll("pong") catch |err| {
+        context.result = err;
+        return;
+    };
 }
 
 test "compat networking resolves loopback address" {
-    const address = try resolveAddress(std.testing.allocator, "127.0.0.1", 0);
+    const address = try resolveAddress("127.0.0.1", 0);
     try std.testing.expectEqual(@as(u16, 0), address.getPort());
 }
 
 test "compat networking can listen on loopback" {
-    const address = try resolveAddress(std.testing.allocator, "127.0.0.1", 0);
+    const address = try resolveAddress("127.0.0.1", 0);
     var server = try tcpListen(address, .{ .reuse_address = true });
     defer server.deinit();
 
-    try std.testing.expect(server.listen_address.getPort() != 0);
+    try std.testing.expect(server.listenAddress().getPort() != 0);
+}
+
+test "compat networking loopback connect read write round trip" {
+    const address = try resolveAddress("127.0.0.1", 0);
+    var server = try tcpListen(address, .{ .reuse_address = true });
+    defer server.deinit();
+
+    var context = LoopbackServerContext{ .server = &server };
+    const thread = try std.Thread.spawn(.{}, loopbackServerThread, .{&context});
+
+    var client = try tcpConnect(server.listenAddress());
+    defer client.close();
+
+    try client.writeAll("ping");
+
+    var response: [4]u8 = undefined;
+    const bytes_read = try client.read(&response);
+    try std.testing.expectEqualStrings("pong", response[0..bytes_read]);
+
+    thread.join();
+    try context.result;
 }

--- a/zig/src/compat/net.zig
+++ b/zig/src/compat/net.zig
@@ -68,13 +68,20 @@ pub const Server = struct {
     }
 };
 
-/// Resolve an IPv4/IPv6 string host and port into an address.
+/// Resolve a host/port into an address.
 ///
-/// Zig 0.15.2: wraps `std.net.Address.resolveIp`.
+/// Zig 0.15.2: wraps `std.net.getAddressList` and returns the first resolved
+/// address, preserving DNS hostname support in addition to literal IP inputs.
 /// 0.16: keep this public signature and route through the selected Makai
 /// networking context internally.
-pub fn resolveAddress(host: []const u8, port: u16) !Address {
-    return std.net.Address.resolveIp(host, port);
+///
+/// `allocator` owns temporary DNS resolver allocations during this call.
+pub fn resolveAddress(allocator: std.mem.Allocator, host: []const u8, port: u16) !Address {
+    var list = try std.net.getAddressList(allocator, host, port);
+    defer list.deinit();
+
+    if (list.addrs.len == 0) return error.UnknownHostName;
+    return list.addrs[0];
 }
 
 /// Resolve a host/port into an owned address list for DNS-style consumers.
@@ -112,13 +119,21 @@ fn loopbackServerThread(context: *LoopbackServerContext) void {
     };
     defer connection.stream.close();
 
-    var buffer: [32]u8 = undefined;
-    const bytes_read = connection.stream.read(&buffer) catch |err| {
-        context.result = err;
-        return;
-    };
+    var buffer: [4]u8 = undefined;
+    var total_read: usize = 0;
+    while (total_read < buffer.len) {
+        const bytes_read = connection.stream.read(buffer[total_read..]) catch |err| {
+            context.result = err;
+            return;
+        };
+        if (bytes_read == 0) {
+            context.result = error.EndOfStream;
+            return;
+        }
+        total_read += bytes_read;
+    }
 
-    if (!std.mem.eql(u8, buffer[0..bytes_read], "ping")) {
+    if (!std.mem.eql(u8, &buffer, "ping")) {
         context.result = error.UnexpectedRequest;
         return;
     }
@@ -130,12 +145,17 @@ fn loopbackServerThread(context: *LoopbackServerContext) void {
 }
 
 test "compat networking resolves loopback address" {
-    const address = try resolveAddress("127.0.0.1", 0);
+    const address = try resolveAddress(std.testing.allocator, "127.0.0.1", 0);
+    try std.testing.expectEqual(@as(u16, 0), address.getPort());
+}
+
+test "compat networking resolves localhost hostname" {
+    const address = try resolveAddress(std.testing.allocator, "localhost", 0);
     try std.testing.expectEqual(@as(u16, 0), address.getPort());
 }
 
 test "compat networking can listen on loopback" {
-    const address = try resolveAddress("127.0.0.1", 0);
+    const address = try resolveAddress(std.testing.allocator, "127.0.0.1", 0);
     var server = try tcpListen(address, .{ .reuse_address = true });
     defer server.deinit();
 
@@ -143,12 +163,13 @@ test "compat networking can listen on loopback" {
 }
 
 test "compat networking loopback connect read write round trip" {
-    const address = try resolveAddress("127.0.0.1", 0);
+    const address = try resolveAddress(std.testing.allocator, "127.0.0.1", 0);
     var server = try tcpListen(address, .{ .reuse_address = true });
     defer server.deinit();
 
     var context = LoopbackServerContext{ .server = &server };
     const thread = try std.Thread.spawn(.{}, loopbackServerThread, .{&context});
+    defer thread.join();
 
     var client = try tcpConnect(server.listenAddress());
     defer client.close();
@@ -156,9 +177,13 @@ test "compat networking loopback connect read write round trip" {
     try client.writeAll("ping");
 
     var response: [4]u8 = undefined;
-    const bytes_read = try client.read(&response);
-    try std.testing.expectEqualStrings("pong", response[0..bytes_read]);
+    var total_read: usize = 0;
+    while (total_read < response.len) {
+        const bytes_read = try client.read(response[total_read..]);
+        if (bytes_read == 0) return error.EndOfStream;
+        total_read += bytes_read;
+    }
+    try std.testing.expectEqualStrings("pong", &response);
 
-    thread.join();
     try context.result;
 }

--- a/zig/src/compat/net.zig
+++ b/zig/src/compat/net.zig
@@ -3,6 +3,7 @@ const std = @import("std");
 pub const Address = std.net.Address;
 pub const AddressList = std.net.AddressList;
 pub const ListenOptions = Address.ListenOptions;
+pub const Server = std.net.Server;
 
 /// TCP stream wrapper used as the stable Makai networking boundary.
 ///
@@ -34,39 +35,31 @@ pub const Stream = struct {
     }
 };
 
-/// Accepted TCP connection returned by `Server.accept`.
+/// Accepted TCP connection returned by `accept`.
 pub const Connection = struct {
     stream: Stream,
     address: Address,
 };
 
-/// TCP listener wrapper used by OAuth callback and transport networking paths.
+/// Return the bound listener address.
 ///
-/// Zig 0.15.2: owns a `std.net.Server`. 0.16: use Makai's selected networking
-/// backend internally while preserving this listen/accept shape.
-pub const Server = struct {
-    inner: std.net.Server,
+/// Zig 0.15.2: reads `std.net.Server.listen_address`.
+/// 0.16: route through Makai's selected networking backend internally.
+pub fn listenAddress(server: *const Server) Address {
+    return server.listen_address;
+}
 
-    pub fn init(inner: std.net.Server) Server {
-        return .{ .inner = inner };
-    }
-
-    pub fn listenAddress(self: *const Server) Address {
-        return self.inner.listen_address;
-    }
-
-    pub fn accept(self: *Server) !Connection {
-        const connection = try self.inner.accept();
-        return .{
-            .stream = Stream.init(connection.stream),
-            .address = connection.address,
-        };
-    }
-
-    pub fn deinit(self: *Server) void {
-        self.inner.deinit();
-    }
-};
+/// Accept a TCP connection and wrap its stream at the Makai compatibility seam.
+///
+/// Zig 0.15.2: wraps `std.net.Server.accept`.
+/// 0.16: preserve this helper shape over Makai's selected networking backend.
+pub fn accept(server: *Server) !Connection {
+    const connection = try server.accept();
+    return .{
+        .stream = Stream.init(connection.stream),
+        .address = connection.address,
+    };
+}
 
 /// Resolve a host/port into an address.
 ///
@@ -104,7 +97,7 @@ pub fn tcpConnect(address: Address) !Stream {
 /// Zig 0.15.2: wraps `std.net.Address.listen`.
 /// 0.16: use std.Io.net.tcpListen internally.
 pub fn tcpListen(address: Address, options: ListenOptions) !Server {
-    return Server.init(try address.listen(options));
+    return address.listen(options);
 }
 
 const LoopbackServerContext = struct {
@@ -113,7 +106,7 @@ const LoopbackServerContext = struct {
 };
 
 fn loopbackServerThread(context: *LoopbackServerContext) void {
-    var connection = context.server.accept() catch |err| {
+    var connection = accept(context.server) catch |err| {
         context.result = err;
         return;
     };
@@ -159,7 +152,7 @@ test "compat networking can listen on loopback" {
     var server = try tcpListen(address, .{ .reuse_address = true });
     defer server.deinit();
 
-    try std.testing.expect(server.listenAddress().getPort() != 0);
+    try std.testing.expect(listenAddress(&server).getPort() != 0);
 }
 
 test "compat networking loopback connect read write round trip" {
@@ -167,13 +160,13 @@ test "compat networking loopback connect read write round trip" {
     var server = try tcpListen(address, .{ .reuse_address = true });
     defer server.deinit();
 
-    var client = try tcpConnect(server.listenAddress());
-    errdefer client.close();
+    var client = try tcpConnect(listenAddress(&server));
+    defer client.close();
 
     var context = LoopbackServerContext{ .server = &server };
     const thread = try std.Thread.spawn(.{}, loopbackServerThread, .{&context});
-    defer thread.join();
-    defer client.close();
+    var thread_joined = false;
+    defer if (!thread_joined) thread.join();
 
     try client.writeAll("ping");
 
@@ -186,5 +179,7 @@ test "compat networking loopback connect read write round trip" {
     }
     try std.testing.expectEqualStrings("pong", &response);
 
+    thread.join();
+    thread_joined = true;
     try context.result;
 }


### PR DESCRIPTION
## Summary
- Add Makai compat networking wrappers for TCP streams, TCP listeners, accept results, address resolution, connect, and listen.
- Keep the Zig 0.15.2 implementation backed by `std.net` while documenting the future Zig 0.16 internal networking mapping.
- Add loopback coverage for listen/connect/read/write round-trip on 127.0.0.1.

Part of stack: Zig 0.15.2 → 0.16.0 Migration. PR 7 of 24.

## Test plan
- [x] `cd zig && /usr/local/opt/zig@0.15/bin/zig build test-unit-core`
- [x] `cd zig && /usr/local/opt/zig@0.15/bin/zig build test`
- [x] `./scripts/check-zig-patterns.sh`

Note: the default `zig` on this runner is 0.16.0 and fails existing 0.15.2-targeted code before this change; tests above used the installed Zig 0.15.2 binary.