### PR TITLE
Improve timeout diagnostics in TypeScript SDK

### DIFF
--- a/typescript/src/auth_protocol.ts
+++ b/typescript/src/auth_protocol.ts
@@ -6,6 +6,13 @@ import {
   createMakaiStdioClient,
   type CreateMakaiStdioClientOptions,
 } from "./stdio_client";
+import {
+  createTimeoutDiagnostics,
+  formatTimeoutMessage,
+  isTimeoutLikeError,
+  type TimeoutDiagnosticContext,
+  type TimeoutDiagnostics,
+} from "./timeout_diagnostics";
 
 // ---------------------------------------------------------------------------
 // Spec-aligned types (docs/v1-sdk-agent-provider-spec.md §3, §3.6, §4).
@@ -85,15 +92,17 @@ export type MakaiAuthErrorKind =
 export class MakaiAuthError extends Error {
   public readonly kind: MakaiAuthErrorKind;
   public readonly code?: string;
+  public readonly diagnostics?: TimeoutDiagnostics;
 
   constructor(
     message: string,
-    options: { kind?: MakaiAuthErrorKind; code?: string } = {},
+    options: { kind?: MakaiAuthErrorKind; code?: string; diagnostics?: TimeoutDiagnostics } = {},
   ) {
     super(message);
     this.name = "MakaiAuthError";
     this.kind = options.kind ?? "unknown";
     this.code = options.code;
+    this.diagnostics = options.diagnostics;
   }
 }
 
@@ -272,7 +281,10 @@ export class MakaiAuthClient implements MakaiAuthApi {
     this.sendOrThrow(envelope);
 
     while (true) {
-      const frame = await this.nextFrameForStream(streamId);
+      const frame = await this.nextFrameForStream(streamId, {
+        operation: "auth_providers_response",
+        message_id: messageId,
+      });
       if (frame.type === "ack") continue;
       if (frame.type === "nack") {
         throw nackToAuthError(frame);
@@ -299,10 +311,11 @@ export class MakaiAuthClient implements MakaiAuthApi {
     const flowId = ulid();
     let outboundSequence = 1;
 
+    const startMessageId = ulid();
     this.sendOrThrow({
       type: "auth_login_start",
       stream_id: flowId,
-      message_id: ulid(),
+      message_id: startMessageId,
       sequence: outboundSequence++,
       timestamp: Date.now(),
       version: PROTOCOL_VERSION,
@@ -315,7 +328,11 @@ export class MakaiAuthClient implements MakaiAuthApi {
     let cancelled = false;
 
     while (true) {
-      const frame = await this.nextFrameForStream(flowId);
+      const frame = await this.nextFrameForStream(flowId, {
+        operation: "auth_login_result/auth_event",
+        message_id: startMessageId,
+        provider_id: providerId,
+      });
 
       if (frame.type === "ack") continue;
       if (frame.type === "nack") {
@@ -413,18 +430,26 @@ export class MakaiAuthClient implements MakaiAuthApi {
 
   private async drainLoginResult(flowId: string): Promise<void> {
     while (true) {
-      const frame = await this.nextFrameForStream(flowId);
+      const frame = await this.nextFrameForStream(flowId, {
+        operation: "auth_login_result",
+      });
       if (frame.type === "auth_login_result") return;
     }
   }
 
-  private async nextFrameForStream(streamId: string): Promise<RawEnvelope> {
+  private async nextFrameForStream(streamId: string, context: Omit<TimeoutDiagnosticContext, "timeout_ms" | "stream_id">): Promise<RawEnvelope> {
     try {
       return (await this.transport.nextFrameForStream(streamId, this.frameTimeoutMs)) as RawEnvelope;
     } catch (error) {
+      const diagnosticsContext = { ...context, timeout_ms: this.frameTimeoutMs, stream_id: streamId };
       throw new MakaiAuthError(
-        error instanceof Error ? error.message : String(error),
-        { kind: "transport_error" },
+        isTimeoutLikeError(error)
+          ? formatTimeoutMessage(diagnosticsContext)
+          : error instanceof Error ? error.message : String(error),
+        {
+          kind: "transport_error",
+          diagnostics: isTimeoutLikeError(error) ? createTimeoutDiagnostics(diagnosticsContext) : undefined,
+        },
       );
     }
   }

--- a/typescript/src/execution_client.ts
+++ b/typescript/src/execution_client.ts
@@ -6,6 +6,12 @@ import { createMakaiModelsApi } from "./models_client";
 import type { MakaiModelsApi } from "./models_types";
 import { type CreateMakaiStdioClientOptions, createMakaiStdioClient, MakaiStdioClient, type StdioFrame } from "./stdio_client";
 import {
+  createTimeoutDiagnostics,
+  formatTimeoutMessage,
+  isTimeoutLikeError,
+  type TimeoutDiagnosticContext,
+} from "./timeout_diagnostics";
+import {
   MakaiAuthRequiredError,
   MakaiStreamError,
   type AgentRunRequest,
@@ -106,8 +112,9 @@ class StdioProviderApi implements MakaiProviderApi {
     const streamId = ulid();
     const fallbackProviderId = providerIdFromRequest(request);
     this.transport.send(buildEnvelope("complete_request", streamId, buildExecutionPayload(request, { authRetryPolicy: effectivePolicy })));
+    const timeoutContext = executionTimeoutContext("provider complete_response", this.responseTimeoutMs, streamId, request);
     while (true) {
-      const frame = await nextFrame(this.transport, streamId, this.responseTimeoutMs);
+      const frame = await nextFrame(this.transport, streamId, timeoutContext);
       if (frame.type === "ack") continue;
       if (frame.type === "nack") throw nackToStreamError(frame, fallbackProviderId);
       if (frame.type === "stream_error") throw streamErrorFrameToError(frame);
@@ -161,11 +168,12 @@ class StdioProviderApi implements MakaiProviderApi {
     const streamId = ulid();
     const fallbackProviderId = providerIdFromRequest(request);
     this.transport.send(buildEnvelope("stream_request", streamId, buildExecutionPayload(request, { suppressPartial: true, authRetryPolicy: effectivePolicy })));
+    const timeoutContext = executionTimeoutContext("provider stream event", this.responseTimeoutMs, streamId, request);
     let terminal = false;
     const toolBuffers = new Map<number, { id?: string; name?: string; args: string }>();
     try {
       while (!terminal) {
-        const frame = await nextFrame(this.transport, streamId, this.responseTimeoutMs);
+        const frame = await nextFrame(this.transport, streamId, timeoutContext);
         if (frame.type === "ack") continue;
         if (frame.type === "nack") throw nackToStreamError(frame, fallbackProviderId);
         const event = normalizeProviderFrame(frame, toolBuffers);
@@ -225,11 +233,12 @@ class StdioAgentApi implements MakaiAgentApi {
     const sessionId = agentSessionId(request);
     const fallbackProviderId = providerIdFromRequest(request);
     this.transport.send(buildAgentEnvelope("agent_start", sessionId, 1, buildAgentStartPayload(request, sessionId)));
+    const timeoutContext = agentTimeoutContext("agent result", this.responseTimeoutMs, sessionId, request);
     const events: AgentStreamEvent[] = [];
     const toolBuffers = new Map<number, { id?: string; name?: string; args: string }>();
     let messageSent = false;
     while (true) {
-      const frame = await nextAgentFrame(this.transport, sessionId, this.responseTimeoutMs);
+      const frame = await nextAgentFrame(this.transport, sessionId, timeoutContext);
       if (frame.type === "ack") continue;
       if (frame.type === "nack") throw nackToStreamError(frame, fallbackProviderId);
       if (frame.type === "agent_error") throw streamErrorFrameToError(frame);
@@ -303,6 +312,7 @@ class StdioAgentApi implements MakaiAgentApi {
     const sessionId = agentSessionId(request);
     const fallbackProviderId = providerIdFromRequest(request);
     this.transport.send(buildAgentEnvelope("agent_start", sessionId, 1, buildAgentStartPayload(request, sessionId)));
+    const timeoutContext = agentTimeoutContext("agent stream event", this.responseTimeoutMs, sessionId, request);
     let terminal = false;
     let messageSent = false;
     let started = false;
@@ -310,7 +320,7 @@ class StdioAgentApi implements MakaiAgentApi {
     const toolBuffers = new Map<number, { id?: string; name?: string; args: string }>();
     try {
       while (!terminal) {
-        const frame = await nextAgentFrame(this.transport, sessionId, this.responseTimeoutMs);
+        const frame = await nextAgentFrame(this.transport, sessionId, timeoutContext);
         if (frame.type === "ack") continue;
         if (frame.type === "nack") throw nackToStreamError(frame, fallbackProviderId);
         if (frame.type === "agent_started" && !messageSent) {
@@ -551,19 +561,74 @@ function serializeOptionsWithDefaults(
   return out;
 }
 
-async function nextFrame(transport: MakaiStdioClient, streamId: string, timeoutMs: number): Promise<StdioFrame> {
+async function nextFrame(transport: MakaiStdioClient, streamId: string, context: TimeoutDiagnosticContext): Promise<StdioFrame> {
   try {
-    return await transport.nextFrameForStream(streamId, timeoutMs);
+    return await transport.nextFrameForStream(streamId, context.timeout_ms);
   } catch (error) {
-    throw new MakaiStreamError(error instanceof Error ? error.message : String(error), { kind: "transport_error" });
+    throw timeoutAwareStreamError(error, context);
   }
 }
 
-async function nextAgentFrame(transport: MakaiStdioClient, sessionId: string, timeoutMs: number): Promise<StdioFrame> {
+async function nextAgentFrame(transport: MakaiStdioClient, sessionId: string, context: TimeoutDiagnosticContext): Promise<StdioFrame> {
   try {
-    return await transport.nextFrameForSession(sessionId, timeoutMs);
+    return await transport.nextFrameForSession(sessionId, context.timeout_ms);
   } catch (error) {
-    throw new MakaiStreamError(error instanceof Error ? error.message : String(error), { kind: "transport_error" });
+    throw timeoutAwareStreamError(error, context);
+  }
+}
+
+function timeoutAwareStreamError(error: unknown, context: TimeoutDiagnosticContext): MakaiStreamError {
+  if (isTimeoutLikeError(error)) {
+    return new MakaiStreamError(formatTimeoutMessage(context), {
+      kind: "transport_error",
+      diagnostics: createTimeoutDiagnostics(context),
+    });
+  }
+  return new MakaiStreamError(error instanceof Error ? error.message : String(error), { kind: "transport_error" });
+}
+
+function executionTimeoutContext(
+  operation: string,
+  timeoutMs: number,
+  streamId: string,
+  request: ProviderCompleteRequest | AgentRunRequest,
+): TimeoutDiagnosticContext {
+  const parsed = safeParseModelRef(request.model_ref);
+  return {
+    operation,
+    timeout_ms: timeoutMs,
+    stream_id: streamId,
+    message_id: streamId,
+    provider_id: parsed?.providerId,
+    api: parsed?.api,
+    model_ref: request.model_ref,
+    model_id: parsed?.modelId,
+  };
+}
+
+function agentTimeoutContext(
+  operation: string,
+  timeoutMs: number,
+  sessionId: string,
+  request: AgentRunRequest,
+): TimeoutDiagnosticContext {
+  const parsed = safeParseModelRef(request.model_ref);
+  return {
+    operation,
+    timeout_ms: timeoutMs,
+    session_id: sessionId,
+    provider_id: parsed?.providerId,
+    api: parsed?.api,
+    model_ref: request.model_ref,
+    model_id: parsed?.modelId,
+  };
+}
+
+function safeParseModelRef(modelRef: string): ReturnType<typeof parseModelRef> | undefined {
+  try {
+    return parseModelRef(modelRef);
+  } catch {
+    return undefined;
   }
 }
 

--- a/typescript/src/execution_types.ts
+++ b/typescript/src/execution_types.ts
@@ -1,5 +1,6 @@
 import type { ApiId, ProviderId } from "./models_types";
 import type { AuthFlowHandlers } from "./auth_protocol";
+import type { TimeoutDiagnostics } from "./timeout_diagnostics";
 
 export type AuthRetryPolicy = "manual" | "auto_once";
 
@@ -144,13 +145,15 @@ export class MakaiStreamError extends Error {
   public readonly kind: MakaiStreamErrorKind;
   public readonly code?: string;
   public readonly provider_id?: string;
+  public readonly diagnostics?: TimeoutDiagnostics;
 
-  constructor(message: string, options: { kind?: MakaiStreamErrorKind; code?: string; provider_id?: string } = {}) {
+  constructor(message: string, options: { kind?: MakaiStreamErrorKind; code?: string; provider_id?: string; diagnostics?: TimeoutDiagnostics } = {}) {
     super(message);
     this.name = "MakaiStreamError";
     this.kind = options.kind ?? "unknown";
     this.code = options.code;
     this.provider_id = options.provider_id;
+    this.diagnostics = options.diagnostics;
   }
 }
 

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -74,6 +74,11 @@ export {
 } from "./execution_types";
 
 export {
+  type TimeoutDiagnosticContext,
+  type TimeoutDiagnostics,
+} from "./timeout_diagnostics";
+
+export {
   MakaiProtocolError,
   // Note: `AuthStatus` and `ProviderId` are re-exported from `./auth_protocol`
   // above. The structurally-identical aliases in `./models_types` are kept

--- a/typescript/src/models_client.ts
+++ b/typescript/src/models_client.ts
@@ -35,6 +35,12 @@ import {
   ResolveModelResponse,
 } from "./models_types";
 import { MakaiStdioClient, StdioFrame } from "./stdio_client";
+import {
+  createTimeoutDiagnostics,
+  formatTimeoutMessage,
+  isTimeoutLikeError,
+  type TimeoutDiagnosticContext,
+} from "./timeout_diagnostics";
 
 const ENVELOPE_VERSION = 1;
 const DEFAULT_CACHE_MAX_AGE_MS = 300_000; // spec §2.3 fallback when server omits
@@ -154,12 +160,16 @@ class StdioModelsApi implements MakaiModelsApi {
     return { model };
   }
 
-  private async nextFrameForStream(streamId: string, timeoutMs: number): Promise<StdioFrame> {
+  private async nextFrameForStream(streamId: string, timeoutMs: number, context: TimeoutDiagnosticContext): Promise<StdioFrame> {
     try {
       return await this.client.nextFrameForStream(streamId, timeoutMs);
     } catch (error) {
       throw new MakaiProtocolError(
-        error instanceof Error ? error.message : String(error),
+        isTimeoutLikeError(error)
+          ? formatTimeoutMessage(context)
+          : error instanceof Error ? error.message : String(error),
+        undefined,
+        { diagnostics: isTimeoutLikeError(error) ? createTimeoutDiagnostics(context) : undefined },
       );
     }
   }
@@ -177,15 +187,26 @@ class StdioModelsApi implements MakaiModelsApi {
     };
     this.client.send(envelope);
 
+    const timeoutContext: TimeoutDiagnosticContext = {
+      operation: "models_response",
+      timeout_ms: this.responseTimeoutMs,
+      stream_id: streamId,
+      message_id: streamId,
+      provider_id: request.provider_id,
+      api: request.api,
+      model_id: request.model_id,
+    };
     const deadline = Date.now() + this.responseTimeoutMs;
     while (true) {
       const remaining = deadline - Date.now();
       if (remaining <= 0) {
         throw new MakaiProtocolError(
-          `models_request timed out after ${this.responseTimeoutMs}ms`,
+          formatTimeoutMessage(timeoutContext),
+          undefined,
+          { diagnostics: createTimeoutDiagnostics(timeoutContext) },
         );
       }
-      const frame = await this.nextFrameForStream(streamId, remaining);
+      const frame = await this.nextFrameForStream(streamId, remaining, timeoutContext);
 
       switch (frame.type) {
         case "ack":

--- a/typescript/src/models_types.ts
+++ b/typescript/src/models_types.ts
@@ -7,6 +7,8 @@
  * per spec §9 (additive-only V1 evolution rule).
  */
 
+import type { TimeoutDiagnostics } from "./timeout_diagnostics";
+
 export type ProviderId = string;
 
 export type ApiId =
@@ -101,11 +103,15 @@ export interface MakaiModelsApi {
  * or a synthetic code when the client itself rejects a malformed reply.
  */
 export class MakaiProtocolError extends Error {
+  public readonly diagnostics?: TimeoutDiagnostics;
+
   constructor(
     message: string,
     public readonly code?: string,
+    options: { diagnostics?: TimeoutDiagnostics } = {},
   ) {
     super(message);
     this.name = "MakaiProtocolError";
+    this.diagnostics = options.diagnostics;
   }
 }

--- a/typescript/src/timeout_diagnostics.ts
+++ b/typescript/src/timeout_diagnostics.ts
@@ -1,0 +1,59 @@
+export type TimeoutDiagnosticContext = {
+  operation: string;
+  timeout_ms: number;
+  stream_id?: string;
+  message_id?: string;
+  session_id?: string;
+  provider_id?: string;
+  api?: string;
+  model_ref?: string;
+  model_id?: string;
+};
+
+export type TimeoutDiagnostics = TimeoutDiagnosticContext & {
+  suggestions: string[];
+};
+
+export type ErrorWithDiagnostics = Error & {
+  diagnostics?: TimeoutDiagnostics;
+};
+
+export const TIMEOUT_SUGGESTIONS = [
+  "Verify the makai binary is installed, executable, and still running.",
+  "Check network connectivity and provider service health.",
+  "Review server logs using the included stream_id/message_id for correlation.",
+  "Increase the responseTimeoutMs/frameTimeoutMs option if the provider is expected to be slow.",
+] as const;
+
+export function createTimeoutDiagnostics(context: TimeoutDiagnosticContext): TimeoutDiagnostics {
+  return {
+    ...context,
+    suggestions: [...TIMEOUT_SUGGESTIONS],
+  };
+}
+
+export function formatTimeoutMessage(context: TimeoutDiagnosticContext): string {
+  const diagnostics = createTimeoutDiagnostics(context);
+  const ids = formatIds(diagnostics);
+  const provider = diagnostics.provider_id ? ` for provider '${diagnostics.provider_id}'` : "";
+  const model = diagnostics.model_ref ? ` (model_ref='${diagnostics.model_ref}')` : "";
+  return `Timed out waiting for ${diagnostics.operation} after ${diagnostics.timeout_ms}ms${provider}${model}${ids}. Suggestions: ${diagnostics.suggestions.join(" ")}`;
+}
+
+export function timeoutError(message: string, context: TimeoutDiagnosticContext): ErrorWithDiagnostics {
+  const error = new Error(message) as ErrorWithDiagnostics;
+  error.diagnostics = createTimeoutDiagnostics(context);
+  return error;
+}
+
+export function isTimeoutLikeError(error: unknown): boolean {
+  return error instanceof Error && /^timed out waiting for|^Timed out waiting for|timed out after/.test(error.message);
+}
+
+function formatIds(diagnostics: TimeoutDiagnostics): string {
+  const fields: string[] = [];
+  if (diagnostics.stream_id) fields.push(`stream_id=${diagnostics.stream_id}`);
+  if (diagnostics.session_id) fields.push(`session_id=${diagnostics.session_id}`);
+  if (diagnostics.message_id) fields.push(`message_id=${diagnostics.message_id}`);
+  return fields.length > 0 ? ` (${fields.join(", ")})` : "";
+}

--- a/typescript/test/auth_protocol.test.ts
+++ b/typescript/test/auth_protocol.test.ts
@@ -261,6 +261,33 @@ test("client.auth.login rejects with cancelled error on cancelled login result",
   }
 });
 
+test("client.auth.listProviders timeout includes actionable diagnostics", async () => {
+  const client = await createMakaiAuthClient(
+    fixtureClientOptions("auth-protocol-providers-server.js", {
+      frameTimeoutMs: 20,
+      env: { ...process.env, MAKAI_TEST_RESPONSE_DELAY_MS: "100" },
+    }),
+  );
+  try {
+    await assert.rejects(
+      () => client.auth.listProviders(),
+      (error: unknown) =>
+        error instanceof MakaiAuthError &&
+        error.kind === "transport_error" &&
+        error.message.includes("Timed out waiting for auth_providers_response after 20ms") &&
+        error.message.includes("stream_id=") &&
+        error.message.includes("message_id=") &&
+        error.message.includes("Verify the makai binary") &&
+        error.diagnostics?.operation === "auth_providers_response" &&
+        error.diagnostics.timeout_ms === 20 &&
+        typeof error.diagnostics.stream_id === "string" &&
+        typeof error.diagnostics.message_id === "string",
+    );
+  } finally {
+    await client.close();
+  }
+});
+
 test("client.auth.login rejects with provider_error and propagates code/message on failure", async () => {
   const client = await createMakaiAuthClient(
     fixtureClientOptions("auth-protocol-login-failed-server.js"),

--- a/typescript/test/execution_client.test.ts
+++ b/typescript/test/execution_client.test.ts
@@ -147,6 +147,33 @@ test("client.provider.complete maps system prompts and tool messages into provid
   }
 });
 
+test("provider.complete timeout includes actionable diagnostics", async () => {
+  const harness = await setupHarness({ MAKAI_TEST_SUPPRESS_COMPLETE_RESPONSE: "1" });
+  try {
+    const provider = createMakaiProviderApi(harness.client, { responseTimeoutMs: 20 });
+    await assert.rejects(
+      () => provider.complete(request()),
+      (err: unknown) =>
+        err instanceof MakaiStreamError &&
+        err.kind === "transport_error" &&
+        err.message.includes("Timed out waiting for provider complete_response after 20ms for provider 'anthropic'") &&
+        err.message.includes("model_ref='anthropic/anthropic-messages@opaque-model-ref-with%3Acolon'") &&
+        err.message.includes("stream_id=") &&
+        err.message.includes("message_id=") &&
+        err.message.includes("Check network connectivity") &&
+        err.diagnostics?.operation === "provider complete_response" &&
+        err.diagnostics.timeout_ms === 20 &&
+        err.diagnostics.provider_id === "anthropic" &&
+        err.diagnostics.api === "anthropic-messages" &&
+        err.diagnostics.model_id === "opaque-model-ref-with:colon" &&
+        typeof err.diagnostics.stream_id === "string" &&
+        err.diagnostics.message_id === err.diagnostics.stream_id,
+    );
+  } finally {
+    await harness.cleanup();
+  }
+});
+
 test("client.provider.stream yields ProviderStreamEvent sequence including message_end", async () => {
   const harness = await setupHarness();
   try {
@@ -197,6 +224,30 @@ test("client.agent.run resolves with correct AgentRunResponse", async () => {
   } finally {
     await harness.cleanup();
     fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("agent.run timeout includes actionable diagnostics", async () => {
+  const harness = await setupHarness({ MAKAI_TEST_SUPPRESS_AGENT_MESSAGE_RESPONSE: "1" });
+  try {
+    const agent = createMakaiAgentApi(harness.client, { responseTimeoutMs: 20 });
+    await assert.rejects(
+      () => agent.run(request()),
+      (err: unknown) =>
+        err instanceof MakaiStreamError &&
+        err.kind === "transport_error" &&
+        err.message.includes("Timed out waiting for agent result after 20ms for provider 'anthropic'") &&
+        err.message.includes("session_id=testNanoIdSess1234567") &&
+        err.message.includes("Verify the makai binary") &&
+        err.diagnostics?.operation === "agent result" &&
+        err.diagnostics.timeout_ms === 20 &&
+        err.diagnostics.provider_id === "anthropic" &&
+        err.diagnostics.api === "anthropic-messages" &&
+        err.diagnostics.model_id === "opaque-model-ref-with:colon" &&
+        err.diagnostics.session_id === "testNanoIdSess1234567",
+    );
+  } finally {
+    await harness.cleanup();
   }
 });
 

--- a/typescript/test/fixtures/auth-protocol-providers-server.js
+++ b/typescript/test/fixtures/auth-protocol-providers-server.js
@@ -37,36 +37,41 @@ rl.on("line", (line) => {
 
   if (envelope.type === "auth_providers_request") {
     appendLog(requestLog, JSON.stringify(envelope));
-    send({
-      type: "ack",
-      stream_id: envelope.stream_id,
-      message_id: ulid(),
-      sequence: nextSeq(envelope.stream_id),
-      in_reply_to: envelope.message_id,
-      timestamp: Date.now(),
-      version: 1,
-      payload: { acknowledged_id: envelope.message_id },
-    });
-    send({
-      type: "auth_providers_response",
-      stream_id: envelope.stream_id,
-      message_id: ulid(),
-      sequence: nextSeq(envelope.stream_id),
-      in_reply_to: envelope.message_id,
-      timestamp: Date.now(),
-      version: 1,
-      payload: {
-        providers: [
-          { id: "anthropic", name: "Anthropic", auth_status: "login_required" },
-          { id: "github-copilot", name: "GitHub Copilot", auth_status: "authenticated" },
-          {
-            id: "test-fixture",
-            name: "Test Fixture (CI)",
-            auth_status: "failed",
-            last_error: "previous attempt rejected",
-          },
-        ],
-      },
-    });
+    const respond = () => {
+      send({
+        type: "ack",
+        stream_id: envelope.stream_id,
+        message_id: ulid(),
+        sequence: nextSeq(envelope.stream_id),
+        in_reply_to: envelope.message_id,
+        timestamp: Date.now(),
+        version: 1,
+        payload: { acknowledged_id: envelope.message_id },
+      });
+      send({
+        type: "auth_providers_response",
+        stream_id: envelope.stream_id,
+        message_id: ulid(),
+        sequence: nextSeq(envelope.stream_id),
+        in_reply_to: envelope.message_id,
+        timestamp: Date.now(),
+        version: 1,
+        payload: {
+          providers: [
+            { id: "anthropic", name: "Anthropic", auth_status: "login_required" },
+            { id: "github-copilot", name: "GitHub Copilot", auth_status: "authenticated" },
+            {
+              id: "test-fixture",
+              name: "Test Fixture (CI)",
+              auth_status: "failed",
+              last_error: "previous attempt rejected",
+            },
+          ],
+        },
+      });
+    };
+    const responseDelayMs = Number(process.env.MAKAI_TEST_RESPONSE_DELAY_MS || "0");
+    if (responseDelayMs > 0) setTimeout(respond, responseDelayMs);
+    else respond();
   }
 });

--- a/typescript/test/fixtures/execution-server.js
+++ b/typescript/test/fixtures/execution-server.js
@@ -172,6 +172,7 @@ rl.on("line", (line) => {
       emit(frame(env, "nack", authRequiredPayload(), 3));
       return;
     }
+    if (process.env.MAKAI_TEST_SUPPRESS_COMPLETE_RESPONSE) return;
     emit(frame(env, "result", providerResult, 3));
   } else if (env.type === "stream_request") {
     if (shouldAuthReject("stream_request")) {
@@ -190,6 +191,7 @@ rl.on("line", (line) => {
     }
     emit(frame(env, "agent_started", { session_id: env.session_id }, 3));
   } else if (env.type === "agent_message") {
+    if (process.env.MAKAI_TEST_SUPPRESS_AGENT_MESSAGE_RESPONSE) return;
     if (process.env.MAKAI_TEST_AGENT_MALFORMED_RESULT_JSON) {
       emit(frame(env, "agent_result", { result_json: "not-json" }, 3));
     } else if (process.env.MAKAI_TEST_AGENT_MALFORMED_EVENT_JSON) {

--- a/typescript/test/models_client.test.ts
+++ b/typescript/test/models_client.test.ts
@@ -414,6 +414,33 @@ test("models.resolve throws invalid_request 'model not found' when no match", as
   }
 });
 
+test("models.list timeout includes actionable diagnostics", async () => {
+  const harness = await setupHarness({
+    response: makeResponse([makeDescriptor()]),
+    responseDelayMs: 100,
+  });
+  try {
+    const api = createMakaiModelsApi(harness.client, { responseTimeoutMs: 20 });
+    await assert.rejects(
+      () => api.list({ provider_id: "anthropic", api: "anthropic-messages" }),
+      (err: unknown) =>
+        err instanceof MakaiProtocolError &&
+        err.message.includes("Timed out waiting for models_response after 20ms for provider 'anthropic'") &&
+        err.message.includes("stream_id=") &&
+        err.message.includes("message_id=") &&
+        err.message.includes("Check network connectivity") &&
+        err.diagnostics?.operation === "models_response" &&
+        err.diagnostics.timeout_ms === 20 &&
+        err.diagnostics.provider_id === "anthropic" &&
+        err.diagnostics.api === "anthropic-messages" &&
+        typeof err.diagnostics.stream_id === "string" &&
+        err.diagnostics.message_id === err.diagnostics.stream_id,
+    );
+  } finally {
+    await harness.cleanup();
+  }
+});
+
 test("models.list propagates nack error_code as MakaiProtocolError", async () => {
   const harness = await setupHarness({
     nack: { reason: "model not found", error_code: "invalid_request" },

--- a/typescript/test/stream_client.test.ts
+++ b/typescript/test/stream_client.test.ts
@@ -27,14 +27,14 @@ class ScriptedTransport {
     this.sent.push(frame);
   }
 
-  async nextFrameForStream(streamId: string): Promise<StdioFrame> {
+  async nextFrameForStream(streamId: string, _timeoutMs?: number): Promise<StdioFrame> {
     if (this.failWith) throw this.failWith;
     const frame = this.frames.shift();
     if (!frame) throw new Error(`no scripted frame for ${streamId}`);
     return { stream_id: streamId, ...frame };
   }
 
-  async nextFrameForSession(sessionId: string): Promise<StdioFrame> {
+  async nextFrameForSession(sessionId: string, _timeoutMs?: number): Promise<StdioFrame> {
     if (this.failWith) throw this.failWith;
     const frame = this.frames.shift();
     if (!frame) throw new Error(`no scripted frame for ${sessionId}`);
@@ -221,6 +221,50 @@ test("agent stream single failure emits one error and no agent_end", async () =>
   assert.equal(events.filter((event) => event.type === "error").length, 1);
   assert.deepEqual(events.at(-1), { type: "error", message: "boom", code: "provider_error" });
   assert.equal(events.some((event) => event.type === "agent_end"), false);
+});
+
+test("provider stream timeout includes actionable diagnostics", async () => {
+  const transport = new ScriptedTransport([], new Error("timed out waiting for frame for stream s1 after 25ms"));
+  const iterable = createMakaiProviderApi(transport as never, { responseTimeoutMs: 25 }).stream(REQUEST);
+
+  await assert.rejects(
+    async () => collect(iterable),
+    (error: unknown) =>
+      error instanceof MakaiStreamError &&
+      error.kind === "transport_error" &&
+      error.message.includes("Timed out waiting for provider stream event after 25ms for provider 'fixture'") &&
+      error.message.includes("model_ref='fixture/anthropic-messages@model'") &&
+      error.message.includes("stream_id=") &&
+      error.message.includes("Suggestions:") &&
+      error.diagnostics?.operation === "provider stream event" &&
+      error.diagnostics.timeout_ms === 25 &&
+      error.diagnostics.provider_id === "fixture" &&
+      error.diagnostics.api === "anthropic-messages" &&
+      error.diagnostics.model_id === "model" &&
+      typeof error.diagnostics.stream_id === "string" &&
+      error.diagnostics.message_id === error.diagnostics.stream_id,
+  );
+});
+
+test("agent stream timeout includes actionable diagnostics", async () => {
+  const transport = new ScriptedTransport([], new Error("timed out waiting for frame for session abc after 30ms"));
+  const iterable = createMakaiAgentApi(transport as never, { responseTimeoutMs: 30 }).stream({
+    ...REQUEST,
+    options: { session_id: "abcdefghijklmnopqrstu" },
+  });
+
+  await assert.rejects(
+    async () => collect(iterable),
+    (error: unknown) =>
+      error instanceof MakaiStreamError &&
+      error.kind === "transport_error" &&
+      error.message.includes("Timed out waiting for agent stream event after 30ms for provider 'fixture'") &&
+      error.message.includes("session_id=abcdefghijklmnopqrstu") &&
+      error.diagnostics?.operation === "agent stream event" &&
+      error.diagnostics.timeout_ms === 30 &&
+      error.diagnostics.provider_id === "fixture" &&
+      error.diagnostics.session_id === "abcdefghijklmnopqrstu",
+  );
 });
 
 test("MakaiStreamError is thrown on provider async iterator failure", async () => {


### PR DESCRIPTION
## Summary
- Add shared timeout diagnostic formatting with actionable suggestions and machine-readable context.
- Attach diagnostics to models, auth, provider, and agent timeout errors with stream/session/message IDs where available.
- Cover timeout diagnostics in models, auth, and streaming SDK tests.

## Test plan
- [x] npm run test:sdk