### PR TITLE
Ignore TypeScript dist artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ Thumbs.db
 # Node.js (package.json present)
 node_modules/
 dist/
+typescript/dist/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*


### PR DESCRIPTION
## Summary
- Add `typescript/dist/` to `.gitignore` so stale TypeScript build outputs stay untracked.
- Verified no files under `typescript/dist/` are tracked in git.

## Test plan
- [x] `npm run build` (script is not defined; repository exposes `build:sdk` instead)
- [x] `npm run build:sdk`
- [x] `npm test`