### PR TITLE
Require checksums for URL binary downloads

### DIFF
--- a/typescript/src/binary_resolver.ts
+++ b/typescript/src/binary_resolver.ts
@@ -3,12 +3,35 @@ import { promises as fs } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-export type BinaryResolverOptions = {
-  binaryPath?: string;
-  binaryUrl?: string;
-  checksumSha256?: string;
+type BinaryResolverBaseOptions = {
   cacheDir?: string;
 };
+
+type BinaryPathResolverOptions = BinaryResolverBaseOptions & {
+  type?: "path";
+  binaryPath: string;
+  binaryUrl?: undefined;
+  checksumSha256?: string;
+};
+
+type BinaryUrlResolverOptions = BinaryResolverBaseOptions & {
+  type?: "url";
+  binaryPath?: undefined;
+  binaryUrl: string;
+  checksumSha256: string;
+};
+
+type BinaryAutoResolverOptions = BinaryResolverBaseOptions & {
+  type?: "auto";
+  binaryPath?: undefined;
+  binaryUrl?: undefined;
+  checksumSha256?: string;
+};
+
+export type BinaryResolverOptions =
+  | BinaryPathResolverOptions
+  | BinaryUrlResolverOptions
+  | BinaryAutoResolverOptions;
 
 const ENV_BINARY_PATH = "MAKAI_BINARY_PATH";
 const ENV_BINARY_URL = "MAKAI_BINARY_URL";
@@ -38,8 +61,14 @@ function sha256(content: Buffer): string {
   return createHash("sha256").update(content).digest("hex");
 }
 
-async function verifyChecksumIfPresent(filePath: string, checksumSha256?: string): Promise<void> {
-  if (!checksumSha256) return;
+function requireChecksumForUrl(binaryUrl: string, checksumSha256: string | undefined): string {
+  if (!checksumSha256) {
+    throw new Error(`SHA256 checksum is required when downloading makai binary from URL: ${binaryUrl}`);
+  }
+  return checksumSha256;
+}
+
+async function verifyChecksum(filePath: string, checksumSha256: string): Promise<void> {
   const content = await fs.readFile(filePath);
   const actual = sha256(content);
   if (actual !== checksumSha256.toLowerCase()) {
@@ -47,7 +76,7 @@ async function verifyChecksumIfPresent(filePath: string, checksumSha256?: string
   }
 }
 
-async function downloadToCache(url: string, targetPath: string, checksumSha256?: string): Promise<void> {
+async function downloadToCache(url: string, targetPath: string, checksumSha256: string): Promise<void> {
   const response = await fetch(url);
   if (!response.ok) {
     throw new Error(`failed to download binary: ${response.status} ${response.statusText}`);
@@ -55,11 +84,9 @@ async function downloadToCache(url: string, targetPath: string, checksumSha256?:
   const arrayBuffer = await response.arrayBuffer();
   const content = Buffer.from(arrayBuffer);
 
-  if (checksumSha256) {
-    const actual = sha256(content);
-    if (actual !== checksumSha256.toLowerCase()) {
-      throw new Error(`binary checksum mismatch: expected ${checksumSha256}, got ${actual}`);
-    }
+  const actual = sha256(content);
+  if (actual !== checksumSha256.toLowerCase()) {
+    throw new Error(`binary checksum mismatch: expected ${checksumSha256}, got ${actual}`);
   }
 
   await fs.mkdir(path.dirname(targetPath), { recursive: true });
@@ -82,6 +109,7 @@ export async function resolveMakaiBinary(options: BinaryResolverOptions = {}): P
   const binaryUrl = process.env[ENV_BINARY_URL] ?? options.binaryUrl;
   const checksumSha256 = process.env[ENV_BINARY_SHA256] ?? options.checksumSha256;
   if (binaryUrl) {
+    const requiredChecksumSha256 = requireChecksumForUrl(binaryUrl, checksumSha256);
     const binaryName = binaryNameForPlatform();
     const cacheDir = options.cacheDir ?? path.join(os.homedir(), ".cache", "makai", "bin");
     const urlPathName = new URL(binaryUrl).pathname;
@@ -90,7 +118,7 @@ export async function resolveMakaiBinary(options: BinaryResolverOptions = {}): P
 
     if (await fileExists(cachePath)) {
       try {
-        await verifyChecksumIfPresent(cachePath, checksumSha256);
+        await verifyChecksum(cachePath, requiredChecksumSha256);
         return cachePath;
       } catch (error: unknown) {
         if (error instanceof Error && error.message.startsWith("binary checksum mismatch")) {
@@ -102,7 +130,7 @@ export async function resolveMakaiBinary(options: BinaryResolverOptions = {}): P
     }
 
     if (!(await fileExists(cachePath))) {
-      await downloadToCache(binaryUrl, cachePath, checksumSha256);
+      await downloadToCache(binaryUrl, cachePath, requiredChecksumSha256);
       return cachePath;
     }
 

--- a/typescript/test/binary_resolver.test.ts
+++ b/typescript/test/binary_resolver.test.ts
@@ -53,14 +53,29 @@ test("resolveMakaiBinary rejects URL override without checksum", async () => {
 });
 
 test("resolveMakaiBinary rejects resolver URL option without checksum", async () => {
-  await assert.rejects(
-    () =>
-      // @ts-expect-error URL resolver options must include checksumSha256.
-      resolveMakaiBinary({
-        binaryUrl: "http://127.0.0.1:1/makai-test.bin",
-      }),
-    /SHA256 checksum is required when downloading makai binary from URL/,
-  );
+  const prevUrl = process.env[ENV_BINARY_URL];
+  const prevChecksum = process.env[ENV_BINARY_SHA256];
+  const prevPath = process.env[ENV_BINARY_PATH];
+  delete process.env[ENV_BINARY_URL];
+  delete process.env[ENV_BINARY_SHA256];
+  delete process.env[ENV_BINARY_PATH];
+  try {
+    await assert.rejects(
+      () =>
+        // @ts-expect-error URL resolver options must include checksumSha256.
+        resolveMakaiBinary({
+          binaryUrl: "http://127.0.0.1:1/makai-test.bin",
+        }),
+      /SHA256 checksum is required when downloading makai binary from URL/,
+    );
+  } finally {
+    if (prevUrl === undefined) delete process.env[ENV_BINARY_URL];
+    else process.env[ENV_BINARY_URL] = prevUrl;
+    if (prevChecksum === undefined) delete process.env[ENV_BINARY_SHA256];
+    else process.env[ENV_BINARY_SHA256] = prevChecksum;
+    if (prevPath === undefined) delete process.env[ENV_BINARY_PATH];
+    else process.env[ENV_BINARY_PATH] = prevPath;
+  }
 });
 
 test("resolveMakaiBinary downloads URL override to cache with checksum", async () => {

--- a/typescript/test/binary_resolver.test.ts
+++ b/typescript/test/binary_resolver.test.ts
@@ -28,6 +28,41 @@ test("resolveMakaiBinary prefers MAKAI_BINARY_PATH override", async () => {
   }
 });
 
+test("resolveMakaiBinary rejects URL override without checksum", async () => {
+  const cacheDir = await fs.mkdtemp(path.join(os.tmpdir(), "makai-cache-"));
+  const prevUrl = process.env[ENV_BINARY_URL];
+  const prevChecksum = process.env[ENV_BINARY_SHA256];
+  const prevPath = process.env[ENV_BINARY_PATH];
+  process.env[ENV_BINARY_URL] = "http://127.0.0.1:1/makai-test.bin";
+  delete process.env[ENV_BINARY_SHA256];
+  delete process.env[ENV_BINARY_PATH];
+  try {
+    await assert.rejects(
+      () => resolveMakaiBinary({ cacheDir }),
+      /SHA256 checksum is required when downloading makai binary from URL/,
+    );
+  } finally {
+    if (prevUrl === undefined) delete process.env[ENV_BINARY_URL];
+    else process.env[ENV_BINARY_URL] = prevUrl;
+    if (prevChecksum === undefined) delete process.env[ENV_BINARY_SHA256];
+    else process.env[ENV_BINARY_SHA256] = prevChecksum;
+    if (prevPath === undefined) delete process.env[ENV_BINARY_PATH];
+    else process.env[ENV_BINARY_PATH] = prevPath;
+    await fs.rm(cacheDir, { recursive: true, force: true });
+  }
+});
+
+test("resolveMakaiBinary rejects resolver URL option without checksum", async () => {
+  await assert.rejects(
+    () =>
+      // @ts-expect-error URL resolver options must include checksumSha256.
+      resolveMakaiBinary({
+        binaryUrl: "http://127.0.0.1:1/makai-test.bin",
+      }),
+    /SHA256 checksum is required when downloading makai binary from URL/,
+  );
+});
+
 test("resolveMakaiBinary downloads URL override to cache with checksum", async () => {
   const payload = Buffer.from("makai-binary-content");
   const checksum = createHash("sha256").update(payload).digest("hex");


### PR DESCRIPTION
## Summary
- Require a SHA256 checksum before resolving makai binaries from URLs, including environment-provided URL overrides.
- Tighten `BinaryResolverOptions` so URL resolver options require `checksumSha256` at compile time.
- Add tests covering missing-checksum rejection and preserving checksum-verified downloads.

## Test plan
- [x] npm run test:sdk