### PR TITLE
Add JSDoc for TypeScript public APIs

### DIFF
--- a/typescript/src/auth_protocol.ts
+++ b/typescript/src/auth_protocol.ts
@@ -11,8 +11,10 @@ import {
 // Spec-aligned types (docs/v1-sdk-agent-provider-spec.md §3, §3.6, §4).
 // ---------------------------------------------------------------------------
 
+/** Stable identifier for an auth-capable provider configured in Makai. */
 export type ProviderId = string;
 
+/** All authentication statuses the TypeScript SDK recognizes on the wire. */
 export const AUTH_STATUSES = [
   "authenticated",
   "login_required",
@@ -23,10 +25,12 @@ export const AUTH_STATUSES = [
   "unknown",
 ] as const;
 
+/** Authentication status reported by {@link MakaiAuthApi.listProviders}. */
 export type AuthStatus = (typeof AUTH_STATUSES)[number];
 
 const VALID_AUTH_STATUSES = new Set<string>(AUTH_STATUSES);
 
+/** Authentication metadata for a provider returned by {@link MakaiAuthApi.listProviders}. */
 export interface ProviderAuthInfo {
   id: ProviderId;
   name: string;
@@ -34,6 +38,7 @@ export interface ProviderAuthInfo {
   last_error?: string;
 }
 
+/** Event emitted during an interactive {@link MakaiAuthApi.login} flow. */
 export type MakaiAuthEvent =
   | {
       type: "auth_url";
@@ -69,6 +74,7 @@ export type MakaiAuthEvent =
       message: string;
     };
 
+/** Callback hooks used to observe and respond to interactive auth flows. */
 export interface AuthFlowHandlers {
   onEvent?: (event: MakaiAuthEvent) => void;
   onPrompt?: (
@@ -76,16 +82,22 @@ export interface AuthFlowHandlers {
   ) => Promise<string> | string;
 }
 
+/** Categorizes failures raised by the Makai auth API. */
 export type MakaiAuthErrorKind =
   | "provider_error"
   | "cancelled"
   | "transport_error"
   | "unknown";
 
+/** Error thrown for auth protocol, provider, cancellation, and transport failures. */
 export class MakaiAuthError extends Error {
   public readonly kind: MakaiAuthErrorKind;
   public readonly code?: string;
 
+  /**
+   * @param message Human-readable auth failure.
+   * @param options Optional structured error metadata.
+   */
   constructor(
     message: string,
     options: { kind?: MakaiAuthErrorKind; code?: string } = {},
@@ -97,10 +109,23 @@ export class MakaiAuthError extends Error {
   }
 }
 
+/** Provider authentication API exposed as `client.auth`. */
 export interface MakaiAuthApi {
+  /**
+   * Lists auth-capable providers and current auth state.
+   *
+   * @returns Provider authentication metadata.
+   * @throws {@link MakaiAuthError} on transport or protocol failures.
+   */
   listProviders(): Promise<ProviderAuthInfo[]>;
   /**
-   * Handler precedence: per-call handlers > client-level defaults > none.
+   * Starts a login flow for a provider. Handler precedence is per-call handlers,
+   * then client-level defaults, then none.
+   *
+   * @param providerId Provider to authenticate.
+   * @param handlers Optional handlers for this login call.
+   * @returns Success status when authentication completes.
+   * @throws {@link MakaiAuthError} if authentication fails or is cancelled.
    */
   login(
     providerId: ProviderId,
@@ -124,6 +149,13 @@ type AuthEventVariant = (typeof AUTH_EVENT_VARIANTS)[number];
 /**
  * Auth events on the wire are Zig union objects (e.g. `{ "prompt": { ... } }`).
  * Flatten to the SDK's `MakaiAuthEvent` shape (`{ type: "prompt", ... }`).
+ */
+/**
+ * Converts a wire-format auth event union into the SDK's discriminated union.
+ *
+ * @param payload Raw auth event payload from the stdio protocol.
+ * @returns A normalized {@link MakaiAuthEvent}.
+ * @throws {@link MakaiAuthError} if the payload is malformed or unknown.
  */
 export function flattenAuthEvent(payload: Record<string, unknown>): MakaiAuthEvent {
   for (const variant of AUTH_EVENT_VARIANTS) {
@@ -225,6 +257,7 @@ type RawEnvelope = StdioFrame & {
   payload?: unknown;
 };
 
+/** Options for constructing a {@link MakaiAuthClient}. */
 export interface MakaiAuthClientOptions {
   /**
    * Default handlers used when `login()` is invoked without per-call handlers.
@@ -245,17 +278,28 @@ export interface MakaiAuthClientOptions {
  * Per docs/v1-sdk-agent-provider-spec.md §3.6, all calls map to auth protocol
  * envelopes; CLI-subprocess wiring is prohibited in V1.
  */
+/** Auth protocol client backed by an already-connected Makai stdio transport. */
 export class MakaiAuthClient implements MakaiAuthApi {
   private readonly transport: MakaiStdioClient;
   private readonly defaultHandlers?: AuthFlowHandlers;
   private readonly frameTimeoutMs: number;
 
+  /**
+   * @param transport Connected stdio transport used for auth envelopes.
+   * @param options Client-level handler and timeout options.
+   */
   constructor(transport: MakaiStdioClient, options: MakaiAuthClientOptions = {}) {
     this.transport = transport;
     this.defaultHandlers = options.handlers;
     this.frameTimeoutMs = options.frameTimeoutMs ?? 30_000;
   }
 
+  /**
+   * Lists auth-capable providers and their current authentication status.
+   *
+   * @returns Provider authentication metadata.
+   * @throws {@link MakaiAuthError} on transport or protocol failures.
+   */
   async listProviders(): Promise<ProviderAuthInfo[]> {
     const streamId = ulid();
     const messageId = ulid();
@@ -287,6 +331,14 @@ export class MakaiAuthClient implements MakaiAuthApi {
     }
   }
 
+  /**
+   * Starts an interactive login flow for a provider.
+   *
+   * @param providerId Provider to authenticate.
+   * @param handlers Optional per-call handlers; these replace client defaults.
+   * @returns Success status when login completes.
+   * @throws {@link MakaiAuthError} if login fails, is cancelled, or the protocol errors.
+   */
   async login(
     providerId: ProviderId,
     handlers?: AuthFlowHandlers,
@@ -527,6 +579,7 @@ function nackToAuthError(frame: RawEnvelope): MakaiAuthError {
 // Factory.
 // ---------------------------------------------------------------------------
 
+/** Options for {@link createMakaiAuthClient}. */
 export type CreateMakaiAuthClientOptions = CreateMakaiStdioClientOptions & {
   /** Default handlers reused by `login(...)` when no per-call handlers are provided. */
   handlers?: AuthFlowHandlers;
@@ -536,6 +589,7 @@ export type CreateMakaiAuthClientOptions = CreateMakaiStdioClientOptions & {
   resolver?: BinaryResolverOptions;
 };
 
+/** Handle returned by {@link createMakaiAuthClient}. */
 export interface MakaiAuthClientHandle {
   auth: MakaiAuthApi;
   close(): Promise<void>;
@@ -544,6 +598,19 @@ export interface MakaiAuthClientHandle {
 /**
  * Creates an auth-capable client backed by `makai --stdio`. Connects the
  * underlying transport (handshake) before returning.
+ *
+ * @param options Transport, resolver, handler, and timeout options.
+ * @returns A connected auth client handle.
+ * @throws If the binary cannot be resolved, the stdio process fails, or handshake fails.
+ *
+ * @example
+ * ```ts
+ * const client = await createMakaiAuthClient({
+ *   handlers: { onEvent: console.log },
+ * });
+ * await client.auth.login("anthropic");
+ * await client.close();
+ * ```
  */
 export async function createMakaiAuthClient(
   options: CreateMakaiAuthClientOptions = {},

--- a/typescript/src/binary_resolver.ts
+++ b/typescript/src/binary_resolver.ts
@@ -3,10 +3,12 @@ import { promises as fs } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
+/** Shared binary resolver options. */
 type BinaryResolverBaseOptions = {
   cacheDir?: string;
 };
 
+/** Resolve Makai from an explicit filesystem path. */
 type BinaryPathResolverOptions = BinaryResolverBaseOptions & {
   type?: "path";
   binaryPath: string;
@@ -14,6 +16,7 @@ type BinaryPathResolverOptions = BinaryResolverBaseOptions & {
   checksumSha256?: string;
 };
 
+/** Download Makai from a URL and verify it with a required SHA-256 checksum. */
 type BinaryUrlResolverOptions = BinaryResolverBaseOptions & {
   type?: "url";
   binaryPath?: undefined;
@@ -21,6 +24,7 @@ type BinaryUrlResolverOptions = BinaryResolverBaseOptions & {
   checksumSha256: string;
 };
 
+/** Resolve Makai automatically from local build outputs or the system PATH. */
 type BinaryAutoResolverOptions = BinaryResolverBaseOptions & {
   type?: "auto";
   binaryPath?: undefined;
@@ -28,6 +32,12 @@ type BinaryAutoResolverOptions = BinaryResolverBaseOptions & {
   checksumSha256?: string;
 };
 
+/**
+ * Strategy options for locating the `makai` executable used by stdio clients.
+ *
+ * Use `binaryPath` for an existing local binary, `binaryUrl` plus
+ * `checksumSha256` for a verified download, or omit both for automatic lookup.
+ */
 export type BinaryResolverOptions =
   | BinaryPathResolverOptions
   | BinaryUrlResolverOptions
@@ -98,6 +108,16 @@ async function downloadToCache(url: string, targetPath: string, checksumSha256: 
   await fs.rename(tempPath, targetPath);
 }
 
+/**
+ * Resolves the Makai executable path according to environment variables and options.
+ *
+ * Environment variables take precedence over options: `MAKAI_BINARY_PATH`,
+ * `MAKAI_BINARY_URL`, and `MAKAI_BINARY_SHA256`.
+ *
+ * @param options Resolver strategy and cache directory options.
+ * @returns Absolute path to a local binary, or `"makai"` to use PATH lookup.
+ * @throws If an explicit binary is missing, download fails, or checksum verification fails.
+ */
 export async function resolveMakaiBinary(options: BinaryResolverOptions = {}): Promise<string> {
   const explicitBinaryPath = process.env[ENV_BINARY_PATH] ?? options.binaryPath;
   if (explicitBinaryPath) {

--- a/typescript/src/execution_client.ts
+++ b/typescript/src/execution_client.ts
@@ -44,16 +44,30 @@ type ExecutionOptions = {
   authHandlers?: AuthFlowHandlers;
 };
 
+/** Root Makai SDK client returned by {@link createMakaiClient}. */
 export interface MakaiClient {
   auth: MakaiAuthApi;
   models: MakaiModelsApi;
   agent: MakaiAgentModelsApi;
   provider: MakaiProviderApi;
+  /**
+   * Closes the underlying shared stdio transport.
+   *
+   * @returns A promise that resolves after the transport closes.
+   */
   close(): Promise<void>;
 }
 
+/** Options for {@link createMakaiClient}. */
 export type CreateMakaiClientOptions = CreateMakaiStdioClientOptions & MakaiClientOptions;
 
+/**
+ * Creates a direct provider API facade over an existing stdio transport.
+ *
+ * @param transport Connected stdio transport.
+ * @param options Execution timeout and auth retry options.
+ * @returns A {@link MakaiProviderApi} bound to the transport.
+ */
 export function createMakaiProviderApi(
   transport: MakaiStdioClient,
   options: ExecutionOptions = {},
@@ -61,6 +75,13 @@ export function createMakaiProviderApi(
   return new StdioProviderApi(transport, options);
 }
 
+/**
+ * Creates an agent execution API facade over an existing stdio transport.
+ *
+ * @param transport Connected stdio transport.
+ * @param options Execution timeout and auth retry options.
+ * @returns A {@link MakaiAgentApi} bound to the transport.
+ */
 export function createMakaiAgentApi(
   transport: MakaiStdioClient,
   options: ExecutionOptions = {},
@@ -68,10 +89,18 @@ export function createMakaiAgentApi(
   return new StdioAgentApi(transport, options);
 }
 
+/** Agent API augmented with the model-discovery API for convenience. */
 export interface MakaiAgentModelsApi extends MakaiAgentApi {
   models: MakaiModelsApi;
 }
 
+/**
+ * Creates an agent API facade with a nested {@link MakaiModelsApi}.
+ *
+ * @param transport Connected stdio transport.
+ * @param options Execution timeout and auth retry options.
+ * @returns A {@link MakaiAgentModelsApi} bound to the transport.
+ */
 export function createMakaiAgentApiWithModels(
   transport: MakaiStdioClient,
   options: ExecutionOptions = {},
@@ -1016,6 +1045,29 @@ async function withAuthRetry<T>(
   }
 }
 
+/**
+ * Creates and connects the root Makai SDK client backed by `makai --stdio`.
+ *
+ * The returned client exposes provider execution, agent execution, model
+ * discovery, and authentication APIs over one shared transport. Always call
+ * {@link MakaiClient.close} when finished.
+ *
+ * @param options Binary resolver, stdio transport, auth, and timeout options.
+ * @returns A connected {@link MakaiClient}.
+ * @throws If binary resolution, process startup, or protocol handshake fails.
+ *
+ * @example
+ * ```ts
+ * const client = await createMakaiClient();
+ * const { models } = await client.models.list();
+ * const result = await client.provider.complete({
+ *   model_ref: models[0]!.model_ref,
+ *   messages: [{ role: "user", content: "Hello!" }],
+ * });
+ * console.log(result.message.content);
+ * await client.close();
+ * ```
+ */
 export async function createMakaiClient(options: CreateMakaiClientOptions = {}): Promise<MakaiClient> {
   const { auth: authOptions, responseTimeoutMs, frameTimeoutMs, ...transportOptions } = options;
   const transport = await createMakaiStdioClient(transportOptions);

--- a/typescript/src/execution_types.ts
+++ b/typescript/src/execution_types.ts
@@ -1,8 +1,15 @@
 import type { ApiId, ProviderId } from "./models_types";
 import type { AuthFlowHandlers } from "./auth_protocol";
 
+/** Controls whether execution APIs automatically retry once after an authentication challenge. */
 export type AuthRetryPolicy = "manual" | "auto_once";
 
+/**
+ * Reason a model, provider, or agent turn stopped producing output.
+ *
+ * Known values mirror provider protocol stop reasons, while arbitrary strings are
+ * allowed for forward-compatible provider-specific reasons.
+ */
 export type StopReason =
   | "end_turn"
   | "max_tokens"
@@ -11,24 +18,28 @@ export type StopReason =
   | "max_turns"
   | string;
 
+/** A text block in a {@link ChatMessage} or {@link CompletionResponse}. */
 export type TextContentPart = {
   type: "text";
   text: string;
   text_signature?: string;
 };
 
+/** A reasoning/thinking block emitted by providers that expose extended thinking. */
 export type ThinkingContentPart = {
   type: "thinking";
   thinking: string;
   thinking_signature?: string;
 };
 
+/** A base64-encoded image block supplied as multimodal message content. */
 export type ImageContentPart = {
   type: "image";
   data: string;
   mime_type: string;
 };
 
+/** A tool invocation requested by the assistant. */
 export type ToolCallContentPart = {
   type: "tool_call";
   tool_call_id: string;
@@ -36,6 +47,7 @@ export type ToolCallContentPart = {
   arguments_json: string;
 };
 
+/** The result of executing a tool call, suitable for sending back to the model. */
 export type ToolResultContentPart = {
   type: "tool_result";
   tool_call_id: string;
@@ -45,6 +57,7 @@ export type ToolResultContentPart = {
   details_json?: string;
 };
 
+/** Union of structured message content blocks accepted and returned by Makai. */
 export type ContentPart =
   | TextContentPart
   | ThinkingContentPart
@@ -52,6 +65,11 @@ export type ContentPart =
   | ToolCallContentPart
   | ToolResultContentPart;
 
+/**
+ * A conversation message passed to {@link MakaiAgentApi.run},
+ * {@link MakaiAgentApi.stream}, {@link MakaiProviderApi.complete}, or
+ * {@link MakaiProviderApi.stream}.
+ */
 export interface ChatMessage {
   role: "system" | "developer" | "user" | "assistant" | "tool";
   content: string | ContentPart[];
@@ -59,12 +77,14 @@ export interface ChatMessage {
   tool_call_id?: string;
 }
 
+/** Describes a JSON-schema tool that the model or agent may call. */
 export interface ToolDefinition {
   name: string;
   description: string;
   parameters_schema_json: string;
 }
 
+/** Optional execution controls shared by agent and provider requests. */
 export interface RunOptions {
   temperature?: number;
   max_tokens?: number;
@@ -74,6 +94,7 @@ export interface RunOptions {
   metadata?: Record<string, string>;
 }
 
+/** Token usage reported by a provider or aggregated by an agent run. */
 export interface UsageSummary {
   input: number;
   output: number;
@@ -81,6 +102,7 @@ export interface UsageSummary {
   cache_write?: number;
 }
 
+/** Request body for {@link MakaiAgentApi.run} and {@link MakaiAgentApi.stream}. */
 export interface AgentRunRequest {
   model_ref: string;
   messages: ChatMessage[];
@@ -88,6 +110,7 @@ export interface AgentRunRequest {
   options?: RunOptions;
 }
 
+/** Final non-streaming assistant response returned by provider and agent APIs. */
 export interface CompletionResponse {
   message: {
     role: "assistant";
@@ -100,8 +123,10 @@ export interface CompletionResponse {
   stop_reason?: StopReason;
 }
 
+/** Final response returned by {@link MakaiAgentApi.run}. */
 export type AgentRunResponse = CompletionResponse;
 
+/** Streaming events emitted by {@link MakaiProviderApi.stream}. */
 export type ProviderStreamEvent =
   | { type: "message_start"; provider_id?: ProviderId; api?: ApiId; model_id?: string }
   | { type: "text_delta"; delta: string }
@@ -110,6 +135,7 @@ export type ProviderStreamEvent =
   | { type: "message_end"; usage?: UsageSummary; stop_reason?: StopReason }
   | { type: "error"; message: string; code?: string; provider_id?: string };
 
+/** Streaming events emitted by {@link MakaiAgentApi.stream}, including provider events. */
 export type AgentStreamEvent =
   | ProviderStreamEvent
   | { type: "agent_start"; session_id?: string }
@@ -119,6 +145,7 @@ export type AgentStreamEvent =
   | { type: "tool_execution_start"; tool_call_id: string; tool_name: string }
   | { type: "tool_execution_end"; tool_call_id: string; is_error?: boolean };
 
+/** Request body for {@link MakaiProviderApi.complete} and {@link MakaiProviderApi.stream}. */
 export interface ProviderCompleteRequest {
   model_ref: string;
   messages: ChatMessage[];
@@ -126,25 +153,62 @@ export interface ProviderCompleteRequest {
   options?: RunOptions;
 }
 
+/** Final response returned by {@link MakaiProviderApi.complete}. */
 export type ProviderCompleteResponse = CompletionResponse;
 
+/** High-level agent execution API. */
 export interface MakaiAgentApi {
+  /**
+   * Runs the agent loop to completion.
+   *
+   * @param request Agent run request.
+   * @returns Final assistant response.
+   * @throws {@link MakaiStreamError} for execution or transport failures.
+   */
   run(request: AgentRunRequest): Promise<AgentRunResponse>;
+  /**
+   * Streams agent lifecycle and provider events.
+   *
+   * @param request Agent run request.
+   * @returns Async iterable of {@link AgentStreamEvent} values.
+   * @throws {@link MakaiStreamError} while iterating on execution or transport failures.
+   */
   stream(request: AgentRunRequest): AsyncIterable<AgentStreamEvent>;
 }
 
+/** Direct provider execution API that bypasses the agent loop. */
 export interface MakaiProviderApi {
+  /**
+   * Requests a non-streaming completion directly from a provider.
+   *
+   * @param request Provider completion request.
+   * @returns Final assistant response.
+   * @throws {@link MakaiStreamError} for provider or transport failures.
+   */
   complete(request: ProviderCompleteRequest): Promise<ProviderCompleteResponse>;
+  /**
+   * Streams provider response events directly from a provider.
+   *
+   * @param request Provider completion request.
+   * @returns Async iterable of {@link ProviderStreamEvent} values.
+   * @throws {@link MakaiStreamError} while iterating on provider or transport failures.
+   */
   stream(request: ProviderCompleteRequest): AsyncIterable<ProviderStreamEvent>;
 }
 
+/** Categorizes failures raised by Makai streaming and completion APIs. */
 export type MakaiStreamErrorKind = "provider_error" | "transport_error" | "aborted" | "unknown";
 
+/** Error thrown for provider, stream, transport, cancellation, and unknown execution failures. */
 export class MakaiStreamError extends Error {
   public readonly kind: MakaiStreamErrorKind;
   public readonly code?: string;
   public readonly provider_id?: string;
 
+  /**
+   * @param message Human-readable error message.
+   * @param options Optional structured error metadata.
+   */
   constructor(message: string, options: { kind?: MakaiStreamErrorKind; code?: string; provider_id?: string } = {}) {
     super(message);
     this.name = "MakaiStreamError";
@@ -154,10 +218,15 @@ export class MakaiStreamError extends Error {
   }
 }
 
+/** Error thrown when a request requires provider authentication before it can continue. */
 export class MakaiAuthRequiredError extends MakaiStreamError {
   public readonly code = "auth_required";
   public readonly provider_id: ProviderId;
 
+  /**
+   * @param providerId Provider that requires authentication.
+   * @param message Optional custom message.
+   */
   constructor(providerId: ProviderId, message = `authentication required for provider ${providerId}`) {
     super(message, { kind: "provider_error", code: "auth_required", provider_id: providerId });
     this.name = "MakaiAuthRequiredError";
@@ -165,6 +234,7 @@ export class MakaiAuthRequiredError extends MakaiStreamError {
   }
 }
 
+/** Options shared by {@link createMakaiClient} execution, auth, and frame handling. */
 export interface MakaiClientOptions {
   auth?: {
     auth_retry_policy?: AuthRetryPolicy;

--- a/typescript/src/models_client.ts
+++ b/typescript/src/models_client.ts
@@ -81,6 +81,7 @@ const KNOWN_REASONING_LEVELS: ReadonlySet<string> = new Set([
   "xhigh",
 ]);
 
+/** Options for {@link createMakaiModelsApi}. */
 export interface ModelsApiOptions {
   /** How long `list` / `resolve` waits for a terminal response frame. */
   responseTimeoutMs?: number;
@@ -92,6 +93,16 @@ export interface ModelsApiOptions {
  *
  * The transport is shared, so do not interleave concurrent calls without
  * external synchronization — V1 frame correlation is sequential per stream.
+ *
+ * @param client Connected stdio client used to exchange model-discovery frames.
+ * @param options Response timeout configuration.
+ * @returns A models API facade bound to the supplied transport.
+ *
+ * @example
+ * ```ts
+ * const models = createMakaiModelsApi(transport);
+ * const { models: available } = await models.list();
+ * ```
  */
 export function createMakaiModelsApi(
   client: MakaiStdioClient,

--- a/typescript/src/models_types.ts
+++ b/typescript/src/models_types.ts
@@ -7,8 +7,10 @@
  * per spec §9 (additive-only V1 evolution rule).
  */
 
+/** Stable identifier for a provider configured in the Makai runtime. */
 export type ProviderId = string;
 
+/** Identifier for a provider API implementation supported by Makai. */
 export type ApiId =
   | "anthropic-messages"
   | "openai-completions"
@@ -20,6 +22,7 @@ export type ApiId =
   // Open union for forward compatibility with future providers.
   | (string & {});
 
+/** Authentication state reported for a provider or model. */
 export type AuthStatus =
   | "authenticated"
   | "login_required"
@@ -29,8 +32,10 @@ export type AuthStatus =
   | "failed"
   | "unknown";
 
+/** Lifecycle state for a model descriptor. */
 export type ModelLifecycle = "stable" | "preview" | "deprecated";
 
+/** Capability advertised by a model. */
 export type ModelCapability =
   | "chat"
   | "streaming"
@@ -41,10 +46,13 @@ export type ModelCapability =
   | "audio_input"
   | "audio_output";
 
+/** Indicates whether model metadata came from live discovery or bundled fallback data. */
 export type ModelSource = "dynamic" | "static_fallback";
 
+/** Supported reasoning-effort levels for models that expose reasoning controls. */
 export type ReasoningLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
 
+/** Describes one model returned by {@link MakaiModelsApi.list} or {@link MakaiModelsApi.resolve}. */
 export interface ModelDescriptor {
   /** Opaque, server-issued stable handle. Clients must not parse it. */
   model_ref: string;
@@ -63,6 +71,7 @@ export interface ModelDescriptor {
   metadata?: Record<string, string>;
 }
 
+/** Filters accepted by {@link MakaiModelsApi.list}. */
 export interface ListModelsRequest {
   provider_id?: ProviderId;
   api?: ApiId;
@@ -72,24 +81,42 @@ export interface ListModelsRequest {
   include_login_required?: boolean;
 }
 
+/** Response returned by {@link MakaiModelsApi.list}. */
 export interface ListModelsResponse {
   models: ModelDescriptor[];
   fetched_at_ms: number;
   cache_max_age_ms: number;
 }
 
+/** Request used by {@link MakaiModelsApi.resolve} to find exactly one model. */
 export interface ResolveModelRequest {
   provider_id: ProviderId;
   api?: ApiId;
   model_id: string;
 }
 
+/** Response returned by {@link MakaiModelsApi.resolve}. */
 export interface ResolveModelResponse {
   model: ModelDescriptor;
 }
 
+/** Model discovery API exposed as `client.models`. */
 export interface MakaiModelsApi {
+  /**
+   * Lists available models, optionally filtered by provider, API, or model ID.
+   *
+   * @param request Optional model filters.
+   * @returns Model descriptors and cache metadata.
+   * @throws {@link MakaiProtocolError} on protocol failures or malformed responses.
+   */
   list(request?: ListModelsRequest): Promise<ListModelsResponse>;
+  /**
+   * Resolves one exact model by provider, model ID, and optional API.
+   *
+   * @param request Exact model lookup request.
+   * @returns The matching model descriptor.
+   * @throws {@link MakaiProtocolError} if no model, multiple models, or malformed data is returned.
+   */
   resolve(request: ResolveModelRequest): Promise<ResolveModelResponse>;
 }
 
@@ -101,6 +128,10 @@ export interface MakaiModelsApi {
  * or a synthetic code when the client itself rejects a malformed reply.
  */
 export class MakaiProtocolError extends Error {
+  /**
+   * @param message Human-readable protocol failure.
+   * @param code Optional protocol error code.
+   */
   constructor(
     message: string,
     public readonly code?: string,

--- a/typescript/src/stdio_client.ts
+++ b/typescript/src/stdio_client.ts
@@ -2,11 +2,13 @@ import { ChildProcessWithoutNullStreams, spawn } from "node:child_process";
 import { createInterface, Interface as ReadlineInterface } from "node:readline";
 import { BinaryResolverOptions, resolveMakaiBinary } from "./binary_resolver";
 
+/** A single JSON-line protocol frame exchanged with `makai --stdio`. */
 export type StdioFrame = {
   type: string;
   [key: string]: unknown;
 };
 
+/** Options for constructing a {@link MakaiStdioClient}. */
 export type MakaiStdioClientOptions = {
   command: string;
   args?: string[];
@@ -20,7 +22,12 @@ export type MakaiStdioClientOptions = {
 /** @deprecated Use MakaiStdioClientOptions. Kept for backward compatibility. */
 export type MakaiClientOptions = MakaiStdioClientOptions;
 
+/** Error raised for stdio protocol negotiation failures. */
 export class StdioProtocolError extends Error {
+  /**
+   * @param message Human-readable protocol failure.
+   * @param code Optional protocol error code.
+   */
   constructor(
     message: string,
     public readonly code?: string,
@@ -49,6 +56,7 @@ type StreamQueueEntry = {
 
 const STREAM_FRAME_QUEUE_TTL_MS = 30_000;
 
+/** Low-level stdio transport client used by higher-level Makai APIs. */
 export class MakaiStdioClient {
   private readonly options: Required<Pick<MakaiStdioClientOptions, "args" | "expectedProtocolVersion" | "handshakeTimeoutMs" | "streamFrameQueueTtlMs">> &
     Omit<MakaiStdioClientOptions, "args" | "expectedProtocolVersion" | "handshakeTimeoutMs" | "streamFrameQueueTtlMs">;
@@ -61,6 +69,9 @@ export class MakaiStdioClient {
   private sessionFrameQueues = new Map<string, StreamQueueEntry[]>();
   private streamReadLock: Promise<void> = Promise.resolve();
 
+  /**
+   * @param options Command, process, handshake, and queue options.
+   */
   constructor(options: MakaiStdioClientOptions) {
     this.options = {
       ...options,
@@ -71,6 +82,11 @@ export class MakaiStdioClient {
     };
   }
 
+  /**
+   * Spawns the stdio process and waits for the protocol handshake.
+   *
+   * @throws If the client is already connected, the process errors, or handshake fails.
+   */
   async connect(): Promise<void> {
     if (this.child) {
       throw new Error("client is already connected");
@@ -107,6 +123,12 @@ export class MakaiStdioClient {
     });
   }
 
+  /**
+   * Sends one JSON frame to the child process.
+   *
+   * @param frame Frame to serialize and write.
+   * @throws If the client is not connected.
+   */
   send(frame: StdioFrame): void {
     if (!this.child) {
       throw new Error("client is not connected");
@@ -114,6 +136,13 @@ export class MakaiStdioClient {
     this.child.stdin.write(`${JSON.stringify(frame)}\n`);
   }
 
+  /**
+   * Waits for the next unrouted frame from the transport.
+   *
+   * @param timeoutMs Maximum wait time in milliseconds.
+   * @returns The next frame.
+   * @throws If no frame arrives before the timeout.
+   */
   nextFrame(timeoutMs = 1000): Promise<StdioFrame> {
     if (this.frameQueue.length > 0) {
       return Promise.resolve(this.frameQueue.shift()!);
@@ -126,6 +155,14 @@ export class MakaiStdioClient {
     });
   }
 
+  /**
+   * Waits for the next frame matching a stream ID.
+   *
+   * @param streamId Stream identifier to route by.
+   * @param timeoutMs Maximum wait time in milliseconds.
+   * @returns The next matching frame.
+   * @throws If `streamId` is empty or no matching frame arrives before timeout.
+   */
   async nextFrameForStream(streamId: string, timeoutMs = 1000): Promise<StdioFrame> {
     if (streamId.length === 0) {
       throw new Error("streamId is required");
@@ -162,6 +199,14 @@ export class MakaiStdioClient {
     });
   }
 
+  /**
+   * Waits for the next frame matching an agent session ID.
+   *
+   * @param sessionId Session identifier to route by.
+   * @param timeoutMs Maximum wait time in milliseconds.
+   * @returns The next matching frame.
+   * @throws If `sessionId` is empty or no matching frame arrives before timeout.
+   */
   async nextFrameForSession(sessionId: string, timeoutMs = 1000): Promise<StdioFrame> {
     if (sessionId.length === 0) {
       throw new Error("sessionId is required");
@@ -198,6 +243,11 @@ export class MakaiStdioClient {
     });
   }
 
+  /**
+   * Closes the child process and releases local handles.
+   *
+   * @returns A promise that resolves after graceful shutdown or forced termination.
+   */
   async close(): Promise<void> {
     if (!this.child) return;
 
@@ -368,6 +418,7 @@ function isNextFrameTimeout(error: unknown, timeoutMs: number): boolean {
   return error instanceof Error && error.message === `timed out waiting for frame after ${timeoutMs}ms`;
 }
 
+/** Options for {@link createMakaiStdioClient}; `command` is optional and can be resolved automatically. */
 export type CreateMakaiStdioClientOptions = Omit<MakaiStdioClientOptions, "command"> & {
   command?: string;
   resolver?: BinaryResolverOptions;
@@ -376,6 +427,13 @@ export type CreateMakaiStdioClientOptions = Omit<MakaiStdioClientOptions, "comma
 /** @deprecated Use CreateMakaiStdioClientOptions. Kept for backward compatibility. */
 export type CreateMakaiClientOptions = CreateMakaiStdioClientOptions;
 
+/**
+ * Creates an unconnected {@link MakaiStdioClient}, resolving the binary if needed.
+ *
+ * @param options Transport and binary resolver options.
+ * @returns A stdio client; call {@link MakaiStdioClient.connect} before use.
+ * @throws If binary resolution fails.
+ */
 export async function createMakaiStdioClient(
   options: CreateMakaiStdioClientOptions = {},
 ): Promise<MakaiStdioClient> {


### PR DESCRIPTION
## Summary
- Add JSDoc to exported TypeScript SDK types, interfaces, classes, and factories in the public API surface.
- Document key methods with `@param`, `@returns`, and `@throws` tags plus `{@link}` cross-references.
- Include usage examples for the main client/model/auth factory functions.

## Test plan
- [x] `npm run build:sdk`

Note: `npm run build` is not defined in package.json; `npm run build:sdk` is the available TypeScript build script.