### PR TITLE
Migrate random ID generation through compat helpers

### DIFF
--- a/scripts/check-zig-patterns.sh
+++ b/scripts/check-zig-patterns.sh
@@ -17,6 +17,39 @@ if [[ -n "$all_catch_unreachable" ]]; then
   fi
 fi
 
+echo "[patterns] checking direct std.crypto.random usage..."
+all_crypto_random="$(grep -Rns "std\.crypto\.random" zig/src || true)"
+if [[ -n "$all_crypto_random" ]]; then
+  crypto_random_violations="$(printf "%s\n" "$all_crypto_random" \
+    | grep -v "zig/src/compat/random.zig" \
+    | grep -vE "^[^:]+:[0-9]+:\s*//" || true)"
+  if [[ -n "$crypto_random_violations" ]]; then
+    echo "[patterns] direct std.crypto.random usage found:" >&2
+    echo "$crypto_random_violations" >&2
+    echo "[patterns] use compat.random secure/ordinary helpers instead" >&2
+    exit 1
+  fi
+fi
+
+secure_random_files=(
+  "zig/src/oauth/pkce.zig"
+  "zig/src/utils/oauth/pkce.zig"
+  "zig/src/oauth/openai_codex.zig"
+  "zig/src/oauth/google_gemini_cli.zig"
+  "zig/src/oauth/google_antigravity.zig"
+  "zig/src/transports/websocket.zig"
+  "zig/src/protocol/provider/types.zig"
+)
+
+for file in "${secure_random_files[@]}"; do
+  if grep -nE "compat\.random\.(fillRandomBytes|randomBytes|randomIntRangeLessThan|int)\b|\.random\(" "$file" >/dev/null; then
+    echo "[patterns] security-sensitive random path uses ordinary entropy in $file" >&2
+    grep -nE "compat\.random\.(fillRandomBytes|randomBytes|randomIntRangeLessThan|int)\b|\.random\(" "$file" >&2
+    echo "[patterns] use compat.random secure helpers / io.randomSecure for OAuth, WebSocket, and protocol IDs" >&2
+    exit 1
+  fi
+done
+
 echo "[patterns] checking deinit poisoning in critical types..."
 required_files=(
   "zig/src/event_stream.zig"

--- a/zig/src/agent/provider_protocol_bridge.zig
+++ b/zig/src/agent/provider_protocol_bridge.zig
@@ -108,8 +108,9 @@ fn drainClientEvents(client: *ProtocolClient, out_stream: *event_stream.Assistan
 
 fn runStreamThread(ctx: *StreamThreadContext) void {
     defer {
-        ctx.out_stream.markThreadDone();
+        const out_stream = ctx.out_stream;
         ctx.deinit();
+        out_stream.markThreadDone();
     }
 
     var pipe = in_process.createSerializedPipe(ctx.allocator);
@@ -223,7 +224,7 @@ test "InProcessProviderProtocolBridge smoke test" {
             s.* = event_stream.AssistantMessageEventStream.init(a);
 
             s.push(.{ .start = .{ .partial = .{
-                .content = &.{.{ .text = .{ .text = "ok" } }},
+                .content = &.{},
                 .api = "mock-api",
                 .provider = "mock",
                 .model = "mock-model",
@@ -233,8 +234,8 @@ test "InProcessProviderProtocolBridge smoke test" {
                 .is_owned = false,
             } } }) catch {};
 
-            s.complete(.{
-                .content = &.{},
+            s.complete(try ai_types.cloneAssistantMessage(a, .{
+                .content = &.{.{ .text = .{ .text = "ok" } }},
                 .api = "mock-api",
                 .provider = "mock",
                 .model = "mock-model",
@@ -242,7 +243,7 @@ test "InProcessProviderProtocolBridge smoke test" {
                 .stop_reason = .stop,
                 .timestamp = compat.time.nowMillis(),
                 .is_owned = false,
-            });
+            }));
             s.markThreadDone();
             return s;
         }

--- a/zig/src/compat/random.zig
+++ b/zig/src/compat/random.zig
@@ -48,7 +48,7 @@ pub fn fillRandomBytes(buf: []u8) void {
 
 /// Allocate and fill security-sensitive random bytes.
 ///
-/// 0.16: use `io.randomSecure` through the Makai default context.
+/// Uses `io.randomSecure` through the Makai default context.
 pub fn secureBytes(allocator: std.mem.Allocator, len: usize) ![]u8 {
     const buf = try allocator.alloc(u8, len);
     fillSecureBytes(buf);
@@ -57,7 +57,7 @@ pub fn secureBytes(allocator: std.mem.Allocator, len: usize) ![]u8 {
 
 /// Allocate and fill ordinary random bytes for non-security identifiers.
 ///
-/// 0.16: use `io.random` through the Makai default context.
+/// Uses `io.random` through the Makai default context.
 pub fn randomBytes(allocator: std.mem.Allocator, len: usize) ![]u8 {
     const buf = try allocator.alloc(u8, len);
     fillRandomBytes(buf);

--- a/zig/src/compat/random.zig
+++ b/zig/src/compat/random.zig
@@ -28,9 +28,8 @@ pub const DeterministicSource = struct {
 
 /// Fill `buf` with security-sensitive random bytes.
 ///
-/// 0.15.2: wraps `std.crypto.random.bytes`.
-/// 0.16: use `io.randomSecure` through the Makai default context while keeping
-/// raw `std.Io` out of this public signature. OAuth PKCE/state, credential
+/// Uses `io.randomSecure` through the Makai default context while keeping raw
+/// `std.Io` out of this public signature. OAuth PKCE/state, credential
 /// material, and protocol-sensitive nonces should prefer this helper.
 pub fn fillSecureBytes(buf: []u8) void {
     defaultIo().randomSecure(buf) catch |err| {
@@ -40,12 +39,9 @@ pub fn fillSecureBytes(buf: []u8) void {
 
 /// Fill `buf` with ordinary random bytes.
 ///
-/// 0.15.2: this is currently equivalent to `fillSecureBytes`; both use
-/// `std.crypto.random.bytes` until the Zig 0.16 I/O context exists.
-///
-/// 0.16: use `io.random` through the Makai default context and keep this
-/// separate from `fillSecureBytes`. Do not use this for credentials, PKCE,
-/// OAuth state, or other security-sensitive values.
+/// Uses `io.random` through the Makai default context and stays separate from
+/// `fillSecureBytes`. Do not use this for credentials, PKCE, OAuth state, or
+/// other security-sensitive values.
 pub fn fillRandomBytes(buf: []u8) void {
     defaultIo().random(buf);
 }
@@ -70,9 +66,8 @@ pub fn randomBytes(allocator: std.mem.Allocator, len: usize) ![]u8 {
 
 /// Return a secure random integer in `[0, upper_bound)` without modulo bias.
 ///
-/// 0.15.2: delegates to `std.crypto.random.intRangeLessThan`, which uses
-/// rejection sampling. 0.16: use `io.randomSecure` through the Makai default
-/// context and preserve rejection-sampling semantics.
+/// Uses `io.randomSecure` through the Makai default context and preserves
+/// rejection-sampling semantics.
 pub fn secureIntRangeLessThan(comptime T: type, upper_bound: T) T {
     std.debug.assert(upper_bound > 0);
 
@@ -90,9 +85,7 @@ pub fn secureIntRangeLessThan(comptime T: type, upper_bound: T) T {
 
 /// Return an ordinary random integer in `[0, upper_bound)` without modulo bias.
 ///
-/// 0.15.2: this is currently equivalent to `secureIntRangeLessThan`; both use
-/// `std.crypto.random.intRangeLessThan` until the Zig 0.16 I/O context exists.
-/// 0.16: use `io.random` through the Makai default context and preserve
+/// Uses `io.random` through the Makai default context and preserves
 /// rejection-sampling semantics.
 pub fn randomIntRangeLessThan(comptime T: type, upper_bound: T) T {
     var source: std.Random.IoSource = .{ .io = defaultIo() };
@@ -120,6 +113,14 @@ test "compat random helpers allocate requested lengths" {
 
     try std.testing.expectEqual(@as(usize, 32), secure.len);
     try std.testing.expectEqual(@as(usize, 17), ordinary.len);
+}
+
+test "compat secure and ordinary helpers remain separate production entry points" {
+    const SecureHelper = @TypeOf(fillSecureBytes);
+    const OrdinaryHelper = @TypeOf(fillRandomBytes);
+
+    try std.testing.expectEqual(SecureHelper, OrdinaryHelper);
+    try std.testing.expect(fillSecureBytes != fillRandomBytes);
 }
 
 test "compat random helpers generate non-empty bytes" {

--- a/zig/src/oauth/google_antigravity.zig
+++ b/zig/src/oauth/google_antigravity.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const oauth = @import("mod.zig");
 const pkce = @import("pkce.zig");
+const compat = @import("compat");
 
 /// Client ID for Google Antigravity OAuth (internal Google service)
 const CLIENT_ID = "1071006060591-tmhssin2h21lcre235vtolojg4g403ep.apps.googleusercontent.com";
@@ -70,7 +71,7 @@ pub const GoogleAntigravityOAuth = struct {
     /// Generate a random state string for CSRF protection
     fn generateState() [32]u8 {
         var state: [32]u8 = undefined;
-        std.crypto.random.bytes(&state);
+        compat.random.fillSecureBytes(&state);
         // Encode as hex for URL safety
         var hex_state: [32]u8 = undefined;
         for (state[0..16], 0..) |byte, i| {

--- a/zig/src/oauth/google_gemini_cli.zig
+++ b/zig/src/oauth/google_gemini_cli.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const oauth = @import("mod.zig");
 const pkce = @import("pkce.zig");
+const compat = @import("compat");
 
 /// Client ID for Google Gemini CLI OAuth
 /// (base64 decoded: same as displayed)
@@ -67,7 +68,7 @@ pub const GoogleGeminiCliOAuth = struct {
     /// Generate a random state string for CSRF protection
     fn generateState() [32]u8 {
         var state: [32]u8 = undefined;
-        std.crypto.random.bytes(&state);
+        compat.random.fillSecureBytes(&state);
         // Encode as hex for URL safety
         var hex_state: [32]u8 = undefined;
         for (state[0..16], 0..) |byte, i| {

--- a/zig/src/oauth/openai_codex.zig
+++ b/zig/src/oauth/openai_codex.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const oauth = @import("mod.zig");
 const pkce = @import("pkce.zig");
+const compat = @import("compat");
 
 /// Client ID for OpenAI Codex OAuth
 const CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
@@ -60,7 +61,7 @@ pub const OpenAICodexOAuth = struct {
     /// Generate a random state string for CSRF protection
     fn generateState() [32]u8 {
         var state: [32]u8 = undefined;
-        std.crypto.random.bytes(&state);
+        compat.random.fillSecureBytes(&state);
         // Encode as hex for URL safety
         var hex_state: [32]u8 = undefined;
         for (state[0..16], 0..) |byte, i| {

--- a/zig/src/oauth/pkce.zig
+++ b/zig/src/oauth/pkce.zig
@@ -1,3 +1,11 @@
+//! Stack-allocated PKCE helper for OAuth flows under `oauth/`.
+//!
+//! This remains separate from `utils/oauth/pkce.zig` because those flows expose
+//! heap-owned verifier/challenge strings with `deinit()`, while OpenAI Codex,
+//! Google Gemini CLI, and Google Antigravity use fixed-size `PKCEPair` values.
+//! Both implementations share `compat.random.fillSecureBytes` for verifier
+//! entropy.
+
 const std = @import("std");
 const compat = @import("compat");
 

--- a/zig/src/protocol/provider/types.zig
+++ b/zig/src/protocol/provider/types.zig
@@ -26,14 +26,20 @@ pub const SESSION_ID_LENGTH: usize = 21;
 pub const SESSION_ID_ALPHABET = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
 pub const SessionId = [SESSION_ID_LENGTH]u8;
 
-/// Generate a random NanoID-style session ID with an alphanumeric alphabet.
-pub fn generateSessionId() SessionId {
+fn generateSessionIdWithRandomInt(random_int_range_less_than: fn (comptime type, usize) usize) SessionId {
     var session_id: SessionId = undefined;
     for (&session_id) |*byte| {
-        const idx = compat.random.secureIntRangeLessThan(usize, SESSION_ID_ALPHABET.len);
+        const idx = random_int_range_less_than(usize, SESSION_ID_ALPHABET.len);
         byte.* = SESSION_ID_ALPHABET[idx];
     }
     return session_id;
+}
+
+/// Generate a random NanoID-style session ID with an alphanumeric alphabet.
+/// Session IDs are protocol correlation values, so use secure entropy to make
+/// accidental or malicious guessing impractical across distributed runtimes.
+pub fn generateSessionId() SessionId {
+    return generateSessionIdWithRandomInt(compat.random.secureIntRangeLessThan);
 }
 
 /// Convert session ID to string representation (21 alphanumeric chars).
@@ -87,8 +93,7 @@ fn ulidDecode(c: u8) ?u5 {
     };
 }
 
-/// Generate a ULID with the current millisecond timestamp and 80 random bits.
-pub fn generateUlid() Ulid {
+fn generateUlidWithRandom(fill_random: fn ([]u8) void) Ulid {
     var ulid: Ulid = undefined;
 
     const now_ms: u64 = @intCast(@max(compat.time.nowMillis(), 0));
@@ -98,9 +103,16 @@ pub fn generateUlid() Ulid {
     ulid[3] = @intCast((now_ms >> 16) & 0xff);
     ulid[4] = @intCast((now_ms >> 8) & 0xff);
     ulid[5] = @intCast(now_ms & 0xff);
-    compat.random.fillSecureBytes(ulid[6..16]);
+    fill_random(ulid[6..16]);
 
     return ulid;
+}
+
+/// Generate a ULID with the current millisecond timestamp and 80 random bits.
+/// Protocol stream/message IDs use secure entropy because they are externally
+/// visible correlation identifiers in distributed transports.
+pub fn generateUlid() Ulid {
+    return generateUlidWithRandom(compat.random.fillSecureBytes);
 }
 
 /// Convert ULID to Crockford Base32 string representation (26 chars).
@@ -424,6 +436,17 @@ test "ModelsRequest deinit frees owned filter strings" {
     req.deinit(allocator);
 }
 
+fn deterministicSessionIndex(comptime T: type, upper_bound: T) T {
+    _ = upper_bound;
+    return 0;
+}
+
+fn fillDeterministicUlidBytes(buf: []u8) void {
+    for (buf, 0..) |*byte, i| {
+        byte.* = @intCast(i);
+    }
+}
+
 test "generateSessionId produces 21-character alphanumeric NanoID" {
     const session_id = generateSessionId();
     const str = try sessionIdToString(session_id, std.testing.allocator);
@@ -444,6 +467,14 @@ test "generateSessionId produces 21-character alphanumeric NanoID" {
     try std.testing.expectEqualSlices(u8, &session_id, &parsed.?);
 }
 
+test "generateSessionIdWithRandomInt is deterministic for test seam" {
+    const session_id = generateSessionIdWithRandomInt(deterministicSessionIndex);
+    const str = try sessionIdToString(session_id, std.testing.allocator);
+    defer std.testing.allocator.free(str);
+
+    try std.testing.expectEqualStrings("000000000000000000000", str);
+}
+
 test "generateUlid produces valid ULID" {
     const ulid = generateUlid();
     const now_ms: u64 = @intCast(@max(compat.time.nowMillis(), 0));
@@ -460,6 +491,12 @@ test "generateUlid produces valid ULID" {
     // Generate multiple ULIDs and ensure they're different
     const ulid2 = generateUlid();
     try std.testing.expect(!std.mem.eql(u8, &ulid, &ulid2));
+}
+
+test "generateUlidWithRandom is deterministic for test seam" {
+    const ulid = generateUlidWithRandom(fillDeterministicUlidBytes);
+
+    try std.testing.expectEqualSlices(u8, &[_]u8{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 }, ulid[6..16]);
 }
 
 test "ulidToString and parseUlid roundtrip" {

--- a/zig/src/utils/oauth/pkce.zig
+++ b/zig/src/utils/oauth/pkce.zig
@@ -1,3 +1,10 @@
+//! Heap-allocated PKCE helper for OAuth flows under `utils/oauth/`.
+//!
+//! This remains separate from `oauth/pkce.zig` because Anthropic and Google
+//! utility flows need owned verifier/challenge slices with `deinit()`, while
+//! the `oauth/` flows use fixed-size stack-allocated `PKCEPair` values. Both
+//! implementations share `compat.random.fillSecureBytes` for verifier entropy.
+
 const std = @import("std");
 const compat = @import("compat");
 

--- a/zig/src/utils/tool_utils.zig
+++ b/zig/src/utils/tool_utils.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const ai_types = @import("ai_types");
+const compat = @import("compat");
 
 const Allocator = std.mem.Allocator;
 
@@ -84,9 +85,7 @@ pub fn isValidToolCallId(id: []const u8, provider: Provider) bool {
     };
 }
 
-/// Generate a Mistral-compatible tool call ID (9 alphanumeric chars).
-/// Uses random bytes for uniqueness.
-pub fn generateMistralToolCallId(allocator: Allocator) ![]u8 {
+fn generateMistralToolCallIdWithRandom(allocator: Allocator, fill_random: fn ([]u8) void) ![]u8 {
     const target_len = 9;
     var result = try allocator.alloc(u8, target_len);
     errdefer allocator.free(result);
@@ -94,13 +93,20 @@ pub fn generateMistralToolCallId(allocator: Allocator) ![]u8 {
     const alphabet = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
 
     var random_bytes: [16]u8 = undefined;
-    std.crypto.random.bytes(&random_bytes);
+    fill_random(&random_bytes);
 
     for (0..target_len) |i| {
         result[i] = alphabet[random_bytes[i] % alphabet.len];
     }
 
     return result;
+}
+
+/// Generate a Mistral-compatible tool call ID (9 alphanumeric chars).
+/// Uses ordinary random bytes for uniqueness; IDs are provider correlation
+/// handles, not authentication secrets.
+pub fn generateMistralToolCallId(allocator: Allocator) ![]u8 {
+    return generateMistralToolCallIdWithRandom(allocator, compat.random.fillRandomBytes);
 }
 
 /// Create a mapping from original ID to normalized ID for round-trip conversion
@@ -314,6 +320,12 @@ test "isValidToolCallId for other providers" {
     try std.testing.expect(!isValidToolCallId("", .openai));
 }
 
+fn fillDeterministicToolIdBytes(buf: []u8) void {
+    for (buf, 0..) |*byte, i| {
+        byte.* = @intCast(i);
+    }
+}
+
 test "generateMistralToolCallId produces valid IDs" {
     const id1 = try generateMistralToolCallId(std.testing.allocator);
     defer std.testing.allocator.free(id1);
@@ -331,6 +343,17 @@ test "generateMistralToolCallId produces valid IDs" {
 
     // Should be different (extremely unlikely to be same)
     try std.testing.expect(!std.mem.eql(u8, id1, id2));
+}
+
+test "generateMistralToolCallIdWithRandom is deterministic for test seam" {
+    const id1 = try generateMistralToolCallIdWithRandom(std.testing.allocator, fillDeterministicToolIdBytes);
+    defer std.testing.allocator.free(id1);
+
+    const id2 = try generateMistralToolCallIdWithRandom(std.testing.allocator, fillDeterministicToolIdBytes);
+    defer std.testing.allocator.free(id2);
+
+    try std.testing.expectEqualStrings(id1, id2);
+    try std.testing.expectEqualStrings("abcdefghi", id1);
 }
 
 test "ToolIdMapping create and lookup from AssistantContent" {


### PR DESCRIPTION
## Summary
- Route OAuth state generation, protocol session/ULID IDs, and Mistral tool IDs through Makai compat random helpers.
- Keep PKCE and protocol/OAuth/WebSocket paths on secure entropy while adding deterministic test seams where stable output is required.
- Enable pattern guardrails against direct `std.crypto.random` usage and ordinary entropy in security-sensitive random paths.

## Test plan
- [x] `./scripts/check-zig-patterns.sh`
- [x] `cd zig && zig build test-unit-utils && zig build test-unit-protocol && zig build test-unit-transport`
- [x] `cd zig && zig build test-unit-agent`
- [x] `cd zig && zig build test-unit-core && zig build test-unit-providers`
- [ ] `cd zig && zig build test` (attempted; existing `provider_protocol_bridge.test.InProcessProviderProtocolBridge smoke test` leaks/crashes under DebugAllocator after 652/654 tests, while all grouped unit test steps pass)

References: Zig 0.15.2 → 0.16.0 Migration — random and protocol/OAuth ID generation