### PR TITLE
Migrate std.mem indexOf calls to find

### DIFF
--- a/zig/src/oauth/github_copilot.zig
+++ b/zig/src/oauth/github_copilot.zig
@@ -458,12 +458,12 @@ pub const GitHubCopilotOAuth = struct {
 pub fn extractBaseUrlFromToken(token: []const u8) ?[]const u8 {
     // Find "proxy-ep=" in token
     const prefix = "proxy-ep=";
-    const start_idx = std.mem.indexOf(u8, token, prefix) orelse return null;
+    const start_idx = std.mem.find(u8, token, prefix) orelse return null;
     const value_start = start_idx + prefix.len;
 
     // Find end of value (next semicolon or end of string)
     const remaining = token[value_start..];
-    const end_idx = std.mem.indexOf(u8, remaining, ";") orelse remaining.len;
+    const end_idx = std.mem.find(u8, remaining, ";") orelse remaining.len;
 
     const proxy_host = remaining[0..end_idx];
     if (proxy_host.len == 0) return null;
@@ -502,18 +502,18 @@ pub fn normalizeDomain(input: []const u8) ?[]const u8 {
     if (trimmed.len == 0) return null;
 
     // Check if it looks like a URL
-    if (std.mem.indexOf(u8, trimmed, "://")) |idx| {
+    if (std.mem.find(u8, trimmed, "://")) |idx| {
         // Skip the scheme
         const after_scheme = trimmed[idx + 3 ..];
         // Find end of host (before first / or end)
-        if (std.mem.indexOf(u8, after_scheme, "/")) |slash_idx| {
+        if (std.mem.find(u8, after_scheme, "/")) |slash_idx| {
             return after_scheme[0..slash_idx];
         }
         return after_scheme;
     }
 
     // Assume it's already a hostname - find first /
-    if (std.mem.indexOf(u8, trimmed, "/")) |slash_idx| {
+    if (std.mem.find(u8, trimmed, "/")) |slash_idx| {
         return trimmed[0..slash_idx];
     }
 

--- a/zig/src/oauth/google_antigravity.zig
+++ b/zig/src/oauth/google_antigravity.zig
@@ -165,8 +165,8 @@ test "GoogleAntigravityOAuth startAuth returns valid AuthInfo with correct port"
     try std.testing.expect(auth_info.auth_url.len > 0);
     try std.testing.expect(std.mem.startsWith(u8, auth_info.auth_url, "https://accounts.google.com"));
     // Verify it uses port 51121
-    try std.testing.expect(std.mem.indexOf(u8, auth_info.auth_url, "51121") != null);
-    try std.testing.expect(std.mem.indexOf(u8, auth_info.auth_url, "code_challenge") != null);
+    try std.testing.expect(std.mem.find(u8, auth_info.auth_url, "51121") != null);
+    try std.testing.expect(std.mem.find(u8, auth_info.auth_url, "code_challenge") != null);
 }
 
 test "GoogleAntigravityOAuth login returns NotImplemented" {

--- a/zig/src/oauth/google_gemini_cli.zig
+++ b/zig/src/oauth/google_gemini_cli.zig
@@ -162,7 +162,7 @@ test "GoogleGeminiCliOAuth startAuth returns valid AuthInfo" {
 
     try std.testing.expect(auth_info.auth_url.len > 0);
     try std.testing.expect(std.mem.startsWith(u8, auth_info.auth_url, "https://accounts.google.com"));
-    try std.testing.expect(std.mem.indexOf(u8, auth_info.auth_url, "code_challenge") != null);
+    try std.testing.expect(std.mem.find(u8, auth_info.auth_url, "code_challenge") != null);
 }
 
 test "GoogleGeminiCliOAuth login returns NotImplemented" {

--- a/zig/src/oauth/openai_codex.zig
+++ b/zig/src/oauth/openai_codex.zig
@@ -80,9 +80,9 @@ pub const OpenAICodexOAuth = struct {
         // We need to decode the payload and extract the "sub" claim
 
         // Find the first dot (end of header)
-        const first_dot = std.mem.indexOf(u8, access_token, ".") orelse return null;
+        const first_dot = std.mem.find(u8, access_token, ".") orelse return null;
         // Find the second dot (end of payload)
-        const second_dot = std.mem.indexOfPos(u8, access_token, first_dot + 1, ".") orelse return null;
+        const second_dot = std.mem.findPos(u8, access_token, first_dot + 1, ".") orelse return null;
 
         // Extract payload
         const payload_b64 = access_token[first_dot + 1 .. second_dot];
@@ -167,8 +167,8 @@ test "OpenAICodexOAuth startAuth returns valid AuthInfo" {
     try std.testing.expect(auth_info.auth_url.len > 0);
     try std.testing.expect(std.mem.startsWith(u8, auth_info.auth_url, "https://auth.openai.com"));
     // Verify it uses port 1455
-    try std.testing.expect(std.mem.indexOf(u8, auth_info.auth_url, "1455") != null);
-    try std.testing.expect(std.mem.indexOf(u8, auth_info.auth_url, "code_challenge") != null);
+    try std.testing.expect(std.mem.find(u8, auth_info.auth_url, "1455") != null);
+    try std.testing.expect(std.mem.find(u8, auth_info.auth_url, "code_challenge") != null);
 }
 
 test "OpenAICodexOAuth login returns NotImplemented" {

--- a/zig/src/protocol/agent/runtime.zig
+++ b/zig/src/protocol/agent/runtime.zig
@@ -118,7 +118,7 @@ test "AgentProtocolRuntime supports multi-session routing" {
 
     const a = ev1.slice();
     const b = ev2.slice();
-    const ok = (std.mem.indexOf(u8, a, "session") != null) and (std.mem.indexOf(u8, b, "session") != null);
+    const ok = (std.mem.find(u8, a, "session") != null) and (std.mem.find(u8, b, "session") != null);
     try std.testing.expect(ok);
 
     try std.testing.expectEqual(@as(usize, 2), server.sessionCount());

--- a/zig/src/protocol/model_ref.zig
+++ b/zig/src/protocol/model_ref.zig
@@ -45,25 +45,25 @@ pub fn parseModelRef(
     allocator: std.mem.Allocator,
     model_ref: []const u8,
 ) (std.mem.Allocator.Error || ModelRefError)!ParsedModelRef {
-    const slash_index = std.mem.indexOfScalar(u8, model_ref, '/') orelse return error.MissingSeparators;
+    const slash_index = std.mem.findScalar(u8, model_ref, '/') orelse return error.MissingSeparators;
     if (slash_index == 0) return error.MissingProviderId;
 
-    const first_at_index = std.mem.indexOfScalar(u8, model_ref, '@');
+    const first_at_index = std.mem.findScalar(u8, model_ref, '@');
     if (first_at_index) |idx| {
         if (idx < slash_index) return error.AmbiguousSeparators;
     }
 
     const api_and_model = model_ref[slash_index + 1 ..];
-    const at_offset = std.mem.indexOfScalar(u8, api_and_model, '@') orelse return error.MissingSeparators;
+    const at_offset = std.mem.findScalar(u8, api_and_model, '@') orelse return error.MissingSeparators;
     const at_index = slash_index + 1 + at_offset;
 
-    if (std.mem.indexOfScalar(u8, model_ref[slash_index + 1 .. at_index], '/')) |_| {
+    if (std.mem.findScalar(u8, model_ref[slash_index + 1 .. at_index], '/')) |_| {
         return error.AmbiguousSeparators;
     }
-    if (std.mem.indexOfScalar(u8, model_ref[at_index + 1 ..], '@')) |_| {
+    if (std.mem.findScalar(u8, model_ref[at_index + 1 ..], '@')) |_| {
         return error.AmbiguousSeparators;
     }
-    if (std.mem.indexOfScalar(u8, model_ref[at_index + 1 ..], '/')) |_| {
+    if (std.mem.findScalar(u8, model_ref[at_index + 1 ..], '/')) |_| {
         return error.AmbiguousSeparators;
     }
 

--- a/zig/src/protocol/provider/envelope.zig
+++ b/zig/src/protocol/provider/envelope.zig
@@ -1602,10 +1602,10 @@ test "serializeEnvelope with ping payload" {
     defer allocator.free(json);
 
     // Check that the JSON contains expected fields
-    try std.testing.expect(std.mem.indexOf(u8, json, "\"type\":\"ping\"") != null);
-    try std.testing.expect(std.mem.indexOf(u8, json, "\"sequence\":1") != null);
-    try std.testing.expect(std.mem.indexOf(u8, json, "\"timestamp\":1708234567890") != null);
-    try std.testing.expect(std.mem.indexOf(u8, json, "\"payload\":{}") != null);
+    try std.testing.expect(std.mem.find(u8, json, "\"type\":\"ping\"") != null);
+    try std.testing.expect(std.mem.find(u8, json, "\"sequence\":1") != null);
+    try std.testing.expect(std.mem.find(u8, json, "\"timestamp\":1708234567890") != null);
+    try std.testing.expect(std.mem.find(u8, json, "\"payload\":{}") != null);
 }
 
 test "serializeEnvelope with pong payload" {
@@ -1625,9 +1625,9 @@ test "serializeEnvelope with pong payload" {
     const json = try serializeEnvelope(envelope, allocator);
     defer allocator.free(json);
 
-    try std.testing.expect(std.mem.indexOf(u8, json, "\"type\":\"pong\"") != null);
-    try std.testing.expect(std.mem.indexOf(u8, json, "\"sequence\":2") != null);
-    try std.testing.expect(std.mem.indexOf(u8, json, "\"ping_id\":\"test-ping-123\"") != null);
+    try std.testing.expect(std.mem.find(u8, json, "\"type\":\"pong\"") != null);
+    try std.testing.expect(std.mem.find(u8, json, "\"sequence\":2") != null);
+    try std.testing.expect(std.mem.find(u8, json, "\"ping_id\":\"test-ping-123\"") != null);
 
     envelope.deinit(allocator);
 }
@@ -1669,13 +1669,13 @@ test "serializeEnvelope with stream_request payload" {
     const json = try serializeEnvelope(envelope, allocator);
     defer allocator.free(json);
 
-    try std.testing.expect(std.mem.indexOf(u8, json, "\"type\":\"stream_request\"") != null);
+    try std.testing.expect(std.mem.find(u8, json, "\"type\":\"stream_request\"") != null);
     // Check for nested model object format per PROTOCOL.md
-    try std.testing.expect(std.mem.indexOf(u8, json, "\"model\":{") != null);
-    try std.testing.expect(std.mem.indexOf(u8, json, "\"id\":\"gpt-4\"") != null);
-    try std.testing.expect(std.mem.indexOf(u8, json, "\"name\":\"GPT-4\"") != null);
-    try std.testing.expect(std.mem.indexOf(u8, json, "\"system_prompt\":\"You are helpful.\"") != null);
-    try std.testing.expect(std.mem.indexOf(u8, json, "\"include_partial\":true") != null);
+    try std.testing.expect(std.mem.find(u8, json, "\"model\":{") != null);
+    try std.testing.expect(std.mem.find(u8, json, "\"id\":\"gpt-4\"") != null);
+    try std.testing.expect(std.mem.find(u8, json, "\"name\":\"GPT-4\"") != null);
+    try std.testing.expect(std.mem.find(u8, json, "\"system_prompt\":\"You are helpful.\"") != null);
+    try std.testing.expect(std.mem.find(u8, json, "\"include_partial\":true") != null);
 
     envelope.deinit(allocator);
 }
@@ -1938,9 +1938,9 @@ test "serializeEnvelope with abort_request payload" {
     const json = try serializeEnvelope(envelope, allocator);
     defer allocator.free(json);
 
-    try std.testing.expect(std.mem.indexOf(u8, json, "\"type\":\"abort_request\"") != null);
-    try std.testing.expect(std.mem.indexOf(u8, json, "\"reason\":\"User cancelled\"") != null);
-    try std.testing.expect(std.mem.indexOf(u8, json, "\"target_stream_id\"") != null);
+    try std.testing.expect(std.mem.find(u8, json, "\"type\":\"abort_request\"") != null);
+    try std.testing.expect(std.mem.find(u8, json, "\"reason\":\"User cancelled\"") != null);
+    try std.testing.expect(std.mem.find(u8, json, "\"target_stream_id\"") != null);
 
     envelope.deinit(allocator);
 }
@@ -1965,9 +1965,9 @@ test "serializeEnvelope with stream_error payload" {
     const json = try serializeEnvelope(envelope, allocator);
     defer allocator.free(json);
 
-    try std.testing.expect(std.mem.indexOf(u8, json, "\"type\":\"stream_error\"") != null);
-    try std.testing.expect(std.mem.indexOf(u8, json, "\"code\":\"provider_error\"") != null);
-    try std.testing.expect(std.mem.indexOf(u8, json, "\"message\":\"Connection timeout\"") != null);
+    try std.testing.expect(std.mem.find(u8, json, "\"type\":\"stream_error\"") != null);
+    try std.testing.expect(std.mem.find(u8, json, "\"code\":\"provider_error\"") != null);
+    try std.testing.expect(std.mem.find(u8, json, "\"message\":\"Connection timeout\"") != null);
 
     envelope.deinit(allocator);
 }
@@ -2181,8 +2181,8 @@ test "serializeEnvelope with goodbye payload" {
     const json = try serializeEnvelope(envelope, allocator);
     defer allocator.free(json);
 
-    try std.testing.expect(std.mem.indexOf(u8, json, "\"type\":\"goodbye\"") != null);
-    try std.testing.expect(std.mem.indexOf(u8, json, "\"reason\":\"Server shutting down\"") != null);
+    try std.testing.expect(std.mem.find(u8, json, "\"type\":\"goodbye\"") != null);
+    try std.testing.expect(std.mem.find(u8, json, "\"reason\":\"Server shutting down\"") != null);
 
     envelope.deinit(allocator);
 }
@@ -2201,8 +2201,8 @@ test "serializeEnvelope with goodbye payload (no reason)" {
     const json = try serializeEnvelope(envelope, allocator);
     defer allocator.free(json);
 
-    try std.testing.expect(std.mem.indexOf(u8, json, "\"type\":\"goodbye\"") != null);
-    try std.testing.expect(std.mem.indexOf(u8, json, "\"reason\"") == null); // reason should not be present
+    try std.testing.expect(std.mem.find(u8, json, "\"type\":\"goodbye\"") != null);
+    try std.testing.expect(std.mem.find(u8, json, "\"reason\"") == null); // reason should not be present
 
     envelope.deinit(allocator);
 }
@@ -2222,8 +2222,8 @@ test "serializeEnvelope with sync_request payload" {
     const json = try serializeEnvelope(envelope, allocator);
     defer allocator.free(json);
 
-    try std.testing.expect(std.mem.indexOf(u8, json, "\"type\":\"sync_request\"") != null);
-    try std.testing.expect(std.mem.indexOf(u8, json, "\"target_stream_id\"") != null);
+    try std.testing.expect(std.mem.find(u8, json, "\"type\":\"sync_request\"") != null);
+    try std.testing.expect(std.mem.find(u8, json, "\"target_stream_id\"") != null);
 
     envelope.deinit(allocator);
 }
@@ -2256,9 +2256,9 @@ test "serializeEnvelope with sync payload" {
     const json = try serializeEnvelope(envelope, allocator);
     defer allocator.free(json);
 
-    try std.testing.expect(std.mem.indexOf(u8, json, "\"type\":\"sync\"") != null);
-    try std.testing.expect(std.mem.indexOf(u8, json, "\"target_stream_id\"") != null);
-    try std.testing.expect(std.mem.indexOf(u8, json, "\"partial\"") != null);
+    try std.testing.expect(std.mem.find(u8, json, "\"type\":\"sync\"") != null);
+    try std.testing.expect(std.mem.find(u8, json, "\"target_stream_id\"") != null);
+    try std.testing.expect(std.mem.find(u8, json, "\"partial\"") != null);
 
     envelope.deinit(allocator);
 }

--- a/zig/src/protocol/provider/partial_serializer.zig
+++ b/zig/src/protocol/provider/partial_serializer.zig
@@ -479,12 +479,12 @@ test "serializeEvent without partial omits partial field" {
     defer std.testing.allocator.free(json);
 
     // Should not contain "partial" field
-    try std.testing.expect(std.mem.indexOf(u8, json, "\"partial\"") == null);
+    try std.testing.expect(std.mem.find(u8, json, "\"partial\"") == null);
 
     // Should contain basic fields
-    try std.testing.expect(std.mem.indexOf(u8, json, "\"type\":\"text_delta\"") != null);
-    try std.testing.expect(std.mem.indexOf(u8, json, "\"content_index\":0") != null);
-    try std.testing.expect(std.mem.indexOf(u8, json, "\"delta\":\"Hello\"") != null);
+    try std.testing.expect(std.mem.find(u8, json, "\"type\":\"text_delta\"") != null);
+    try std.testing.expect(std.mem.find(u8, json, "\"content_index\":0") != null);
+    try std.testing.expect(std.mem.find(u8, json, "\"delta\":\"Hello\"") != null);
 }
 
 test "serializeEvent with lightweight partial includes block partial" {
@@ -525,13 +525,13 @@ test "serializeEvent with lightweight partial includes block partial" {
     defer std.testing.allocator.free(json);
 
     // Should contain partial field
-    try std.testing.expect(std.mem.indexOf(u8, json, "\"partial\"") != null);
+    try std.testing.expect(std.mem.find(u8, json, "\"partial\"") != null);
 
     // Should contain accumulated length
-    try std.testing.expect(std.mem.indexOf(u8, json, "\"accumulated_len\":11") != null);
+    try std.testing.expect(std.mem.find(u8, json, "\"accumulated_len\":11") != null);
 
     // Should contain text block partial
-    try std.testing.expect(std.mem.indexOf(u8, json, "\"text\":") != null);
+    try std.testing.expect(std.mem.find(u8, json, "\"text\":") != null);
 }
 
 test "serializeEvent produces valid JSON" {
@@ -568,7 +568,7 @@ test "serializeEvent produces valid JSON" {
         try std.testing.expect(json[json.len - 1] == '}');
 
         // Should contain type field
-        try std.testing.expect(std.mem.indexOf(u8, json, "\"type\"") != null);
+        try std.testing.expect(std.mem.find(u8, json, "\"type\"") != null);
     }
 }
 
@@ -609,8 +609,8 @@ test "serializeEvent for thinking_delta includes partial" {
     defer std.testing.allocator.free(json);
 
     // Should contain thinking partial
-    try std.testing.expect(std.mem.indexOf(u8, json, "\"thinking\":") != null);
-    try std.testing.expect(std.mem.indexOf(u8, json, "\"accumulated_len\":11") != null);
+    try std.testing.expect(std.mem.find(u8, json, "\"thinking\":") != null);
+    try std.testing.expect(std.mem.find(u8, json, "\"accumulated_len\":11") != null);
 }
 
 test "serializeEvent for toolcall_delta includes partial" {
@@ -643,8 +643,8 @@ test "serializeEvent for toolcall_delta includes partial" {
     defer std.testing.allocator.free(json);
 
     // Should contain tool_call partial
-    try std.testing.expect(std.mem.indexOf(u8, json, "\"tool_call\":") != null);
-    try std.testing.expect(std.mem.indexOf(u8, json, "\"json_len\":7") != null);
+    try std.testing.expect(std.mem.find(u8, json, "\"tool_call\":") != null);
+    try std.testing.expect(std.mem.find(u8, json, "\"json_len\":7") != null);
 }
 
 test "processEvent handles multiple blocks" {

--- a/zig/src/protocol/provider/server.zig
+++ b/zig/src/protocol/provider/server.zig
@@ -166,8 +166,8 @@ const AUTH_EXPIRED_MESSAGE = "auth_expired";
 fn defaultAuthFailureDetector(err_msg: []const u8) bool {
     return std.mem.eql(u8, err_msg, AUTH_REQUIRED_MESSAGE) or
         std.mem.eql(u8, err_msg, AUTH_EXPIRED_MESSAGE) or
-        std.mem.indexOf(u8, err_msg, "401") != null or
-        std.mem.indexOf(u8, err_msg, "403") != null or
+        std.mem.find(u8, err_msg, "401") != null or
+        std.mem.find(u8, err_msg, "403") != null or
         std.ascii.indexOfIgnoreCase(err_msg, "unauthorized") != null or
         std.ascii.indexOfIgnoreCase(err_msg, "forbidden") != null;
 }
@@ -1553,7 +1553,7 @@ test "handleModelsRequest returns invalid_request for ambiguous or missing model
     defer ambiguous_nack.deinit(std.testing.allocator);
     try std.testing.expect(ambiguous_nack.payload == .nack);
     try std.testing.expectEqual(protocol_types.ErrorCode.invalid_request, ambiguous_nack.payload.nack.error_code.?);
-    try std.testing.expect(std.mem.indexOf(u8, ambiguous_nack.payload.nack.reason.slice(), "multiple APIs") != null);
+    try std.testing.expect(std.mem.find(u8, ambiguous_nack.payload.nack.reason.slice(), "multiple APIs") != null);
 
     var missing = protocol_types.Envelope{
         .stream_id = protocol_types.generateUlid(),
@@ -1573,7 +1573,7 @@ test "handleModelsRequest returns invalid_request for ambiguous or missing model
     defer missing_nack.deinit(std.testing.allocator);
     try std.testing.expect(missing_nack.payload == .nack);
     try std.testing.expectEqual(protocol_types.ErrorCode.invalid_request, missing_nack.payload.nack.error_code.?);
-    try std.testing.expect(std.mem.indexOf(u8, missing_nack.payload.nack.reason.slice(), "model not found") != null);
+    try std.testing.expect(std.mem.find(u8, missing_nack.payload.nack.reason.slice(), "model not found") != null);
 }
 
 test "handleModelsRequest prefers dynamic fetch and falls back to static catalog when unavailable" {

--- a/zig/src/providers/anthropic_messages_api.zig
+++ b/zig/src/providers/anthropic_messages_api.zig
@@ -37,8 +37,8 @@ fn anthropicGetApiKey(credentials: oauth_storage.Credentials, allocator: std.mem
 }
 
 fn anthropicIsAuthFailure(err_msg: []const u8) bool {
-    return std.mem.indexOf(u8, err_msg, "401") != null or
-        std.mem.indexOf(u8, err_msg, "403") != null or
+    return std.mem.find(u8, err_msg, "401") != null or
+        std.mem.find(u8, err_msg, "403") != null or
         std.ascii.indexOfIgnoreCase(err_msg, "unauthorized") != null or
         std.ascii.indexOfIgnoreCase(err_msg, "forbidden") != null or
         std.ascii.indexOfIgnoreCase(err_msg, "authentication_error") != null or
@@ -55,7 +55,7 @@ fn envApiKey(allocator: std.mem.Allocator) ?[]const u8 {
 }
 
 fn isOAuthToken(key: []const u8) bool {
-    return std.mem.indexOf(u8, key, "sk-ant-oat") != null;
+    return std.mem.find(u8, key, "sk-ant-oat") != null;
 }
 
 fn buildUrlWithSuffix(allocator: std.mem.Allocator, base_url: []const u8, suffix: []const u8) ![]const u8 {
@@ -107,7 +107,7 @@ fn getCacheControl(base_url: []const u8, cache_retention: ?ai_types.CacheRetenti
     if (retention == .none) return null;
 
     // Only add ttl for "long" retention on api.anthropic.com
-    const has_ttl = retention == .long and std.mem.indexOf(u8, base_url, "api.anthropic.com") != null;
+    const has_ttl = retention == .long and std.mem.find(u8, base_url, "api.anthropic.com") != null;
 
     return .{
         .retention = retention,
@@ -117,8 +117,8 @@ fn getCacheControl(base_url: []const u8, cache_retention: ?ai_types.CacheRetenti
 
 /// Check if a model supports adaptive thinking (Opus 4.6+)
 fn supportsAdaptiveThinking(model_id: []const u8) bool {
-    return std.mem.indexOf(u8, model_id, "opus-4-6") != null or
-        std.mem.indexOf(u8, model_id, "opus-4.6") != null;
+    return std.mem.find(u8, model_id, "opus-4-6") != null or
+        std.mem.find(u8, model_id, "opus-4.6") != null;
 }
 
 /// Map ThinkingLevel to Anthropic effort levels for adaptive thinking
@@ -1336,7 +1336,7 @@ fn runThread(ctx: *ThreadCtx) void {
             var delay = retry_util.calculateDelay(retry_attempt, BASE_DELAY_MS, max_delay_ms);
 
             // Check Retry-After header (only if headers contain valid \r\n separator)
-            if (std.mem.indexOf(u8, response.head.bytes, "\r\n") != null) {
+            if (std.mem.find(u8, response.head.bytes, "\r\n") != null) {
                 var retry_after_iter = response.head.iterateHeaders();
                 while (retry_after_iter.next()) |header| {
                     if (std.ascii.eqlIgnoreCase(header.name, "retry-after")) {
@@ -1985,9 +1985,9 @@ test "buildRequestBody includes cache_control in system prompt" {
     defer allocator.free(body);
 
     // Verify system prompt is an array with cache_control
-    try std.testing.expect(std.mem.indexOf(u8, body, "\"system\":[") != null);
-    try std.testing.expect(std.mem.indexOf(u8, body, "\"cache_control\":{\"type\":\"ephemeral\"}") != null);
-    try std.testing.expect(std.mem.indexOf(u8, body, "\"ttl\"") == null); // short retention, no ttl
+    try std.testing.expect(std.mem.find(u8, body, "\"system\":[") != null);
+    try std.testing.expect(std.mem.find(u8, body, "\"cache_control\":{\"type\":\"ephemeral\"}") != null);
+    try std.testing.expect(std.mem.find(u8, body, "\"ttl\"") == null); // short retention, no ttl
 }
 
 test "buildRequestBody includes ttl for long retention on anthropic url" {
@@ -2024,7 +2024,7 @@ test "buildRequestBody includes ttl for long retention on anthropic url" {
     defer allocator.free(body);
 
     // Verify ttl is included for long retention
-    try std.testing.expect(std.mem.indexOf(u8, body, "\"cache_control\":{\"type\":\"ephemeral\",\"ttl\":\"1h\"}") != null);
+    try std.testing.expect(std.mem.find(u8, body, "\"cache_control\":{\"type\":\"ephemeral\",\"ttl\":\"1h\"}") != null);
 }
 
 test "buildRequestBody serializes tool_result as tool_result content block" {
@@ -2127,7 +2127,7 @@ test "buildRequestBody serializes tool_result with is_error=true" {
     defer allocator.free(body);
 
     // Verify is_error is true
-    try std.testing.expect(std.mem.indexOf(u8, body, "\"is_error\":true") != null);
+    try std.testing.expect(std.mem.find(u8, body, "\"is_error\":true") != null);
 }
 
 test "buildRequestBody adds cache_control to last user message" {

--- a/zig/src/providers/google_generative_api.zig
+++ b/zig/src/providers/google_generative_api.zig
@@ -106,19 +106,19 @@ fn buildStreamGenerateContentUrl(allocator: std.mem.Allocator, base_url: []const
 
 // Model detection helpers
 fn isGemini3ProModel(model_id: []const u8) bool {
-    return std.mem.indexOf(u8, model_id, "3-pro") != null;
+    return std.mem.find(u8, model_id, "3-pro") != null;
 }
 
 fn isGemini3FlashModel(model_id: []const u8) bool {
-    return std.mem.indexOf(u8, model_id, "3-flash") != null;
+    return std.mem.find(u8, model_id, "3-flash") != null;
 }
 
 fn isGemini25ProModel(model_id: []const u8) bool {
-    return std.mem.indexOf(u8, model_id, "2.5-pro") != null;
+    return std.mem.find(u8, model_id, "2.5-pro") != null;
 }
 
 fn isGemini25FlashModel(model_id: []const u8) bool {
-    return std.mem.indexOf(u8, model_id, "2.5-flash") != null;
+    return std.mem.find(u8, model_id, "2.5-flash") != null;
 }
 
 /// Check if a thought signature is valid base64
@@ -916,7 +916,7 @@ fn runThread(ctx: *ThreadCtx) void {
             var delay = retry_util.calculateDelay(retry_attempt, BASE_DELAY_MS, max_delay_ms);
 
             // Check Retry-After header (only if headers contain valid \r\n separator)
-            if (std.mem.indexOf(u8, response.head.bytes, "\r\n") != null) {
+            if (std.mem.find(u8, response.head.bytes, "\r\n") != null) {
                 var retry_after_iter = response.head.iterateHeaders();
                 while (retry_after_iter.next()) |header| {
                     if (std.ascii.eqlIgnoreCase(header.name, "retry-after")) {

--- a/zig/src/providers/google_vertex_api.zig
+++ b/zig/src/providers/google_vertex_api.zig
@@ -129,19 +129,19 @@ fn resolveApiKey(options: ?VertexOptions, allocator: std.mem.Allocator) VertexEr
 
 // Model detection helpers (shared with google_generative_api)
 fn isGemini3ProModel(model_id: []const u8) bool {
-    return std.mem.indexOf(u8, model_id, "3-pro") != null;
+    return std.mem.find(u8, model_id, "3-pro") != null;
 }
 
 fn isGemini3FlashModel(model_id: []const u8) bool {
-    return std.mem.indexOf(u8, model_id, "3-flash") != null;
+    return std.mem.find(u8, model_id, "3-flash") != null;
 }
 
 fn isGemini25ProModel(model_id: []const u8) bool {
-    return std.mem.indexOf(u8, model_id, "2.5-pro") != null;
+    return std.mem.find(u8, model_id, "2.5-pro") != null;
 }
 
 fn isGemini25FlashModel(model_id: []const u8) bool {
-    return std.mem.indexOf(u8, model_id, "2.5-flash") != null;
+    return std.mem.find(u8, model_id, "2.5-flash") != null;
 }
 
 /// Check if a thought signature is valid base64
@@ -882,7 +882,7 @@ fn runThread(ctx: *ThreadCtx) void {
             var delay = retry_util.calculateDelay(retry_attempt, BASE_DELAY_MS, max_delay_ms);
 
             // Check Retry-After header (only if headers contain valid \r\n separator)
-            if (std.mem.indexOf(u8, response.head.bytes, "\r\n") != null) {
+            if (std.mem.find(u8, response.head.bytes, "\r\n") != null) {
                 var retry_after_iter = response.head.iterateHeaders();
                 while (retry_after_iter.next()) |header| {
                     if (std.ascii.eqlIgnoreCase(header.name, "retry-after")) {

--- a/zig/src/providers/ollama_api.zig
+++ b/zig/src/providers/ollama_api.zig
@@ -772,7 +772,7 @@ fn runThread(ctx: *ThreadCtx) void {
             var delay = retry_util.calculateDelay(retry_attempt, BASE_DELAY_MS, max_delay_ms);
 
             // Check Retry-After header (only if headers contain valid \r\n separator)
-            if (std.mem.indexOf(u8, response.head.bytes, "\r\n") != null) {
+            if (std.mem.find(u8, response.head.bytes, "\r\n") != null) {
                 var retry_after_iter = response.head.iterateHeaders();
                 while (retry_after_iter.next()) |header| {
                     if (std.ascii.eqlIgnoreCase(header.name, "retry-after")) {
@@ -1340,12 +1340,12 @@ test "buildBody includes model stream options and messages" {
     const body = try buildBody(model, ctx, .{ .temperature = 0.2, .max_tokens = 12 }, std.testing.allocator);
     defer std.testing.allocator.free(body);
 
-    try std.testing.expect(std.mem.indexOf(u8, body, "\"model\":\"llama3.2:1b\"") != null);
-    try std.testing.expect(std.mem.indexOf(u8, body, "\"stream\":true") != null);
-    try std.testing.expect(std.mem.indexOf(u8, body, "\"num_predict\":12") != null);
-    try std.testing.expect(std.mem.indexOf(u8, body, "\"temperature\":0.2") != null);
-    try std.testing.expect(std.mem.indexOf(u8, body, "\"role\":\"system\"") != null);
-    try std.testing.expect(std.mem.indexOf(u8, body, "\"content\":\"hello\"") != null);
+    try std.testing.expect(std.mem.find(u8, body, "\"model\":\"llama3.2:1b\"") != null);
+    try std.testing.expect(std.mem.find(u8, body, "\"stream\":true") != null);
+    try std.testing.expect(std.mem.find(u8, body, "\"num_predict\":12") != null);
+    try std.testing.expect(std.mem.find(u8, body, "\"temperature\":0.2") != null);
+    try std.testing.expect(std.mem.find(u8, body, "\"role\":\"system\"") != null);
+    try std.testing.expect(std.mem.find(u8, body, "\"content\":\"hello\"") != null);
 }
 
 test "buildBody includes images array for user message with image parts" {
@@ -1378,9 +1378,9 @@ test "buildBody includes images array for user message with image parts" {
     defer std.testing.allocator.free(body);
 
     // Verify the images array is present with the base64 data
-    try std.testing.expect(std.mem.indexOf(u8, body, "\"images\":[\"iVBORw0KGgoAAAANSUhEUgAAAAE\"]") != null);
+    try std.testing.expect(std.mem.find(u8, body, "\"images\":[\"iVBORw0KGgoAAAANSUhEUgAAAAE\"]") != null);
     // Verify text content is also present
-    try std.testing.expect(std.mem.indexOf(u8, body, "What is in this image?") != null);
+    try std.testing.expect(std.mem.find(u8, body, "What is in this image?") != null);
 }
 
 test "buildBody includes images array for tool_result with image" {
@@ -1420,10 +1420,10 @@ test "buildBody includes images array for tool_result with image" {
 
     // Verify the tool message has the images array
     // Note: Ollama doesn't use tool_call_id for tool results, just role: "tool"
-    try std.testing.expect(std.mem.indexOf(u8, body, "\"role\":\"tool\"") != null);
-    try std.testing.expect(std.mem.indexOf(u8, body, "\"images\":[\"screenshotaBCD123\"]") != null);
+    try std.testing.expect(std.mem.find(u8, body, "\"role\":\"tool\"") != null);
+    try std.testing.expect(std.mem.find(u8, body, "\"images\":[\"screenshotaBCD123\"]") != null);
     // Verify text content is present
-    try std.testing.expect(std.mem.indexOf(u8, body, "Here is the screenshot") != null);
+    try std.testing.expect(std.mem.find(u8, body, "Here is the screenshot") != null);
 }
 
 test "parseLineExtended - text content" {
@@ -1554,9 +1554,9 @@ test "parseLineExtended - tool call with nested arguments" {
     const tc = result.tool_calls[0];
     try std.testing.expectEqualStrings("execute", tc.name);
     // Verify nested structure is preserved
-    try std.testing.expect(std.mem.indexOf(u8, tc.arguments_json, "\"options\"") != null);
-    try std.testing.expect(std.mem.indexOf(u8, tc.arguments_json, "\"verbose\":true") != null);
-    try std.testing.expect(std.mem.indexOf(u8, tc.arguments_json, "\"command\":\"echo hello\"") != null);
+    try std.testing.expect(std.mem.find(u8, tc.arguments_json, "\"options\"") != null);
+    try std.testing.expect(std.mem.find(u8, tc.arguments_json, "\"verbose\":true") != null);
+    try std.testing.expect(std.mem.find(u8, tc.arguments_json, "\"command\":\"echo hello\"") != null);
 }
 
 test "parseLineExtended - tool call with array arguments" {
@@ -1575,7 +1575,7 @@ test "parseLineExtended - tool call with array arguments" {
 
     const tc = result.tool_calls[0];
     try std.testing.expectEqualStrings("multi_cmd", tc.name);
-    try std.testing.expect(std.mem.indexOf(u8, tc.arguments_json, "[\"ls\",\"pwd\",\"whoami\"]") != null);
+    try std.testing.expect(std.mem.find(u8, tc.arguments_json, "[\"ls\",\"pwd\",\"whoami\"]") != null);
 }
 
 

--- a/zig/src/providers/openai_completions_api.zig
+++ b/zig/src/providers/openai_completions_api.zig
@@ -33,7 +33,7 @@ const MergedCompat = struct {
 fn mergeCompat(model: ai_types.Model) MergedCompat {
     const caps = provider_caps.detectCapabilities(model.base_url);
     const compat = model.compat;
-    const is_openai_native = std.mem.indexOf(u8, model.base_url, "openai.com") != null;
+    const is_openai_native = std.mem.find(u8, model.base_url, "openai.com") != null;
 
     return .{
         .supports_store = if (compat) |c| c.supports_store orelse is_openai_native else is_openai_native,
@@ -113,7 +113,7 @@ fn appendTextContent(msg: ai_types.Message, out: *std.ArrayList(u8), allocator: 
 /// Check if we're using OpenRouter with an Anthropic model
 fn isOpenRouterAnthropic(model: ai_types.Model) bool {
     if (model.base_url.len == 0) return false;
-    if (std.mem.indexOf(u8, model.base_url, "openrouter") == null) return false;
+    if (std.mem.find(u8, model.base_url, "openrouter") == null) return false;
     if (!std.mem.startsWith(u8, model.id, "anthropic/")) return false;
     return true;
 }
@@ -639,7 +639,7 @@ fn buildRequestBody(
         .target_api = model.api,
         .target_provider = model.provider,
         .target_model_id = model.id,
-        .max_tool_id_len = if (std.mem.indexOf(u8, model.base_url, "openai.com") != null) 40 else 0,
+        .max_tool_id_len = if (std.mem.find(u8, model.base_url, "openai.com") != null) 40 else 0,
         .mistral_tool_ids = merged.requires_mistral_tool_ids,
         .insert_synthetic_results = true,
         .tools = context.tools,
@@ -1292,7 +1292,7 @@ fn runThread(ctx: *ThreadCtx) void {
             var delay = retry.calculateDelay(retry_attempt, BASE_DELAY_MS, max_delay_ms);
 
             // Check Retry-After header (only if headers contain valid \r\n separator)
-            if (std.mem.indexOf(u8, response.head.bytes, "\r\n") != null) {
+            if (std.mem.find(u8, response.head.bytes, "\r\n") != null) {
                 var retry_after_iter = response.head.iterateHeaders();
                 while (retry_after_iter.next()) |header| {
                     if (std.ascii.eqlIgnoreCase(header.name, "retry-after")) {
@@ -1904,11 +1904,11 @@ test "buildRequestBody includes stream_options and tools without memory leak" {
     defer allocator.free(body);
 
     // Verify the body contains expected fields
-    try std.testing.expect(std.mem.indexOf(u8, body, "stream_options") != null);
-    try std.testing.expect(std.mem.indexOf(u8, body, "include_usage") != null);
-    try std.testing.expect(std.mem.indexOf(u8, body, "tools") != null);
-    try std.testing.expect(std.mem.indexOf(u8, body, "tool_calls") != null);
-    try std.testing.expect(std.mem.indexOf(u8, body, "test_tool") != null);
+    try std.testing.expect(std.mem.find(u8, body, "stream_options") != null);
+    try std.testing.expect(std.mem.find(u8, body, "include_usage") != null);
+    try std.testing.expect(std.mem.find(u8, body, "tools") != null);
+    try std.testing.expect(std.mem.find(u8, body, "tool_calls") != null);
+    try std.testing.expect(std.mem.find(u8, body, "test_tool") != null);
 }
 
 test "buildRequestBody with assistant message containing tool_calls" {
@@ -1954,10 +1954,10 @@ test "buildRequestBody with assistant message containing tool_calls" {
     defer allocator.free(body);
 
     // Verify the body contains tool_calls
-    try std.testing.expect(std.mem.indexOf(u8, body, "tool_calls") != null);
-    try std.testing.expect(std.mem.indexOf(u8, body, "call_456") != null);
-    try std.testing.expect(std.mem.indexOf(u8, body, "bash") != null);
-    try std.testing.expect(std.mem.indexOf(u8, body, "ls -la") != null);
+    try std.testing.expect(std.mem.find(u8, body, "tool_calls") != null);
+    try std.testing.expect(std.mem.find(u8, body, "call_456") != null);
+    try std.testing.expect(std.mem.find(u8, body, "bash") != null);
+    try std.testing.expect(std.mem.find(u8, body, "ls -la") != null);
 }
 
 test "parseChunk does not leak memory with reasoning content" {
@@ -2344,13 +2344,13 @@ test "buildRequestBody adds cache_control for OpenRouter Anthropic models" {
     defer allocator.free(body);
 
     // Verify cache_control is added to the last user message
-    try std.testing.expect(std.mem.indexOf(u8, body, "cache_control") != null);
-    try std.testing.expect(std.mem.indexOf(u8, body, "ephemeral") != null);
+    try std.testing.expect(std.mem.find(u8, body, "cache_control") != null);
+    try std.testing.expect(std.mem.find(u8, body, "ephemeral") != null);
 
     // The body should contain array content format for the last user message
     // Verify structure contains the expected format
-    try std.testing.expect(std.mem.indexOf(u8, body, "\"content\":[") != null);
-    try std.testing.expect(std.mem.indexOf(u8, body, "\"type\":\"text\"") != null);
+    try std.testing.expect(std.mem.find(u8, body, "\"content\":[") != null);
+    try std.testing.expect(std.mem.find(u8, body, "\"type\":\"text\"") != null);
 }
 
 test "buildRequestBody does not add cache_control for non-OpenRouter Anthropic" {
@@ -2379,7 +2379,7 @@ test "buildRequestBody does not add cache_control for non-OpenRouter Anthropic" 
     defer allocator.free(body);
 
     // Verify cache_control is NOT added for non-OpenRouter
-    try std.testing.expect(std.mem.indexOf(u8, body, "cache_control") == null);
+    try std.testing.expect(std.mem.find(u8, body, "cache_control") == null);
 }
 
 test "mergeCompat uses model-level compat options over detected capabilities" {
@@ -2464,10 +2464,10 @@ test "buildRequestBody uses max_tokens field from compat options" {
     defer allocator.free(body);
 
     // Should use max_tokens, not max_completion_tokens
-    try std.testing.expect(std.mem.indexOf(u8, body, "\"max_tokens\":50") != null);
-    try std.testing.expect(std.mem.indexOf(u8, body, "max_completion_tokens") == null);
+    try std.testing.expect(std.mem.find(u8, body, "\"max_tokens\":50") != null);
+    try std.testing.expect(std.mem.find(u8, body, "max_completion_tokens") == null);
     // Should not include store field
-    try std.testing.expect(std.mem.indexOf(u8, body, "\"store\"") == null);
+    try std.testing.expect(std.mem.find(u8, body, "\"store\"") == null);
 }
 
 test "buildRequestBody adds strict mode when supported" {
@@ -2504,7 +2504,7 @@ test "buildRequestBody adds strict mode when supported" {
     defer allocator.free(body);
 
     // Should include strict: true in tool definition
-    try std.testing.expect(std.mem.indexOf(u8, body, "\"strict\":true") != null);
+    try std.testing.expect(std.mem.find(u8, body, "\"strict\":true") != null);
 }
 
 test "buildRequestBody omits strict mode when not supported" {
@@ -2541,7 +2541,7 @@ test "buildRequestBody omits strict mode when not supported" {
     defer allocator.free(body);
 
     // Should NOT include strict field
-    try std.testing.expect(std.mem.indexOf(u8, body, "\"strict\"") == null);
+    try std.testing.expect(std.mem.find(u8, body, "\"strict\"") == null);
 }
 
 test "buildRequestBody adds store: false for OpenAI native" {
@@ -2568,7 +2568,7 @@ test "buildRequestBody adds store: false for OpenAI native" {
     defer allocator.free(body);
 
     // Should include store: false
-    try std.testing.expect(std.mem.indexOf(u8, body, "\"store\":false") != null);
+    try std.testing.expect(std.mem.find(u8, body, "\"store\":false") != null);
 }
 
 test "buildRequestBody omits store field for non-OpenAI providers" {
@@ -2595,7 +2595,7 @@ test "buildRequestBody omits store field for non-OpenAI providers" {
     defer allocator.free(body);
 
     // Should NOT include store field for Mistral
-    try std.testing.expect(std.mem.indexOf(u8, body, "\"store\"") == null);
+    try std.testing.expect(std.mem.find(u8, body, "\"store\"") == null);
 }
 
 test "parseChunk extracts reasoning_details for encrypted reasoning round-trip" {
@@ -2670,9 +2670,9 @@ test "parseChunk extracts reasoning_details for encrypted reasoning round-trip" 
     // Should have extracted the reasoning_detail event
     try std.testing.expectEqual(@as(usize, 1), reasoning_detail_events.items.len);
     try std.testing.expectEqualStrings("call_abc123", reasoning_detail_events.items[0].tool_call_id);
-    try std.testing.expect(std.mem.indexOf(u8, reasoning_detail_events.items[0].detail_json, "reasoning.encrypted") != null);
-    try std.testing.expect(std.mem.indexOf(u8, reasoning_detail_events.items[0].detail_json, "call_abc123") != null);
-    try std.testing.expect(std.mem.indexOf(u8, reasoning_detail_events.items[0].detail_json, "encrypted_data_here") != null);
+    try std.testing.expect(std.mem.find(u8, reasoning_detail_events.items[0].detail_json, "reasoning.encrypted") != null);
+    try std.testing.expect(std.mem.find(u8, reasoning_detail_events.items[0].detail_json, "call_abc123") != null);
+    try std.testing.expect(std.mem.find(u8, reasoning_detail_events.items[0].detail_json, "encrypted_data_here") != null);
 }
 
 test "buildRequestBody includes reasoning_details for tool calls with thought_signature" {
@@ -2732,9 +2732,9 @@ test "buildRequestBody includes reasoning_details for tool calls with thought_si
     defer allocator.free(body);
 
     // Should include reasoning_details array
-    try std.testing.expect(std.mem.indexOf(u8, body, "reasoning_details") != null);
-    try std.testing.expect(std.mem.indexOf(u8, body, "reasoning.encrypted") != null);
-    try std.testing.expect(std.mem.indexOf(u8, body, "call_abc123") != null);
+    try std.testing.expect(std.mem.find(u8, body, "reasoning_details") != null);
+    try std.testing.expect(std.mem.find(u8, body, "reasoning.encrypted") != null);
+    try std.testing.expect(std.mem.find(u8, body, "call_abc123") != null);
 }
 
 test "streamSimpleOpenAICompletions exits early when pre-cancelled" {

--- a/zig/src/providers/openai_responses_api.zig
+++ b/zig/src/providers/openai_responses_api.zig
@@ -182,7 +182,7 @@ fn buildRequestBody(model: ai_types.Model, context: ai_types.Context, options: a
     }
 
     // Privacy: don't store requests for OpenAI training
-    if (std.mem.indexOf(u8, model.base_url, "openai.com") != null) {
+    if (std.mem.find(u8, model.base_url, "openai.com") != null) {
         try w.writeBoolField("store", false);
     }
 
@@ -207,7 +207,7 @@ fn buildRequestBody(model: ai_types.Model, context: ai_types.Context, options: a
 
     // Cache retention for OpenAI API
     if (options.cache_retention) |retention| {
-        if (retention == .long and std.mem.indexOf(u8, model.base_url, "openai.com") != null) {
+        if (retention == .long and std.mem.find(u8, model.base_url, "openai.com") != null) {
             try w.writeStringField("prompt_cache_retention", "24h");
         }
     }
@@ -842,7 +842,7 @@ fn runThread(ctx: *ThreadCtx) void {
             var delay = retry_util.calculateDelay(retry_attempt, BASE_DELAY_MS, max_delay_ms);
 
             // Check Retry-After header (only if headers contain valid \r\n separator)
-            if (std.mem.indexOf(u8, response.head.bytes, "\r\n") != null) {
+            if (std.mem.find(u8, response.head.bytes, "\r\n") != null) {
                 var retry_after_iter = response.head.iterateHeaders();
                 while (retry_after_iter.next()) |header| {
                     if (std.ascii.eqlIgnoreCase(header.name, "retry-after")) {
@@ -1785,7 +1785,7 @@ test "buildRequestBody includes service_tier when set" {
     const body = try buildRequestBody(model, context, options, allocator);
     defer allocator.free(body);
 
-    try std.testing.expect(std.mem.indexOf(u8, body, "\"service_tier\":\"flex\"") != null);
+    try std.testing.expect(std.mem.find(u8, body, "\"service_tier\":\"flex\"") != null);
 }
 
 test "buildRequestBody omits service_tier when null" {
@@ -1810,7 +1810,7 @@ test "buildRequestBody omits service_tier when null" {
     const body = try buildRequestBody(model, context, options, allocator);
     defer allocator.free(body);
 
-    try std.testing.expect(std.mem.indexOf(u8, body, "service_tier") == null);
+    try std.testing.expect(std.mem.find(u8, body, "service_tier") == null);
 }
 
 test "buildRequestBody includes GPT-5 juice workaround when reasoning disabled" {
@@ -1838,8 +1838,8 @@ test "buildRequestBody includes GPT-5 juice workaround when reasoning disabled" 
     const body = try buildRequestBody(model, context, options, allocator);
     defer allocator.free(body);
 
-    try std.testing.expect(std.mem.indexOf(u8, body, "# Juice: 0 !important") != null);
-    try std.testing.expect(std.mem.indexOf(u8, body, "\"role\":\"developer\"") != null);
+    try std.testing.expect(std.mem.find(u8, body, "# Juice: 0 !important") != null);
+    try std.testing.expect(std.mem.find(u8, body, "\"role\":\"developer\"") != null);
 }
 
 test "buildRequestBody omits GPT-5 juice workaround when reasoning enabled" {
@@ -1867,7 +1867,7 @@ test "buildRequestBody omits GPT-5 juice workaround when reasoning enabled" {
     const body = try buildRequestBody(model, context, options, allocator);
     defer allocator.free(body);
 
-    try std.testing.expect(std.mem.indexOf(u8, body, "Juice") == null);
+    try std.testing.expect(std.mem.find(u8, body, "Juice") == null);
 }
 
 test "buildRequestBody omits juice workaround for non-GPT-5 models" {
@@ -1895,7 +1895,7 @@ test "buildRequestBody omits juice workaround for non-GPT-5 models" {
     const body = try buildRequestBody(model, context, options, allocator);
     defer allocator.free(body);
 
-    try std.testing.expect(std.mem.indexOf(u8, body, "Juice") == null);
+    try std.testing.expect(std.mem.find(u8, body, "Juice") == null);
 }
 
 test "ServiceTier enum values are correct" {

--- a/zig/src/providers/sse_parser.zig
+++ b/zig/src/providers/sse_parser.zig
@@ -99,7 +99,7 @@ pub const SSEParser = struct {
         if (line[0] == ':') return;
 
         // Find the colon separator
-        if (std.mem.indexOfScalar(u8, line, ':')) |colon_pos| {
+        if (std.mem.findScalar(u8, line, ':')) |colon_pos| {
             const field = line[0..colon_pos];
             var value = line[colon_pos + 1 ..];
 
@@ -365,6 +365,6 @@ test "sse_parser_provider_error_body_path_surfaces_error_event" {
 
     try std.testing.expectEqual(@as(usize, 1), events.len);
     try std.testing.expectEqualStrings("error", events[0].event_type.?);
-    try std.testing.expect(std.mem.indexOf(u8, events[0].data, "invalid_request_error") != null);
-    try std.testing.expect(std.mem.indexOf(u8, events[0].data, "bad input") != null);
+    try std.testing.expect(std.mem.find(u8, events[0].data, "invalid_request_error") != null);
+    try std.testing.expect(std.mem.find(u8, events[0].data, "bad input") != null);
 }

--- a/zig/src/tool_call_tracker.zig
+++ b/zig/src/tool_call_tracker.zig
@@ -369,7 +369,7 @@ test "ToolCallTracker - setThoughtSignatureById sets signature on matching tool 
     }
 
     try std.testing.expect(tc.thought_signature != null);
-    try std.testing.expect(std.mem.indexOf(u8, tc.thought_signature.?, "reasoning.encrypted") != null);
+    try std.testing.expect(std.mem.find(u8, tc.thought_signature.?, "reasoning.encrypted") != null);
 }
 
 test "ToolCallTracker - setThoughtSignatureById does nothing for non-existent ID" {

--- a/zig/src/tools/auth_cli.zig
+++ b/zig/src/tools/auth_cli.zig
@@ -565,7 +565,7 @@ pub const FileIo = struct {
 
     fn readLine(self: *FileIo, allocator: std.mem.Allocator) ![]u8 {
         while (true) {
-            if (std.mem.indexOfScalar(u8, self.leftover.items, '\n')) |nl_pos| {
+            if (std.mem.findScalar(u8, self.leftover.items, '\n')) |nl_pos| {
                 const raw = self.leftover.items[0..nl_pos];
                 const trimmed = std.mem.trim(u8, raw, " \t\r");
                 const dup = try allocator.dupe(u8, trimmed);
@@ -684,9 +684,9 @@ test "runProvidersCommand plain mode emits provider ids one per line" {
     try runProvidersCommand(allocator, test_io.io(), test_server_options, .{ .json_mode = false });
 
     // Expect at least the built-in provider ids on their own lines.
-    try std.testing.expect(std.mem.indexOf(u8, test_io.out.items, "anthropic\n") != null);
-    try std.testing.expect(std.mem.indexOf(u8, test_io.out.items, "github-copilot\n") != null);
-    try std.testing.expect(std.mem.indexOf(u8, test_io.out.items, "test-fixture\n") != null);
+    try std.testing.expect(std.mem.find(u8, test_io.out.items, "anthropic\n") != null);
+    try std.testing.expect(std.mem.find(u8, test_io.out.items, "github-copilot\n") != null);
+    try std.testing.expect(std.mem.find(u8, test_io.out.items, "test-fixture\n") != null);
     try std.testing.expectEqual(@as(usize, 0), test_io.err.items.len);
 }
 
@@ -734,22 +734,22 @@ test "runLoginCommand routes through protocol runtime and completes test-fixture
         .json_mode = false,
     });
 
-    try std.testing.expect(std.mem.indexOf(u8, test_io.out.items, "https://example.invalid/makai-test-fixture-login") != null);
-    try std.testing.expect(std.mem.indexOf(u8, test_io.out.items, "Enter code 'ok' to complete fixture login.") != null);
+    try std.testing.expect(std.mem.find(u8, test_io.out.items, "https://example.invalid/makai-test-fixture-login") != null);
+    try std.testing.expect(std.mem.find(u8, test_io.out.items, "Enter code 'ok' to complete fixture login.") != null);
     // Two prompts must have been issued (one for the rejected code, one for "ok").
     var prompt_count: usize = 0;
     var idx: usize = 0;
-    while (std.mem.indexOfPos(u8, test_io.out.items, idx, "Enter fixture code:")) |found| {
+    while (std.mem.findPos(u8, test_io.out.items, idx, "Enter fixture code:")) |found| {
         prompt_count += 1;
         idx = found + 1;
     }
     try std.testing.expect(prompt_count >= 2);
-    try std.testing.expect(std.mem.indexOf(u8, test_io.out.items, "Login successful.") != null);
+    try std.testing.expect(std.mem.find(u8, test_io.out.items, "Login successful.") != null);
     // Tokens must never appear in the wrapper-visible output.
-    try std.testing.expect(std.mem.indexOf(u8, test_io.out.items, "fixture-refresh-token") == null);
-    try std.testing.expect(std.mem.indexOf(u8, test_io.out.items, "fixture-access-token") == null);
-    try std.testing.expect(std.mem.indexOf(u8, test_io.err.items, "fixture-refresh-token") == null);
-    try std.testing.expect(std.mem.indexOf(u8, test_io.err.items, "fixture-access-token") == null);
+    try std.testing.expect(std.mem.find(u8, test_io.out.items, "fixture-refresh-token") == null);
+    try std.testing.expect(std.mem.find(u8, test_io.out.items, "fixture-access-token") == null);
+    try std.testing.expect(std.mem.find(u8, test_io.err.items, "fixture-refresh-token") == null);
+    try std.testing.expect(std.mem.find(u8, test_io.err.items, "fixture-access-token") == null);
 }
 
 test "runLoginCommand json mode emits per-event envelopes followed by terminal success" {
@@ -772,8 +772,8 @@ test "runLoginCommand json mode emits per-event envelopes followed by terminal s
     var line_iter = std.mem.splitScalar(u8, test_io.out.items, '\n');
     while (line_iter.next()) |line| {
         if (line.len == 0) continue;
-        if (std.mem.indexOf(u8, line, "fixture-refresh-token") != null) saw_token_leak = true;
-        if (std.mem.indexOf(u8, line, "fixture-access-token") != null) saw_token_leak = true;
+        if (std.mem.find(u8, line, "fixture-refresh-token") != null) saw_token_leak = true;
+        if (std.mem.find(u8, line, "fixture-access-token") != null) saw_token_leak = true;
 
         var parsed = std.json.parseFromSlice(std.json.Value, allocator, line, .{}) catch continue;
         defer parsed.deinit();
@@ -810,5 +810,5 @@ test "runLoginCommand surfaces typed error for unknown provider" {
     });
 
     try std.testing.expectError(AuthCliError.AuthLoginFailed, result);
-    try std.testing.expect(std.mem.indexOf(u8, test_io.err.items, "auth login failed") != null);
+    try std.testing.expect(std.mem.find(u8, test_io.err.items, "auth login failed") != null);
 }

--- a/zig/src/tools/makai.zig
+++ b/zig/src/tools/makai.zig
@@ -823,8 +823,8 @@ test "stdio auth login flow supports prompt loop terminal ordering and no secret
         }
 
         for (outbound.items) |line| {
-            if (std.mem.indexOf(u8, line, "fixture-refresh-token") != null or
-                std.mem.indexOf(u8, line, "fixture-access-token") != null)
+            if (std.mem.find(u8, line, "fixture-refresh-token") != null or
+                std.mem.find(u8, line, "fixture-access-token") != null)
             {
                 saw_secret_leak = true;
             }
@@ -1437,9 +1437,9 @@ test "handleAuth providers end-to-end through CLI wrapper emits provider ids" {
     harness.stderr_read.close(defaultIo());
 
     try std.testing.expect(harness.err == null);
-    try std.testing.expect(std.mem.indexOf(u8, stdout_bytes, "anthropic\n") != null);
-    try std.testing.expect(std.mem.indexOf(u8, stdout_bytes, "github-copilot\n") != null);
-    try std.testing.expect(std.mem.indexOf(u8, stdout_bytes, "test-fixture\n") != null);
+    try std.testing.expect(std.mem.find(u8, stdout_bytes, "anthropic\n") != null);
+    try std.testing.expect(std.mem.find(u8, stdout_bytes, "github-copilot\n") != null);
+    try std.testing.expect(std.mem.find(u8, stdout_bytes, "test-fixture\n") != null);
     try std.testing.expectEqual(@as(usize, 0), stderr_bytes.len);
 }
 
@@ -1493,18 +1493,18 @@ test "handleAuth login end-to-end drives prompt loop through CLI wrapper" {
     harness.stderr_read.close(defaultIo());
 
     try std.testing.expect(harness.err == null);
-    try std.testing.expect(std.mem.indexOf(
+    try std.testing.expect(std.mem.find(
         u8,
         stdout_bytes,
         "https://example.invalid/makai-test-fixture-login",
     ) != null);
-    try std.testing.expect(std.mem.indexOf(u8, stdout_bytes, "Login successful.") != null);
+    try std.testing.expect(std.mem.find(u8, stdout_bytes, "Login successful.") != null);
 
     // Tokens must never appear in CLI-visible streams.
-    try std.testing.expect(std.mem.indexOf(u8, stdout_bytes, "fixture-refresh-token") == null);
-    try std.testing.expect(std.mem.indexOf(u8, stdout_bytes, "fixture-access-token") == null);
-    try std.testing.expect(std.mem.indexOf(u8, stderr_bytes, "fixture-refresh-token") == null);
-    try std.testing.expect(std.mem.indexOf(u8, stderr_bytes, "fixture-access-token") == null);
+    try std.testing.expect(std.mem.find(u8, stdout_bytes, "fixture-refresh-token") == null);
+    try std.testing.expect(std.mem.find(u8, stdout_bytes, "fixture-access-token") == null);
+    try std.testing.expect(std.mem.find(u8, stderr_bytes, "fixture-refresh-token") == null);
+    try std.testing.expect(std.mem.find(u8, stderr_bytes, "fixture-access-token") == null);
 }
 
 test "handleAuth login surfaces typed error for unknown provider via CLI wrapper" {
@@ -1525,7 +1525,7 @@ test "handleAuth login surfaces typed error for unknown provider via CLI wrapper
     harness.stderr_read.close(defaultIo());
 
     try std.testing.expectEqual(auth_cli.AuthCliError.AuthLoginFailed, harness.err.?);
-    try std.testing.expect(std.mem.indexOf(u8, stderr_bytes, "auth login failed") != null);
+    try std.testing.expect(std.mem.find(u8, stderr_bytes, "auth login failed") != null);
 }
 
 pub fn main(init: std.process.Init.Minimal) !void {

--- a/zig/src/transport.zig
+++ b/zig/src/transport.zig
@@ -1386,8 +1386,8 @@ test "serialize and deserialize toolcall_start event with id and name" {
     defer allocator.free(json);
 
     // Verify the serialized JSON contains id and name
-    try std.testing.expect(std.mem.indexOf(u8, json, "\"id\":\"toolu_abc\"") != null);
-    try std.testing.expect(std.mem.indexOf(u8, json, "\"name\":\"calculator\"") != null);
+    try std.testing.expect(std.mem.find(u8, json, "\"id\":\"toolu_abc\"") != null);
+    try std.testing.expect(std.mem.find(u8, json, "\"name\":\"calculator\"") != null);
 
     const msg = try deserialize(json, allocator);
     try std.testing.expect(msg == .event);
@@ -1477,9 +1477,9 @@ test "serialize and deserialize error event" {
     defer allocator.free(json);
 
     // Verify JSON contains the new fields
-    try std.testing.expect(std.mem.indexOf(u8, json, "\"error_message\":\"API rate limit exceeded\"") != null);
-    try std.testing.expect(std.mem.indexOf(u8, json, "\"input\":100") != null);
-    try std.testing.expect(std.mem.indexOf(u8, json, "\"output\":50") != null);
+    try std.testing.expect(std.mem.find(u8, json, "\"error_message\":\"API rate limit exceeded\"") != null);
+    try std.testing.expect(std.mem.find(u8, json, "\"input\":100") != null);
+    try std.testing.expect(std.mem.find(u8, json, "\"output\":50") != null);
 
     const msg = try deserialize(json, allocator);
     try std.testing.expect(msg == .event);

--- a/zig/src/transports/in_process.zig
+++ b/zig/src/transports/in_process.zig
@@ -397,7 +397,7 @@ pub const SerializedPipe = struct {
             if (read_pos >= self.buffer.items.len) return null;
 
             const remaining = self.buffer.items[read_pos..];
-            if (std.mem.indexOfScalar(u8, remaining, '\n')) |nl_pos| {
+            if (std.mem.findScalar(u8, remaining, '\n')) |nl_pos| {
                 const line_end = read_pos + nl_pos;
                 const line = self.buffer.items[read_pos..line_end];
                 const result = try allocator.dupe(u8, line);

--- a/zig/src/transports/stdio.zig
+++ b/zig/src/transports/stdio.zig
@@ -68,7 +68,7 @@ pub const StdioReceiver = struct {
 
         while (true) {
             // Check leftover buffer for a complete line
-            if (std.mem.indexOfScalar(u8, self.leftover.items, '\n')) |nl_pos| {
+            if (std.mem.findScalar(u8, self.leftover.items, '\n')) |nl_pos| {
                 const line = try allocator.dupe(u8, self.leftover.items[0..nl_pos]);
                 // Remove consumed bytes including the newline
                 const remaining = self.leftover.items[nl_pos + 1 ..];
@@ -286,7 +286,7 @@ pub const AsyncStdioReceiver = struct {
 
         while (!ctx.cancel_token.load(.acquire)) {
             // Check for complete line in leftover
-            if (std.mem.indexOfScalar(u8, ctx.leftover.items, '\n')) |nl_pos| {
+            if (std.mem.findScalar(u8, ctx.leftover.items, '\n')) |nl_pos| {
                 const line = ctx.leftover.items[0..nl_pos];
                 const chunk = transport.ByteChunk{
                     .data = ctx.allocator.dupe(u8, line) catch {
@@ -347,7 +347,7 @@ pub const AsyncStdioReceiver = struct {
 
         while (true) {
             // Check for complete line
-            if (std.mem.indexOfScalar(u8, leftover.items, '\n')) |nl_pos| {
+            if (std.mem.findScalar(u8, leftover.items, '\n')) |nl_pos| {
                 const line = try allocator.dupe(u8, leftover.items[0..nl_pos]);
                 return line;
             }

--- a/zig/src/transports/websocket.zig
+++ b/zig/src/transports/websocket.zig
@@ -609,15 +609,15 @@ fn performHandshake(
     }
 
     // Verify Upgrade: websocket
-    if (std.mem.indexOf(u8, response, "Upgrade: websocket") == null and
-        std.mem.indexOf(u8, response, "Upgrade: Websocket") == null)
+    if (std.mem.find(u8, response, "Upgrade: websocket") == null and
+        std.mem.find(u8, response, "Upgrade: Websocket") == null)
     {
         return error.HandshakeFailed;
     }
 
     // Verify Connection: Upgrade
-    if (std.mem.indexOf(u8, response, "Connection: Upgrade") == null and
-        std.mem.indexOf(u8, response, "Connection: upgrade") == null)
+    if (std.mem.find(u8, response, "Connection: Upgrade") == null and
+        std.mem.find(u8, response, "Connection: upgrade") == null)
     {
         return error.HandshakeFailed;
     }
@@ -625,8 +625,8 @@ fn performHandshake(
     // Verify Sec-WebSocket-Accept header
     // The accept key is base64(sha1(key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"))
     // For simplicity, just verify the header exists
-    if (std.mem.indexOf(u8, response, "Sec-WebSocket-Accept:") == null and
-        std.mem.indexOf(u8, response, "Sec-WebSocket-Protocol:") == null)
+    if (std.mem.find(u8, response, "Sec-WebSocket-Accept:") == null and
+        std.mem.find(u8, response, "Sec-WebSocket-Protocol:") == null)
     {
         return error.HandshakeFailed;
     }
@@ -667,16 +667,16 @@ fn parseUrl(url: []const u8) !ParsedUrl {
     var host_end = url.len;
 
     // Look for port
-    if (std.mem.indexOfScalarPos(u8, url, offset, ':')) |colon_pos| {
+    if (std.mem.findScalarPos(u8, url, offset, ':')) |colon_pos| {
         host_end = colon_pos;
         offset = colon_pos + 1;
 
         // Parse port
-        const port_end = std.mem.indexOfScalarPos(u8, url, offset, '/') orelse url.len;
+        const port_end = std.mem.findScalarPos(u8, url, offset, '/') orelse url.len;
         const port_str = url[offset..port_end];
         result.port = try std.fmt.parseInt(u16, port_str, 10);
         offset = port_end;
-    } else if (std.mem.indexOfScalarPos(u8, url, offset, '/')) |slash_pos| {
+    } else if (std.mem.findScalarPos(u8, url, offset, '/')) |slash_pos| {
         host_end = slash_pos;
         offset = slash_pos;
     } else {

--- a/zig/src/utils/aws_sigv4.zig
+++ b/zig/src/utils/aws_sigv4.zig
@@ -310,9 +310,9 @@ test "buildCanonicalHeaders" {
     const canonical = try buildCanonicalHeaders(headers, allocator);
     defer allocator.free(canonical);
 
-    try std.testing.expect(std.mem.indexOf(u8, canonical, "content-type:application/json\n") != null);
-    try std.testing.expect(std.mem.indexOf(u8, canonical, "host:example.com\n") != null);
-    try std.testing.expect(std.mem.indexOf(u8, canonical, "x-amz-date:20210101T000000Z\n") != null);
+    try std.testing.expect(std.mem.find(u8, canonical, "content-type:application/json\n") != null);
+    try std.testing.expect(std.mem.find(u8, canonical, "host:example.com\n") != null);
+    try std.testing.expect(std.mem.find(u8, canonical, "x-amz-date:20210101T000000Z\n") != null);
 }
 
 test "getSignedHeaders" {
@@ -354,8 +354,8 @@ test "buildCanonicalRequest" {
     );
     defer allocator.free(canonical);
 
-    try std.testing.expect(std.mem.indexOf(u8, canonical, "GET\n") != null);
-    try std.testing.expect(std.mem.indexOf(u8, canonical, "/\n") != null);
+    try std.testing.expect(std.mem.find(u8, canonical, "GET\n") != null);
+    try std.testing.expect(std.mem.find(u8, canonical, "/\n") != null);
 }
 
 test "signRequest complete flow" {

--- a/zig/src/utils/oauth/anthropic.zig
+++ b/zig/src/utils/oauth/anthropic.zig
@@ -116,30 +116,30 @@ const ParsedAuth = struct {
 /// Parse code and state from manual input (format: "code#state" or just "code")
 fn parseAuthFromManualInput(allocator: std.mem.Allocator, input: []const u8) !ParsedAuth {
     // Try to find #code= in URL
-    if (std.mem.indexOf(u8, input, "#code=")) |idx| {
+    if (std.mem.find(u8, input, "#code=")) |idx| {
         const code_start = idx + 6;
         var code_end = input.len;
         var state: []const u8 = "";
 
         // Look for & or # after code
-        if (std.mem.indexOfAny(u8, input[code_start..], "#&")) |end| {
+        if (std.mem.findAny(u8, input[code_start..], "#&")) |end| {
             code_end = code_start + end;
         }
 
         const code = try allocator.dupe(u8, input[code_start..code_end]);
 
         // Look for state parameter
-        if (std.mem.indexOf(u8, input, "&state=")) |state_idx| {
+        if (std.mem.find(u8, input, "&state=")) |state_idx| {
             const state_start = state_idx + 7;
             var state_end = input.len;
-            if (std.mem.indexOf(u8, input[state_start..], "&")) |end| {
+            if (std.mem.find(u8, input[state_start..], "&")) |end| {
                 state_end = state_start + end;
             }
             state = try allocator.dupe(u8, input[state_start..state_end]);
-        } else if (std.mem.indexOf(u8, input, "#state=")) |state_idx| {
+        } else if (std.mem.find(u8, input, "#state=")) |state_idx| {
             const state_start = state_idx + 7;
             var state_end = input.len;
-            if (std.mem.indexOf(u8, input[state_start..], "&")) |end| {
+            if (std.mem.find(u8, input[state_start..], "&")) |end| {
                 state_end = state_start + end;
             }
             state = try allocator.dupe(u8, input[state_start..state_end]);
@@ -149,23 +149,23 @@ fn parseAuthFromManualInput(allocator: std.mem.Allocator, input: []const u8) !Pa
     }
 
     // Try to find ?code= in URL
-    if (std.mem.indexOf(u8, input, "?code=")) |idx| {
+    if (std.mem.find(u8, input, "?code=")) |idx| {
         const code_start = idx + 6;
         var code_end = input.len;
         var state: []const u8 = "";
 
         // Look for & or # after code
-        if (std.mem.indexOfAny(u8, input[code_start..], "#&")) |end| {
+        if (std.mem.findAny(u8, input[code_start..], "#&")) |end| {
             code_end = code_start + end;
         }
 
         const code = try allocator.dupe(u8, input[code_start..code_end]);
 
         // Look for state parameter
-        if (std.mem.indexOf(u8, input, "&state=")) |state_idx| {
+        if (std.mem.find(u8, input, "&state=")) |state_idx| {
             const state_start = state_idx + 7;
             var state_end = input.len;
-            if (std.mem.indexOf(u8, input[state_start..], "&")) |end| {
+            if (std.mem.find(u8, input[state_start..], "&")) |end| {
                 state_end = state_start + end;
             }
             state = try allocator.dupe(u8, input[state_start..state_end]);
@@ -175,7 +175,7 @@ fn parseAuthFromManualInput(allocator: std.mem.Allocator, input: []const u8) !Pa
     }
 
     // Assume raw "code#state" format
-    if (std.mem.indexOf(u8, input, "#")) |hash_idx| {
+    if (std.mem.find(u8, input, "#")) |hash_idx| {
         const code = try allocator.dupe(u8, input[0..hash_idx]);
         const state = try allocator.dupe(u8, input[hash_idx + 1 ..]);
         return .{ .code = code, .state = state };
@@ -397,7 +397,7 @@ test "buildAuthUrl includes code=true" {
     const url = try buildAuthUrl(std.testing.allocator, "challenge-value", "state-value");
     defer std.testing.allocator.free(url);
 
-    try std.testing.expect(std.mem.indexOf(u8, url, "code=true") != null);
+    try std.testing.expect(std.mem.find(u8, url, "code=true") != null);
 }
 
 test "parseTokenResponse handles camelCase token fields" {

--- a/zig/src/utils/oauth/callback_server.zig
+++ b/zig/src/utils/oauth/callback_server.zig
@@ -48,12 +48,12 @@ pub const CallbackServer = struct {
 
             // Parse query string from GET request
             if (std.mem.startsWith(u8, request, "GET ")) {
-                const query_start = std.mem.indexOf(u8, request, "?") orelse {
+                const query_start = std.mem.find(u8, request, "?") orelse {
                     try self.sendResponse(connection.stream, false, "No query parameters");
                     continue;
                 };
 
-                const query_end = std.mem.indexOf(u8, request[query_start..], " ") orelse request.len - query_start;
+                const query_end = std.mem.find(u8, request[query_start..], " ") orelse request.len - query_start;
                 const query = request[query_start + 1 .. query_start + query_end];
 
                 // Parse code and state

--- a/zig/src/utils/oauth/github_copilot.zig
+++ b/zig/src/utils/oauth/github_copilot.zig
@@ -74,12 +74,12 @@ pub const Prompt = struct {
 pub fn getBaseUrlFromToken(token: []const u8, allocator: std.mem.Allocator) ?[]const u8 {
     // Find "proxy-ep=" in token
     const prefix = "proxy-ep=";
-    const start_idx = std.mem.indexOf(u8, token, prefix) orelse return null;
+    const start_idx = std.mem.find(u8, token, prefix) orelse return null;
     const value_start = start_idx + prefix.len;
 
     // Find end of value (semicolon or end of string)
     const remaining = token[value_start..];
-    const end_idx = std.mem.indexOf(u8, remaining, ";") orelse remaining.len;
+    const end_idx = std.mem.find(u8, remaining, ";") orelse remaining.len;
     const proxy_host = remaining[0..end_idx];
 
     // Convert "proxy.xxx" to "api.xxx"
@@ -259,10 +259,10 @@ pub fn login(callbacks: Callbacks, allocator: std.mem.Allocator) !Credentials {
 pub fn refreshToken(credentials: Credentials, allocator: std.mem.Allocator) !Credentials {
     // Parse enterprise URL from provider_data
     const github_domain = if (credentials.provider_data) |data| blk: {
-        if (std.mem.indexOf(u8, data, "enterpriseUrl")) |_| {
-            if (std.mem.indexOf(u8, data, "https://")) |idx| {
+        if (std.mem.find(u8, data, "enterpriseUrl")) |_| {
+            if (std.mem.find(u8, data, "https://")) |idx| {
                 const start = idx + 8;
-                const end = std.mem.indexOfScalar(u8, data[start..], '"') orelse data.len - start;
+                const end = std.mem.findScalar(u8, data[start..], '"') orelse data.len - start;
                 break :blk data[start .. start + end];
             }
         }
@@ -591,8 +591,8 @@ fn getCopilotToken(domain: []const u8, github_token: []const u8, allocator: std.
         // Some endpoints may return the raw token string directly instead of JSON.
         // Accept token-like payloads as a fallback.
         const trimmed = std.mem.trim(u8, response_body, " \r\n\t\"");
-        if (std.mem.indexOf(u8, trimmed, "tid=") != null or
-            std.mem.indexOf(u8, trimmed, "proxy-ep=") != null)
+        if (std.mem.find(u8, trimmed, "tid=") != null or
+            std.mem.find(u8, trimmed, "proxy-ep=") != null)
         {
             return try allocator.dupe(u8, trimmed);
         }

--- a/zig/src/utils/oauth/google.zig
+++ b/zig/src/utils/oauth/google.zig
@@ -130,9 +130,9 @@ pub fn getApiKey(credentials: Credentials, allocator: std.mem.Allocator) ![]cons
 
 /// Parse code from URL
 fn parseCodeFromUrl(allocator: std.mem.Allocator, url: []const u8) ![]const u8 {
-    if (std.mem.indexOf(u8, url, "code=")) |idx| {
+    if (std.mem.find(u8, url, "code=")) |idx| {
         const code_start = idx + 5;
-        const code_end = std.mem.indexOfAny(u8, url[code_start..], "&# ") orelse url.len - code_start;
+        const code_end = std.mem.findAny(u8, url[code_start..], "&# ") orelse url.len - code_start;
         return try allocator.dupe(u8, url[code_start .. code_start + code_end]);
     }
     return error.NoCodeInUrl;

--- a/zig/src/utils/oauth/pkce.zig
+++ b/zig/src/utils/oauth/pkce.zig
@@ -63,13 +63,13 @@ test "generate - returns valid PKCE challenge" {
     try std.testing.expect(challenge.challenge.len == 43);
 
     // Should not contain standard base64 characters
-    try std.testing.expect(std.mem.indexOf(u8, challenge.verifier, "+") == null);
-    try std.testing.expect(std.mem.indexOf(u8, challenge.verifier, "/") == null);
-    try std.testing.expect(std.mem.indexOf(u8, challenge.verifier, "=") == null);
+    try std.testing.expect(std.mem.find(u8, challenge.verifier, "+") == null);
+    try std.testing.expect(std.mem.find(u8, challenge.verifier, "/") == null);
+    try std.testing.expect(std.mem.find(u8, challenge.verifier, "=") == null);
 
-    try std.testing.expect(std.mem.indexOf(u8, challenge.challenge, "+") == null);
-    try std.testing.expect(std.mem.indexOf(u8, challenge.challenge, "/") == null);
-    try std.testing.expect(std.mem.indexOf(u8, challenge.challenge, "=") == null);
+    try std.testing.expect(std.mem.find(u8, challenge.challenge, "+") == null);
+    try std.testing.expect(std.mem.find(u8, challenge.challenge, "/") == null);
+    try std.testing.expect(std.mem.find(u8, challenge.challenge, "=") == null);
 }
 
 test "generate - creates unique verifiers" {
@@ -103,5 +103,5 @@ test "base64urlEncode - encodes correctly" {
 
     // Should be base64url without padding
     try std.testing.expectEqualStrings("aGVsbG8gd29ybGQ", encoded);
-    try std.testing.expect(std.mem.indexOf(u8, encoded, "=") == null);
+    try std.testing.expect(std.mem.find(u8, encoded, "=") == null);
 }

--- a/zig/src/utils/oauth/refresh_lock.zig
+++ b/zig/src/utils/oauth/refresh_lock.zig
@@ -188,12 +188,12 @@ pub const RefreshLock = struct {
     fn keyMatches(key: []const u8, provider_id: []const u8, user_id: ?[]const u8) bool {
         if (user_id) |uid| {
             // Multi-tenant key: "provider_id\x00user_id"
-            const null_pos = std.mem.indexOfScalar(u8, key, 0) orelse return false;
+            const null_pos = std.mem.findScalar(u8, key, 0) orelse return false;
             return std.mem.eql(u8, key[0..null_pos], provider_id) and
                 std.mem.eql(u8, key[null_pos + 1 ..], uid);
         } else {
             // Single-tenant: key must be exactly provider_id with no null byte.
-            if (std.mem.indexOfScalar(u8, key, 0) != null) return false;
+            if (std.mem.findScalar(u8, key, 0) != null) return false;
             return std.mem.eql(u8, key, provider_id);
         }
     }

--- a/zig/src/utils/oauth/storage.zig
+++ b/zig/src/utils/oauth/storage.zig
@@ -385,8 +385,8 @@ test "saveToFile writes atomically via temp file + rename" {
     const content = try result_file.readToEndAlloc(std.testing.allocator, 1024);
     defer std.testing.allocator.free(content);
 
-    try std.testing.expect(std.mem.indexOf(u8, content, "sk-test-key-12345") != null);
-    try std.testing.expect(std.mem.indexOf(u8, content, "test-provider") != null);
+    try std.testing.expect(std.mem.find(u8, content, "sk-test-key-12345") != null);
+    try std.testing.expect(std.mem.find(u8, content, "test-provider") != null);
 }
 
 
@@ -455,8 +455,8 @@ test "oauth_storage_saveToFile_direct_sets_0600_and_same_directory_temp_rename" 
     const content = try file.readToEndAlloc(std.testing.allocator, 4096);
     defer std.testing.allocator.free(content);
 
-    try std.testing.expect(std.mem.indexOf(u8, content, "direct-provider") != null);
-    try std.testing.expect(std.mem.indexOf(u8, content, "secret-key") != null);
+    try std.testing.expect(std.mem.find(u8, content, "direct-provider") != null);
+    try std.testing.expect(std.mem.find(u8, content, "secret-key") != null);
 
     if (builtin.os.tag != .windows) {
         const stat = try file.stat();

--- a/zig/src/utils/overflow.zig
+++ b/zig/src/utils/overflow.zig
@@ -41,7 +41,7 @@ pub fn isContextOverflow(message: ai_types.AssistantMessage, context_window: ?u6
 
 /// Check if error message matches known overflow patterns
 fn matchesOverflowPattern(err_msg: []const u8) bool {
-    // Use std.mem.indexOfPosScalar for case-insensitive matching
+    // Use std.mem.findPosScalar for case-insensitive matching
     // We use std.ascii.lower to do case-insensitive comparisons
 
     // Anthropic: "prompt is too long"

--- a/zig/src/utils/pre_transform.zig
+++ b/zig/src/utils/pre_transform.zig
@@ -44,7 +44,7 @@ fn isSameModel(msg: ai_types.AssistantMessage, config: TransformConfig) bool {
 pub fn normalizeToolId(allocator: std.mem.Allocator, id: []const u8, max_len: usize) ![]const u8 {
     // Strip pipe-separated suffix
     var effective_id = id;
-    if (std.mem.indexOf(u8, id, "|")) |pipe_pos| {
+    if (std.mem.find(u8, id, "|")) |pipe_pos| {
         effective_id = id[0..pipe_pos];
     }
 
@@ -218,7 +218,7 @@ pub fn preTransform(
 
                         // Build normalized ID if needed
                         if (config.max_tool_id_len > 0 or config.mistral_tool_ids or
-                            std.mem.indexOf(u8, c.tool_call.id, "|") != null)
+                            std.mem.find(u8, c.tool_call.id, "|") != null)
                         {
                             const normalized = if (config.mistral_tool_ids)
                                 try mistralToolId(allocator, c.tool_call.id)

--- a/zig/src/utils/provider_caps.zig
+++ b/zig/src/utils/provider_caps.zig
@@ -61,67 +61,67 @@ pub const ProviderCapabilities = struct {
 /// Check if URL is GitHub Copilot
 pub fn isGitHubCopilot(base_url: ?[]const u8) bool {
     const url = base_url orelse return false;
-    return std.mem.indexOf(u8, url, "api.githubcopilot.com") != null;
+    return std.mem.find(u8, url, "api.githubcopilot.com") != null;
 }
 
 /// Check if URL is Mistral
 pub fn isMistral(base_url: ?[]const u8) bool {
     const url = base_url orelse return false;
-    return std.mem.indexOf(u8, url, "api.mistral.ai") != null;
+    return std.mem.find(u8, url, "api.mistral.ai") != null;
 }
 
 /// Check if URL is Groq
 pub fn isGroq(base_url: ?[]const u8) bool {
     const url = base_url orelse return false;
-    return std.mem.indexOf(u8, url, "api.groq.com") != null;
+    return std.mem.find(u8, url, "api.groq.com") != null;
 }
 
 /// Check if URL is Cerebras
 pub fn isCerebras(base_url: ?[]const u8) bool {
     const url = base_url orelse return false;
-    return std.mem.indexOf(u8, url, "api.cerebras.ai") != null;
+    return std.mem.find(u8, url, "api.cerebras.ai") != null;
 }
 
 /// Check if URL is Z.ai
 pub fn isZai(base_url: ?[]const u8) bool {
     const url = base_url orelse return false;
-    return std.mem.indexOf(u8, url, "api.zukijourney.com") != null or std.mem.indexOf(u8, url, "zai") != null;
+    return std.mem.find(u8, url, "api.zukijourney.com") != null or std.mem.find(u8, url, "zai") != null;
 }
 
 /// Check if URL is OpenRouter
 pub fn isOpenRouter(base_url: ?[]const u8) bool {
     const url = base_url orelse return false;
-    return std.mem.indexOf(u8, url, "openrouter.ai") != null;
+    return std.mem.find(u8, url, "openrouter.ai") != null;
 }
 
 /// Check if URL is Chutes
 pub fn isChutes(base_url: ?[]const u8) bool {
     const url = base_url orelse return false;
-    return std.mem.indexOf(u8, url, "chutes.ai") != null;
+    return std.mem.find(u8, url, "chutes.ai") != null;
 }
 
 /// Check if URL is Qwen
 pub fn isQwen(base_url: ?[]const u8) bool {
     const url = base_url orelse return false;
-    return std.mem.indexOf(u8, url, "dashscope") != null or std.mem.indexOf(u8, url, "qwen") != null;
+    return std.mem.find(u8, url, "dashscope") != null or std.mem.find(u8, url, "qwen") != null;
 }
 
 /// Check if URL is DeepSeek
 pub fn isDeepSeek(base_url: ?[]const u8) bool {
     const url = base_url orelse return false;
-    return std.mem.indexOf(u8, url, "api.deepseek.com") != null;
+    return std.mem.find(u8, url, "api.deepseek.com") != null;
 }
 
 /// Check if URL is OpenAI native
 pub fn isOpenAINative(base_url: ?[]const u8) bool {
     const url = base_url orelse return false;
-    return std.mem.indexOf(u8, url, "api.openai.com") != null;
+    return std.mem.find(u8, url, "api.openai.com") != null;
 }
 
 /// Check if URL is Anthropic
 pub fn isAnthropic(base_url: ?[]const u8) bool {
     const url = base_url orelse return false;
-    return std.mem.indexOf(u8, url, "api.anthropic.com") != null;
+    return std.mem.find(u8, url, "api.anthropic.com") != null;
 }
 
 /// Detect provider type from base URL
@@ -136,11 +136,11 @@ pub fn detectProviderType(base_url: ?[]const u8) ProviderType {
     if (isCerebras(url)) return .openai_compatible;
     if (isZai(url)) return .openai_compatible;
     if (isOpenRouter(url)) return .openai_compatible;
-    if (std.mem.indexOf(u8, url, "generativelanguage.googleapis.com") != null) return .google;
-    if (std.mem.indexOf(u8, url, "aiplatform.googleapis.com") != null) return .google;
-    if (std.mem.indexOf(u8, url, "bedrock-runtime.") != null or std.mem.indexOf(u8, url, "bedrock.") != null) return .bedrock;
-    if (std.mem.indexOf(u8, url, ".openai.azure.com") != null or std.mem.indexOf(u8, url, "cognitiveservices.azure.com") != null) return .azure;
-    if (std.mem.indexOf(u8, url, "localhost:11434") != null or std.mem.indexOf(u8, url, "127.0.0.1:11434") != null or std.mem.indexOf(u8, url, "ollama") != null) return .ollama;
+    if (std.mem.find(u8, url, "generativelanguage.googleapis.com") != null) return .google;
+    if (std.mem.find(u8, url, "aiplatform.googleapis.com") != null) return .google;
+    if (std.mem.find(u8, url, "bedrock-runtime.") != null or std.mem.find(u8, url, "bedrock.") != null) return .bedrock;
+    if (std.mem.find(u8, url, ".openai.azure.com") != null or std.mem.find(u8, url, "cognitiveservices.azure.com") != null) return .azure;
+    if (std.mem.find(u8, url, "localhost:11434") != null or std.mem.find(u8, url, "127.0.0.1:11434") != null or std.mem.find(u8, url, "ollama") != null) return .ollama;
 
     // Default to OpenAI-compatible for unknown URLs
     if (url.len > 0) return .openai_compatible;

--- a/zig/src/utils/retry.zig
+++ b/zig/src/utils/retry.zig
@@ -96,18 +96,18 @@ fn parseHttpDate(date_str: []const u8) ?u64 {
     var idx: usize = 5;
 
     // Parse day
-    const day_end = std.mem.indexOfPos(u8, date_str, idx, " ") orelse return null;
+    const day_end = std.mem.findPos(u8, date_str, idx, " ") orelse return null;
     const day = std.fmt.parseInt(u32, date_str[idx..day_end], 10) catch return null;
     idx = day_end + 1;
 
     // Parse month
-    const month_end = std.mem.indexOfPos(u8, date_str, idx, " ") orelse return null;
+    const month_end = std.mem.findPos(u8, date_str, idx, " ") orelse return null;
     const month_str = date_str[idx..month_end];
     const month = monthFromString(month_str) orelse return null;
     idx = month_end + 1;
 
     // Parse year
-    const year_end = std.mem.indexOfPos(u8, date_str, idx, " ") orelse return null;
+    const year_end = std.mem.findPos(u8, date_str, idx, " ") orelse return null;
     const year = std.fmt.parseInt(u32, date_str[idx..year_end], 10) catch return null;
     idx = year_end + 1;
 
@@ -197,7 +197,7 @@ pub fn extractRetryDelayFromBody(error_text: []const u8) ?u64 {
     if (indexOfCaseInsensitive(error_text, "\"retrydelay\"")) |start_idx| {
         // Find the colon and value
         const after_key = error_text[start_idx..];
-        if (std.mem.indexOf(u8, after_key, ":")) |colon_idx| {
+        if (std.mem.find(u8, after_key, ":")) |colon_idx| {
             const after_colon = std.mem.trimStart(u8, after_key[colon_idx + 1 ..], " \t");
             if (parseRetryInFormat(after_colon)) |ms| {
                 return normalizeDelay(ms);

--- a/zig/test/e2e/protocol.zig
+++ b/zig/test/e2e/protocol.zig
@@ -118,9 +118,9 @@ test "Envelope serialization roundtrip with ping" {
     defer allocator.free(serialized);
 
     // Verify structure
-    try testing.expect(std.mem.indexOf(u8, serialized, "\"type\":\"ping\"") != null);
-    try testing.expect(std.mem.indexOf(u8, serialized, "\"sequence\":1") != null);
-    try testing.expect(std.mem.indexOf(u8, serialized, "\"timestamp\":1708234567890") != null);
+    try testing.expect(std.mem.find(u8, serialized, "\"type\":\"ping\"") != null);
+    try testing.expect(std.mem.find(u8, serialized, "\"sequence\":1") != null);
+    try testing.expect(std.mem.find(u8, serialized, "\"timestamp\":1708234567890") != null);
 }
 
 test "Envelope serialization roundtrip with pong" {
@@ -146,8 +146,8 @@ test "Envelope serialization roundtrip with pong" {
     const serialized = try envelope.serializeEnvelope(parsed, allocator);
     defer allocator.free(serialized);
 
-    try testing.expect(std.mem.indexOf(u8, serialized, "\"type\":\"pong\"") != null);
-    try testing.expect(std.mem.indexOf(u8, serialized, "\"ping_id\":\"test-ping-123\"") != null);
+    try testing.expect(std.mem.find(u8, serialized, "\"type\":\"pong\"") != null);
+    try testing.expect(std.mem.find(u8, serialized, "\"ping_id\":\"test-ping-123\"") != null);
 }
 
 test "Envelope roundtrip preserves ACK structure" {
@@ -174,8 +174,8 @@ test "Envelope roundtrip preserves ACK structure" {
     defer allocator.free(serialized);
 
     try testing.expect(parsed.payload == .ack);
-    try testing.expect(std.mem.indexOf(u8, serialized, "\"type\":\"ack\"") != null);
-    try testing.expect(std.mem.indexOf(u8, serialized, "\"acknowledged_id\"") != null);
+    try testing.expect(std.mem.find(u8, serialized, "\"type\":\"ack\"") != null);
+    try testing.expect(std.mem.find(u8, serialized, "\"acknowledged_id\"") != null);
 }
 
 test "Envelope roundtrip preserves NACK structure" {
@@ -786,5 +786,5 @@ test "Envelope preserves in_reply_to field" {
     const serialized = try envelope.serializeEnvelope(parsed, allocator);
     defer allocator.free(serialized);
 
-    try testing.expect(std.mem.indexOf(u8, serialized, "\"in_reply_to\"") != null);
+    try testing.expect(std.mem.find(u8, serialized, "\"in_reply_to\"") != null);
 }

--- a/zig/test/e2e/test_helpers.zig
+++ b/zig/test/e2e/test_helpers.zig
@@ -243,7 +243,7 @@ pub fn getAnthropicCredential(allocator: std.mem.Allocator) !?AnthropicCredentia
     // 1. Try ANTHROPIC_AUTH_TOKEN first (OAuth token)
     if (compat.getEnvVarOwned(allocator, "ANTHROPIC_AUTH_TOKEN")) |token| {
         // OAuth token format: "refresh_token:access_token" or just "access_token"
-        if (std.mem.indexOfScalar(u8, token, ':')) |colon_pos| {
+        if (std.mem.findScalar(u8, token, ':')) |colon_pos| {
             const access_token = try allocator.dupe(u8, token[colon_pos + 1 ..]);
             allocator.free(token);
             return AnthropicCredential{
@@ -453,7 +453,7 @@ pub fn getGitHubCopilotCredentials(allocator: std.mem.Allocator) !?GitHubCopilot
     if (compat.getEnvVarOwned(allocator, "COPILOT_TOKEN")) |token| {
         // Check for combined format: "github_token:copilot_token"
         // Split on the first colon - copilot_token may contain colons (semicolons in the token)
-        if (std.mem.indexOfScalar(u8, token, ':')) |colon_pos| {
+        if (std.mem.findScalar(u8, token, ':')) |colon_pos| {
             const github_token = token[0..colon_pos];
             const copilot_token = token[colon_pos + 1 ..];
             const result = GitHubCopilotCredentials{
@@ -510,7 +510,7 @@ fn getGitHubCopilotCredentialsFromAuthFile(allocator: std.mem.Allocator) !?GitHu
     if (provider_val == .string) {
         const combined = provider_val.string;
         // Split on the first colon - copilot_token may contain colons
-        if (std.mem.indexOfScalar(u8, combined, ':')) |colon_pos| {
+        if (std.mem.findScalar(u8, combined, ':')) |colon_pos| {
             const github_token = combined[0..colon_pos];
             const copilot_token = combined[colon_pos + 1 ..];
             return GitHubCopilotCredentials{
@@ -578,7 +578,7 @@ pub fn getAnthropicOAuthCredentials(allocator: std.mem.Allocator) !?AnthropicOAu
     // 1. Try ANTHROPIC_AUTH_TOKEN (combined format: "refresh_token:access_token" or single token)
     if (compat.getEnvVarOwned(allocator, "ANTHROPIC_AUTH_TOKEN")) |token| {
         // Split on the first colon
-        if (std.mem.indexOfScalar(u8, token, ':')) |colon_pos| {
+        if (std.mem.findScalar(u8, token, ':')) |colon_pos| {
             const refresh_token = token[0..colon_pos];
             const access_token = token[colon_pos + 1 ..];
             const result = AnthropicOAuthCredentials{
@@ -633,7 +633,7 @@ fn getAnthropicOAuthCredentialsFromAuthFile(allocator: std.mem.Allocator) !?Anth
     // Support combined format: if the value is a string, parse as "refresh_token:access_token"
     if (provider_val == .string) {
         const combined = provider_val.string;
-        if (std.mem.indexOfScalar(u8, combined, ':')) |colon_pos| {
+        if (std.mem.findScalar(u8, combined, ':')) |colon_pos| {
             const refresh_token = combined[0..colon_pos];
             const access_token = combined[colon_pos + 1 ..];
             return AnthropicOAuthCredentials{


### PR DESCRIPTION
## Summary
- Replace remaining `std.mem.indexOf*` call sites with Zig 0.16 `std.mem.find*` equivalents across production and test Zig sources.
- Preserve existing behavior while moving scalar, positional, and any searches to the new std.mem API.

References: Zig 0.15.2 → 0.16.0 Migration — indexOf → find migration

## Test plan
- [x] `cd zig && ../scripts/check-zig-patterns.sh`
- [x] `cd zig && zig build test-unit-core`
- [x] `cd zig && zig build test-unit-transport`
- [x] `cd zig && zig build test-unit-protocol`
- [x] `cd zig && zig build test-unit-providers`
- [x] `cd zig && zig build test-unit-utils`
- [x] `cd zig && zig build test-unit-agent`
- [x] `cd zig && zig build test`