### PR TITLE
Validate Zig 0.16 unit and mock E2E suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        group: [core, transport, protocol, providers, utils, agent-types, agent-loop, agent-mod, agent-bridge, agent-unit, agent-chain]
+        group: [core, transport, protocol, providers, utils, makai-cli, agent-types, agent-loop, agent-mod, agent-bridge, agent-unit, agent-chain]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Add `test-unit-makai-cli` to the CI unit-test matrix so the full Zig 0.16 validation gate covers CLI wrapper tests.
- Completed Zig 0.15.2 → 0.16.0 Migration — full validation across grouped unit tests, split agent tests, mock protocol E2E, TS SDK validation, and CLI smoke checks.
- No external provider E2E tests were added or required, and no CI timeout changes were needed.

## Validation
- [x] `../scripts/check-zig-patterns.sh`
- [x] `zig build test-unit-core`
- [x] `zig build test-unit-transport`
- [x] `zig build test-unit-protocol`
- [x] `zig build test-unit-providers`
- [x] `zig build test-unit-utils`
- [x] `zig build test-unit-makai-cli`
- [x] `zig build test-unit-agent`
- [x] `zig build test-unit-agent-types`
- [x] `zig build test-unit-agent-loop`
- [x] `zig build test-unit-agent-mod`
- [x] `zig build test-unit-agent-bridge`
- [x] `zig build test-unit-agent-unit`
- [x] `zig build test-unit-agent-chain`
- [x] `zig build test-e2e-protocol`
- [x] `MAKAI_BINARY_PATH=/tmp/makai-smoke/bin/makai npm run test:sdk` (126 passing)
- [x] CLI smoke checks: `makai --version`, no-arg usage output/exit code, `auth providers` output/exit code, and unknown-provider auth login failure prompt/error flow.

## Notes
- Local npm configuration omitted dev dependencies by default; reran SDK validation after `npm ci --include=dev`, matching CI's dependency intent for TypeScript compilation.