### PR TITLE
Migrate OpenAI provider HTTP calls

### DIFF
--- a/zig/src/compat/http.zig
+++ b/zig/src/compat/http.zig
@@ -70,6 +70,12 @@ pub fn readAllResponse(reader: *ResponseReader, buffer: []u8) !void {
     try inner.readSliceAll(buffer);
 }
 
+/// Allocate and read the remaining response body up to `max_bytes`.
+pub fn allocRemainingResponse(allocator: std.mem.Allocator, reader: *ResponseReader, max_bytes: usize) ![]u8 {
+    const inner: *std.Io.Reader = @ptrCast(@alignCast(reader));
+    return inner.allocRemaining(allocator, std.Io.Limit.limited(max_bytes));
+}
+
 /// Return a streaming reader for a response body.
 pub fn responseReader(response: *Response, transfer_buf: []u8) *ResponseReader {
     return @ptrCast(@alignCast(response.reader(transfer_buf)));

--- a/zig/src/providers/azure_openai_responses_api.zig
+++ b/zig/src/providers/azure_openai_responses_api.zig
@@ -243,7 +243,7 @@ fn runThread(ctx: *ThreadCtx) void {
         }
     }
 
-    var client = std.http.Client{ .allocator = ctx.allocator, .io = if (@import("builtin").is_test) std.testing.io else std.Io.Threaded.global_single_threaded.io() };
+    var client = compat.http.HttpClient.init(ctx.allocator);
     defer client.deinit();
 
     const url = std.fmt.allocPrint(ctx.allocator, "{s}/openai/v1/responses", .{ctx.base_url}) catch {
@@ -270,22 +270,21 @@ fn runThread(ctx: *ThreadCtx) void {
         return ctx.stream.completeWithError("oom headers");
     };
 
-    var req = client.request(.POST, uri, .{ .extra_headers = headers.items }) catch {
+    var req = client.openRequest(.POST, uri, .{ .extra_headers = headers.items }) catch {
         ctx.stream.markThreadDone();
         ctx.stream.completeWithError("request failed");
         return;
     };
     defer req.deinit();
 
-    req.transfer_encoding = .{ .content_length = ctx.body.len };
-    req.sendBodyComplete(ctx.body) catch {
+    compat.http.sendRequest(&req, ctx.body) catch {
         ctx.stream.markThreadDone();
         ctx.stream.completeWithError("send failed");
         return;
     };
 
     var head_buf: [4096]u8 = undefined;
-    var response = req.receiveHead(&head_buf) catch {
+    var response = compat.http.receiveResponse(&req, &head_buf) catch {
         ctx.stream.markThreadDone();
         ctx.stream.completeWithError("receive failed");
         return;
@@ -302,7 +301,7 @@ fn runThread(ctx: *ThreadCtx) void {
 
     var transfer_buf: [4096]u8 = undefined;
     var read_buf: [8192]u8 = undefined;
-    const reader = response.reader(&transfer_buf);
+    const reader = compat.http.responseReader(&response, &transfer_buf);
 
     var text = std.ArrayList(u8).empty;
     defer text.deinit(ctx.allocator);
@@ -323,7 +322,7 @@ fn runThread(ctx: *ThreadCtx) void {
             }
         }
 
-        const n = reader.*.readSliceShort(&read_buf) catch {
+        const n = compat.http.readResponse(reader, &read_buf) catch {
             ctx.stream.markThreadDone();
             ctx.stream.completeWithError("read failed");
             return;

--- a/zig/src/providers/azure_openai_responses_api.zig
+++ b/zig/src/providers/azure_openai_responses_api.zig
@@ -291,6 +291,17 @@ fn runThread(ctx: *ThreadCtx) void {
     };
 
     if (response.head.status != .ok) {
+        // Read error body for debugging
+        var error_buf: [4096]u8 = undefined;
+        const error_reader = compat.http.responseReader(&response, &error_buf);
+        const error_body = compat.http.allocRemainingResponse(ctx.allocator, error_reader, 8192) catch null;
+        defer if (error_body) |eb| ctx.allocator.free(eb);
+
+        std.debug.print("Azure OpenAI Responses API error: status={d}, model={s}\n", .{ @intFromEnum(response.head.status), ctx.model.name });
+        if (error_body) |eb| {
+            std.debug.print("Error body: {s}\n", .{eb});
+        }
+
         ctx.stream.markThreadDone();
         ctx.stream.completeWithError("azure request failed");
         return;

--- a/zig/src/providers/openai_completions_api.zig
+++ b/zig/src/providers/openai_completions_api.zig
@@ -1069,7 +1069,7 @@ fn runThread(ctx: *ThreadCtx) void {
         }
     }
 
-    var client = std.http.Client{ .allocator = allocator, .io = if (@import("builtin").is_test) std.testing.io else std.Io.Threaded.global_single_threaded.io() };
+    var client = compat_mod.http.HttpClient.init(allocator);
     defer client.deinit();
 
     // GitHub Copilot uses /chat/completions, others use /v1/chat/completions
@@ -1182,10 +1182,10 @@ fn runThread(ctx: *ThreadCtx) void {
     const BASE_DELAY_MS: u32 = 1000;
     const max_delay_ms: u32 = if (retry_config) |rc| rc.max_retry_delay_ms orelse 60000 else 60000;
 
-    var response: std.http.Client.Response = undefined;
+    var response: compat_mod.http.Response = undefined;
     var head_buf: [4096]u8 = undefined;
     var retry_attempt: u8 = 0;
-    var req: std.http.Client.Request = undefined;
+    var req: compat_mod.http.Request = undefined;
     var req_initialized = false;
     defer if (req_initialized) req.deinit();
 
@@ -1206,7 +1206,7 @@ fn runThread(ctx: *ThreadCtx) void {
             req_initialized = false;
         }
 
-        req = client.request(.POST, uri, .{ .extra_headers = headers.items }) catch {
+        req = client.openRequest(.POST, uri, .{ .extra_headers = headers.items }) catch {
             // Network error - check if we should retry
             if (retry_attempt < MAX_RETRIES) {
                 const delay = retry.calculateDelay(retry_attempt, BASE_DELAY_MS, max_delay_ms);
@@ -1227,9 +1227,7 @@ fn runThread(ctx: *ThreadCtx) void {
         };
         req_initialized = true;
 
-        req.transfer_encoding = .{ .content_length = request_body.len };
-
-        req.sendBodyComplete(request_body) catch {
+        compat_mod.http.sendRequest(&req, request_body) catch {
             // Network error - check if we should retry
             if (retry_attempt < MAX_RETRIES) {
                 const delay = retry.calculateDelay(retry_attempt, BASE_DELAY_MS, max_delay_ms);
@@ -1249,7 +1247,7 @@ fn runThread(ctx: *ThreadCtx) void {
             return;
         };
 
-        response = req.receiveHead(&head_buf) catch {
+        response = compat_mod.http.receiveResponse(&req, &head_buf) catch {
             // Network error - check if we should retry
             if (retry_attempt < MAX_RETRIES) {
                 const delay = retry.calculateDelay(retry_attempt, BASE_DELAY_MS, max_delay_ms);
@@ -1339,7 +1337,8 @@ fn runThread(ctx: *ThreadCtx) void {
     if (response.head.status != .ok) {
         // Read error body for debugging
         var error_buf: [4096]u8 = undefined;
-        const error_body = response.reader(&error_buf).*.allocRemaining(allocator, std.Io.Limit.limited(8192)) catch null;
+        const error_reader = compat_mod.http.responseReader(&response, &error_buf);
+        const error_body = compat_mod.http.allocRemainingResponse(allocator, error_reader, 8192) catch null;
         defer if (error_body) |eb| allocator.free(eb);
 
         std.debug.print("OpenAI API error: status={d}, model={s}\n", .{ @intFromEnum(response.head.status), model.name });
@@ -1388,7 +1387,7 @@ fn runThread(ctx: *ThreadCtx) void {
 
     var transfer_buf: [4096]u8 = undefined;
     var read_buf: [8192]u8 = undefined;
-    const reader = response.reader(&transfer_buf);
+    const reader = compat_mod.http.responseReader(&response, &transfer_buf);
 
     // Ping tracking
     var last_ping_time: i64 = 0;
@@ -1429,7 +1428,7 @@ fn runThread(ctx: *ThreadCtx) void {
             }
         }
 
-        const n = reader.*.readSliceShort(&read_buf) catch {
+        const n = compat_mod.http.readResponse(reader, &read_buf) catch {
             ctx.deinit();
             stream.markThreadDone();
             stream.completeWithError("read error");

--- a/zig/src/providers/openai_responses_api.zig
+++ b/zig/src/providers/openai_responses_api.zig
@@ -890,6 +890,17 @@ fn runThread(ctx: *ThreadCtx) void {
 
     // After retry loop, check final status
     if (response.head.status != .ok) {
+        // Read error body for debugging
+        var error_buf: [4096]u8 = undefined;
+        const error_reader = compat.http.responseReader(&response, &error_buf);
+        const error_body = compat.http.allocRemainingResponse(allocator, error_reader, 8192) catch null;
+        defer if (error_body) |eb| allocator.free(eb);
+
+        std.debug.print("OpenAI Responses API error: status={d}, model={s}\n", .{ @intFromEnum(response.head.status), model.name });
+        if (error_body) |eb| {
+            std.debug.print("Error body: {s}\n", .{eb});
+        }
+
         allocator.free(auth);
         allocator.free(url);
         allocator.free(api_key);

--- a/zig/src/providers/openai_responses_api.zig
+++ b/zig/src/providers/openai_responses_api.zig
@@ -644,7 +644,7 @@ fn runThread(ctx: *ThreadCtx) void {
         }
     }
 
-    var client = std.http.Client{ .allocator = allocator, .io = if (@import("builtin").is_test) std.testing.io else std.Io.Threaded.global_single_threaded.io() };
+    var client = compat.http.HttpClient.init(allocator);
     defer client.deinit();
 
     const url = buildUrlWithSuffix(allocator, model.base_url, "/v1/responses") catch {
@@ -705,10 +705,10 @@ fn runThread(ctx: *ThreadCtx) void {
     const BASE_DELAY_MS: u32 = 1000;
     const max_delay_ms: u32 = if (retry_opts) |rc| rc.max_retry_delay_ms orelse 60000 else 60000;
 
-    var response: std.http.Client.Response = undefined;
+    var response: compat.http.Response = undefined;
     var head_buf: [4096]u8 = undefined;
     var retry_attempt: u8 = 0;
-    var req: std.http.Client.Request = undefined;
+    var req: compat.http.Request = undefined;
     var req_initialized = false;
     defer if (req_initialized) req.deinit();
 
@@ -733,7 +733,7 @@ fn runThread(ctx: *ThreadCtx) void {
             req_initialized = false;
         }
 
-        req = client.request(.POST, uri, .{ .extra_headers = headers.items }) catch {
+        req = client.openRequest(.POST, uri, .{ .extra_headers = headers.items }) catch {
             // Network error - check if we should retry
             if (retry_attempt < MAX_RETRIES) {
                 const delay = retry_util.calculateDelay(retry_attempt, BASE_DELAY_MS, max_delay_ms);
@@ -762,8 +762,7 @@ fn runThread(ctx: *ThreadCtx) void {
         };
         req_initialized = true;
 
-        req.transfer_encoding = .{ .content_length = body.len };
-        req.sendBodyComplete(body) catch {
+        compat.http.sendRequest(&req, body) catch {
             // Network error - check if we should retry
             if (retry_attempt < MAX_RETRIES) {
                 const delay = retry_util.calculateDelay(retry_attempt, BASE_DELAY_MS, max_delay_ms);
@@ -791,7 +790,7 @@ fn runThread(ctx: *ThreadCtx) void {
             return;
         };
 
-        response = req.receiveHead(&head_buf) catch {
+        response = compat.http.receiveResponse(&req, &head_buf) catch {
             // Network error - check if we should retry
             if (retry_attempt < MAX_RETRIES) {
                 const delay = retry_util.calculateDelay(retry_attempt, BASE_DELAY_MS, max_delay_ms);
@@ -906,7 +905,7 @@ fn runThread(ctx: *ThreadCtx) void {
 
     var transfer_buf: [4096]u8 = undefined;
     var read_buf: [8192]u8 = undefined;
-    const reader = response.reader(&transfer_buf);
+    const reader = compat.http.responseReader(&response, &transfer_buf);
 
     var text = std.ArrayList(u8).empty;
     defer text.deinit(allocator);
@@ -990,7 +989,7 @@ fn runThread(ctx: *ThreadCtx) void {
             }
         }
 
-        const n = reader.*.readSliceShort(&read_buf) catch {
+        const n = compat.http.readResponse(reader, &read_buf) catch {
             allocator.free(auth);
             allocator.free(url);
             allocator.free(api_key);


### PR DESCRIPTION
## Summary
- Route OpenAI Completions, OpenAI Responses, and Azure OpenAI Responses provider requests through the shared HTTP compatibility abstraction.
- Add an HTTP seam helper for bounded error-body reads so OpenAI error-body handling remains preserved.
- Keep streaming/cancellation, usage accounting, and tool-call delta parsing behavior unchanged.

References: Zig 0.15.2 → 0.16.0 Migration — OpenAI/Azure provider migration

## Test plan
- [x] `cd zig && zig build test-unit-providers`
- [x] `cd zig && zig build test-e2e-protocol`
- [x] `cd zig && zig build test`