### PR TITLE
Validate JSON writer migration on Zig 0.16

### DIFF
--- a/zig/src/json/writer.zig
+++ b/zig/src/json/writer.zig
@@ -189,6 +189,25 @@ test "string escaping" {
     try std.testing.expectEqualStrings(expected, result);
 }
 
+test "control characters escape as unicode sequences" {
+    const allocator = std.testing.allocator;
+    var buffer = std.ArrayList(u8).empty;
+    defer buffer.deinit(allocator);
+
+    var writer = JsonWriter.init(&buffer, allocator);
+
+    const value = [_]u8{ 'A', 0x01, 'B' };
+
+    try writer.beginObject();
+    try writer.writeStringField("control", &value);
+    try writer.endObject();
+
+    const result = getResult(&writer);
+    const expected = "{\"control\":\"A\\u0001B\"}";
+
+    try std.testing.expectEqualStrings(expected, result);
+}
+
 test "nested objects and arrays" {
     const allocator = std.testing.allocator;
     var buffer = std.ArrayList(u8).empty;


### PR DESCRIPTION
## Summary
- Reference: Zig 0.15.2 → 0.16.0 Migration — ArrayList, formatting, JSON writer
- Verified targeted protocol/provider/utils and full Zig unit test groups compile cleanly on Zig 0.16.0 without additional ArrayList or std.json call-site churn.
- Added a custom JSON writer regression test for unicode control-character escaping through the current ArrayList-backed writer path.

## Test plan
- [x] `cd zig && zig version` → `0.16.0`
- [x] `cd zig && zig build test-unit-protocol test-unit-providers test-unit-utils`
- [x] `cd zig && zig build test-unit-core test-unit-transport test-unit-protocol test-unit-providers test-unit-utils test-unit-agent`
- [x] `cd zig && zig build test`
- [x] `./scripts/check-zig-patterns.sh`