### PR TITLE
Migrate OAuth HTTP networking seams

### DIFF
--- a/zig/src/compat/http.zig
+++ b/zig/src/compat/http.zig
@@ -42,12 +42,21 @@ pub const HttpClient = struct {
             .headers = .{ .accept_encoding = if (options.accept_encoding) |value| .{ .override = value } else .default },
         });
     }
+
+    pub fn initDefaultProxies(self: *HttpClient, allocator: std.mem.Allocator, environ_map: *std.process.Environ.Map) !void {
+        try self.client.initDefaultProxies(allocator, environ_map);
+    }
 };
 
 /// Send a request body and complete the outbound request.
 pub fn sendRequest(request: *Request, body: []const u8) !void {
     request.transfer_encoding = .{ .content_length = body.len };
     try request.sendBodyComplete(@constCast(body));
+}
+
+/// Send a request without an outbound body.
+pub fn sendBodilessRequest(request: *Request) !void {
+    try request.sendBodiless();
 }
 
 /// Receive the response headers/body metadata for a request.

--- a/zig/src/compat/net.zig
+++ b/zig/src/compat/net.zig
@@ -80,6 +80,11 @@ pub fn listenAddress(server: *const Server) Address {
     return server.socket.address;
 }
 
+/// Stop a TCP listener through the compatibility networking boundary.
+pub fn closeServer(server: *Server) void {
+    server.deinit(defaultIo());
+}
+
 /// Accept a TCP connection and wrap its stream at the Makai compatibility seam.
 ///
 /// Zig 0.15.2: wraps `std.net.Server.accept`.

--- a/zig/src/oauth/github_copilot.zig
+++ b/zig/src/oauth/github_copilot.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const compat = @import("compat");
+const http = compat.http;
 const oauth = @import("mod.zig");
 
 /// Decoded client ID for GitHub Copilot (Iv1.b507a08c87ecfe98)
@@ -97,7 +98,7 @@ pub const GitHubCopilotOAuth = struct {
 
     /// Start device flow - returns user_code and verification_uri
     pub fn startDeviceFlow(self: *Self) CopilotError!DeviceFlowInfo {
-        var client = std.http.Client{ .allocator = self.allocator };
+        var client = http.HttpClient.init(self.allocator);
         defer client.deinit();
 
         var url_buf: [256]u8 = undefined;
@@ -114,32 +115,23 @@ pub const GitHubCopilotOAuth = struct {
         headers.appendAssumeCapacity(.{ .name = "content-type", .value = "application/x-www-form-urlencoded" });
         headers.appendAssumeCapacity(.{ .name = "user-agent", .value = "GitHubCopilot/1.0.0" });
 
-        var req = client.request(.POST, uri, .{ .extra_headers = headers.items }) catch return CopilotError.HttpError;
+        var req = client.openRequest(.POST, uri, .{ .extra_headers = headers.items }) catch return CopilotError.HttpError;
         defer req.deinit();
 
-        req.transfer_encoding = .{ .content_length = body.len };
-        req.sendBodyComplete(body) catch return CopilotError.HttpError;
+        http.sendRequest(&req, body) catch return CopilotError.HttpError;
 
         var head_buf: [4096]u8 = undefined;
-        var response = req.receiveHead(&head_buf) catch return CopilotError.HttpError;
+        var response = http.receiveResponse(&req, &head_buf) catch return CopilotError.HttpError;
 
         if (response.head.status != .ok) return CopilotError.DeviceFlowFailed;
 
-        // Read response body
-        var body_list = std.ArrayList(u8).init(self.allocator);
-        defer body_list.deinit(self.allocator);
-
+        // Read response body with a fixed upper bound for OAuth JSON payloads.
         var transfer_buf: [4096]u8 = undefined;
-        var read_buf: [4096]u8 = undefined;
-        const reader = response.reader(&transfer_buf);
+        const reader = http.responseReader(&response, &transfer_buf);
+        const response_body = http.allocRemainingResponse(self.allocator, reader, 8192) catch return CopilotError.HttpError;
+        defer self.allocator.free(response_body);
 
-        while (true) {
-            const n = reader.*.readSliceShort(&read_buf) catch break;
-            if (n.len == 0) break;
-            body_list.appendSlice(self.allocator, n) catch return CopilotError.OutOfMemory;
-        }
-
-        return self.parseDeviceCodeResponse(body_list.items);
+        return self.parseDeviceCodeResponse(response_body);
     }
 
     fn parseDeviceCodeResponse(self: *Self, body: []const u8) CopilotError!DeviceFlowInfo {
@@ -182,7 +174,7 @@ pub const GitHubCopilotOAuth = struct {
     /// Poll for access token after user enters code
     /// Returns null if still pending, credentials if successful
     pub fn pollForAccessToken(self: *Self, device_code: []const u8) CopilotError!?oauth.OAuthCredentials {
-        var client = std.http.Client{ .allocator = self.allocator };
+        var client = http.HttpClient.init(self.allocator);
         defer client.deinit();
 
         var url_buf: [256]u8 = undefined;
@@ -203,32 +195,23 @@ pub const GitHubCopilotOAuth = struct {
         headers.appendAssumeCapacity(.{ .name = "content-type", .value = "application/x-www-form-urlencoded" });
         headers.appendAssumeCapacity(.{ .name = "user-agent", .value = "GitHubCopilot/1.0.0" });
 
-        var req = client.request(.POST, uri, .{ .extra_headers = headers.items }) catch return CopilotError.HttpError;
+        var req = client.openRequest(.POST, uri, .{ .extra_headers = headers.items }) catch return CopilotError.HttpError;
         defer req.deinit();
 
-        req.transfer_encoding = .{ .content_length = body.len };
-        req.sendBodyComplete(body) catch return CopilotError.HttpError;
+        http.sendRequest(&req, body) catch return CopilotError.HttpError;
 
         var head_buf: [4096]u8 = undefined;
-        var response = req.receiveHead(&head_buf) catch return CopilotError.HttpError;
+        var response = http.receiveResponse(&req, &head_buf) catch return CopilotError.HttpError;
 
         if (response.head.status != .ok) return CopilotError.HttpError;
 
-        // Read response body
-        var body_list = std.ArrayList(u8).init(self.allocator);
-        defer body_list.deinit(self.allocator);
-
+        // Read response body with a fixed upper bound for OAuth JSON payloads.
         var transfer_buf: [4096]u8 = undefined;
-        var read_buf: [4096]u8 = undefined;
-        const reader = response.reader(&transfer_buf);
+        const reader = http.responseReader(&response, &transfer_buf);
+        const response_body = http.allocRemainingResponse(self.allocator, reader, 8192) catch return CopilotError.HttpError;
+        defer self.allocator.free(response_body);
 
-        while (true) {
-            const n = reader.*.readSliceShort(&read_buf) catch break;
-            if (n.len == 0) break;
-            body_list.appendSlice(self.allocator, n) catch return CopilotError.OutOfMemory;
-        }
-
-        return self.parseAccessTokenResponse(body_list.items);
+        return self.parseAccessTokenResponse(response_body);
     }
 
     fn parseAccessTokenResponse(self: *Self, body: []const u8) CopilotError!?oauth.OAuthCredentials {
@@ -281,7 +264,7 @@ pub const GitHubCopilotOAuth = struct {
 
     /// Exchange GitHub access token for Copilot API token
     pub fn exchangeForCopilotToken(self: *Self, access_token: []const u8) CopilotError!CopilotToken {
-        var client = std.http.Client{ .allocator = self.allocator };
+        var client = http.HttpClient.init(self.allocator);
         defer client.deinit();
 
         var url_buf: [256]u8 = undefined;
@@ -300,31 +283,23 @@ pub const GitHubCopilotOAuth = struct {
             headers.appendAssumeCapacity(h);
         }
 
-        var req = client.request(.GET, uri, .{ .extra_headers = headers.items }) catch return CopilotError.HttpError;
+        var req = client.openRequest(.GET, uri, .{ .extra_headers = headers.items }) catch return CopilotError.HttpError;
         defer req.deinit();
 
-        req.sendBodyComplete("") catch return CopilotError.HttpError;
+        http.sendBodilessRequest(&req) catch return CopilotError.HttpError;
 
         var head_buf: [4096]u8 = undefined;
-        var response = req.receiveHead(&head_buf) catch return CopilotError.HttpError;
+        var response = http.receiveResponse(&req, &head_buf) catch return CopilotError.HttpError;
 
         if (response.head.status != .ok) return CopilotError.TokenExchangeFailed;
 
-        // Read response body
-        var body_list = std.ArrayList(u8).init(self.allocator);
-        defer body_list.deinit(self.allocator);
-
+        // Read response body with a fixed upper bound for OAuth JSON payloads.
         var transfer_buf: [4096]u8 = undefined;
-        var read_buf: [4096]u8 = undefined;
-        const reader = response.reader(&transfer_buf);
+        const reader = http.responseReader(&response, &transfer_buf);
+        const response_body = http.allocRemainingResponse(self.allocator, reader, 8192) catch return CopilotError.HttpError;
+        defer self.allocator.free(response_body);
 
-        while (true) {
-            const n = reader.*.readSliceShort(&read_buf) catch break;
-            if (n.len == 0) break;
-            body_list.appendSlice(self.allocator, n) catch return CopilotError.OutOfMemory;
-        }
-
-        return self.parseCopilotTokenResponse(body_list.items);
+        return self.parseCopilotTokenResponse(response_body);
     }
 
     fn parseCopilotTokenResponse(self: *Self, body: []const u8) CopilotError!CopilotToken {
@@ -410,7 +385,7 @@ pub const GitHubCopilotOAuth = struct {
 
     /// Enable a model for use (POST to /models/{id}/policy)
     pub fn enableModel(self: *Self, token: []const u8, model_id: []const u8) !bool {
-        var client = std.http.Client{ .allocator = self.allocator };
+        var client = http.HttpClient.init(self.allocator);
         defer client.deinit();
 
         // Determine base URL
@@ -437,15 +412,14 @@ pub const GitHubCopilotOAuth = struct {
             headers.appendAssumeCapacity(h);
         }
 
-        var req = client.request(.POST, uri, .{ .extra_headers = headers.items }) catch return false;
+        var req = client.openRequest(.POST, uri, .{ .extra_headers = headers.items }) catch return false;
         defer req.deinit();
 
         const body = "{\"state\":\"enabled\"}";
-        req.transfer_encoding = .{ .content_length = body.len };
-        req.sendBodyComplete(body) catch return false;
+        http.sendRequest(&req, body) catch return false;
 
         var head_buf: [4096]u8 = undefined;
-        const response = req.receiveHead(&head_buf) catch return false;
+        const response = http.receiveResponse(&req, &head_buf) catch return false;
 
         return response.head.status == .ok or response.head.status == .created or response.head.status == .no_content;
     }

--- a/zig/src/utils/oauth/anthropic.zig
+++ b/zig/src/utils/oauth/anthropic.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const compat = @import("compat");
+const http = compat.http;
 const pkce_mod = @import("oauth/pkce");
 
 const client_id = "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
@@ -278,7 +279,7 @@ fn exchangeCode(code: []const u8, state: []const u8, verifier: []const u8, alloc
 
 /// Exchange tokens with Anthropic API
 fn exchangeTokens(body: []const u8, allocator: std.mem.Allocator) !TokenResponse {
-    var client = std.http.Client{ .allocator = allocator, .io = if (@import("builtin").is_test) std.testing.io else std.Io.Threaded.global_single_threaded.io() };
+    var client = http.HttpClient.init(allocator);
     defer client.deinit();
 
     // Initialize proxy from environment variables (HTTP_PROXY, HTTPS_PROXY, ALL_PROXY)
@@ -298,30 +299,32 @@ fn exchangeTokens(body: []const u8, allocator: std.mem.Allocator) !TokenResponse
     try headers.append(allocator, .{ .name = "accept", .value = "application/json" });
     try headers.append(allocator, .{ .name = "content-type", .value = "application/json" });
 
-    var request = try client.request(.POST, uri, .{
+    var request = try client.openRequest(.POST, uri, .{
         .extra_headers = headers.items,
+        .accept_encoding = "identity",
     });
     defer request.deinit();
 
     // Avoid compressed response bodies for stable token JSON parsing.
     request.headers.accept_encoding = .omit;
 
-    request.transfer_encoding = .{ .content_length = body.len };
-    try request.sendBodyComplete(@constCast(body));
+    try http.sendRequest(&request, body);
 
     var header_buffer: [4096]u8 = undefined;
-    var response = try request.receiveHead(&header_buffer);
+    var response = try http.receiveResponse(&request, &header_buffer);
 
     if (response.head.status != .ok) {
         var buffer: [4096]u8 = undefined;
-        const error_body = try response.reader(&buffer).*.allocRemaining(allocator, std.Io.Limit.limited(8192));
+        const reader = http.responseReader(&response, &buffer);
+        const error_body = try http.allocRemainingResponse(allocator, reader, 8192);
         defer allocator.free(error_body);
         std.debug.print("Token exchange error {d}: {s}\n", .{ @intFromEnum(response.head.status), error_body });
         return error.OAuthFailed;
     }
 
     var response_buffer: [8192]u8 = undefined;
-    const response_body = try response.reader(&response_buffer).*.allocRemaining(allocator, std.Io.Limit.limited(8192));
+    const reader = http.responseReader(&response, &response_buffer);
+    const response_body = try http.allocRemainingResponse(allocator, reader, 8192);
     defer allocator.free(response_body);
 
     return try parseTokenResponse(response_body, allocator);

--- a/zig/src/utils/oauth/callback_server.zig
+++ b/zig/src/utils/oauth/callback_server.zig
@@ -1,19 +1,20 @@
 const std = @import("std");
 const compat = @import("compat");
+const net = compat.net;
 
 /// Local HTTP callback server for OAuth
 pub const CallbackServer = struct {
     allocator: std.mem.Allocator,
     port: u16,
-    listener: std.net.Server,
+    listener: net.Server,
     code: ?[]const u8 = null,
     state: ?[]const u8 = null,
     error_msg: ?[]const u8 = null,
 
     /// Start callback server on 127.0.0.1
     pub fn start(allocator: std.mem.Allocator, port: u16) !CallbackServer {
-        const address = try std.net.Address.parseIp4("127.0.0.1", port);
-        const listener = try address.listen(.{
+        const address = try net.resolveAddress(allocator, "127.0.0.1", port);
+        const listener = try net.tcpListen(address, .{
             .reuse_address = true,
         });
 
@@ -30,7 +31,7 @@ pub const CallbackServer = struct {
 
         while (compat.time.nowMillis() < deadline) {
             // Accept connection with timeout
-            var connection = self.listener.accept() catch |err| {
+            var connection = net.accept(&self.listener) catch |err| {
                 if (err == error.WouldBlock) {
                     compat.time.sleepMs(100);
                     continue;
@@ -49,7 +50,7 @@ pub const CallbackServer = struct {
             // Parse query string from GET request
             if (std.mem.startsWith(u8, request, "GET ")) {
                 const query_start = std.mem.find(u8, request, "?") orelse {
-                    try self.sendResponse(connection.stream, false, "No query parameters");
+                    try self.sendResponse(&connection.stream, false, "No query parameters");
                     continue;
                 };
 
@@ -74,18 +75,18 @@ pub const CallbackServer = struct {
 
                 if (error_param) |err_msg| {
                     self.error_msg = err_msg;
-                    try self.sendResponse(connection.stream, false, err_msg);
+                    try self.sendResponse(&connection.stream, false, err_msg);
                     return error.OAuthError;
                 }
 
                 if (code) |c| {
                     self.code = c;
                     self.state = state;
-                    try self.sendResponse(connection.stream, true, null);
+                    try self.sendResponse(&connection.stream, true, null);
                     return c;
                 }
 
-                try self.sendResponse(connection.stream, false, "No code parameter");
+                try self.sendResponse(&connection.stream, false, "No code parameter");
             }
         }
 
@@ -93,8 +94,7 @@ pub const CallbackServer = struct {
     }
 
     /// Send HTML response to browser
-    fn sendResponse(self: *CallbackServer, stream: std.net.Stream, success: bool, error_msg: ?[]const u8) !void {
-        _ = self;
+    fn sendResponse(self: *CallbackServer, stream: *net.Stream, success: bool, error_msg: ?[]const u8) !void {
         const html = if (success)
             \\HTTP/1.1 200 OK
             \\Content-Type: text/html; charset=utf-8
@@ -107,7 +107,7 @@ pub const CallbackServer = struct {
             \\</body></html>
         else blk: {
             const msg = error_msg orelse "Unknown error";
-            break :blk try std.fmt.allocPrint(std.testing.allocator,
+            break :blk try std.fmt.allocPrint(self.allocator,
                 \\HTTP/1.1 400 Bad Request
                 \\Content-Type: text/html; charset=utf-8
                 \\Connection: close
@@ -120,13 +120,13 @@ pub const CallbackServer = struct {
             , .{msg});
         };
 
-        defer if (!success) std.testing.allocator.free(html);
-        _ = try stream.write(html);
+        defer if (!success) self.allocator.free(html);
+        try stream.writeAll(html);
     }
 
     /// Stop callback server and free resources
     pub fn stop(self: *CallbackServer) void {
-        self.listener.deinit();
+        net.closeServer(&self.listener);
         if (self.code) |code| {
             self.allocator.free(code);
         }

--- a/zig/src/utils/oauth/github_copilot.zig
+++ b/zig/src/utils/oauth/github_copilot.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const compat = @import("compat");
+const http = compat.http;
 const ai_types = @import("ai_types");
 
 // GitHub OAuth configuration
@@ -105,7 +106,7 @@ pub fn enableModel(
     model_id: []const u8,
     base_url: []const u8,
 ) !bool {
-    var client = std.http.Client{ .allocator = allocator, .io = if (@import("builtin").is_test) std.testing.io else std.Io.Threaded.global_single_threaded.io() };
+    var client = http.HttpClient.init(allocator);
     defer client.deinit();
 
     // Build URL
@@ -128,16 +129,15 @@ pub fn enableModel(
     try headers.append(allocator, .{ .name = "openai-intent", .value = "chat-policy" });
     try headers.append(allocator, .{ .name = "x-interaction-type", .value = "chat-policy" });
 
-    var request = try client.request(.POST, uri, .{
+    var request = try client.openRequest(.POST, uri, .{
         .extra_headers = headers.items,
     });
     defer request.deinit();
 
-    request.transfer_encoding = .{ .content_length = body.len };
-    try request.sendBodyComplete(body);
+    try http.sendRequest(&request, body);
 
     var header_buffer: [4096]u8 = undefined;
-    const response = try request.receiveHead(&header_buffer);
+    const response = try http.receiveResponse(&request, &header_buffer);
 
     // Return true if status is 200, false otherwise
     return response.head.status == .ok;
@@ -373,7 +373,7 @@ const DeviceCodeResponse = struct {
 
 /// Start GitHub device code flow
 fn startDeviceFlow(domain: []const u8, allocator: std.mem.Allocator) !DeviceCodeResponse {
-    var client = std.http.Client{ .allocator = allocator, .io = if (@import("builtin").is_test) std.testing.io else std.Io.Threaded.global_single_threaded.io() };
+    var client = http.HttpClient.init(allocator);
     defer client.deinit();
 
     // Build URL (support enterprise domains)
@@ -394,20 +394,20 @@ fn startDeviceFlow(domain: []const u8, allocator: std.mem.Allocator) !DeviceCode
     try headers.append(allocator, .{ .name = "accept", .value = "application/json" });
     try headers.append(allocator, .{ .name = "content-type", .value = "application/x-www-form-urlencoded" });
 
-    var request = try client.request(.POST, uri, .{
+    var request = try client.openRequest(.POST, uri, .{
         .extra_headers = headers.items,
     });
     defer request.deinit();
 
-    request.transfer_encoding = .{ .content_length = body.len };
-    try request.sendBodyComplete(@constCast(body));
+    try http.sendRequest(&request, body);
 
     var header_buffer: [4096]u8 = undefined;
-    var response = try request.receiveHead(&header_buffer);
+    var response = try http.receiveResponse(&request, &header_buffer);
 
     if (response.head.status != .ok) {
         var buffer: [4096]u8 = undefined;
-        const error_body = try response.reader(&buffer).*.allocRemaining(allocator, std.Io.Limit.limited(8192));
+        const reader = http.responseReader(&response, &buffer);
+        const error_body = try http.allocRemainingResponse(allocator, reader, 8192);
         defer allocator.free(error_body);
         const err_msg = try std.fmt.allocPrint(allocator, "Device flow error {d}: {s}", .{ @intFromEnum(response.head.status), error_body });
         defer allocator.free(err_msg);
@@ -415,7 +415,8 @@ fn startDeviceFlow(domain: []const u8, allocator: std.mem.Allocator) !DeviceCode
     }
 
     var response_buffer: [8192]u8 = undefined;
-    const response_body = try response.reader(&response_buffer).*.allocRemaining(allocator, std.Io.Limit.limited(8192));
+    const reader = http.responseReader(&response, &response_buffer);
+    const response_body = try http.allocRemainingResponse(allocator, reader, 8192);
     defer allocator.free(response_body);
 
     // Parse JSON response
@@ -449,7 +450,7 @@ const PollResult = struct {
 
 /// Poll for GitHub access token
 fn pollForToken(domain: []const u8, device_code: []const u8, allocator: std.mem.Allocator) !PollResult {
-    var client = std.http.Client{ .allocator = allocator, .io = if (@import("builtin").is_test) std.testing.io else std.Io.Threaded.global_single_threaded.io() };
+    var client = http.HttpClient.init(allocator);
     defer client.deinit();
 
     // Build URL (support enterprise domains)
@@ -474,16 +475,15 @@ fn pollForToken(domain: []const u8, device_code: []const u8, allocator: std.mem.
     try headers.append(allocator, .{ .name = "accept", .value = "application/json" });
     try headers.append(allocator, .{ .name = "content-type", .value = "application/x-www-form-urlencoded" });
 
-    var request = try client.request(.POST, uri, .{
+    var request = try client.openRequest(.POST, uri, .{
         .extra_headers = headers.items,
     });
     defer request.deinit();
 
-    request.transfer_encoding = .{ .content_length = body.len };
-    try request.sendBodyComplete(@constCast(body));
+    try http.sendRequest(&request, body);
 
     var header_buffer: [4096]u8 = undefined;
-    var response = try request.receiveHead(&header_buffer);
+    var response = try http.receiveResponse(&request, &header_buffer);
 
     if (response.head.status != .ok) {
         return .{
@@ -492,7 +492,8 @@ fn pollForToken(domain: []const u8, device_code: []const u8, allocator: std.mem.
     }
 
     var response_buffer: [8192]u8 = undefined;
-    const response_body = try response.reader(&response_buffer).*.allocRemaining(allocator, std.Io.Limit.limited(8192));
+    const reader = http.responseReader(&response, &response_buffer);
+    const response_body = try http.allocRemainingResponse(allocator, reader, 8192);
     defer allocator.free(response_body);
 
     // Parse JSON response (can be success or error)
@@ -527,7 +528,7 @@ fn pollForToken(domain: []const u8, device_code: []const u8, allocator: std.mem.
 
 /// Get Copilot token from GitHub token
 fn getCopilotToken(domain: []const u8, github_token: []const u8, allocator: std.mem.Allocator) ![]const u8 {
-    var client = std.http.Client{ .allocator = allocator, .io = if (@import("builtin").is_test) std.testing.io else std.Io.Threaded.global_single_threaded.io() };
+    var client = http.HttpClient.init(allocator);
     defer client.deinit();
 
     // Build URL (support enterprise domains)
@@ -553,7 +554,7 @@ fn getCopilotToken(domain: []const u8, github_token: []const u8, allocator: std.
     try headers.append(allocator, .{ .name = "user-agent", .value = COPILOT_HEADERS.user_agent });
     try headers.append(allocator, .{ .name = "copilot-integration-id", .value = COPILOT_HEADERS.copilot_integration_id });
 
-    var request = try client.request(.GET, uri, .{
+    var request = try client.openRequest(.GET, uri, .{
         .extra_headers = headers.items,
     });
     defer request.deinit();
@@ -561,14 +562,15 @@ fn getCopilotToken(domain: []const u8, github_token: []const u8, allocator: std.
     // Avoid compressed response bodies for simpler token JSON parsing
     request.headers.accept_encoding = .omit;
 
-    try request.sendBodiless();
+    try http.sendBodilessRequest(&request);
 
     var header_buffer: [4096]u8 = undefined;
-    var response = try request.receiveHead(&header_buffer);
+    var response = try http.receiveResponse(&request, &header_buffer);
 
     if (response.head.status != .ok) {
         var buffer: [4096]u8 = undefined;
-        const error_body = try response.reader(&buffer).*.allocRemaining(allocator, std.Io.Limit.limited(8192));
+        const reader = http.responseReader(&response, &buffer);
+        const error_body = try http.allocRemainingResponse(allocator, reader, 8192);
         defer allocator.free(error_body);
         const err_msg = try std.fmt.allocPrint(allocator, "Copilot token error {d}: {s}", .{ @intFromEnum(response.head.status), error_body });
         defer allocator.free(err_msg);
@@ -576,7 +578,8 @@ fn getCopilotToken(domain: []const u8, github_token: []const u8, allocator: std.
     }
 
     var response_buffer: [8192]u8 = undefined;
-    const response_body = try response.reader(&response_buffer).*.allocRemaining(allocator, std.Io.Limit.limited(8192));
+    const reader = http.responseReader(&response, &response_buffer);
+    const response_body = try http.allocRemainingResponse(allocator, reader, 8192);
     defer allocator.free(response_body);
 
     // Parse JSON response (expected format: {"token": "..."})


### PR DESCRIPTION
## Summary
- Route GitHub Copilot and Anthropic OAuth HTTP requests through the shared compat HTTP seam.
- Move OAuth response-body reads to bounded compat helpers and preserve 8 KiB token/device payload limits.
- Route the local OAuth callback server through compat networking helpers and remove runtime dependency on `std.testing.allocator` for error responses.

## Migration reference
Zig 0.15.2 → 0.16.0 Migration — OAuth HTTP flows and callback networking

## Test plan
- [x] `cd zig && zig build test-unit-utils`
- [x] `cd zig && zig build test-unit-providers`
- [x] `./scripts/check-zig-patterns.sh`
- [x] `cd zig && zig build test`