### PR TITLE
Migrate stdio transport and CLI IO

### DIFF
--- a/zig/build.zig
+++ b/zig/build.zig
@@ -398,6 +398,7 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
         .imports = &.{
+            .{ .name = "compat", .module = compat_mod },
             .{ .name = "transport", .module = transport_mod },
         },
     });

--- a/zig/src/compat/stdio.zig
+++ b/zig/src/compat/stdio.zig
@@ -1,5 +1,9 @@
 const std = @import("std");
 
+// TODO(zig-0.16-migration): replace this alias with an opaque Makai-owned
+// handle wrapper in a later phase. This PR keeps the transport/CLI migration
+// small, but callers should already route all operations through this module so
+// the public surface does not depend on `std.Io` operations directly.
 pub const File = std.Io.File;
 pub const Pipe = [2]File;
 

--- a/zig/src/compat/stdio.zig
+++ b/zig/src/compat/stdio.zig
@@ -1,24 +1,86 @@
 const std = @import("std");
 
+pub const File = std.Io.File;
+pub const Pipe = [2]File;
+
+fn defaultIo() std.Io {
+    return if (@import("builtin").is_test)
+        std.testing.io
+    else
+        std.Io.Threaded.global_single_threaded.io();
+}
+
+fn fileFromPipeHandle(handle: File.Handle) File {
+    return .{ .handle = handle, .flags = .{ .nonblocking = false } };
+}
+
 /// Return the process stdin file handle.
 ///
-/// Zig 0.16 mapping: this will borrow stdin from the Makai default I/O context
-/// or test context, preserving public APIs that avoid raw `std.Io`.
-pub fn stdin() std.Io.File {
-    return std.Io.File.stdin();
+/// Zig 0.16 mapping: this borrows stdin from the Makai default I/O context while
+/// keeping raw `std.Io` out of public call sites.
+pub fn stdin() File {
+    return File.stdin();
 }
 
 /// Return the process stdout file handle.
 ///
-/// Zig 0.16 mapping: this will borrow stdout from the Makai default I/O context
-/// or test context, preserving public APIs that avoid raw `std.Io`.
-pub fn stdout() std.Io.File {
-    return std.Io.File.stdout();
+/// Zig 0.16 mapping: this borrows stdout from the Makai default I/O context while
+/// keeping raw `std.Io` out of public call sites.
+pub fn stdout() File {
+    return File.stdout();
+}
+
+/// Return the process stderr file handle.
+pub fn stderr() File {
+    return File.stderr();
+}
+
+/// Write all bytes to a stdio/file handle.
+pub fn writeAll(file: File, data: []const u8) !void {
+    try file.writeStreamingAll(defaultIo(), data);
+}
+
+/// Write bytes followed by a newline to a stdio/file handle.
+pub fn writeLine(file: File, data: []const u8) !void {
+    try writeAll(file, data);
+    try writeAll(file, "\n");
+}
+
+/// Read bytes from a stdio/file handle into one buffer.
+pub fn read(file: File, buffer: []u8) !usize {
+    return file.readStreaming(defaultIo(), &.{buffer});
+}
+
+/// Close a stdio/file handle.
+pub fn close(file: File) void {
+    file.close(defaultIo());
+}
+
+/// Create a blocking pipe for stdio transport and CLI harness tests.
+pub fn pipe() !Pipe {
+    const handles = try std.Io.Threaded.pipe2(.{});
+    return .{ fileFromPipeHandle(handles[0]), fileFromPipeHandle(handles[1]) };
 }
 
 test "compat stdio helpers construct file handles" {
     const in = stdin();
     const out = stdout();
+    const err = stderr();
     _ = in;
     _ = out;
+    _ = err;
+}
+
+test "compat stdio helpers round trip through pipe" {
+    const p = try pipe();
+    const read_file = p[0];
+    const write_file = p[1];
+    defer close(read_file);
+
+    try writeLine(write_file, "hello");
+    close(write_file);
+
+    var buf: [16]u8 = undefined;
+    const n = try read(read_file, &buf);
+    try std.testing.expectEqualStrings("hello\n", buf[0..n]);
 }

--- a/zig/src/tools/makai.zig
+++ b/zig/src/tools/makai.zig
@@ -33,13 +33,6 @@ const STDIO_PROTOCOL_VERSION = "1";
 const STDIO_IDLE_SLEEP_NS = std.time.ns_per_ms;
 const STDIO_THREAD_JOIN_TIMEOUT_MS: u64 = 5_000;
 
-fn defaultIo() std.Io {
-    return if (@import("builtin").is_test)
-        std.testing.io
-    else
-        std.Io.Threaded.global_single_threaded.io();
-}
-
 const TEST_AUTH_POLL_ITERS_SHORT: usize = 20; // ~20ms with STDIO_IDLE_SLEEP_NS.
 const TEST_AUTH_POLL_ITERS_DEFAULT: usize = 600; // ~600ms with STDIO_IDLE_SLEEP_NS.
 const TEST_AUTH_POLL_ITERS_FAILURE: usize = 200; // ~200ms with STDIO_IDLE_SLEEP_NS.
@@ -277,8 +270,7 @@ fn writeOwnedLinesAndClear(
     defer clearOwnedLines(allocator, lines);
 
     for (lines.items) |line| {
-        try file.writeStreamingAll(defaultIo(), line);
-        try file.writeStreamingAll(defaultIo(), "\n");
+        try compat.stdio.writeLine(file, line);
     }
 }
 
@@ -295,15 +287,14 @@ fn emitRuntimeError(
         .message = message,
     }, .{});
     defer allocator.free(payload);
-    try file.writeStreamingAll(defaultIo(), payload);
-    try file.writeStreamingAll(defaultIo(), "\n");
+    try compat.stdio.writeLine(file, payload);
 }
 
 fn runStdioMode(allocator: std.mem.Allocator, stdin: std.Io.File, stdout: std.Io.File) !void {
     var stdio_loop = try StdioProtocolLoop.initWithBuiltins(allocator);
     defer stdio_loop.deinit();
 
-    try stdout.writeStreamingAll(defaultIo(), READY_FRAME);
+    try compat.stdio.writeAll(stdout, READY_FRAME);
 
     var async_receiver = stdio.AsyncStdioReceiver.initWithFile(stdin);
     var stdin_handle = try async_receiver.receiveStreamWithHandle(allocator);
@@ -392,7 +383,7 @@ fn runStdioMode(allocator: std.mem.Allocator, stdin: std.Io.File, stdout: std.Io
 }
 
 fn printUsage(file: std.Io.File) !void {
-    try file.writeStreamingAll(defaultIo(), 
+    try compat.stdio.writeAll(file,
         \\Usage:
         \\  makai --version
         \\  makai --stdio
@@ -1166,13 +1157,13 @@ test "stdio protocol loop forwards provider event result and error envelopes" {
 
 test "writeOwnedLinesAndClear clears owned lines on write failure" {
     const allocator = std.testing.allocator;
-    const pipe = try std.Io.Threaded.pipe2(.{});
-    const read_file = std.Io.File{ .flags = .{ .nonblocking = false }, .handle = pipe[0] };
-    const write_file = std.Io.File{ .flags = .{ .nonblocking = false }, .handle = pipe[1] };
-    defer read_file.close(defaultIo());
+    const pipe = try compat.stdio.pipe();
+    const read_file = pipe[0];
+    const write_file = pipe[1];
+    defer compat.stdio.close(read_file);
 
     // Force write error path.
-    write_file.close(defaultIo());
+    compat.stdio.close(write_file);
 
     var lines = std.ArrayList([]const u8).empty;
     defer lines.deinit(allocator);
@@ -1191,18 +1182,18 @@ test "writeOwnedLinesAndClear clears owned lines on write failure" {
 test "stdio mode preserves ready handshake compatibility" {
     const allocator = std.testing.allocator;
 
-    const stdin_pipe = try std.Io.Threaded.pipe2(.{});
-    const stdout_pipe = try std.Io.Threaded.pipe2(.{});
+    const stdin_pipe = try compat.stdio.pipe();
+    const stdout_pipe = try compat.stdio.pipe();
 
-    var stdin_read = std.Io.File{ .flags = .{ .nonblocking = false }, .handle = stdin_pipe[0] };
-    var stdin_write = std.Io.File{ .flags = .{ .nonblocking = false }, .handle = stdin_pipe[1] };
-    var stdout_read = std.Io.File{ .flags = .{ .nonblocking = false }, .handle = stdout_pipe[0] };
-    var stdout_write = std.Io.File{ .flags = .{ .nonblocking = false }, .handle = stdout_pipe[1] };
+    const stdin_read = stdin_pipe[0];
+    const stdin_write = stdin_pipe[1];
+    const stdout_read = stdout_pipe[0];
+    const stdout_write = stdout_pipe[1];
     errdefer {
-        stdin_read.close(defaultIo());
-        stdin_write.close(defaultIo());
-        stdout_read.close(defaultIo());
-        stdout_write.close(defaultIo());
+        compat.stdio.close(stdin_read);
+        compat.stdio.close(stdin_write);
+        compat.stdio.close(stdout_read);
+        compat.stdio.close(stdout_write);
     }
 
     const Runner = struct {
@@ -1215,8 +1206,8 @@ test "stdio mode preserves ready handshake compatibility" {
             runStdioMode(self.allocator, self.stdin_file, self.stdout_file) catch |err| {
                 self.err = err;
             };
-            self.stdin_file.close(defaultIo());
-            self.stdout_file.close(defaultIo());
+            compat.stdio.close(self.stdin_file);
+            compat.stdio.close(self.stdout_file);
         }
     };
 
@@ -1229,11 +1220,11 @@ test "stdio mode preserves ready handshake compatibility" {
     defer thread.join();
 
     var stdin_write_closed = false;
-    defer if (!stdin_write_closed) stdin_write.close(defaultIo());
+    defer if (!stdin_write_closed) compat.stdio.close(stdin_write);
 
     var out_receiver = stdio.StdioReceiver.initWithFile(stdout_read, allocator);
     defer out_receiver.deinit();
-    defer stdout_read.close(defaultIo());
+    defer compat.stdio.close(stdout_read);
 
     var receiver = out_receiver.receiver();
 
@@ -1243,8 +1234,7 @@ test "stdio mode preserves ready handshake compatibility" {
 
     const ping = try makeProviderPingEnvelopeJson(allocator);
     defer allocator.free(ping);
-    try stdin_write.writeStreamingAll(defaultIo(), ping);
-    try stdin_write.writeStreamingAll(defaultIo(), "\n");
+    try compat.stdio.writeLine(stdin_write, ping);
 
     const response_line = (try receiver.read(allocator)).?;
     defer allocator.free(response_line);
@@ -1252,7 +1242,7 @@ test "stdio mode preserves ready handshake compatibility" {
     defer pong.deinit(allocator);
     try std.testing.expect(pong.payload == .pong);
 
-    stdin_write.close(defaultIo());
+    compat.stdio.close(stdin_write);
     stdin_write_closed = true;
     try std.testing.expect(runner.err == null);
 }
@@ -1260,18 +1250,18 @@ test "stdio mode preserves ready handshake compatibility" {
 test "stdio mode emits unknown_envelope error and continues processing" {
     const allocator = std.testing.allocator;
 
-    const stdin_pipe = try std.Io.Threaded.pipe2(.{});
-    const stdout_pipe = try std.Io.Threaded.pipe2(.{});
+    const stdin_pipe = try compat.stdio.pipe();
+    const stdout_pipe = try compat.stdio.pipe();
 
-    var stdin_read = std.Io.File{ .flags = .{ .nonblocking = false }, .handle = stdin_pipe[0] };
-    var stdin_write = std.Io.File{ .flags = .{ .nonblocking = false }, .handle = stdin_pipe[1] };
-    var stdout_read = std.Io.File{ .flags = .{ .nonblocking = false }, .handle = stdout_pipe[0] };
-    var stdout_write = std.Io.File{ .flags = .{ .nonblocking = false }, .handle = stdout_pipe[1] };
+    const stdin_read = stdin_pipe[0];
+    const stdin_write = stdin_pipe[1];
+    const stdout_read = stdout_pipe[0];
+    const stdout_write = stdout_pipe[1];
     errdefer {
-        stdin_read.close(defaultIo());
-        stdin_write.close(defaultIo());
-        stdout_read.close(defaultIo());
-        stdout_write.close(defaultIo());
+        compat.stdio.close(stdin_read);
+        compat.stdio.close(stdin_write);
+        compat.stdio.close(stdout_read);
+        compat.stdio.close(stdout_write);
     }
 
     const Runner = struct {
@@ -1284,8 +1274,8 @@ test "stdio mode emits unknown_envelope error and continues processing" {
             runStdioMode(self.allocator, self.stdin_file, self.stdout_file) catch |err| {
                 self.err = err;
             };
-            self.stdin_file.close(defaultIo());
-            self.stdout_file.close(defaultIo());
+            compat.stdio.close(self.stdin_file);
+            compat.stdio.close(self.stdout_file);
         }
     };
 
@@ -1298,11 +1288,11 @@ test "stdio mode emits unknown_envelope error and continues processing" {
     defer thread.join();
 
     var stdin_write_closed = false;
-    defer if (!stdin_write_closed) stdin_write.close(defaultIo());
+    defer if (!stdin_write_closed) compat.stdio.close(stdin_write);
 
     var out_receiver = stdio.StdioReceiver.initWithFile(stdout_read, allocator);
     defer out_receiver.deinit();
-    defer stdout_read.close(defaultIo());
+    defer compat.stdio.close(stdout_read);
 
     var receiver = out_receiver.receiver();
 
@@ -1310,12 +1300,11 @@ test "stdio mode emits unknown_envelope error and continues processing" {
     defer allocator.free(ready_line);
     try std.testing.expectEqualStrings("{\"type\":\"ready\",\"protocol_version\":\"1\"}", ready_line);
 
-    try stdin_write.writeStreamingAll(defaultIo(), "{\"type\":\"unknown\",\"payload\":{}}\n");
+    try compat.stdio.writeAll(stdin_write, "{\"type\":\"unknown\",\"payload\":{}}\n");
 
     const ping = try makeProviderPingEnvelopeJson(allocator);
     defer allocator.free(ping);
-    try stdin_write.writeStreamingAll(defaultIo(), ping);
-    try stdin_write.writeStreamingAll(defaultIo(), "\n");
+    try compat.stdio.writeLine(stdin_write, ping);
 
     const error_line = (try receiver.read(allocator)).?;
     defer allocator.free(error_line);
@@ -1333,7 +1322,7 @@ test "stdio mode emits unknown_envelope error and continues processing" {
     defer pong.deinit(allocator);
     try std.testing.expect(pong.payload == .pong);
 
-    stdin_write.close(defaultIo());
+    compat.stdio.close(stdin_write);
     stdin_write_closed = true;
     try std.testing.expect(runner.err == null);
 }
@@ -1368,19 +1357,19 @@ const AuthCliHarness = struct {
     err: ?anyerror = null,
 
     fn init(allocator: std.mem.Allocator, args: []const []const u8) !AuthCliHarness {
-        const stdin_pipe = try std.Io.Threaded.pipe2(.{});
-        const stdout_pipe = try std.Io.Threaded.pipe2(.{});
-        const stderr_pipe = try std.Io.Threaded.pipe2(.{});
+        const stdin_pipe = try compat.stdio.pipe();
+        const stdout_pipe = try compat.stdio.pipe();
+        const stderr_pipe = try compat.stdio.pipe();
 
         return .{
             .allocator = allocator,
             .args = args,
-            .stdin_read = std.Io.File{ .flags = .{ .nonblocking = false }, .handle = stdin_pipe[0] },
-            .stdin_write = std.Io.File{ .flags = .{ .nonblocking = false }, .handle = stdin_pipe[1] },
-            .stdout_read = std.Io.File{ .flags = .{ .nonblocking = false }, .handle = stdout_pipe[0] },
-            .stdout_write = std.Io.File{ .flags = .{ .nonblocking = false }, .handle = stdout_pipe[1] },
-            .stderr_read = std.Io.File{ .flags = .{ .nonblocking = false }, .handle = stderr_pipe[0] },
-            .stderr_write = std.Io.File{ .flags = .{ .nonblocking = false }, .handle = stderr_pipe[1] },
+            .stdin_read = stdin_pipe[0],
+            .stdin_write = stdin_pipe[1],
+            .stdout_read = stdout_pipe[0],
+            .stdout_write = stdout_pipe[1],
+            .stderr_read = stderr_pipe[0],
+            .stderr_write = stderr_pipe[1],
         };
     }
 
@@ -1388,9 +1377,9 @@ const AuthCliHarness = struct {
         defer {
             // The wrapper does not own these fds; closing them here lets the
             // reader side observe EOF after the command finishes.
-            self.stdout_write.close(defaultIo());
-            self.stderr_write.close(defaultIo());
-            self.stdin_read.close(defaultIo());
+            compat.stdio.close(self.stdout_write);
+            compat.stdio.close(self.stderr_write);
+            compat.stdio.close(self.stdin_read);
         }
 
         handleAuthWithOptions(
@@ -1410,7 +1399,7 @@ const AuthCliHarness = struct {
         defer buf.deinit(allocator);
         var chunk: [4096]u8 = undefined;
         while (true) {
-            const n = file.readStreaming(defaultIo(), &.{&chunk}) catch break;
+            const n = compat.stdio.read(file, &chunk) catch break;
             if (n == 0) break;
             try buf.appendSlice(allocator, chunk[0..n]);
         }
@@ -1425,7 +1414,7 @@ test "handleAuth providers end-to-end through CLI wrapper emits provider ids" {
     const thread = try std.Thread.spawn(.{}, AuthCliHarness.run, .{&harness});
 
     // No stdin needed; close immediately so the worker doesn't block on read.
-    harness.stdin_write.close(defaultIo());
+    compat.stdio.close(harness.stdin_write);
 
     const stdout_bytes = try AuthCliHarness.readAll(harness.stdout_read, allocator);
     defer allocator.free(stdout_bytes);
@@ -1433,8 +1422,8 @@ test "handleAuth providers end-to-end through CLI wrapper emits provider ids" {
     defer allocator.free(stderr_bytes);
 
     thread.join();
-    harness.stdout_read.close(defaultIo());
-    harness.stderr_read.close(defaultIo());
+    compat.stdio.close(harness.stdout_read);
+    compat.stdio.close(harness.stderr_read);
 
     try std.testing.expect(harness.err == null);
     try std.testing.expect(std.mem.find(u8, stdout_bytes, "anthropic\n") != null);
@@ -1449,7 +1438,7 @@ test "handleAuth providers --json end-to-end emits backward-compatible shape" {
     var harness = try AuthCliHarness.init(allocator, &.{ "providers", "--json" });
     const thread = try std.Thread.spawn(.{}, AuthCliHarness.run, .{&harness});
 
-    harness.stdin_write.close(defaultIo());
+    compat.stdio.close(harness.stdin_write);
 
     const stdout_bytes = try AuthCliHarness.readAll(harness.stdout_read, allocator);
     defer allocator.free(stdout_bytes);
@@ -1457,8 +1446,8 @@ test "handleAuth providers --json end-to-end emits backward-compatible shape" {
     defer allocator.free(stderr_bytes);
 
     thread.join();
-    harness.stdout_read.close(defaultIo());
-    harness.stderr_read.close(defaultIo());
+    compat.stdio.close(harness.stdout_read);
+    compat.stdio.close(harness.stderr_read);
 
     try std.testing.expect(harness.err == null);
 
@@ -1480,8 +1469,8 @@ test "handleAuth login end-to-end drives prompt loop through CLI wrapper" {
     const thread = try std.Thread.spawn(.{}, AuthCliHarness.run, .{&harness});
 
     // Reject first attempt to force the prompt loop to iterate, then accept.
-    try harness.stdin_write.writeStreamingAll(defaultIo(), "not-the-answer\nok\n");
-    harness.stdin_write.close(defaultIo());
+    try compat.stdio.writeAll(harness.stdin_write, "not-the-answer\nok\n");
+    compat.stdio.close(harness.stdin_write);
 
     const stdout_bytes = try AuthCliHarness.readAll(harness.stdout_read, allocator);
     defer allocator.free(stdout_bytes);
@@ -1489,8 +1478,8 @@ test "handleAuth login end-to-end drives prompt loop through CLI wrapper" {
     defer allocator.free(stderr_bytes);
 
     thread.join();
-    harness.stdout_read.close(defaultIo());
-    harness.stderr_read.close(defaultIo());
+    compat.stdio.close(harness.stdout_read);
+    compat.stdio.close(harness.stderr_read);
 
     try std.testing.expect(harness.err == null);
     try std.testing.expect(std.mem.find(
@@ -1513,7 +1502,7 @@ test "handleAuth login surfaces typed error for unknown provider via CLI wrapper
     var harness = try AuthCliHarness.init(allocator, &.{ "login", "--provider", "no-such-provider" });
     const thread = try std.Thread.spawn(.{}, AuthCliHarness.run, .{&harness});
 
-    harness.stdin_write.close(defaultIo());
+    compat.stdio.close(harness.stdin_write);
 
     const stdout_bytes = try AuthCliHarness.readAll(harness.stdout_read, allocator);
     defer allocator.free(stdout_bytes);
@@ -1521,8 +1510,8 @@ test "handleAuth login surfaces typed error for unknown provider via CLI wrapper
     defer allocator.free(stderr_bytes);
 
     thread.join();
-    harness.stdout_read.close(defaultIo());
-    harness.stderr_read.close(defaultIo());
+    compat.stdio.close(harness.stdout_read);
+    compat.stdio.close(harness.stderr_read);
 
     try std.testing.expectEqual(auth_cli.AuthCliError.AuthLoginFailed, harness.err.?);
     try std.testing.expect(std.mem.find(u8, stderr_bytes, "auth login failed") != null);
@@ -1533,9 +1522,9 @@ pub fn main(init: std.process.Init.Minimal) !void {
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
-    const stdout = std.Io.File.stdout();
-    const stderr = std.Io.File.stderr();
-    const stdin = std.Io.File.stdin();
+    const stdout = compat.stdio.stdout();
+    const stderr = compat.stdio.stderr();
+    const stdin = compat.stdio.stdin();
 
     const args = try init.args.toSlice(allocator);
     defer allocator.free(args);
@@ -1546,7 +1535,7 @@ pub fn main(init: std.process.Init.Minimal) !void {
     }
 
     if (std.mem.eql(u8, args[1], "--version")) {
-        try stdout.writeStreamingAll(defaultIo(), VERSION ++ "\n");
+        try compat.stdio.writeAll(stdout, VERSION ++ "\n");
         return;
     }
 
@@ -1567,7 +1556,7 @@ pub fn main(init: std.process.Init.Minimal) !void {
 
     var msg_buf: [512]u8 = undefined;
     const msg = try std.fmt.bufPrint(&msg_buf, "unknown argument: {s}\n\n", .{args[1]});
-    try stderr.writeStreamingAll(defaultIo(), msg);
+    try compat.stdio.writeAll(stderr, msg);
     try printUsage(stderr);
     return error.InvalidArgument;
 }

--- a/zig/src/transports/stdio.zig
+++ b/zig/src/transports/stdio.zig
@@ -216,10 +216,10 @@ pub const AsyncStdioReceiver = struct {
 
         const thread = try std.Thread.spawn(.{}, producerThread, .{thread_ctx});
 
-        // Store thread handle in the stream's result field (hack for backward compat)
-        // Actually, we cannot do this cleanly without changing the ByteStream type.
-        // For backward compatibility with receiveStreamFn signature, we detach but
-        // the caller should use receiveStreamWithHandle() for proper lifecycle management.
+        // TODO(zig-0.16-migration): deprecate this legacy receiveStream() path
+        // once transport migration callers use receiveStreamWithHandle(). It
+        // detaches the producer for backward compatibility, while the handle
+        // API below keeps lifecycle ownership explicit.
         thread.detach();
 
         return stream;

--- a/zig/src/transports/stdio.zig
+++ b/zig/src/transports/stdio.zig
@@ -1,25 +1,15 @@
 const std = @import("std");
+const compat = @import("compat");
 const transport = @import("transport");
 
-fn defaultIo() std.Io {
-    return if (@import("builtin").is_test)
-        std.testing.io
-    else
-        std.Io.Threaded.global_single_threaded.io();
-}
-
-fn fileFromPipeHandle(handle: std.Io.File.Handle) std.Io.File {
-    return .{ .handle = handle, .flags = .{ .nonblocking = false } };
-}
-
 pub const StdioSender = struct {
-    file: std.Io.File,
+    file: compat.stdio.File,
 
     pub fn init() StdioSender {
-        return .{ .file = std.Io.File.stdout() };
+        return .{ .file = compat.stdio.stdout() };
     }
 
-    pub fn initWithFile(file: std.Io.File) StdioSender {
+    pub fn initWithFile(file: compat.stdio.File) StdioSender {
         return .{ .file = file };
     }
 
@@ -32,23 +22,22 @@ pub const StdioSender = struct {
 
     fn writeFn(ctx: *anyopaque, data: []const u8) !void {
         const self: *StdioSender = @ptrCast(@alignCast(ctx));
-        try self.file.writeStreamingAll(defaultIo(), data);
-        try self.file.writeStreamingAll(defaultIo(), "\n");
+        try compat.stdio.writeLine(self.file, data);
     }
 };
 
 pub const StdioReceiver = struct {
-    file: std.Io.File,
+    file: compat.stdio.File,
     read_buf: [4096]u8 = undefined,
     /// Unprocessed data carried over from previous read
     leftover: std.ArrayList(u8) = std.ArrayList(u8).empty,
     allocator: std.mem.Allocator,
 
     pub fn init(allocator: std.mem.Allocator) StdioReceiver {
-        return .{ .file = std.Io.File.stdin(), .allocator = allocator };
+        return .{ .file = compat.stdio.stdin(), .allocator = allocator };
     }
 
-    pub fn initWithFile(file: std.Io.File, allocator: std.mem.Allocator) StdioReceiver {
+    pub fn initWithFile(file: compat.stdio.File, allocator: std.mem.Allocator) StdioReceiver {
         return .{ .file = file, .allocator = allocator };
     }
 
@@ -78,7 +67,7 @@ pub const StdioReceiver = struct {
             }
 
             // Read more data
-            const bytes_read = self.file.readStreaming(defaultIo(), &.{&self.read_buf}) catch return null;
+            const bytes_read = compat.stdio.read(self.file, &self.read_buf) catch return null;
             if (bytes_read == 0) {
                 // EOF - return remaining data as last line if any
                 if (self.leftover.items.len > 0) {
@@ -150,13 +139,13 @@ pub const AsyncStreamHandle = struct {
 };
 
 pub const AsyncStdioSender = struct {
-    file: std.Io.File,
+    file: compat.stdio.File,
 
     pub fn init() AsyncStdioSender {
-        return .{ .file = std.Io.File.stdout() };
+        return .{ .file = compat.stdio.stdout() };
     }
 
-    pub fn initWithFile(file: std.Io.File) AsyncStdioSender {
+    pub fn initWithFile(file: compat.stdio.File) AsyncStdioSender {
         return .{ .file = file };
     }
 
@@ -169,21 +158,20 @@ pub const AsyncStdioSender = struct {
 
     fn writeFn(ctx: *anyopaque, data: []const u8) !void {
         const self: *AsyncStdioSender = @ptrCast(@alignCast(ctx));
-        try self.file.writeStreamingAll(defaultIo(), data);
-        try self.file.writeStreamingAll(defaultIo(), "\n");
+        try compat.stdio.writeLine(self.file, data);
     }
 };
 
 pub const AsyncStdioReceiver = struct {
-    file: std.Io.File,
+    file: compat.stdio.File,
 
     const Self = @This();
 
     pub fn init() Self {
-        return .{ .file = std.Io.File.stdin() };
+        return .{ .file = compat.stdio.stdin() };
     }
 
-    pub fn initWithFile(file: std.Io.File) Self {
+    pub fn initWithFile(file: compat.stdio.File) Self {
         return .{ .file = file };
     }
 
@@ -197,7 +185,7 @@ pub const AsyncStdioReceiver = struct {
 
     const ProducerContext = struct {
         stream: *transport.ByteStream,
-        file: std.Io.File,
+        file: compat.stdio.File,
         allocator: std.mem.Allocator,
         leftover: std.ArrayList(u8),
         read_buf: [4096]u8 = undefined,
@@ -307,7 +295,7 @@ pub const AsyncStdioReceiver = struct {
             }
 
             // Read more data
-            const bytes_read = ctx.file.readStreaming(defaultIo(), &.{&ctx.read_buf}) catch {
+            const bytes_read = compat.stdio.read(ctx.file, &ctx.read_buf) catch {
                 ctx.stream.completeWithError("Read error");
                 return;
             };
@@ -353,7 +341,7 @@ pub const AsyncStdioReceiver = struct {
             }
 
             // Read more data
-            const bytes_read = self.file.readStreaming(defaultIo(), &.{&read_buf}) catch return null;
+            const bytes_read = compat.stdio.read(self.file, &read_buf) catch return null;
             if (bytes_read == 0) {
                 // EOF - return remaining data if any
                 if (leftover.items.len > 0) {
@@ -373,10 +361,10 @@ test "StdioSender and StdioReceiver round-trip via pipe" {
     const allocator = std.testing.allocator;
 
     // Create a pipe for testing
-    const pipe = try std.Io.Threaded.pipe2(.{});
-    const read_file = fileFromPipeHandle(pipe[0]);
-    const write_file = fileFromPipeHandle(pipe[1]);
-    defer read_file.close(defaultIo());
+    const pipe = try compat.stdio.pipe();
+    const read_file = pipe[0];
+    const write_file = pipe[1];
+    defer compat.stdio.close(read_file);
 
     // Set up sender and receiver
     var stdio_sender = StdioSender.initWithFile(write_file);
@@ -391,7 +379,7 @@ test "StdioSender and StdioReceiver round-trip via pipe" {
     try s.write("{\"type\":\"start\",\"model\":\"test\"}");
 
     // Close write end so receiver gets EOF after reading
-    write_file.close(defaultIo());
+    compat.stdio.close(write_file);
 
     // Read it back
     const line1 = try r.read(allocator);
@@ -413,10 +401,10 @@ test "AsyncStdioReceiver with handle lifecycle management" {
     const allocator = std.testing.allocator;
 
     // Create a pipe for testing
-    const pipe = try std.Io.Threaded.pipe2(.{});
-    const read_file = fileFromPipeHandle(pipe[0]);
-    const write_file = fileFromPipeHandle(pipe[1]);
-    defer read_file.close(defaultIo());
+    const pipe = try compat.stdio.pipe();
+    const read_file = pipe[0];
+    const write_file = pipe[1];
+    defer compat.stdio.close(read_file);
 
     // Set up async receiver with handle
     var async_receiver = AsyncStdioReceiver.initWithFile(read_file);
@@ -424,11 +412,11 @@ test "AsyncStdioReceiver with handle lifecycle management" {
 
     // Write test data from another thread (simulate producer)
     const WriterContext = struct {
-        file: std.Io.File,
+        file: compat.stdio.File,
         fn writeData(ctx: *@This()) void {
-            defaultIo().sleep(.fromNanoseconds(std.time.ns_per_ms * 10), .boot) catch {}; // Small delay
-            ctx.file.writeStreamingAll(defaultIo(), "line1\nline2\n") catch {};
-            ctx.file.close(defaultIo());
+            compat.time.sleepNs(std.time.ns_per_ms * 10); // Small delay
+            compat.stdio.writeAll(ctx.file, "line1\nline2\n") catch {};
+            compat.stdio.close(ctx.file);
         }
     };
     var writer_ctx = WriterContext{ .file = write_file };
@@ -468,9 +456,9 @@ test "AsyncStreamHandle cancellation" {
     const allocator = std.testing.allocator;
 
     // Create a pipe - we won't write to it, so the reader will block
-    const pipe = try std.Io.Threaded.pipe2(.{});
-    const read_file = fileFromPipeHandle(pipe[0]);
-    const write_file = fileFromPipeHandle(pipe[1]);
+    const pipe = try compat.stdio.pipe();
+    const read_file = pipe[0];
+    const write_file = pipe[1];
 
     var async_receiver = AsyncStdioReceiver.initWithFile(read_file);
     var handle = try async_receiver.receiveStreamWithHandle(allocator);
@@ -483,7 +471,7 @@ test "AsyncStreamHandle cancellation" {
     try std.testing.expect(handle.isCancelled());
 
     // Close the write end to unblock the read (in case cancellation isn't instant)
-    write_file.close(defaultIo());
+    compat.stdio.close(write_file);
 
     // Clean up - should exit quickly due to cancellation
     const exited = handle.deinit(5000);
@@ -495,10 +483,10 @@ test "AsyncStdioReceiver legacy interface still works" {
     const allocator = std.testing.allocator;
 
     // Create a pipe for testing
-    const pipe = try std.Io.Threaded.pipe2(.{});
-    const read_file = fileFromPipeHandle(pipe[0]);
-    const write_file = fileFromPipeHandle(pipe[1]);
-    defer read_file.close(defaultIo());
+    const pipe = try compat.stdio.pipe();
+    const read_file = pipe[0];
+    const write_file = pipe[1];
+    defer compat.stdio.close(read_file);
 
     // Set up async receiver using the legacy interface
     var async_receiver = AsyncStdioReceiver.initWithFile(read_file);
@@ -508,8 +496,8 @@ test "AsyncStdioReceiver legacy interface still works" {
     const stream = try receiver.receiveStream(allocator);
 
     // Write test data and close
-    try write_file.writeStreamingAll(defaultIo(), "test_data\n");
-    write_file.close(defaultIo());
+    try compat.stdio.writeAll(write_file, "test_data\n");
+    compat.stdio.close(write_file);
 
     // Read from stream
     if (stream.wait()) |chunk| {


### PR DESCRIPTION
## Summary
- Adds compat stdio helpers for stdin/stdout/stderr, byte reads/writes, close, and pipe-backed test harnesses without exposing raw `std.Io` in wrapper APIs.
- Routes stdio transport reads/writes and targeted `makai` CLI stdio/file operations through the helpers.
- Preserves stdio ready/error framing and auth CLI harness behavior while avoiding OAuth storage changes.

References: Zig 0.15.2 → 0.16.0 Migration — stdio transport and CLI file I/O

## Test plan
- [x] `cd zig && zig build test-unit-transport test-unit-makai-cli`
- [x] `cd zig && zig build test`