### PR TITLE
Document Zig 0.16 migration guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+## Unreleased
+
+### Changed
+
+- Upgraded the Zig toolchain requirement from Zig 0.15.2 to Zig 0.16.0.
+- Removed the unused `libxev` Zig package declaration; `zig/build.zig.zon` now declares no external Zig package dependencies.
+- Routed Makai runtime I/O, HTTP, filesystem, random, stdio, timing, and networking internals through Zig 0.16 `std.Io`-based APIs while preserving Makai-owned wrapper boundaries for future backend evolution.
+- Split and documented the expanded Zig unit test matrix used by CI, including the Makai CLI and agent subgroups.
+
+### Migration Notes
+
+- See [`docs/zig-0.16.0-downstream-migration.md`](docs/zig-0.16.0-downstream-migration.md) for downstream source migration guidance for Makai Zig consumers.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,14 @@ zig build test-unit-transport     # transport, stdio, sse, websocket, in_process
 zig build test-unit-protocol      # content_partial, partial_serializer, protocol types/envelope/reconstructor, server, client, agent types, tool types
 zig build test-unit-providers     # api_registry, stream, register_builtins, all provider APIs
 zig build test-unit-utils         # github_copilot, oauth/pkce, oauth/mod, overflow, retry, sanitize, pre_transform
-zig build test-unit-agent         # agent types, agent_loop, agent module, agent unit test
+zig build test-unit-makai-cli     # makai CLI unit tests
+zig build test-unit-agent         # aggregate agent unit tests
+zig build test-unit-agent-types   # agent types
+zig build test-unit-agent-loop    # agent loop
+zig build test-unit-agent-mod     # agent module
+zig build test-unit-agent-bridge  # agent provider protocol bridge
+zig build test-unit-agent-unit    # agent unit test file
+zig build test-unit-agent-chain   # agent protocol chain tests
 ```
 
 E2E tests require API keys (set via env vars, see `.github/workflows/ci.yml`):
@@ -46,7 +53,7 @@ There is no single-test command. Tests are inline in each `.zig` file using Zig'
 
 ## Dependencies
 
-No external Zig package dependencies are currently declared in `zig/build.zig.zon`.
+No external Zig package dependencies are currently declared in `zig/build.zig.zon`; the unused `libxev` declaration was removed during the Zig 0.16.0 migration.
 
 ## Architecture
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -185,9 +185,10 @@ At minimum:
 
 ### 8.3 Low-level socket/C-C++ interop options (Batch G note)
 
-1. **Option A (default): pure Zig + `libxev` hardening**
+1. **Option A (default): pure Zig + Zig 0.16 `std.Io` networking**
    - continue improving current websocket transport and tests
    - lowest integration risk and simplest ownership model
+   - Makai does not currently depend on `libxev`; any future event-loop backend must pass the objective gate below before adoption
 
 2. **Option B: hybrid C socket engine + Zig protocol/runtime**
    - wrap battle-tested C/C++ socket stack (for example uSockets/libuv-family)

--- a/docs/zig-0.16.0-downstream-migration.md
+++ b/docs/zig-0.16.0-downstream-migration.md
@@ -1,0 +1,130 @@
+# Zig 0.16.0 Downstream Migration Guide
+
+This guide is for downstream Zig consumers that import Makai modules or instantiate Makai public types directly. It summarizes the public-source changes made while upgrading Makai from Zig 0.15.2 to Zig 0.16.0.
+
+Makai now requires Zig 0.16.0. Downstream packages should update their local toolchain, CI setup, and `build.zig.zon` metadata before updating to a Makai revision after this migration.
+
+## Build and dependency changes
+
+- Use Zig 0.16.0 for all Makai builds and tests. The repository CI and release binary workflows both use `mlugg/setup-zig@v2` with `version: 0.16.0`.
+- Run Zig commands from the `zig/` directory:
+  - `zig build test` runs the full unit suite.
+  - `zig build run` runs the demo application.
+  - `zig build test-unit-<group>` runs grouped unit steps used by CI.
+- `zig/build.zig.zon` no longer declares external Zig package dependencies. The previously declared `libxev` package was unused by Makai source and build wiring, so it was removed instead of repinned for Zig 0.16.0.
+
+## Public API compatibility overview
+
+The migration intentionally keeps Makai's domain model and protocol-facing abstractions stable where practical:
+
+- Provider streaming entry points continue to use `stream(...)`, `streamSimple(...)`, `complete(...)`, and `completeSimple(...)` with Makai `Model`, `Context`, and stream option types.
+- `ApiRegistry` registration and lookup patterns remain provider-name based.
+- Core event and result types (`AssistantMessageEvent`, `AssistantMessage`, `ContentBlock`, `Usage`, `Model`, `StreamOptions`, `CancelToken`) keep their Makai-owned shapes rather than exposing raw Zig I/O handles.
+- Transport interfaces (`Sender`, `Receiver`, `AsyncSender`, `AsyncReceiver`, `ByteStream`) remain the public protocol boundary. Some compatibility fields and methods remain intentionally for older callers; prefer the newer lifecycle-explicit APIs described below.
+
+Most required source changes are in code that directly touched Makai compatibility wrappers or Zig standard-library handles.
+
+## I/O wrapper and constructor changes
+
+Zig 0.16 moves several blocking and nondeterministic operations behind `std.Io`. Makai keeps deliberate wrapper modules under `zig/src/compat/` so downstream callers do not need to thread raw `std.Io` contexts through Makai public APIs. These wrappers are no longer temporary Zig-version shims; they are the supported Makai boundary for I/O-adjacent functionality.
+
+### Time and sleep
+
+Use `compat.time` helpers instead of direct `std.time` calls in Makai-integrated code that should follow Makai's selected I/O context:
+
+- `compat.time.nowMillis() -> i64`
+- `compat.time.nowSeconds() -> i64`
+- `compat.time.nowNanos() -> i64`
+- `compat.time.monotonicNanos() -> !u64`
+- `compat.time.sleepNs(ns: u64) -> void`
+- `compat.time.sleepMs(ms: u64) -> void`
+
+`monotonicNanos()` is fallible because it routes through the active Zig 0.16 I/O clock.
+
+### Random and secure random
+
+Security-sensitive code should use the secure helpers and ordinary non-security identifiers should use the ordinary helpers:
+
+- `compat.random.fillSecureBytes(buf)`
+- `compat.random.secureBytes(allocator, len)`
+- `compat.random.secureIntRangeLessThan(T, upper_bound)`
+- `compat.random.fillRandomBytes(buf)`
+- `compat.random.randomBytes(allocator, len)`
+- `compat.random.randomIntRangeLessThan(T, upper_bound)`
+- `compat.random.int(T)`
+
+OAuth state, PKCE, credentials, WebSocket keys, and protocol IDs should stay on the secure helpers.
+
+### Filesystem and stdio
+
+Makai filesystem helpers now wrap Zig 0.16 `std.Io` file and directory operations while keeping Makai-owned function names:
+
+- `compat.fs.getCwd()`
+- `compat.fs.openFile(dir, path, flags)`
+- `compat.fs.readFileAlloc(allocator, dir, path, max_bytes)`
+- `compat.fs.writeFile(dir, path, data)`
+- `compat.fs.atomicReplace(dir, target_path, tmp_path, data)`
+- `compat.fs.createDir(dir, path)`
+
+`compat.fs.writeFile` and `compat.fs.atomicReplace` create files with restrictive `0o600` permissions where the platform exposes permissions. Consumers that previously relied on broader default modes should set or adjust permissions explicitly after writing.
+
+For terminal and pipe operations, prefer:
+
+- `compat.stdio.stdin()` / `stdout()` / `stderr()`
+- `compat.stdio.writeAll(file, data)` / `writeLine(file, data)`
+- `compat.stdio.read(file, buffer)`
+- `compat.stdio.close(file)`
+- `compat.stdio.pipe()`
+
+`compat.stdio.File` is currently an alias of the Zig file handle used by the implementation, but callers should treat it as a Makai boundary and route operations through `compat.stdio` so future backend evolution does not require broad source changes.
+
+### Networking
+
+Use `compat.net` for TCP and address operations:
+
+- `compat.net.resolveAddress(allocator, host, port)`
+- `compat.net.resolveAddressList(allocator, host, port)` returning an owned list that must be deinitialized
+- `compat.net.tcpConnect(address)`
+- `compat.net.tcpConnectHost(allocator, host, port)`
+- `compat.net.tcpConnectAny(list)`
+- `compat.net.tcpListen(address, options)`
+- `compat.net.accept(server)`
+- `compat.net.listenAddress(server)`
+- `compat.net.closeServer(server)`
+
+`compat.net.Stream` wraps the Zig 0.16 stream and provides `read`, `write`, `writeAll`, and `close`. Do not depend on its internal field layout.
+
+### HTTP
+
+Use `compat.http.HttpClient` and response helpers instead of constructing Makai HTTP clients around older Zig standard-library request APIs:
+
+- `compat.http.HttpClient.init(allocator)` constructs a Zig 0.16-backed HTTP client.
+- `client.openRequest(method, uri, options)` opens a request using `compat.http.RequestOptions`.
+- `compat.http.sendRequest(request, body)` sends a request with a body.
+- `compat.http.sendBodilessRequest(request)` sends a request without a body.
+- `compat.http.receiveResponse(request, redirect_buffer)` receives response metadata.
+- `compat.http.responseReader(response, transfer_buf)` returns a Makai response reader.
+- `compat.http.readResponse`, `readAllResponse`, and `allocRemainingResponse` read response bodies.
+
+`RequestOptions.accept_encoding` is optional; pass `"identity"` when a caller needs to disable compressed response bodies.
+
+## Transport lifecycle guidance
+
+`AsyncReceiver.receiveStream(...)` remains available for compatibility, and `AsyncReceiver.read(...)` remains optional for callers that still need a synchronous read fallback. For new async transport code, prefer APIs that return an explicit lifecycle handle, such as stdio transport `receiveStreamWithHandle(...)`, so producer threads can be joined and cancellation ownership remains clear.
+
+Code that used `receiveStream(...)` should be audited for detached producer lifetimes. The compatibility path is intentionally retained because it is part of the public transport abstraction, not because Makai still supports Zig 0.15.2.
+
+## Agent and protocol notes
+
+- `AgentOptions.protocol` remains required. Agent logic stays auth-agnostic; provider authentication remains owned by the provider/protocol boundary.
+- `Agent` internals now use Zig 0.16 synchronization primitives through Makai defaults. Callers should continue using `Agent.init`, `run`, `runAsync`, `cancel`, and `wait` instead of depending on internal fields.
+- `ProtocolClient` continues to support multiplexed streams with legacy single-stream mirrors (`current_stream_id`, `last_result`, `stream_complete`, and `sequence`) for older callers. New code should prefer per-stream request references and stream-specific result/error accessors where available.
+
+## Source migration checklist
+
+1. Update downstream CI and local development to Zig 0.16.0.
+2. Remove any downstream direct dependency on Makai's old `libxev` package declaration; Makai does not expose or require it.
+3. Replace direct Zig 0.15 standard-library I/O assumptions in Makai-integrated code with `compat.time`, `compat.random`, `compat.fs`, `compat.stdio`, `compat.net`, and `compat.http` helpers.
+4. Treat `compat.*` wrappers as stable Makai boundaries even when a wrapper currently aliases a Zig standard-library type.
+5. Prefer lifecycle-explicit async transport APIs over detached compatibility helpers in new code.
+6. Run `zig build test` from `zig/` and, when changing Makai source, run `./scripts/check-zig-patterns.sh` from the repository root.

--- a/zig/src/compat/mod.zig
+++ b/zig/src/compat/mod.zig
@@ -1,10 +1,10 @@
-//! Compatibility seams for the Zig 0.15.2 -> 0.16.0 migration.
+//! Makai-owned I/O compatibility seams for Zig 0.16.0.
 //!
 //! These modules intentionally expose Makai-owned wrapper boundaries, not raw
 //! `std.Io`, matching `docs/zig-0.16.0-io-architecture-decision.md`.
-//! Current implementations are thin Zig 0.15.2-compatible pass-throughs; later
-//! migration PRs will remap internals to Zig 0.16 `std.Io.Threaded`/default
-//! context plumbing without changing these stable names unnecessarily.
+//! Implementations route through the selected Zig 0.16 `std.Io.Threaded`/default
+//! context plumbing without forcing callers to thread `std.Io` through Makai
+//! public APIs.
 //!
 //! Names intentionally follow the task's stable helper list where it is more
 //! specific than the architecture note's examples (`monotonicNanos`, `sleepNs`,

--- a/zig/src/compat/net.zig
+++ b/zig/src/compat/net.zig
@@ -25,10 +25,8 @@ pub const AddressList = struct {
 
 /// TCP stream wrapper used as the stable Makai networking boundary.
 ///
-/// Zig 0.15.2: owns a `std.net.Stream` and forwards byte reads/writes.
-/// 0.16: use streams produced by Makai default-context networking helpers
-/// (`std.Io.net.tcpConnect` internally) without exposing raw `std.Io` in this
-/// public wrapper API.
+/// Uses streams produced by Makai default-context networking helpers without
+/// exposing raw `std.Io` in this public wrapper API.
 pub const Stream = struct {
     inner: std.Io.net.Stream,
 
@@ -72,10 +70,7 @@ pub const Connection = struct {
     address: Address,
 };
 
-/// Return the bound listener address.
-///
-/// Zig 0.15.2: reads `std.net.Server.listen_address`.
-/// 0.16: route through Makai's selected networking backend internally.
+/// Return the bound listener address through Makai's selected networking backend.
 pub fn listenAddress(server: *const Server) Address {
     return server.socket.address;
 }
@@ -87,8 +82,7 @@ pub fn closeServer(server: *Server) void {
 
 /// Accept a TCP connection and wrap its stream at the Makai compatibility seam.
 ///
-/// Zig 0.15.2: wraps `std.net.Server.accept`.
-/// 0.16: preserve this helper shape over Makai's selected networking backend.
+/// Preserves this helper shape over Makai's selected networking backend.
 pub fn accept(server: *Server) !Connection {
     const stream = try server.accept(defaultIo());
     return .{
@@ -99,10 +93,9 @@ pub fn accept(server: *Server) !Connection {
 
 /// Resolve a host/port into an address.
 ///
-/// Zig 0.15.2: wraps `std.net.getAddressList` and returns the first resolved
-/// address, preserving DNS hostname support in addition to literal IP inputs.
-/// 0.16: keep this public signature and route through the selected Makai
-/// networking context internally.
+/// Returns the first resolved address, preserving DNS hostname support in
+/// addition to literal IP inputs. Keeps this public signature while routing
+/// through the selected Makai networking context internally.
 ///
 /// `allocator` owns temporary DNS resolver allocations during this call.
 pub fn resolveAddress(allocator: std.mem.Allocator, host: []const u8, port: u16) !Address {
@@ -176,18 +169,12 @@ pub fn tcpConnectHost(allocator: std.mem.Allocator, host: []const u8, port: u16)
     return tcpConnectAny(list);
 }
 
-/// Connect to a TCP peer.
-///
-/// Zig 0.15.2: wraps `std.net.tcpConnectToAddress`.
-/// 0.16: use std.Io.net.tcpConnect internally.
+/// Connect to a TCP peer through the Makai default I/O context.
 pub fn tcpConnect(address: Address) !Stream {
     return Stream.init(try address.connect(defaultIo(), .{ .mode = .stream, .protocol = .tcp }));
 }
 
-/// Listen for TCP connections on `address`.
-///
-/// Zig 0.15.2: wraps `std.net.Address.listen`.
-/// 0.16: use std.Io.net.tcpListen internally.
+/// Listen for TCP connections on `address` through the Makai default I/O context.
 pub fn tcpListen(address: Address, options: ListenOptions) !Server {
     return address.listen(defaultIo(), options);
 }

--- a/zig/src/compat/stdio.zig
+++ b/zig/src/compat/stdio.zig
@@ -1,9 +1,8 @@
 const std = @import("std");
 
-// TODO(zig-0.16-migration): replace this alias with an opaque Makai-owned
-// handle wrapper in a later phase. This PR keeps the transport/CLI migration
-// small, but callers should already route all operations through this module so
-// the public surface does not depend on `std.Io` operations directly.
+// Keep this alias as the Makai stdio boundary for the current Zig 0.16 backend.
+// Callers should route operations through this module so the public surface does
+// not depend on raw `std.Io` operations directly.
 pub const File = std.Io.File;
 pub const Pipe = [2]File;
 

--- a/zig/src/compat/time.zig
+++ b/zig/src/compat/time.zig
@@ -2,9 +2,8 @@ const std = @import("std");
 
 /// Wall-clock milliseconds since the Unix epoch.
 ///
-/// 0.15.2: wraps `compat.time.nowMillis()`.
-/// 0.16: use `std.Io.Timestamp.now` through the Makai default context while
-/// keeping raw `std.Io` out of this public signature.
+/// Uses `std.Io.Timestamp.now` through the Makai default context while keeping
+/// raw `std.Io` out of this public signature.
 fn defaultIo() std.Io {
     return if (@import("builtin").is_test)
         std.testing.io
@@ -18,8 +17,7 @@ pub fn nowMillis() i64 {
 
 /// Wall-clock seconds since the Unix epoch.
 ///
-/// 0.15.2: wraps `std.time.timestamp()`.
-/// 0.16: use `std.Io.Timestamp.now` through the Makai default context while
+/// Uses `std.Io.Timestamp.now` through the Makai default context while
 /// preserving wall-clock semantics.
 pub fn nowSeconds() i64 {
     return std.Io.Timestamp.now(defaultIo(), .real).toSeconds();
@@ -27,9 +25,8 @@ pub fn nowSeconds() i64 {
 
 /// Wall-clock nanoseconds since the Unix epoch.
 ///
-/// 0.15.2: wraps `std.time.nanoTimestamp()`.
-/// 0.16: use `std.Io.Timestamp.now` through the Makai default context and keep
-/// this separate from monotonic-duration measurements.
+/// Uses `std.Io.Timestamp.now` through the Makai default context and keeps this
+/// separate from monotonic-duration measurements.
 pub fn nowNanos() i64 {
     return @intCast(std.Io.Timestamp.now(defaultIo(), .real).toNanoseconds());
 }
@@ -39,10 +36,9 @@ var monotonic_mutex: std.Io.Mutex = .init;
 
 /// Monotonic nanoseconds suitable for durations and deadlines.
 ///
-/// 0.15.2: use a process-wide `std.time.Timer` so readings share a stable
-/// monotonic origin and can be subtracted for elapsed-duration math.
-/// 0.16: use `std.Io.Clock`/the chosen default-context monotonic clock
-/// internally while keeping raw `std.Io` out of this API.
+/// Uses the chosen default-context monotonic clock internally while keeping raw
+/// `std.Io` out of this API. Readings share a stable monotonic origin and can be
+/// subtracted for elapsed-duration math.
 pub fn monotonicNanos() !u64 {
     monotonic_mutex.lockUncancelable(defaultIo());
     defer monotonic_mutex.unlock(defaultIo());
@@ -57,9 +53,8 @@ pub fn monotonicNanos() !u64 {
 
 /// Sleep for a number of nanoseconds.
 ///
-/// 0.15.2: wraps `std.Thread.sleep`.
-/// 0.16: route through the Makai default I/O context timeout/sleep primitive
-/// while keeping this public helper stable.
+/// Routes through the Makai default I/O context timeout/sleep primitive while
+/// keeping this public helper stable.
 pub fn sleepNs(ns: u64) void {
     const capped_ns = @min(ns, @as(u64, std.math.maxInt(i64)));
     defaultIo().sleep(.fromNanoseconds(@intCast(capped_ns)), .boot) catch {};

--- a/zig/src/tools/anthropic_login.zig
+++ b/zig/src/tools/anthropic_login.zig
@@ -26,7 +26,7 @@ fn onPrompt(prompt: oauth.Prompt) []const u8 {
     stdout_file.writeAll(prompt.message) catch return "";
     stdout_file.writeAll(" ") catch return "";
 
-    // Read line from stdin using new Zig 0.15 API
+    // Read line from stdin using the Zig 0.16 file reader API.
     var reader = stdin_file.reader(&reader_buf);
     const line = reader.interface.takeDelimiter('\n') catch return "";
 

--- a/zig/src/tools/copilot_login.zig
+++ b/zig/src/tools/copilot_login.zig
@@ -26,7 +26,7 @@ fn onPrompt(prompt: oauth.Prompt) []const u8 {
     stdout_file.writeAll(prompt.message) catch return "";
     stdout_file.writeAll(" ") catch return "";
 
-    // Read line from stdin using new Zig 0.15 API
+    // Read line from stdin using the Zig 0.16 file reader API.
     var reader = stdin_file.reader(&reader_buf);
     const line = reader.interface.takeDelimiter('\n') catch return "";
     

--- a/zig/src/transports/stdio.zig
+++ b/zig/src/transports/stdio.zig
@@ -216,10 +216,10 @@ pub const AsyncStdioReceiver = struct {
 
         const thread = try std.Thread.spawn(.{}, producerThread, .{thread_ctx});
 
-        // TODO(zig-0.16-migration): deprecate this legacy receiveStream() path
-        // once transport migration callers use receiveStreamWithHandle(). It
-        // detaches the producer for backward compatibility, while the handle
-        // API below keeps lifecycle ownership explicit.
+        // Keep this legacy receiveStream() path for transport interface callers
+        // that do not yet use receiveStreamWithHandle(). It detaches the producer
+        // for backward compatibility, while the handle API below keeps lifecycle
+        // ownership explicit.
         thread.detach();
 
         return stream;


### PR DESCRIPTION
## Summary
- Update developer docs and release notes for the Zig 0.15.2 → 0.16.0 Migration — documentation and cleanup.
- Add downstream migration guidance covering Makai public wrapper boundaries, transport lifecycle guidance, and build/dependency changes.
- Remove obsolete 0.15.2-only comments/TODOs while retaining deliberate compatibility wrappers that still provide abstraction value.

## Test plan
- [x] ./scripts/check-zig-patterns.sh
- [x] git diff --check
- [x] zig build test