### PR TITLE
Validate agent/auth OAuth sync migration

### DIFF
--- a/zig/build.zig
+++ b/zig/build.zig
@@ -1024,6 +1024,10 @@ pub fn build(b: *std.Build) void {
             },
         }),
     });
+    // TODO: Remove once Zig 0.16 self-hosted backend handles this test correctly.
+    // The distributed fullstack test uses in-process threading + condition variables
+    // and currently matches the bridge test backend issue; LLVM handles it fine.
+    e2e_distributed_fullstack_test.use_llvm = true;
 
     const e2e_distributed_fullstack_github_test = b.addTest(.{
         .root_module = b.createModule(.{

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -1102,6 +1102,9 @@ pub fn build(b: *std.Build) void {
     const agent_mod_test = b.addTest(.{ .root_module = agent_mod });
 
     const agent_provider_protocol_bridge_test = b.addTest(.{ .root_module = agent_provider_protocol_bridge_mod });
+    // TODO: Remove once Zig 0.16 self-hosted backend handles this test correctly.
+    // The bridge test uses in-process threading + condition variables that trigger
+    // a known backend bug; LLVM handles it fine.
     agent_provider_protocol_bridge_test.use_llvm = true;
 
     const agent_test = b.addTest(.{

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -1102,6 +1102,7 @@ pub fn build(b: *std.Build) void {
     const agent_mod_test = b.addTest(.{ .root_module = agent_mod });
 
     const agent_provider_protocol_bridge_test = b.addTest(.{ .root_module = agent_provider_protocol_bridge_mod });
+    agent_provider_protocol_bridge_test.use_llvm = true;
 
     const agent_test = b.addTest(.{
         .root_module = b.createModule(.{

--- a/zig/src/agent/agent.zig
+++ b/zig/src/agent/agent.zig
@@ -417,8 +417,9 @@ pub const Agent = struct {
                 const steering = try self.dequeueSteeringMessages();
                 defer if (steering) |s| self._allocator.free(s);
 
+                var run_messages: ?[]const ai_types.Message = if (steering) |s| s else null;
                 try self.runLoopInternal(
-                    if (steering) |s| s else null,
+                    &run_messages,
                     .{ .skip_initial_steering_poll = true },
                 );
                 return;
@@ -429,8 +430,9 @@ pub const Agent = struct {
                 const follow_up = try self.dequeueFollowUpMessages();
                 defer if (follow_up) |f| self._allocator.free(f);
 
+                var run_messages: ?[]const ai_types.Message = if (follow_up) |f| f else null;
                 try self.runLoopInternal(
-                    if (follow_up) |f| f else null,
+                    &run_messages,
                     .{},
                 );
                 return;
@@ -439,7 +441,8 @@ pub const Agent = struct {
             return error.CannotContinueFromAssistant;
         }
 
-        try self.runLoopInternal(null, .{});
+        var run_messages: ?[]const ai_types.Message = null;
+        try self.runLoopInternal(&run_messages, .{});
     }
 
     /// Abort the current operation.
@@ -638,19 +641,17 @@ pub const Agent = struct {
             return;
         }
 
-        // runLoopInternal takes ownership of non-empty prompt messages once it
-        // reaches agentLoop; the model precheck above keeps the known early
-        // validation path from leaking the cloned async payloads.
-        const run_messages = if (messages.len > 0) blk: {
-            messages_owned = false;
-            break :blk messages;
-        } else null;
+        var run_messages: ?[]const ai_types.Message = if (messages.len > 0) messages else null;
 
-        // Run the loop (errors are handled internally)
+        // Run the loop. runLoopInternal only clears run_messages after the
+        // prompt slice has been consumed successfully. If an error occurs before
+        // that transfer, messages_owned remains true and the thread cleanup
+        // frees the cloned payloads here.
         self.runLoopInternal(
-            run_messages,
+            &run_messages,
             .{ .skip_initial_steering_poll = skip_steering },
         ) catch {};
+        messages_owned = run_messages != null;
     }
 
     /// Reset all state (clear messages, queues, error).
@@ -671,12 +672,13 @@ pub const Agent = struct {
     };
 
     fn runLoop(self: *Agent, messages: []const ai_types.Message) !void {
-        try self.runLoopInternal(messages, .{});
+        var run_messages: ?[]const ai_types.Message = messages;
+        try self.runLoopInternal(&run_messages, .{});
     }
 
     fn runLoopInternal(
         self: *Agent,
-        messages: ?[]const ai_types.Message,
+        messages: *?[]const ai_types.Message,
         options: RunLoopOptions,
     ) !void {
         const model = self._state.model orelse return error.NoModelConfigured;
@@ -730,10 +732,15 @@ pub const Agent = struct {
         };
 
         // Run loop
-        const stream = if (messages) |msgs|
+        const stream = if (messages.*) |msgs|
             try agent_loop.agentLoop(self._allocator, msgs, &context, config)
         else
             try agent_loop.agentLoopContinue(self._allocator, &context, config);
+
+        // agentLoop has successfully copied the prompt payloads into its result
+        // stream. The caller no longer owns the per-message payloads and should
+        // only release the outer slice container.
+        messages.* = null;
 
         defer {
             stream.deinit();

--- a/zig/src/agent/agent.zig
+++ b/zig/src/agent/agent.zig
@@ -632,10 +632,8 @@ pub const Agent = struct {
             .{ .skip_initial_steering_poll = skip_steering },
         ) catch {};
 
-        // Free the owned messages
-        for (messages) |*m| {
-            m.deinit(self._allocator);
-        }
+        // runLoopInternal moves messages into its AgentContext, which owns and
+        // frees their contents. Free only the thread-owned slice container here.
         self._allocator.free(messages);
     }
 
@@ -997,6 +995,71 @@ test "Agent isIdle and waitForIdle" {
 
     // Still idle after waitForIdle
     try std.testing.expect(agent.isIdle());
+}
+
+fn delayedErrorStreamFn(
+    ctx: ?*anyopaque,
+    model: ai_types.Model,
+    context: ai_types.Context,
+    options: types.ProtocolOptions,
+    allocator: std.mem.Allocator,
+) anyerror!*event_stream_mod.AssistantMessageEventStream {
+    _ = ctx;
+    _ = model;
+    _ = context;
+    _ = options;
+
+    defaultIo().sleep(.fromNanoseconds(10 * std.time.ns_per_ms), .boot) catch {};
+
+    const stream = try allocator.create(event_stream_mod.AssistantMessageEventStream);
+    stream.* = event_stream_mod.AssistantMessageEventStream.init(allocator);
+    const message = ai_types.AssistantMessage{
+        .content = &.{},
+        .api = "test-api",
+        .provider = "test-provider",
+        .model = "test-model",
+        .usage = .{},
+        .stop_reason = .@"error",
+        .error_message = ai_types.OwnedSlice(u8).initBorrowed("test done"),
+        .timestamp = 0,
+    };
+    stream.push(.{ .done = .{ .reason = .@"error", .message = message } }) catch {};
+    stream.complete(message);
+    return stream;
+}
+
+fn createDelayedErrorProtocol() types.ProtocolClient {
+    return .{
+        .stream_fn = delayedErrorStreamFn,
+        .ctx = null,
+    };
+}
+
+const test_model = ai_types.Model{
+    .id = "test-model",
+    .name = "Test Model",
+    .api = "test-api",
+    .provider = "test-provider",
+    .base_url = "https://example.invalid",
+    .reasoning = false,
+    .input = &.{"text"},
+    .cost = .{ .input = 0, .output = 0, .cache_read = 0, .cache_write = 0 },
+    .context_window = 8192,
+    .max_tokens = 1024,
+};
+
+test "Agent async completion signals waitForIdle" {
+    var agent = Agent.init(std.testing.allocator, .{ .protocol = createDelayedErrorProtocol() });
+    defer agent.deinit();
+    agent.setModel(test_model);
+
+    try agent.promptAsync(@as([]const ai_types.Message, &.{}));
+    try std.testing.expect(!agent.isIdle());
+
+    agent.waitForIdle();
+
+    try std.testing.expect(agent.isIdle());
+    try std.testing.expect(agent._thread == null);
 }
 
 test "Agent cloneMessage" {

--- a/zig/src/agent/agent.zig
+++ b/zig/src/agent/agent.zig
@@ -616,7 +616,15 @@ pub const Agent = struct {
 
     /// Thread entry point for async execution
     fn runLoopThread(self: *Agent, messages: []ai_types.Message, skip_steering: bool) void {
+        var messages_owned = true;
         defer {
+            if (messages_owned) {
+                for (messages) |*m| {
+                    m.deinit(self._allocator);
+                }
+            }
+            self._allocator.free(messages);
+
             // Signal completion
             self._done_event.set(defaultIo());
 
@@ -626,15 +634,23 @@ pub const Agent = struct {
             self._mutex.unlock(defaultIo());
         }
 
+        if (messages.len > 0 and self._state.model == null) {
+            return;
+        }
+
+        // runLoopInternal takes ownership of non-empty prompt messages once it
+        // reaches agentLoop; the model precheck above keeps the known early
+        // validation path from leaking the cloned async payloads.
+        const run_messages = if (messages.len > 0) blk: {
+            messages_owned = false;
+            break :blk messages;
+        } else null;
+
         // Run the loop (errors are handled internally)
         self.runLoopInternal(
-            if (messages.len > 0) messages else null,
+            run_messages,
             .{ .skip_initial_steering_poll = skip_steering },
         ) catch {};
-
-        // runLoopInternal moves messages into its AgentContext, which owns and
-        // frees their contents. Free only the thread-owned slice container here.
-        self._allocator.free(messages);
     }
 
     /// Reset all state (clear messages, queues, error).
@@ -1054,7 +1070,6 @@ test "Agent async completion signals waitForIdle" {
     agent.setModel(test_model);
 
     try agent.promptAsync(@as([]const ai_types.Message, &.{}));
-    try std.testing.expect(!agent.isIdle());
 
     agent.waitForIdle();
 

--- a/zig/src/agent/provider_protocol_bridge.zig
+++ b/zig/src/agent/provider_protocol_bridge.zig
@@ -303,6 +303,10 @@ test "InProcessProviderProtocolBridge smoke test" {
         if (ev == .start) saw_start = true;
     }
 
+    const result = stream.getResult().?;
+    var owned_result = result;
+    owned_result.deinit(allocator);
+    stream.result = null;
+
     try std.testing.expect(saw_start);
-    try std.testing.expect(stream.getResult() != null);
 }

--- a/zig/src/agent/provider_protocol_bridge.zig
+++ b/zig/src/agent/provider_protocol_bridge.zig
@@ -298,6 +298,8 @@ test "InProcessProviderProtocolBridge smoke test" {
 
     var saw_start = false;
     while (stream.wait()) |ev| {
+        var owned_ev = ev;
+        defer ai_types.deinitAssistantMessageEvent(allocator, &owned_ev);
         if (ev == .start) saw_start = true;
     }
 

--- a/zig/src/agent/provider_protocol_bridge.zig
+++ b/zig/src/agent/provider_protocol_bridge.zig
@@ -306,6 +306,8 @@ test "InProcessProviderProtocolBridge smoke test" {
     const result = stream.getResult().?;
     var owned_result = result;
     owned_result.deinit(allocator);
+    // We already freed the result contents above. Null the reference so
+    // stream.deinit() doesn't attempt a double-free.
     stream.result = null;
 
     try std.testing.expect(saw_start);

--- a/zig/src/protocol/auth/server.zig
+++ b/zig/src/protocol/auth/server.zig
@@ -887,3 +887,89 @@ fn saveOAuthCredentials(provider_id: []const u8, credentials: oauth_storage.Cred
 test "AuthProtocolServer type is available" {
     _ = AuthProtocolServer;
 }
+
+test "AuthProtocolServer fixture login waits for prompt response" {
+    const allocator = std.testing.allocator;
+    var server = AuthProtocolServer.init(allocator, .{
+        .persist_credentials = false,
+        .enable_real_oauth = false,
+    });
+    defer server.deinit();
+
+    const flow_id = auth_types.generateUlid();
+    const start_id = auth_types.generateUlid();
+    var start_env = auth_types.Envelope{
+        .stream_id = flow_id,
+        .message_id = start_id,
+        .sequence = 1,
+        .timestamp = compat.time.nowMillis(),
+        .payload = .{ .auth_login_start = .{
+            .provider_id = OwnedSlice(u8).initOwned(try allocator.dupe(u8, "test-fixture")),
+        } },
+    };
+    defer start_env.deinit(allocator);
+
+    var ack = (try server.handleEnvelope(start_env)).?;
+    defer ack.deinit(allocator);
+    try std.testing.expect(ack.payload == .ack);
+
+    var prompt_id: ?[]u8 = null;
+    defer if (prompt_id) |id| allocator.free(id);
+
+    var attempts: usize = 0;
+    while (attempts < 1_000) : (attempts += 1) {
+        if (server.popOutbound()) |env| {
+            var outbound = env;
+            defer outbound.deinit(allocator);
+            if (outbound.payload == .auth_event and outbound.payload.auth_event == .prompt) {
+                prompt_id = try allocator.dupe(u8, outbound.payload.auth_event.prompt.prompt_id.slice());
+                break;
+            }
+        } else {
+            defaultIo().sleep(.fromNanoseconds(1 * std.time.ns_per_ms), .boot) catch {};
+        }
+    }
+    const id = prompt_id orelse return error.TestExpectedPrompt;
+
+    var response_env = auth_types.Envelope{
+        .stream_id = flow_id,
+        .message_id = auth_types.generateUlid(),
+        .sequence = 2,
+        .timestamp = compat.time.nowMillis(),
+        .payload = .{ .auth_prompt_response = .{
+            .flow_id = flow_id,
+            .prompt_id = OwnedSlice(u8).initOwned(try allocator.dupe(u8, id)),
+            .answer = OwnedSlice(u8).initOwned(try allocator.dupe(u8, "ok")),
+        } },
+    };
+    defer response_env.deinit(allocator);
+
+    var response_ack = (try server.handleEnvelope(response_env)).?;
+    defer response_ack.deinit(allocator);
+    try std.testing.expect(response_ack.payload == .ack);
+
+    var saw_success = false;
+    var saw_result = false;
+    attempts = 0;
+    while (attempts < 1_000 and !(saw_success and saw_result)) : (attempts += 1) {
+        if (server.popOutbound()) |env| {
+            var outbound = env;
+            defer outbound.deinit(allocator);
+            switch (outbound.payload) {
+                .auth_event => |event| {
+                    if (event == .success) saw_success = true;
+                },
+                .auth_login_result => |result| {
+                    try std.testing.expectEqual(auth_types.AuthLoginStatus.success, result.status);
+                    saw_result = true;
+                },
+                else => {},
+            }
+        } else {
+            defaultIo().sleep(.fromNanoseconds(1 * std.time.ns_per_ms), .boot) catch {};
+        }
+    }
+
+    try std.testing.expect(saw_success);
+    try std.testing.expect(saw_result);
+}

--- a/zig/src/protocol/auth/server.zig
+++ b/zig/src/protocol/auth/server.zig
@@ -888,6 +888,23 @@ test "AuthProtocolServer type is available" {
     _ = AuthProtocolServer;
 }
 
+fn waitForAuthOutbound(server: *AuthProtocolServer, comptime predicate: anytype, timeout_ms: u64) !auth_types.Envelope {
+    const start = compat.time.monotonicNanos() catch 0;
+    const timeout_ns = timeout_ms * std.time.ns_per_ms;
+
+    while (true) {
+        if (server.popOutbound()) |env| {
+            if (predicate(env)) return env;
+            var discard = env;
+            discard.deinit(server.allocator);
+        } else {
+            const now = compat.time.monotonicNanos() catch 0;
+            if (now -| start >= timeout_ns) return error.TestAuthOutboundTimeout;
+            defaultIo().sleep(.fromNanoseconds(1 * std.time.ns_per_ms), .boot) catch {};
+        }
+    }
+}
+
 test "AuthProtocolServer fixture login waits for prompt response" {
     const allocator = std.testing.allocator;
     var server = AuthProtocolServer.init(allocator, .{
@@ -913,23 +930,13 @@ test "AuthProtocolServer fixture login waits for prompt response" {
     defer ack.deinit(allocator);
     try std.testing.expect(ack.payload == .ack);
 
-    var prompt_id: ?[]u8 = null;
-    defer if (prompt_id) |id| allocator.free(id);
-
-    var attempts: usize = 0;
-    while (attempts < 1_000) : (attempts += 1) {
-        if (server.popOutbound()) |env| {
-            var outbound = env;
-            defer outbound.deinit(allocator);
-            if (outbound.payload == .auth_event and outbound.payload.auth_event == .prompt) {
-                prompt_id = try allocator.dupe(u8, outbound.payload.auth_event.prompt.prompt_id.slice());
-                break;
-            }
-        } else {
-            defaultIo().sleep(.fromNanoseconds(1 * std.time.ns_per_ms), .boot) catch {};
+    var prompt_env = try waitForAuthOutbound(&server, struct {
+        fn isPrompt(env: auth_types.Envelope) bool {
+            return env.payload == .auth_event and env.payload.auth_event == .prompt;
         }
-    }
-    const id = prompt_id orelse return error.TestExpectedPrompt;
+    }.isPrompt, 30_000);
+    defer prompt_env.deinit(allocator);
+    const id = prompt_env.payload.auth_event.prompt.prompt_id.slice();
 
     var response_env = auth_types.Envelope{
         .stream_id = flow_id,
@@ -948,28 +955,18 @@ test "AuthProtocolServer fixture login waits for prompt response" {
     defer response_ack.deinit(allocator);
     try std.testing.expect(response_ack.payload == .ack);
 
-    var saw_success = false;
-    var saw_result = false;
-    attempts = 0;
-    while (attempts < 1_000 and !(saw_success and saw_result)) : (attempts += 1) {
-        if (server.popOutbound()) |env| {
-            var outbound = env;
-            defer outbound.deinit(allocator);
-            switch (outbound.payload) {
-                .auth_event => |event| {
-                    if (event == .success) saw_success = true;
-                },
-                .auth_login_result => |result| {
-                    try std.testing.expectEqual(auth_types.AuthLoginStatus.success, result.status);
-                    saw_result = true;
-                },
-                else => {},
-            }
-        } else {
-            defaultIo().sleep(.fromNanoseconds(1 * std.time.ns_per_ms), .boot) catch {};
+    var success_env = try waitForAuthOutbound(&server, struct {
+        fn isSuccess(env: auth_types.Envelope) bool {
+            return env.payload == .auth_event and env.payload.auth_event == .success;
         }
-    }
+    }.isSuccess, 30_000);
+    defer success_env.deinit(allocator);
 
-    try std.testing.expect(saw_success);
-    try std.testing.expect(saw_result);
+    var result_env = try waitForAuthOutbound(&server, struct {
+        fn isLoginResult(env: auth_types.Envelope) bool {
+            return env.payload == .auth_login_result;
+        }
+    }.isLoginResult, 30_000);
+    defer result_env.deinit(allocator);
+    try std.testing.expectEqual(auth_types.AuthLoginStatus.success, result_env.payload.auth_login_result.status);
 }


### PR DESCRIPTION
## Summary
- Migrates agent async cleanup to avoid double-freeing messages now owned by the run-loop context under Zig 0.16 synchronization.
- Adds targeted coverage for agent async completion signaling and auth protocol prompt-response coordination.
- Preserves the auth boundary: agent logic remains credential/auth agnostic while auth/OAuth layers own provider credentials.

References: Zig 0.15.2 → 0.16.0 Migration — agent/auth/OAuth sync migration

## Test plan
- [x] `cd zig && zig build test-unit-agent-mod && zig build test-unit-agent-types && zig build test-unit-agent-loop && zig build test-unit-agent-unit && zig build test-unit-agent-chain && zig build test-unit-protocol && zig build test-unit-utils`
- [x] `cd . && ./scripts/check-zig-patterns.sh`
- [x] `cd zig && zig build test-unit-agent-bridge`
- [x] `cd . && ./scripts/check-zig-patterns.sh && cd zig && zig build test`