### PR TITLE
Document agent.models passthrough convenience alias

### DIFF
--- a/typescript/README.md
+++ b/typescript/README.md
@@ -157,6 +157,18 @@ void main();
 
 For agent streaming, iterate over `client.agent.stream(request)` and handle `agent_start`, `turn_start`, `tool_execution_start`, `tool_execution_end`, provider deltas, and the terminal `agent_end` event.
 
+### Agent model discovery
+
+`client.agent.models` is a convenience alias for `client.models` — both invoke the same underlying model-discovery API over the shared transport. This means `client.agent.models.list()` returns the same results as `client.models.list()`.
+
+```ts
+// These are equivalent:
+const { models } = await client.models.list();
+const { models: agentModels } = await client.agent.models.list();
+```
+
+Prefer `client.models` when you only need model discovery. Use `client.agent.models` when chaining discovery with an agent call on the same namespace.
+
 ## Auth
 
 Use `client.auth.listProviders()` to inspect auth state, and `client.auth.login(providerId, handlers)` to start an interactive login flow. Token material is owned by the runtime and is not exposed by the SDK.
@@ -429,6 +441,7 @@ import type {
   ListModelsRequest,
   ListModelsResponse,
   MakaiAgentApi,
+  MakaiAgentModelsApi,
   MakaiAuthApi,
   MakaiClient,
   MakaiModelsApi,
@@ -475,7 +488,7 @@ Core namespaces:
 type MakaiClient = {
   auth: MakaiAuthApi;
   models: MakaiModelsApi;
-  agent: MakaiAgentApi;
+  agent: MakaiAgentModelsApi; // extends MakaiAgentApi with a `models` convenience alias
   provider: MakaiProviderApi;
   close(): Promise<void>;
 };

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -159,10 +159,10 @@ For agent streaming, iterate over `client.agent.stream(request)` and handle `age
 
 ### Agent model discovery
 
-`client.agent.models` is a convenience alias for `client.models` — both invoke the same underlying model-discovery API over the shared transport. This means `client.agent.models.list()` returns the same results as `client.models.list()`.
+`client.agent.models` is a separate `MakaiModelsApi` instance that delegates to the same underlying model-discovery API over the shared transport as `client.models`. The two instances produce the same results but are not the same object (`client.agent.models !== client.models`).
 
 ```ts
-// These are equivalent:
+// Both call the same underlying API and return the same results:
 const { models } = await client.models.list();
 const { models: agentModels } = await client.agent.models.list();
 ```

--- a/typescript/src/execution_client.ts
+++ b/typescript/src/execution_client.ts
@@ -98,8 +98,17 @@ export function createMakaiAgentApi(
   return new StdioAgentApi(transport, options);
 }
 
-/** Agent API augmented with the model-discovery API for convenience. */
+/**
+ * Agent API augmented with the model-discovery API for convenience.
+ *
+ * `client.agent.models` is a convenience alias for `client.models` — both call
+ * the same underlying models API over the shared transport. Prefer
+ * `client.models` when you don't also need agent methods; use
+ * `client.agent.models` when chaining discovery with an agent call on the same
+ * namespace.
+ */
 export interface MakaiAgentModelsApi extends MakaiAgentApi {
+  /** Convenience alias for {@link MakaiClient.models}. */
   models: MakaiModelsApi;
 }
 

--- a/typescript/src/execution_client.ts
+++ b/typescript/src/execution_client.ts
@@ -101,14 +101,14 @@ export function createMakaiAgentApi(
 /**
  * Agent API augmented with the model-discovery API for convenience.
  *
- * `client.agent.models` is a convenience alias for `client.models` — both call
- * the same underlying models API over the shared transport. Prefer
- * `client.models` when you don't also need agent methods; use
- * `client.agent.models` when chaining discovery with an agent call on the same
- * namespace.
+ * `client.agent.models` is a separate {@link MakaiModelsApi} instance that
+ * delegates to the same underlying model-discovery API over the shared
+ * transport as `client.models`. Prefer `client.models` when you don't also
+ * need agent methods; use `client.agent.models` when chaining discovery with
+ * an agent call on the same namespace.
  */
 export interface MakaiAgentModelsApi extends MakaiAgentApi {
-  /** Convenience alias for {@link MakaiClient.models}. */
+  /** Convenience accessor for model discovery; delegates to the same API as {@link MakaiClient.models}. */
   models: MakaiModelsApi;
 }
 


### PR DESCRIPTION
## Summary

- Adds JSDoc to `MakaiAgentModelsApi` and its `models` field explaining that `client.agent.models` is a convenience alias for `client.models`
- Adds a README section ("Agent model discovery") under the Agent section documenting the relationship between `client.models` and `client.agent.models`
- Fixes the `MakaiClient` type snippet in the README to show the actual type (`MakaiAgentModelsApi`) instead of the base `MakaiAgentApi`
- Adds `MakaiAgentModelsApi` to the exported types listing in the README

## Test plan

- [x] All 122 TypeScript SDK tests pass (including the existing acceptance test that validates `agent.models` and `models` return identical results)
- [x] `npm run build:sdk` compiles without errors
- [x] Verified the one test using `agent.models` ("provider and agent model lists have identical output shape") is a legitimate validation of the passthrough behavior