### PR TITLE
Document EventStream Zig 0.16 sync migration

### DIFF
--- a/docs/zig-0.16.0-migration-plan.md
+++ b/docs/zig-0.16.0-migration-plan.md
@@ -209,6 +209,8 @@ Suggested scope for one PR:
 - Preserve existing error messages and error types for stream completion/error paths unless a compiler-enforced change is documented.
 - Document semantic differences in timeout or wake behavior.
 
+Phase 2 item 11 implementation note: EventStream synchronization now uses `std.Io.Mutex` and `std.Io` futex wait/wake operations. The public semantics intentionally remain unchanged: push, completion, and thread-done paths increment the futex word before waking waiters; waiters re-check queue/completion state after every wake. Timed `waitForThread` waits use `std.Io.Timeout` on the boot clock and still collapse timeout/spurious-wake errors into the existing bool-returning deadline loop, so callers observe the same timeout behavior.
+
 Depends on: work items 8 and 9.
 
 #### Work item 12 — Migrate agent/auth/OAuth synchronization

--- a/zig/src/event_stream.zig
+++ b/zig/src/event_stream.zig
@@ -51,6 +51,11 @@ pub fn EventStream(comptime T: type, comptime R: type) type {
                 std.Io.Threaded.global_single_threaded.io();
         }
 
+        /// Zig 0.16 routes futex operations through the active `std.Io` context.
+        /// The EventStream still uses a monotonically increasing futex word so
+        /// wake/wait semantics match the previous `std.Thread.Futex` design:
+        /// waiters sleep only while the observed word remains unchanged, and
+        /// every push/completion/thread-done transition increments before wake.
         fn wake(self: *Self, max_waiters: u32) void {
             defaultIo().futexWake(u32, &self.futex.raw, max_waiters);
         }
@@ -59,6 +64,10 @@ pub fn EventStream(comptime T: type, comptime R: type) type {
             defaultIo().futexWaitUncancelable(u32, &self.futex.raw, expected);
         }
 
+        /// Timed waits now use `std.Io.Timeout` on the boot clock. Timeout and
+        /// spurious-wake errors are intentionally collapsed here because callers
+        /// re-check `thread_done` and their monotonic deadline after every wait,
+        /// preserving the public bool-returning timeout behavior.
         fn waitTimeoutMs(self: *Self, expected: u32, timeout_ms: u64) void {
             const capped_ms = @min(timeout_ms, @as(u64, std.math.maxInt(i64)));
             defaultIo().futexWaitTimeout(u32, &self.futex.raw, expected, .{ .duration = .{

--- a/zig/src/stream.zig
+++ b/zig/src/stream.zig
@@ -45,6 +45,10 @@ pub fn complete(
         allocator.destroy(s);
     }
 
+    // Zig 0.16 exposes futex waits through the active I/O context. The stream
+    // completion path increments this word before waking waiters, so using the
+    // currently observed value preserves the prior `std.Thread.Futex.wait`
+    // behavior while avoiding missed completion notifications.
     while (!s.isDone()) {
         defaultIo().futexWaitUncancelable(u32, &s.futex.raw, s.futex.load(.acquire));
     }
@@ -66,6 +70,10 @@ pub fn completeSimple(
         allocator.destroy(s);
     }
 
+    // Zig 0.16 exposes futex waits through the active I/O context. The stream
+    // completion path increments this word before waking waiters, so using the
+    // currently observed value preserves the prior `std.Thread.Futex.wait`
+    // behavior while avoiding missed completion notifications.
     while (!s.isDone()) {
         defaultIo().futexWaitUncancelable(u32, &s.futex.raw, s.futex.load(.acquire));
     }

--- a/zig/test/e2e/distributed_fullstack.zig
+++ b/zig/test/e2e/distributed_fullstack.zig
@@ -302,6 +302,12 @@ test "distributed fullstack: agent loop via provider protocol and tool protocol"
         // `auth_required`. The mock provider does not validate the key.
         .api_key = "test-key",
     });
+    // agentLoop transfers prompt ownership into the AgentContext. The prompt is
+    // deep-copied into AgentLoopResult as well, so clear context after the loop
+    // to avoid keeping a duplicate owned prompt alive until the test allocator's
+    // leak check runs.
+    for (context.messages.items) |*message| message.deinit(allocator);
+    context.messages.clearRetainingCapacity();
     defer {
         stream.deinit();
         allocator.destroy(stream);

--- a/zig/test/e2e/distributed_fullstack.zig
+++ b/zig/test/e2e/distributed_fullstack.zig
@@ -302,12 +302,6 @@ test "distributed fullstack: agent loop via provider protocol and tool protocol"
         // `auth_required`. The mock provider does not validate the key.
         .api_key = "test-key",
     });
-    // agentLoop transfers prompt ownership into the AgentContext. The prompt is
-    // deep-copied into AgentLoopResult as well, so clear context after the loop
-    // to avoid keeping a duplicate owned prompt alive until the test allocator's
-    // leak check runs.
-    for (context.messages.items) |*message| message.deinit(allocator);
-    context.messages.clearRetainingCapacity();
     defer {
         stream.deinit();
         allocator.destroy(stream);


### PR DESCRIPTION
## Summary
- Reference Zig 0.15.2 → 0.16.0 Migration — EventStream sync migration.
- Document that EventStream and stream completion waits now route through `std.Io` futex/mutex primitives.
- Capture timeout/wake semantics for the core streaming migration: futex words still increment before wake, waiters re-check state after wake, and `waitForThread` keeps its bool-returning deadline behavior.

## Test plan
- [x] `cd zig && zig build test-unit-core`
- [x] `./scripts/check-zig-patterns.sh`