### PR TITLE
Add input length validation on model_ref, provider_id, and model_id

### DIFF
--- a/typescript/src/execution_client.ts
+++ b/typescript/src/execution_client.ts
@@ -524,9 +524,10 @@ function buildAgentMessagePayload(
   return payload;
 }
 
-// Must accommodate max valid canonical ref: 256 (provider) + 1 (/) + 256 (api) + 1 (@) + 512 (model_id) = 1026.
-// Using 2048 to also cover percent-encoded model_id expansion (up to 3x) with margin.
-const MAX_MODEL_REF_LENGTH = 2048;
+// Must accommodate max valid canonical ref: 256 (provider) + 1 (/) + 256 (api) + 1 (@) +
+// 512 model_id bytes fully percent-encoded (512 * 3 = 1536) = 2050 chars.  Using 4096
+// for a clean power-of-2 cap with margin against pathological multi-KB strings.
+const MAX_MODEL_REF_LENGTH = 4096;
 const MAX_IDENTIFIER_LENGTH = 256;
 const MAX_MODEL_FIELD_LENGTH = 512;
 
@@ -549,24 +550,36 @@ function validateExecutionRequest(request: ProviderCompleteRequest | AgentRunReq
 /**
  * Best-effort segment-level length validation on model_ref.
  * Tries canonical parse first, then fallback slice extraction.
- * If neither applies (fully opaque ref), silently skips — the server
- * validates individual fields as the trust boundary.
+ * When neither applies (fully opaque ref), validates total length
+ * against MAX_MODEL_FIELD_LENGTH since the entire ref becomes model.id/model.name
+ * which the server caps at that limit.
  */
 function validateModelRefSegments(modelRef: string): void {
   try {
     const parsed = parseModelRef(modelRef);
     validateModelSegments(parsed.providerId, parsed.api, parsed.modelId);
+    return;
   } catch {
-    const slashIndex = modelRef.indexOf("/");
-    const atIndex = modelRef.indexOf("@");
-    if (slashIndex !== -1 && atIndex !== -1 && slashIndex < atIndex) {
-      const provider = modelRef.slice(0, slashIndex);
-      const api = modelRef.slice(slashIndex + 1, atIndex);
-      const id = modelRef.slice(atIndex + 1);
-      if (provider.length > 0 && api.length > 0) {
-        validateModelSegments(provider, api, id);
-      }
+    // Not a canonical ref — try fallback extraction
+  }
+  const slashIndex = modelRef.indexOf("/");
+  const atIndex = modelRef.indexOf("@");
+  if (slashIndex !== -1 && atIndex !== -1 && slashIndex < atIndex) {
+    const provider = modelRef.slice(0, slashIndex);
+    const api = modelRef.slice(slashIndex + 1, atIndex);
+    const id = modelRef.slice(atIndex + 1);
+    if (provider.length > 0 && api.length > 0) {
+      validateModelSegments(provider, api, id);
+      return;
     }
+  }
+  // Fully opaque ref: the entire string becomes model.id/model.name on the wire.
+  // The server caps those fields at MAX_MODEL_FIELD_LENGTH (512).
+  if (modelRef.length > MAX_MODEL_FIELD_LENGTH) {
+    throw new MakaiProtocolError(
+      `model_ref exceeds maximum length of ${MAX_MODEL_FIELD_LENGTH} characters for opaque refs`,
+      "invalid_request",
+    );
   }
 }
 

--- a/typescript/src/execution_client.ts
+++ b/typescript/src/execution_client.ts
@@ -525,7 +525,6 @@ function buildAgentMessagePayload(
 }
 
 const MAX_MODEL_REF_LENGTH = 512;
-const MODEL_REF_REQUIRED_SEPARATOR = "/";
 
 function validateExecutionRequest(request: ProviderCompleteRequest | AgentRunRequest): void {
   if (!request || typeof request.model_ref !== "string" || request.model_ref.length === 0) {
@@ -534,12 +533,6 @@ function validateExecutionRequest(request: ProviderCompleteRequest | AgentRunReq
   if (request.model_ref.length > MAX_MODEL_REF_LENGTH) {
     throw new MakaiProtocolError(
       `model_ref exceeds maximum length of ${MAX_MODEL_REF_LENGTH} characters`,
-      "invalid_request",
-    );
-  }
-  if (!request.model_ref.includes(MODEL_REF_REQUIRED_SEPARATOR)) {
-    throw new MakaiProtocolError(
-      "model_ref must contain a '/' separator (expected format: {provider_id}/{...})",
       "invalid_request",
     );
   }

--- a/typescript/src/execution_client.ts
+++ b/typescript/src/execution_client.ts
@@ -525,6 +525,8 @@ function buildAgentMessagePayload(
 }
 
 const MAX_MODEL_REF_LENGTH = 512;
+const MAX_IDENTIFIER_LENGTH = 256;
+const MAX_MODEL_FIELD_LENGTH = 512;
 
 function validateExecutionRequest(request: ProviderCompleteRequest | AgentRunRequest): void {
   if (!request || typeof request.model_ref !== "string" || request.model_ref.length === 0) {
@@ -536,14 +538,40 @@ function validateExecutionRequest(request: ProviderCompleteRequest | AgentRunReq
       "invalid_request",
     );
   }
+  validateModelRefSegments(request.model_ref);
   if (!Array.isArray(request.messages)) {
     throw new TypeError("request requires messages array");
+  }
+}
+
+/**
+ * Best-effort segment-level length validation on model_ref.
+ * Tries canonical parse first, then fallback slice extraction.
+ * If neither applies (fully opaque ref), silently skips — the server
+ * validates individual fields as the trust boundary.
+ */
+function validateModelRefSegments(modelRef: string): void {
+  try {
+    const parsed = parseModelRef(modelRef);
+    validateModelSegments(parsed.providerId, parsed.api, parsed.modelId);
+  } catch {
+    const slashIndex = modelRef.indexOf("/");
+    const atIndex = modelRef.indexOf("@");
+    if (slashIndex !== -1 && atIndex !== -1 && slashIndex < atIndex) {
+      const provider = modelRef.slice(0, slashIndex);
+      const api = modelRef.slice(slashIndex + 1, atIndex);
+      const id = modelRef.slice(atIndex + 1);
+      if (provider.length > 0 && api.length > 0) {
+        validateModelSegments(provider, api, id);
+      }
+    }
   }
 }
 
 function modelFromRef(modelRef: string): Record<string, unknown> {
   try {
     const parsed = parseModelRef(modelRef);
+    validateModelSegments(parsed.providerId, parsed.api, parsed.modelId);
     return {
       id: parsed.modelId,
       name: parsed.modelId,
@@ -561,6 +589,7 @@ function modelFromRef(modelRef: string): Record<string, unknown> {
       const api = modelRef.slice(slashIndex + 1, atIndex);
       const id = modelRef.slice(atIndex + 1);
       if (provider.length > 0 && api.length > 0) {
+        validateModelSegments(provider, api, id);
         return {
           id,
           name: id,
@@ -571,6 +600,27 @@ function modelFromRef(modelRef: string): Record<string, unknown> {
       }
     }
     return opaqueModel(modelRef);
+  }
+}
+
+function validateModelSegments(provider: string, api: string, id: string): void {
+  if (provider.length > MAX_IDENTIFIER_LENGTH) {
+    throw new MakaiProtocolError(
+      `model_ref provider segment exceeds maximum length of ${MAX_IDENTIFIER_LENGTH} characters`,
+      "invalid_request",
+    );
+  }
+  if (api.length > MAX_IDENTIFIER_LENGTH) {
+    throw new MakaiProtocolError(
+      `model_ref api segment exceeds maximum length of ${MAX_IDENTIFIER_LENGTH} characters`,
+      "invalid_request",
+    );
+  }
+  if (id.length > MAX_MODEL_FIELD_LENGTH) {
+    throw new MakaiProtocolError(
+      `model_ref model_id segment exceeds maximum length of ${MAX_MODEL_FIELD_LENGTH} characters`,
+      "invalid_request",
+    );
   }
 }
 

--- a/typescript/src/execution_client.ts
+++ b/typescript/src/execution_client.ts
@@ -5,7 +5,7 @@ import { MakaiAuthClient, MakaiAuthError, type AuthFlowHandlers, type MakaiAuthA
 import { parseModelRef } from "./diagnostics/model_ref";
 import { getNoopLogger, isNoopLogger, type MakaiLogger } from "./logger";
 import { createMakaiModelsApi } from "./models_client";
-import type { MakaiModelsApi } from "./models_types";
+import { MakaiProtocolError, type MakaiModelsApi } from "./models_types";
 import { type CreateMakaiStdioClientOptions, createMakaiStdioClient, MakaiStdioClient, type StdioFrame } from "./stdio_client";
 import {
   createTimeoutDiagnostics,
@@ -524,9 +524,24 @@ function buildAgentMessagePayload(
   return payload;
 }
 
+const MAX_MODEL_REF_LENGTH = 512;
+const MODEL_REF_REQUIRED_SEPARATOR = "/";
+
 function validateExecutionRequest(request: ProviderCompleteRequest | AgentRunRequest): void {
   if (!request || typeof request.model_ref !== "string" || request.model_ref.length === 0) {
     throw new TypeError("request requires opaque model_ref");
+  }
+  if (request.model_ref.length > MAX_MODEL_REF_LENGTH) {
+    throw new MakaiProtocolError(
+      `model_ref exceeds maximum length of ${MAX_MODEL_REF_LENGTH} characters`,
+      "invalid_request",
+    );
+  }
+  if (!request.model_ref.includes(MODEL_REF_REQUIRED_SEPARATOR)) {
+    throw new MakaiProtocolError(
+      "model_ref must contain a '/' separator (expected format: {provider_id}/{...})",
+      "invalid_request",
+    );
   }
   if (!Array.isArray(request.messages)) {
     throw new TypeError("request requires messages array");

--- a/typescript/src/execution_client.ts
+++ b/typescript/src/execution_client.ts
@@ -524,7 +524,9 @@ function buildAgentMessagePayload(
   return payload;
 }
 
-const MAX_MODEL_REF_LENGTH = 512;
+// Must accommodate max valid canonical ref: 256 (provider) + 1 (/) + 256 (api) + 1 (@) + 512 (model_id) = 1026.
+// Using 2048 to also cover percent-encoded model_id expansion (up to 3x) with margin.
+const MAX_MODEL_REF_LENGTH = 2048;
 const MAX_IDENTIFIER_LENGTH = 256;
 const MAX_MODEL_FIELD_LENGTH = 512;
 

--- a/typescript/src/models_client.ts
+++ b/typescript/src/models_client.ts
@@ -138,6 +138,18 @@ class StdioModelsApi implements MakaiModelsApi {
   }
 
   async list(request: ListModelsRequest = {}): Promise<ListModelsResponse> {
+    if (typeof request.provider_id === "string" && request.provider_id.length > MAX_PROVIDER_ID_LENGTH) {
+      throw new MakaiProtocolError(
+        `provider_id exceeds maximum length of ${MAX_PROVIDER_ID_LENGTH} characters`,
+        "invalid_request",
+      );
+    }
+    if (typeof request.model_id === "string" && request.model_id.length > MAX_MODEL_ID_LENGTH) {
+      throw new MakaiProtocolError(
+        `model_id exceeds maximum length of ${MAX_MODEL_ID_LENGTH} characters`,
+        "invalid_request",
+      );
+    }
     return this.dispatch(request, request.signal);
   }
 

--- a/typescript/src/models_client.ts
+++ b/typescript/src/models_client.ts
@@ -47,6 +47,8 @@ import {
 const ENVELOPE_VERSION = 1;
 const DEFAULT_CACHE_MAX_AGE_MS = 300_000; // spec §2.3 fallback when server omits
 const DEFAULT_RESPONSE_TIMEOUT_MS = 5_000;
+const MAX_PROVIDER_ID_LENGTH = 256;
+const MAX_MODEL_ID_LENGTH = 256;
 
 const KNOWN_AUTH_STATUSES: ReadonlySet<string> = new Set([
   "authenticated",
@@ -143,8 +145,20 @@ class StdioModelsApi implements MakaiModelsApi {
     if (!request || typeof request.provider_id !== "string" || request.provider_id.length === 0) {
       throw new MakaiProtocolError("resolve requires provider_id", "invalid_request");
     }
+    if (request.provider_id.length > MAX_PROVIDER_ID_LENGTH) {
+      throw new MakaiProtocolError(
+        `provider_id exceeds maximum length of ${MAX_PROVIDER_ID_LENGTH} characters`,
+        "invalid_request",
+      );
+    }
     if (typeof request.model_id !== "string" || request.model_id.length === 0) {
       throw new MakaiProtocolError("resolve requires model_id", "invalid_request");
+    }
+    if (request.model_id.length > MAX_MODEL_ID_LENGTH) {
+      throw new MakaiProtocolError(
+        `model_id exceeds maximum length of ${MAX_MODEL_ID_LENGTH} characters`,
+        "invalid_request",
+      );
     }
 
     const response = await this.dispatch({

--- a/typescript/test/execution_client.test.ts
+++ b/typescript/test/execution_client.test.ts
@@ -1444,7 +1444,7 @@ test("provider.complete rejects model_ref exceeding 512 characters before transp
   const harness = await setupHarness();
   try {
     const provider = createMakaiProviderApi(harness.client);
-    const longModelRef = "x/@" + "a".repeat(510); // 513 chars total
+    const longModelRef = "a".repeat(513);
     await assert.rejects(
       () => provider.complete({ model_ref: longModelRef, messages: [{ role: "user", content: "hi" }] }),
       (err: unknown) =>
@@ -1462,7 +1462,7 @@ test("provider.stream rejects model_ref exceeding 512 characters before transpor
   const harness = await setupHarness();
   try {
     const provider = createMakaiProviderApi(harness.client);
-    const longModelRef = "x/@" + "a".repeat(510); // 513 chars total
+    const longModelRef = "a".repeat(513);
     await assert.rejects(
       async () => collect(provider.stream({ model_ref: longModelRef, messages: [{ role: "user", content: "hi" }] })),
       (err: unknown) =>
@@ -1476,45 +1476,11 @@ test("provider.stream rejects model_ref exceeding 512 characters before transpor
   }
 });
 
-test("provider.complete rejects model_ref without '/' separator before transport I/O", async () => {
-  const harness = await setupHarness();
-  try {
-    const provider = createMakaiProviderApi(harness.client);
-    await assert.rejects(
-      () => provider.complete({ model_ref: "no-slash-here", messages: [{ role: "user", content: "hi" }] }),
-      (err: unknown) =>
-        err instanceof MakaiProtocolError &&
-        err.code === "invalid_request" &&
-        err.message === "model_ref must contain a '/' separator (expected format: {provider_id}/{...})",
-    );
-    assert.deepEqual(readLoggedRequests(harness.logPath), []);
-  } finally {
-    await harness.cleanup();
-  }
-});
-
-test("provider.stream rejects model_ref without '/' separator before transport I/O", async () => {
-  const harness = await setupHarness();
-  try {
-    const provider = createMakaiProviderApi(harness.client);
-    await assert.rejects(
-      async () => collect(provider.stream({ model_ref: "no-slash-here", messages: [{ role: "user", content: "hi" }] })),
-      (err: unknown) =>
-        err instanceof MakaiProtocolError &&
-        err.code === "invalid_request" &&
-        err.message === "model_ref must contain a '/' separator (expected format: {provider_id}/{...})",
-    );
-    assert.deepEqual(readLoggedRequests(harness.logPath), []);
-  } finally {
-    await harness.cleanup();
-  }
-});
-
 test("agent.run rejects model_ref exceeding 512 characters before transport I/O", async () => {
   const harness = await setupHarness();
   try {
     const agent = createMakaiAgentApi(harness.client);
-    const longModelRef = "x/@" + "a".repeat(510); // 513 chars total
+    const longModelRef = "a".repeat(513);
     await assert.rejects(
       () => agent.run({ model_ref: longModelRef, messages: [{ role: "user", content: "hi" }] }),
       (err: unknown) =>
@@ -1532,7 +1498,7 @@ test("agent.stream rejects model_ref exceeding 512 characters before transport I
   const harness = await setupHarness();
   try {
     const agent = createMakaiAgentApi(harness.client);
-    const longModelRef = "x/@" + "a".repeat(510); // 513 chars total
+    const longModelRef = "a".repeat(513);
     await assert.rejects(
       async () => collect(agent.stream({ model_ref: longModelRef, messages: [{ role: "user", content: "hi" }] })),
       (err: unknown) =>
@@ -1546,47 +1512,11 @@ test("agent.stream rejects model_ref exceeding 512 characters before transport I
   }
 });
 
-test("agent.run rejects model_ref without '/' separator before transport I/O", async () => {
-  const harness = await setupHarness();
-  try {
-    const agent = createMakaiAgentApi(harness.client);
-    await assert.rejects(
-      () => agent.run({ model_ref: "no-slash-here", messages: [{ role: "user", content: "hi" }] }),
-      (err: unknown) =>
-        err instanceof MakaiProtocolError &&
-        err.code === "invalid_request" &&
-        err.message === "model_ref must contain a '/' separator (expected format: {provider_id}/{...})",
-    );
-    assert.deepEqual(readLoggedRequests(harness.logPath), []);
-  } finally {
-    await harness.cleanup();
-  }
-});
-
-test("agent.stream rejects model_ref without '/' separator before transport I/O", async () => {
-  const harness = await setupHarness();
-  try {
-    const agent = createMakaiAgentApi(harness.client);
-    await assert.rejects(
-      async () => collect(agent.stream({ model_ref: "no-slash-here", messages: [{ role: "user", content: "hi" }] })),
-      (err: unknown) =>
-        err instanceof MakaiProtocolError &&
-        err.code === "invalid_request" &&
-        err.message === "model_ref must contain a '/' separator (expected format: {provider_id}/{...})",
-    );
-    assert.deepEqual(readLoggedRequests(harness.logPath), []);
-  } finally {
-    await harness.cleanup();
-  }
-});
-
 test("provider.complete accepts model_ref at exactly 512 characters", async () => {
   const harness = await setupHarness();
   try {
     const provider = createMakaiProviderApi(harness.client);
-    // Build a valid model_ref of exactly 512 chars: provider/api@model
-    const modelId = "a".repeat(512 - "provider/api@".length);
-    const modelRef = `provider/api@${modelId}`;
+    const modelRef = "a".repeat(512);
     assert.equal(modelRef.length, 512);
     // This should NOT throw - it will send to the transport and get a response
     await provider.complete({ model_ref: modelRef, messages: [{ role: "user", content: "hi" }] });
@@ -1601,8 +1531,7 @@ test("provider.complete accepts model_ref at 511 characters", async () => {
   const harness = await setupHarness();
   try {
     const provider = createMakaiProviderApi(harness.client);
-    const modelId = "a".repeat(511 - "provider/api@".length);
-    const modelRef = `provider/api@${modelId}`;
+    const modelRef = "a".repeat(511);
     assert.equal(modelRef.length, 511);
     await provider.complete({ model_ref: modelRef, messages: [{ role: "user", content: "hi" }] });
     const logged = readLoggedRequests(harness.logPath);

--- a/typescript/test/execution_client.test.ts
+++ b/typescript/test/execution_client.test.ts
@@ -1512,6 +1512,105 @@ test("agent.stream rejects model_ref exceeding 512 characters before transport I
   }
 });
 
+// --- model_ref segment-level validation tests ---
+
+test("provider.complete rejects canonical model_ref with provider segment exceeding 256 characters", async () => {
+  const harness = await setupHarness();
+  try {
+    const provider = createMakaiProviderApi(harness.client);
+    const longProvider = "a".repeat(257);
+    const modelRef = `${longProvider}/anthropic-messages@claude-sonnet-4-5`;
+    await assert.rejects(
+      () => provider.complete({ model_ref: modelRef, messages: [{ role: "user", content: "hi" }] }),
+      (err: unknown) =>
+        err instanceof MakaiProtocolError &&
+        err.code === "invalid_request" &&
+        err.message === "model_ref provider segment exceeds maximum length of 256 characters",
+    );
+    assert.deepEqual(readLoggedRequests(harness.logPath), []);
+  } finally {
+    await harness.cleanup();
+  }
+});
+
+test("provider.stream rejects canonical model_ref with api segment exceeding 256 characters", async () => {
+  const harness = await setupHarness();
+  try {
+    const provider = createMakaiProviderApi(harness.client);
+    const longApi = "a".repeat(257);
+    const modelRef = `anthropic/${longApi}@claude-sonnet-4-5`;
+    await assert.rejects(
+      async () => collect(provider.stream({ model_ref: modelRef, messages: [{ role: "user", content: "hi" }] })),
+      (err: unknown) =>
+        err instanceof MakaiProtocolError &&
+        err.code === "invalid_request" &&
+        err.message === "model_ref api segment exceeds maximum length of 256 characters",
+    );
+    assert.deepEqual(readLoggedRequests(harness.logPath), []);
+  } finally {
+    await harness.cleanup();
+  }
+});
+
+test("agent.run rejects canonical model_ref with api segment exceeding 256 characters", async () => {
+  const harness = await setupHarness();
+  try {
+    const agent = createMakaiAgentApi(harness.client);
+    const longApi = "a".repeat(257);
+    const modelRef = `anthropic/${longApi}@claude-sonnet-4-5`;
+    await assert.rejects(
+      () => agent.run({ model_ref: modelRef, messages: [{ role: "user", content: "hi" }] }),
+      (err: unknown) =>
+        err instanceof MakaiProtocolError &&
+        err.code === "invalid_request" &&
+        err.message === "model_ref api segment exceeds maximum length of 256 characters",
+    );
+    assert.deepEqual(readLoggedRequests(harness.logPath), []);
+  } finally {
+    await harness.cleanup();
+  }
+});
+
+test("provider.complete rejects fallback model_ref with provider segment exceeding 256 characters", async () => {
+  const harness = await setupHarness();
+  try {
+    const provider = createMakaiProviderApi(harness.client);
+    const longProvider = "a".repeat(257);
+    // Use colon in model_id to force parseModelRef failure, triggering fallback path
+    const modelRef = `${longProvider}/anthropic-messages@model:id`;
+    await assert.rejects(
+      () => provider.complete({ model_ref: modelRef, messages: [{ role: "user", content: "hi" }] }),
+      (err: unknown) =>
+        err instanceof MakaiProtocolError &&
+        err.code === "invalid_request" &&
+        err.message === "model_ref provider segment exceeds maximum length of 256 characters",
+    );
+    assert.deepEqual(readLoggedRequests(harness.logPath), []);
+  } finally {
+    await harness.cleanup();
+  }
+});
+
+test("provider.complete rejects fallback model_ref with api segment exceeding 256 characters", async () => {
+  const harness = await setupHarness();
+  try {
+    const provider = createMakaiProviderApi(harness.client);
+    const longApi = "a".repeat(257);
+    // Use colon in model_id to force parseModelRef failure, triggering fallback path
+    const modelRef = `anthropic/${longApi}@model:id`;
+    await assert.rejects(
+      () => provider.complete({ model_ref: modelRef, messages: [{ role: "user", content: "hi" }] }),
+      (err: unknown) =>
+        err instanceof MakaiProtocolError &&
+        err.code === "invalid_request" &&
+        err.message === "model_ref api segment exceeds maximum length of 256 characters",
+    );
+    assert.deepEqual(readLoggedRequests(harness.logPath), []);
+  } finally {
+    await harness.cleanup();
+  }
+});
+
 test("provider.complete accepts model_ref at exactly 512 characters", async () => {
   const harness = await setupHarness();
   try {

--- a/typescript/test/execution_client.test.ts
+++ b/typescript/test/execution_client.test.ts
@@ -1440,17 +1440,17 @@ test("acceptance: provider and agent execution accept the same model_ref", async
 
 // --- model_ref input validation tests ---
 
-test("provider.complete rejects model_ref exceeding 512 characters before transport I/O", async () => {
+test("provider.complete rejects model_ref exceeding 2048 characters before transport I/O", async () => {
   const harness = await setupHarness();
   try {
     const provider = createMakaiProviderApi(harness.client);
-    const longModelRef = "a".repeat(513);
+    const longModelRef = "a".repeat(2049);
     await assert.rejects(
       () => provider.complete({ model_ref: longModelRef, messages: [{ role: "user", content: "hi" }] }),
       (err: unknown) =>
         err instanceof MakaiProtocolError &&
         err.code === "invalid_request" &&
-        err.message === "model_ref exceeds maximum length of 512 characters",
+        err.message === "model_ref exceeds maximum length of 2048 characters",
     );
     assert.deepEqual(readLoggedRequests(harness.logPath), []);
   } finally {
@@ -1458,17 +1458,17 @@ test("provider.complete rejects model_ref exceeding 512 characters before transp
   }
 });
 
-test("provider.stream rejects model_ref exceeding 512 characters before transport I/O", async () => {
+test("provider.stream rejects model_ref exceeding 2048 characters before transport I/O", async () => {
   const harness = await setupHarness();
   try {
     const provider = createMakaiProviderApi(harness.client);
-    const longModelRef = "a".repeat(513);
+    const longModelRef = "a".repeat(2049);
     await assert.rejects(
       async () => collect(provider.stream({ model_ref: longModelRef, messages: [{ role: "user", content: "hi" }] })),
       (err: unknown) =>
         err instanceof MakaiProtocolError &&
         err.code === "invalid_request" &&
-        err.message === "model_ref exceeds maximum length of 512 characters",
+        err.message === "model_ref exceeds maximum length of 2048 characters",
     );
     assert.deepEqual(readLoggedRequests(harness.logPath), []);
   } finally {
@@ -1476,17 +1476,17 @@ test("provider.stream rejects model_ref exceeding 512 characters before transpor
   }
 });
 
-test("agent.run rejects model_ref exceeding 512 characters before transport I/O", async () => {
+test("agent.run rejects model_ref exceeding 2048 characters before transport I/O", async () => {
   const harness = await setupHarness();
   try {
     const agent = createMakaiAgentApi(harness.client);
-    const longModelRef = "a".repeat(513);
+    const longModelRef = "a".repeat(2049);
     await assert.rejects(
       () => agent.run({ model_ref: longModelRef, messages: [{ role: "user", content: "hi" }] }),
       (err: unknown) =>
         err instanceof MakaiProtocolError &&
         err.code === "invalid_request" &&
-        err.message === "model_ref exceeds maximum length of 512 characters",
+        err.message === "model_ref exceeds maximum length of 2048 characters",
     );
     assert.deepEqual(readLoggedRequests(harness.logPath), []);
   } finally {
@@ -1494,17 +1494,17 @@ test("agent.run rejects model_ref exceeding 512 characters before transport I/O"
   }
 });
 
-test("agent.stream rejects model_ref exceeding 512 characters before transport I/O", async () => {
+test("agent.stream rejects model_ref exceeding 2048 characters before transport I/O", async () => {
   const harness = await setupHarness();
   try {
     const agent = createMakaiAgentApi(harness.client);
-    const longModelRef = "a".repeat(513);
+    const longModelRef = "a".repeat(2049);
     await assert.rejects(
       async () => collect(agent.stream({ model_ref: longModelRef, messages: [{ role: "user", content: "hi" }] })),
       (err: unknown) =>
         err instanceof MakaiProtocolError &&
         err.code === "invalid_request" &&
-        err.message === "model_ref exceeds maximum length of 512 characters",
+        err.message === "model_ref exceeds maximum length of 2048 characters",
     );
     assert.deepEqual(readLoggedRequests(harness.logPath), []);
   } finally {
@@ -1611,12 +1611,12 @@ test("provider.complete rejects fallback model_ref with api segment exceeding 25
   }
 });
 
-test("provider.complete accepts model_ref at exactly 512 characters", async () => {
+test("provider.complete accepts model_ref at exactly 2048 characters", async () => {
   const harness = await setupHarness();
   try {
     const provider = createMakaiProviderApi(harness.client);
-    const modelRef = "a".repeat(512);
-    assert.equal(modelRef.length, 512);
+    const modelRef = "a".repeat(2048);
+    assert.equal(modelRef.length, 2048);
     // This should NOT throw - it will send to the transport and get a response
     await provider.complete({ model_ref: modelRef, messages: [{ role: "user", content: "hi" }] });
     const logged = readLoggedRequests(harness.logPath);
@@ -1626,12 +1626,12 @@ test("provider.complete accepts model_ref at exactly 512 characters", async () =
   }
 });
 
-test("provider.complete accepts model_ref at 511 characters", async () => {
+test("provider.complete accepts model_ref at 2047 characters", async () => {
   const harness = await setupHarness();
   try {
     const provider = createMakaiProviderApi(harness.client);
-    const modelRef = "a".repeat(511);
-    assert.equal(modelRef.length, 511);
+    const modelRef = "a".repeat(2047);
+    assert.equal(modelRef.length, 2047);
     await provider.complete({ model_ref: modelRef, messages: [{ role: "user", content: "hi" }] });
     const logged = readLoggedRequests(harness.logPath);
     assert.equal(logged.length, 1);

--- a/typescript/test/execution_client.test.ts
+++ b/typescript/test/execution_client.test.ts
@@ -1440,17 +1440,17 @@ test("acceptance: provider and agent execution accept the same model_ref", async
 
 // --- model_ref input validation tests ---
 
-test("provider.complete rejects model_ref exceeding 2048 characters before transport I/O", async () => {
+test("provider.complete rejects model_ref exceeding 4096 characters before transport I/O", async () => {
   const harness = await setupHarness();
   try {
     const provider = createMakaiProviderApi(harness.client);
-    const longModelRef = "a".repeat(2049);
+    const longModelRef = "a".repeat(4097);
     await assert.rejects(
       () => provider.complete({ model_ref: longModelRef, messages: [{ role: "user", content: "hi" }] }),
       (err: unknown) =>
         err instanceof MakaiProtocolError &&
         err.code === "invalid_request" &&
-        err.message === "model_ref exceeds maximum length of 2048 characters",
+        err.message === "model_ref exceeds maximum length of 4096 characters",
     );
     assert.deepEqual(readLoggedRequests(harness.logPath), []);
   } finally {
@@ -1458,17 +1458,17 @@ test("provider.complete rejects model_ref exceeding 2048 characters before trans
   }
 });
 
-test("provider.stream rejects model_ref exceeding 2048 characters before transport I/O", async () => {
+test("provider.stream rejects model_ref exceeding 4096 characters before transport I/O", async () => {
   const harness = await setupHarness();
   try {
     const provider = createMakaiProviderApi(harness.client);
-    const longModelRef = "a".repeat(2049);
+    const longModelRef = "a".repeat(4097);
     await assert.rejects(
       async () => collect(provider.stream({ model_ref: longModelRef, messages: [{ role: "user", content: "hi" }] })),
       (err: unknown) =>
         err instanceof MakaiProtocolError &&
         err.code === "invalid_request" &&
-        err.message === "model_ref exceeds maximum length of 2048 characters",
+        err.message === "model_ref exceeds maximum length of 4096 characters",
     );
     assert.deepEqual(readLoggedRequests(harness.logPath), []);
   } finally {
@@ -1476,17 +1476,17 @@ test("provider.stream rejects model_ref exceeding 2048 characters before transpo
   }
 });
 
-test("agent.run rejects model_ref exceeding 2048 characters before transport I/O", async () => {
+test("agent.run rejects model_ref exceeding 4096 characters before transport I/O", async () => {
   const harness = await setupHarness();
   try {
     const agent = createMakaiAgentApi(harness.client);
-    const longModelRef = "a".repeat(2049);
+    const longModelRef = "a".repeat(4097);
     await assert.rejects(
       () => agent.run({ model_ref: longModelRef, messages: [{ role: "user", content: "hi" }] }),
       (err: unknown) =>
         err instanceof MakaiProtocolError &&
         err.code === "invalid_request" &&
-        err.message === "model_ref exceeds maximum length of 2048 characters",
+        err.message === "model_ref exceeds maximum length of 4096 characters",
     );
     assert.deepEqual(readLoggedRequests(harness.logPath), []);
   } finally {
@@ -1494,17 +1494,17 @@ test("agent.run rejects model_ref exceeding 2048 characters before transport I/O
   }
 });
 
-test("agent.stream rejects model_ref exceeding 2048 characters before transport I/O", async () => {
+test("agent.stream rejects model_ref exceeding 4096 characters before transport I/O", async () => {
   const harness = await setupHarness();
   try {
     const agent = createMakaiAgentApi(harness.client);
-    const longModelRef = "a".repeat(2049);
+    const longModelRef = "a".repeat(4097);
     await assert.rejects(
       async () => collect(agent.stream({ model_ref: longModelRef, messages: [{ role: "user", content: "hi" }] })),
       (err: unknown) =>
         err instanceof MakaiProtocolError &&
         err.code === "invalid_request" &&
-        err.message === "model_ref exceeds maximum length of 2048 characters",
+        err.message === "model_ref exceeds maximum length of 4096 characters",
     );
     assert.deepEqual(readLoggedRequests(harness.logPath), []);
   } finally {
@@ -1611,13 +1611,33 @@ test("provider.complete rejects fallback model_ref with api segment exceeding 25
   }
 });
 
-test("provider.complete accepts model_ref at exactly 2048 characters", async () => {
+// --- opaque model_ref validation tests ---
+
+test("provider.complete rejects opaque model_ref exceeding 512 characters before transport I/O", async () => {
   const harness = await setupHarness();
   try {
     const provider = createMakaiProviderApi(harness.client);
-    const modelRef = "a".repeat(2048);
-    assert.equal(modelRef.length, 2048);
-    // This should NOT throw - it will send to the transport and get a response
+    // No / or @ separators — fully opaque ref that becomes model.id/model.name
+    const longModelRef = "x".repeat(513);
+    await assert.rejects(
+      () => provider.complete({ model_ref: longModelRef, messages: [{ role: "user", content: "hi" }] }),
+      (err: unknown) =>
+        err instanceof MakaiProtocolError &&
+        err.code === "invalid_request" &&
+        err.message === "model_ref exceeds maximum length of 512 characters for opaque refs",
+    );
+    assert.deepEqual(readLoggedRequests(harness.logPath), []);
+  } finally {
+    await harness.cleanup();
+  }
+});
+
+test("provider.complete accepts opaque model_ref at exactly 512 characters", async () => {
+  const harness = await setupHarness();
+  try {
+    const provider = createMakaiProviderApi(harness.client);
+    const modelRef = "x".repeat(512);
+    assert.equal(modelRef.length, 512);
     await provider.complete({ model_ref: modelRef, messages: [{ role: "user", content: "hi" }] });
     const logged = readLoggedRequests(harness.logPath);
     assert.equal(logged.length, 1);
@@ -1626,12 +1646,14 @@ test("provider.complete accepts model_ref at exactly 2048 characters", async () 
   }
 });
 
-test("provider.complete accepts model_ref at 2047 characters", async () => {
+test("provider.complete accepts canonical model_ref with max valid segment sizes", async () => {
   const harness = await setupHarness();
   try {
     const provider = createMakaiProviderApi(harness.client);
-    const modelRef = "a".repeat(2047);
-    assert.equal(modelRef.length, 2047);
+    // Max valid canonical ref: 256-char provider, 256-char api, 512-char model_id = 1026 total
+    const modelRef = `${"p".repeat(256)}/${"a".repeat(256)}@${"m".repeat(512)}`;
+    assert.equal(modelRef.length, 256 + 1 + 256 + 1 + 512);
+    // Passes both total cap (4096) and all segment caps
     await provider.complete({ model_ref: modelRef, messages: [{ role: "user", content: "hi" }] });
     const logged = readLoggedRequests(harness.logPath);
     assert.equal(logged.length, 1);

--- a/typescript/test/execution_client.test.ts
+++ b/typescript/test/execution_client.test.ts
@@ -9,6 +9,7 @@ import {
   createMakaiProviderApi,
   MakaiStdioClient,
   MakaiAuthRequiredError,
+  MakaiProtocolError,
   MakaiStreamError,
   type AgentStreamEvent,
   type ProviderStreamEvent,
@@ -1434,5 +1435,179 @@ test("acceptance: provider and agent execution accept the same model_ref", async
   } finally {
     await handle.close();
     fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+// --- model_ref input validation tests ---
+
+test("provider.complete rejects model_ref exceeding 512 characters before transport I/O", async () => {
+  const harness = await setupHarness();
+  try {
+    const provider = createMakaiProviderApi(harness.client);
+    const longModelRef = "x/@" + "a".repeat(510); // 513 chars total
+    await assert.rejects(
+      () => provider.complete({ model_ref: longModelRef, messages: [{ role: "user", content: "hi" }] }),
+      (err: unknown) =>
+        err instanceof MakaiProtocolError &&
+        err.code === "invalid_request" &&
+        err.message === "model_ref exceeds maximum length of 512 characters",
+    );
+    assert.deepEqual(readLoggedRequests(harness.logPath), []);
+  } finally {
+    await harness.cleanup();
+  }
+});
+
+test("provider.stream rejects model_ref exceeding 512 characters before transport I/O", async () => {
+  const harness = await setupHarness();
+  try {
+    const provider = createMakaiProviderApi(harness.client);
+    const longModelRef = "x/@" + "a".repeat(510); // 513 chars total
+    await assert.rejects(
+      async () => collect(provider.stream({ model_ref: longModelRef, messages: [{ role: "user", content: "hi" }] })),
+      (err: unknown) =>
+        err instanceof MakaiProtocolError &&
+        err.code === "invalid_request" &&
+        err.message === "model_ref exceeds maximum length of 512 characters",
+    );
+    assert.deepEqual(readLoggedRequests(harness.logPath), []);
+  } finally {
+    await harness.cleanup();
+  }
+});
+
+test("provider.complete rejects model_ref without '/' separator before transport I/O", async () => {
+  const harness = await setupHarness();
+  try {
+    const provider = createMakaiProviderApi(harness.client);
+    await assert.rejects(
+      () => provider.complete({ model_ref: "no-slash-here", messages: [{ role: "user", content: "hi" }] }),
+      (err: unknown) =>
+        err instanceof MakaiProtocolError &&
+        err.code === "invalid_request" &&
+        err.message === "model_ref must contain a '/' separator (expected format: {provider_id}/{...})",
+    );
+    assert.deepEqual(readLoggedRequests(harness.logPath), []);
+  } finally {
+    await harness.cleanup();
+  }
+});
+
+test("provider.stream rejects model_ref without '/' separator before transport I/O", async () => {
+  const harness = await setupHarness();
+  try {
+    const provider = createMakaiProviderApi(harness.client);
+    await assert.rejects(
+      async () => collect(provider.stream({ model_ref: "no-slash-here", messages: [{ role: "user", content: "hi" }] })),
+      (err: unknown) =>
+        err instanceof MakaiProtocolError &&
+        err.code === "invalid_request" &&
+        err.message === "model_ref must contain a '/' separator (expected format: {provider_id}/{...})",
+    );
+    assert.deepEqual(readLoggedRequests(harness.logPath), []);
+  } finally {
+    await harness.cleanup();
+  }
+});
+
+test("agent.run rejects model_ref exceeding 512 characters before transport I/O", async () => {
+  const harness = await setupHarness();
+  try {
+    const agent = createMakaiAgentApi(harness.client);
+    const longModelRef = "x/@" + "a".repeat(510); // 513 chars total
+    await assert.rejects(
+      () => agent.run({ model_ref: longModelRef, messages: [{ role: "user", content: "hi" }] }),
+      (err: unknown) =>
+        err instanceof MakaiProtocolError &&
+        err.code === "invalid_request" &&
+        err.message === "model_ref exceeds maximum length of 512 characters",
+    );
+    assert.deepEqual(readLoggedRequests(harness.logPath), []);
+  } finally {
+    await harness.cleanup();
+  }
+});
+
+test("agent.stream rejects model_ref exceeding 512 characters before transport I/O", async () => {
+  const harness = await setupHarness();
+  try {
+    const agent = createMakaiAgentApi(harness.client);
+    const longModelRef = "x/@" + "a".repeat(510); // 513 chars total
+    await assert.rejects(
+      async () => collect(agent.stream({ model_ref: longModelRef, messages: [{ role: "user", content: "hi" }] })),
+      (err: unknown) =>
+        err instanceof MakaiProtocolError &&
+        err.code === "invalid_request" &&
+        err.message === "model_ref exceeds maximum length of 512 characters",
+    );
+    assert.deepEqual(readLoggedRequests(harness.logPath), []);
+  } finally {
+    await harness.cleanup();
+  }
+});
+
+test("agent.run rejects model_ref without '/' separator before transport I/O", async () => {
+  const harness = await setupHarness();
+  try {
+    const agent = createMakaiAgentApi(harness.client);
+    await assert.rejects(
+      () => agent.run({ model_ref: "no-slash-here", messages: [{ role: "user", content: "hi" }] }),
+      (err: unknown) =>
+        err instanceof MakaiProtocolError &&
+        err.code === "invalid_request" &&
+        err.message === "model_ref must contain a '/' separator (expected format: {provider_id}/{...})",
+    );
+    assert.deepEqual(readLoggedRequests(harness.logPath), []);
+  } finally {
+    await harness.cleanup();
+  }
+});
+
+test("agent.stream rejects model_ref without '/' separator before transport I/O", async () => {
+  const harness = await setupHarness();
+  try {
+    const agent = createMakaiAgentApi(harness.client);
+    await assert.rejects(
+      async () => collect(agent.stream({ model_ref: "no-slash-here", messages: [{ role: "user", content: "hi" }] })),
+      (err: unknown) =>
+        err instanceof MakaiProtocolError &&
+        err.code === "invalid_request" &&
+        err.message === "model_ref must contain a '/' separator (expected format: {provider_id}/{...})",
+    );
+    assert.deepEqual(readLoggedRequests(harness.logPath), []);
+  } finally {
+    await harness.cleanup();
+  }
+});
+
+test("provider.complete accepts model_ref at exactly 512 characters", async () => {
+  const harness = await setupHarness();
+  try {
+    const provider = createMakaiProviderApi(harness.client);
+    // Build a valid model_ref of exactly 512 chars: provider/api@model
+    const modelId = "a".repeat(512 - "provider/api@".length);
+    const modelRef = `provider/api@${modelId}`;
+    assert.equal(modelRef.length, 512);
+    // This should NOT throw - it will send to the transport and get a response
+    await provider.complete({ model_ref: modelRef, messages: [{ role: "user", content: "hi" }] });
+    const logged = readLoggedRequests(harness.logPath);
+    assert.equal(logged.length, 1);
+  } finally {
+    await harness.cleanup();
+  }
+});
+
+test("provider.complete accepts model_ref at 511 characters", async () => {
+  const harness = await setupHarness();
+  try {
+    const provider = createMakaiProviderApi(harness.client);
+    const modelId = "a".repeat(511 - "provider/api@".length);
+    const modelRef = `provider/api@${modelId}`;
+    assert.equal(modelRef.length, 511);
+    await provider.complete({ model_ref: modelRef, messages: [{ role: "user", content: "hi" }] });
+    const logged = readLoggedRequests(harness.logPath);
+    assert.equal(logged.length, 1);
+  } finally {
+    await harness.cleanup();
   }
 });

--- a/typescript/test/models_client.test.ts
+++ b/typescript/test/models_client.test.ts
@@ -479,3 +479,119 @@ test("models.resolve rejects locally when provider_id or model_id is missing", a
     await harness.cleanup();
   }
 });
+
+// --- provider_id / model_id input length validation tests ---
+
+test("models.resolve rejects provider_id exceeding 256 characters before transport I/O", async () => {
+  const harness = await setupHarness({ response: makeResponse([makeDescriptor()]) });
+  try {
+    const api = createMakaiModelsApi(harness.client);
+    const longProviderId = "a".repeat(257);
+    await assert.rejects(
+      () => api.resolve({ provider_id: longProviderId, model_id: "claude-sonnet-4-5" }),
+      (err: unknown) =>
+        err instanceof MakaiProtocolError &&
+        err.code === "invalid_request" &&
+        err.message === "provider_id exceeds maximum length of 256 characters",
+    );
+    assert.equal(readLoggedRequests(harness.logPath).length, 0);
+  } finally {
+    await harness.cleanup();
+  }
+});
+
+test("models.resolve rejects model_id exceeding 256 characters before transport I/O", async () => {
+  const harness = await setupHarness({ response: makeResponse([makeDescriptor()]) });
+  try {
+    const api = createMakaiModelsApi(harness.client);
+    const longModelId = "a".repeat(257);
+    await assert.rejects(
+      () => api.resolve({ provider_id: "anthropic", model_id: longModelId }),
+      (err: unknown) =>
+        err instanceof MakaiProtocolError &&
+        err.code === "invalid_request" &&
+        err.message === "model_id exceeds maximum length of 256 characters",
+    );
+    assert.equal(readLoggedRequests(harness.logPath).length, 0);
+  } finally {
+    await harness.cleanup();
+  }
+});
+
+test("models.resolve accepts provider_id at exactly 256 characters", async () => {
+  const descriptor = makeDescriptor({
+    provider_id: "a".repeat(256),
+    model_ref: `${"a".repeat(256)}/anthropic-messages@claude-sonnet-4-5`,
+  });
+  const harness = await setupHarness({ response: makeResponse([descriptor]) });
+  try {
+    const api = createMakaiModelsApi(harness.client);
+    // This should NOT throw — the request is valid; it will reach the server
+    // and either resolve or fail at a later check (model not found etc.)
+    await api.resolve({ provider_id: "a".repeat(256), model_id: "claude-sonnet-4-5" });
+  } catch (err) {
+    // Expected: may fail at model mismatch check, but NOT at length validation
+    assert.ok(err instanceof MakaiProtocolError && err.code === "invalid_request");
+    assert.ok(
+      !err.message.includes("exceeds maximum length"),
+      `unexpected length validation error: ${err.message}`,
+    );
+  } finally {
+    await harness.cleanup();
+  }
+});
+
+test("models.resolve accepts model_id at exactly 256 characters", async () => {
+  const longModelId = "a".repeat(256);
+  const descriptor = makeDescriptor({
+    model_id: longModelId,
+    model_ref: `anthropic/anthropic-messages@${longModelId}`,
+  });
+  const harness = await setupHarness({ response: makeResponse([descriptor]) });
+  try {
+    const api = createMakaiModelsApi(harness.client);
+    await api.resolve({ provider_id: "anthropic", model_id: longModelId });
+  } catch (err) {
+    assert.ok(err instanceof MakaiProtocolError && err.code === "invalid_request");
+    assert.ok(
+      !err.message.includes("exceeds maximum length"),
+      `unexpected length validation error: ${err.message}`,
+    );
+  } finally {
+    await harness.cleanup();
+  }
+});
+
+test("models.resolve rejects provider_id at 257 characters (boundary +1)", async () => {
+  const harness = await setupHarness({ response: makeResponse([makeDescriptor()]) });
+  try {
+    const api = createMakaiModelsApi(harness.client);
+    await assert.rejects(
+      () => api.resolve({ provider_id: "b".repeat(257), model_id: "model" }),
+      (err: unknown) =>
+        err instanceof MakaiProtocolError &&
+        err.code === "invalid_request" &&
+        err.message === "provider_id exceeds maximum length of 256 characters",
+    );
+    assert.equal(readLoggedRequests(harness.logPath).length, 0);
+  } finally {
+    await harness.cleanup();
+  }
+});
+
+test("models.resolve rejects model_id at 257 characters (boundary +1)", async () => {
+  const harness = await setupHarness({ response: makeResponse([makeDescriptor()]) });
+  try {
+    const api = createMakaiModelsApi(harness.client);
+    await assert.rejects(
+      () => api.resolve({ provider_id: "anthropic", model_id: "c".repeat(257) }),
+      (err: unknown) =>
+        err instanceof MakaiProtocolError &&
+        err.code === "invalid_request" &&
+        err.message === "model_id exceeds maximum length of 256 characters",
+    );
+    assert.equal(readLoggedRequests(harness.logPath).length, 0);
+  } finally {
+    await harness.cleanup();
+  }
+});

--- a/typescript/test/models_client.test.ts
+++ b/typescript/test/models_client.test.ts
@@ -526,8 +526,6 @@ test("models.resolve accepts provider_id at exactly 256 characters", async () =>
   const harness = await setupHarness({ response: makeResponse([descriptor]) });
   try {
     const api = createMakaiModelsApi(harness.client);
-    // This should NOT throw — the request is valid; it will reach the server
-    // and either resolve or fail at a later check (model not found etc.)
     await api.resolve({ provider_id: "a".repeat(256), model_id: "claude-sonnet-4-5" });
   } catch (err) {
     // Expected: may fail at model mismatch check, but NOT at length validation
@@ -562,12 +560,13 @@ test("models.resolve accepts model_id at exactly 256 characters", async () => {
   }
 });
 
-test("models.resolve rejects provider_id at 257 characters (boundary +1)", async () => {
+test("models.list rejects provider_id filter exceeding 256 characters before transport I/O", async () => {
   const harness = await setupHarness({ response: makeResponse([makeDescriptor()]) });
   try {
     const api = createMakaiModelsApi(harness.client);
+    const longProviderId = "a".repeat(257);
     await assert.rejects(
-      () => api.resolve({ provider_id: "b".repeat(257), model_id: "model" }),
+      () => api.list({ provider_id: longProviderId }),
       (err: unknown) =>
         err instanceof MakaiProtocolError &&
         err.code === "invalid_request" &&
@@ -579,12 +578,13 @@ test("models.resolve rejects provider_id at 257 characters (boundary +1)", async
   }
 });
 
-test("models.resolve rejects model_id at 257 characters (boundary +1)", async () => {
+test("models.list rejects model_id filter exceeding 256 characters before transport I/O", async () => {
   const harness = await setupHarness({ response: makeResponse([makeDescriptor()]) });
   try {
     const api = createMakaiModelsApi(harness.client);
+    const longModelId = "a".repeat(257);
     await assert.rejects(
-      () => api.resolve({ provider_id: "anthropic", model_id: "c".repeat(257) }),
+      () => api.list({ model_id: longModelId }),
       (err: unknown) =>
         err instanceof MakaiProtocolError &&
         err.code === "invalid_request" &&

--- a/zig/src/protocol/provider/envelope.zig
+++ b/zig/src/protocol/provider/envelope.zig
@@ -730,16 +730,26 @@ fn deserializeStreamRequest(
     // Parse nested model object per PROTOCOL.md
     const model_obj = obj.get("model").?.object;
 
-    // Allocate each field separately with errdefer to avoid leaks on OOM
-    const id = try allocator.dupe(u8, model_obj.get("id").?.string);
+    // Validate and allocate each field separately with errdefer to avoid leaks on OOM
+    const id_str = model_obj.get("id").?.string;
+    try validateLength(id_str, MAX_MODEL_FIELD_LENGTH);
+    const id = try allocator.dupe(u8, id_str);
     errdefer allocator.free(id);
-    const name = try allocator.dupe(u8, model_obj.get("name").?.string);
+    const name_str = model_obj.get("name").?.string;
+    try validateLength(name_str, MAX_MODEL_FIELD_LENGTH);
+    const name = try allocator.dupe(u8, name_str);
     errdefer allocator.free(name);
-    const api = try allocator.dupe(u8, model_obj.get("api").?.string);
+    const api_str = model_obj.get("api").?.string;
+    try validateLength(api_str, MAX_IDENTIFIER_LENGTH);
+    const api = try allocator.dupe(u8, api_str);
     errdefer allocator.free(api);
-    const provider = try allocator.dupe(u8, model_obj.get("provider").?.string);
+    const provider_str = model_obj.get("provider").?.string;
+    try validateLength(provider_str, MAX_IDENTIFIER_LENGTH);
+    const provider = try allocator.dupe(u8, provider_str);
     errdefer allocator.free(provider);
-    const base_url = try allocator.dupe(u8, model_obj.get("base_url").?.string);
+    const base_url_str = model_obj.get("base_url").?.string;
+    try validateLength(base_url_str, MAX_MODEL_FIELD_LENGTH);
+    const base_url = try allocator.dupe(u8, base_url_str);
     errdefer allocator.free(base_url);
 
     const model = ai_types.Model{
@@ -787,16 +797,26 @@ fn deserializeCompleteRequest(
     // Parse nested model object per PROTOCOL.md
     const model_obj = obj.get("model").?.object;
 
-    // Allocate each field separately with errdefer to avoid leaks on OOM
-    const id = try allocator.dupe(u8, model_obj.get("id").?.string);
+    // Validate and allocate each field separately with errdefer to avoid leaks on OOM
+    const id_str = model_obj.get("id").?.string;
+    try validateLength(id_str, MAX_MODEL_FIELD_LENGTH);
+    const id = try allocator.dupe(u8, id_str);
     errdefer allocator.free(id);
-    const name = try allocator.dupe(u8, model_obj.get("name").?.string);
+    const name_str = model_obj.get("name").?.string;
+    try validateLength(name_str, MAX_MODEL_FIELD_LENGTH);
+    const name = try allocator.dupe(u8, name_str);
     errdefer allocator.free(name);
-    const api = try allocator.dupe(u8, model_obj.get("api").?.string);
+    const api_str = model_obj.get("api").?.string;
+    try validateLength(api_str, MAX_IDENTIFIER_LENGTH);
+    const api = try allocator.dupe(u8, api_str);
     errdefer allocator.free(api);
-    const provider = try allocator.dupe(u8, model_obj.get("provider").?.string);
+    const provider_str = model_obj.get("provider").?.string;
+    try validateLength(provider_str, MAX_IDENTIFIER_LENGTH);
+    const provider = try allocator.dupe(u8, provider_str);
     errdefer allocator.free(provider);
-    const base_url = try allocator.dupe(u8, model_obj.get("base_url").?.string);
+    const base_url_str = model_obj.get("base_url").?.string;
+    try validateLength(base_url_str, MAX_MODEL_FIELD_LENGTH);
+    const base_url = try allocator.dupe(u8, base_url_str);
     errdefer allocator.free(base_url);
 
     const model = ai_types.Model{
@@ -853,10 +873,10 @@ fn deserializeModelsRequest(
     obj: std.json.ObjectMap,
     allocator: std.mem.Allocator,
 ) !protocol_types.ModelsRequest {
-    const provider_id = if (obj.get("provider_id")) |value|
-        protocol_types.OwnedSlice(u8).initOwned(try allocator.dupe(u8, value.string))
-    else
-        protocol_types.OwnedSlice(u8).initBorrowed("");
+    const provider_id = if (obj.get("provider_id")) |value| blk: {
+        try validateLength(value.string, MAX_IDENTIFIER_LENGTH);
+        break :blk protocol_types.OwnedSlice(u8).initOwned(try allocator.dupe(u8, value.string));
+    } else protocol_types.OwnedSlice(u8).initBorrowed("");
     errdefer {
         var mutable = provider_id;
         mutable.deinit(allocator);
@@ -871,10 +891,10 @@ fn deserializeModelsRequest(
         mutable.deinit(allocator);
     }
 
-    const model_id = if (obj.get("model_id")) |value|
-        protocol_types.OwnedSlice(u8).initOwned(try allocator.dupe(u8, value.string))
-    else
-        protocol_types.OwnedSlice(u8).initBorrowed("");
+    const model_id = if (obj.get("model_id")) |value| blk: {
+        try validateLength(value.string, MAX_IDENTIFIER_LENGTH);
+        break :blk protocol_types.OwnedSlice(u8).initOwned(try allocator.dupe(u8, value.string));
+    } else protocol_types.OwnedSlice(u8).initBorrowed("");
     errdefer {
         var mutable = model_id;
         mutable.deinit(allocator);
@@ -1583,7 +1603,22 @@ pub const EnvelopeError = error{
     UnknownContentPartType,
     MissingContent,
     InvalidEnumValue,
+    InputTooLong,
 };
+
+/// Maximum allowed length for user-supplied provider_id and model_id strings.
+/// Client-side TS SDK enforces the same 256-char cap.
+pub const MAX_IDENTIFIER_LENGTH: usize = 256;
+
+/// Maximum allowed length for user-supplied model fields in stream/complete requests.
+/// These come from client-side model_ref parsing and carry similar size constraints.
+pub const MAX_MODEL_FIELD_LENGTH: usize = 512;
+
+/// Validate that a string slice does not exceed the given maximum length.
+/// Returns an error if the input is too long.
+fn validateLength(slice: []const u8, max_len: usize) EnvelopeError!void {
+    if (slice.len > max_len) return error.InputTooLong;
+}
 
 // Tests
 
@@ -2527,4 +2562,197 @@ test "serializeEnvelope and deserializeEnvelope roundtrip with models_response" 
     try std.testing.expectEqual(protocol_types.ErrorCode.not_implemented, parseErrorCode("not_implemented"));
 
     original.deinit(allocator);
+}
+
+test "deserializeEnvelope rejects models_request with oversized provider_id" {
+    const allocator = std.testing.allocator;
+    const long_id = "a" ** 257; // 257 chars, exceeds MAX_IDENTIFIER_LENGTH (256)
+
+    const json = std.fmt.allocPrint(allocator,
+        \\{{
+        \\  "type": "models_request",
+        \\  "stream_id": "014D2PF2DBSQQZXQ5TK1V58CGG",
+        \\  "message_id": "0J6HB7H6NWVVRFXX5TK1V58CGG",
+        \\  "sequence": 1,
+        \\  "timestamp": 1708234567890,
+        \\  "version": 1,
+        \\  "payload": {{
+        \\    "provider_id": "{s}"
+        \\  }}
+        \\}}
+    , .{long_id}) catch @panic("OOM");
+    defer allocator.free(json);
+
+    const result = deserializeEnvelope(json, allocator);
+    try std.testing.expectError(error.InputTooLong, result);
+}
+
+test "deserializeEnvelope rejects models_request with oversized model_id" {
+    const allocator = std.testing.allocator;
+    const long_id = "b" ** 257;
+
+    const json = std.fmt.allocPrint(allocator,
+        \\{{
+        \\  "type": "models_request",
+        \\  "stream_id": "014D2PF2DBSQQZXQ5TK1V58CGG",
+        \\  "message_id": "0J6HB7H6NWVVRFXX5TK1V58CGG",
+        \\  "sequence": 1,
+        \\  "timestamp": 1708234567890,
+        \\  "version": 1,
+        \\  "payload": {{
+        \\    "model_id": "{s}"
+        \\  }}
+        \\}}
+    , .{long_id}) catch @panic("OOM");
+    defer allocator.free(json);
+
+    const result = deserializeEnvelope(json, allocator);
+    try std.testing.expectError(error.InputTooLong, result);
+}
+
+test "deserializeEnvelope accepts models_request with provider_id at exactly 256 chars" {
+    const allocator = std.testing.allocator;
+    const exact_id = "a" ** 256;
+
+    const json = std.fmt.allocPrint(allocator,
+        \\{{
+        \\  "type": "models_request",
+        \\  "stream_id": "014D2PF2DBSQQZXQ5TK1V58CGG",
+        \\  "message_id": "0J6HB7H6NWVVRFXX5TK1V58CGG",
+        \\  "sequence": 1,
+        \\  "timestamp": 1708234567890,
+        \\  "version": 1,
+        \\  "payload": {{
+        \\    "provider_id": "{s}"
+        \\  }}
+        \\}}
+    , .{exact_id}) catch @panic("OOM");
+    defer allocator.free(json);
+
+    var env = try deserializeEnvelope(json, allocator);
+    defer env.deinit(allocator);
+    try std.testing.expect(env.payload == .models_request);
+    try std.testing.expectEqualStrings(exact_id, env.payload.models_request.provider_id.slice());
+}
+
+test "deserializeEnvelope rejects stream_request with oversized model id" {
+    const allocator = std.testing.allocator;
+    const long_id = "a" ** 513; // exceeds MAX_MODEL_FIELD_LENGTH (512)
+
+    const json = std.fmt.allocPrint(allocator,
+        \\{{
+        \\  "type": "stream_request",
+        \\  "stream_id": "014D2PF2DBSQQZXQ5TK1V58CGG",
+        \\  "message_id": "0J6HB7H6NWVVRFXX5TK1V58CGG",
+        \\  "sequence": 1,
+        \\  "timestamp": 1708234567890,
+        \\  "version": 1,
+        \\  "payload": {{
+        \\    "model": {{
+        \\      "id": "{s}",
+        \\      "name": "test",
+        \\      "api": "test-api",
+        \\      "provider": "test-provider",
+        \\      "base_url": ""
+        \\    }},
+        \\    "context": {{ "messages": [] }}
+        \\  }}
+        \\}}
+    , .{long_id}) catch @panic("OOM");
+    defer allocator.free(json);
+
+    const result = deserializeEnvelope(json, allocator);
+    try std.testing.expectError(error.InputTooLong, result);
+}
+
+test "deserializeEnvelope rejects stream_request with oversized provider" {
+    const allocator = std.testing.allocator;
+    const long_provider = "p" ** 257; // exceeds MAX_IDENTIFIER_LENGTH (256)
+
+    const json = std.fmt.allocPrint(allocator,
+        \\{{
+        \\  "type": "stream_request",
+        \\  "stream_id": "014D2PF2DBSQQZXQ5TK1V58CGG",
+        \\  "message_id": "0J6HB7H6NWVVRFXX5TK1V58CGG",
+        \\  "sequence": 1,
+        \\  "timestamp": 1708234567890,
+        \\  "version": 1,
+        \\  "payload": {{
+        \\    "model": {{
+        \\      "id": "test-model",
+        \\      "name": "test",
+        \\      "api": "test-api",
+        \\      "provider": "{s}",
+        \\      "base_url": ""
+        \\    }},
+        \\    "context": {{ "messages": [] }}
+        \\  }}
+        \\}}
+    , .{long_provider}) catch @panic("OOM");
+    defer allocator.free(json);
+
+    const result = deserializeEnvelope(json, allocator);
+    try std.testing.expectError(error.InputTooLong, result);
+}
+
+test "deserializeEnvelope rejects complete_request with oversized model id" {
+    const allocator = std.testing.allocator;
+    const long_id = "x" ** 513;
+
+    const json = std.fmt.allocPrint(allocator,
+        \\{{
+        \\  "type": "complete_request",
+        \\  "stream_id": "014D2PF2DBSQQZXQ5TK1V58CGG",
+        \\  "message_id": "0J6HB7H6NWVVRFXX5TK1V58CGG",
+        \\  "sequence": 1,
+        \\  "timestamp": 1708234567890,
+        \\  "version": 1,
+        \\  "payload": {{
+        \\    "model": {{
+        \\      "id": "{s}",
+        \\      "name": "test",
+        \\      "api": "test-api",
+        \\      "provider": "test-provider",
+        \\      "base_url": ""
+        \\    }},
+        \\    "context": {{ "messages": [] }}
+        \\  }}
+        \\}}
+    , .{long_id}) catch @panic("OOM");
+    defer allocator.free(json);
+
+    const result = deserializeEnvelope(json, allocator);
+    try std.testing.expectError(error.InputTooLong, result);
+}
+
+test "deserializeEnvelope accepts stream_request with model id at exactly 512 chars" {
+    const allocator = std.testing.allocator;
+    const exact_id = "a" ** 512;
+
+    const json = std.fmt.allocPrint(allocator,
+        \\{{
+        \\  "type": "stream_request",
+        \\  "stream_id": "014D2PF2DBSQQZXQ5TK1V58CGG",
+        \\  "message_id": "0J6HB7H6NWVVRFXX5TK1V58CGG",
+        \\  "sequence": 1,
+        \\  "timestamp": 1708234567890,
+        \\  "version": 1,
+        \\  "payload": {{
+        \\    "model": {{
+        \\      "id": "{s}",
+        \\      "name": "test",
+        \\      "api": "test-api",
+        \\      "provider": "test-provider",
+        \\      "base_url": ""
+        \\    }},
+        \\    "context": {{ "messages": [] }}
+        \\  }}
+        \\}}
+    , .{exact_id}) catch @panic("OOM");
+    defer allocator.free(json);
+
+    var env = try deserializeEnvelope(json, allocator);
+    defer env.deinit(allocator);
+    try std.testing.expect(env.payload == .stream_request);
+    try std.testing.expectEqualStrings(exact_id, env.payload.stream_request.model.id);
 }

--- a/zig/src/protocol/provider/runtime.zig
+++ b/zig/src/protocol/provider/runtime.zig
@@ -103,7 +103,12 @@ pub const ProviderProtocolRuntime = struct {
         while (try receiver.readLine(self.allocator)) |line| {
             defer self.allocator.free(line);
 
-            var env = envelope.deserializeEnvelope(line, self.allocator) catch continue;
+            var env = envelope.deserializeEnvelope(line, self.allocator) catch |err| {
+                if (err == error.InputTooLong) {
+                    self.sendNackForOversizedInput(line) catch {};
+                }
+                continue;
+            };
             defer env.deinit(self.allocator);
 
             if (try self.server.handleEnvelope(env)) |response| {
@@ -118,6 +123,49 @@ pub const ProviderProtocolRuntime = struct {
                 try sender.flush();
             }
         }
+    }
+
+    /// Attempt to send a NACK for an oversized envelope that failed deserialization.
+    /// Best-effort: extracts stream_id/message_id from raw JSON to construct the NACK.
+    /// If parsing fails, silently skips — the client will time out regardless.
+    fn sendNackForOversizedInput(self: *Self, raw_json: []const u8) !void {
+        const parsed = std.json.parseFromSlice(std.json.Value, self.allocator, raw_json, .{}) catch return;
+        defer parsed.deinit();
+
+        const obj = parsed.value.object;
+
+        const stream_id_str = obj.get("stream_id") orelse return;
+        if (stream_id_str != .string) return;
+        const stream_id = protocol_types.parseUlid(stream_id_str.string) orelse return;
+
+        const message_id_str = obj.get("message_id") orelse return;
+        if (message_id_str != .string) return;
+        const message_id = protocol_types.parseUlid(message_id_str.string) orelse return;
+
+        // Construct a minimal envelope for the NACK
+        const dummy_envelope = protocol_types.Envelope{
+            .stream_id = stream_id,
+            .message_id = message_id,
+            .sequence = 0,
+            .timestamp = compat.time.nowMillis(),
+            .payload = .ping,
+        };
+
+        const nack = try envelope.createNack(
+            dummy_envelope,
+            "input field exceeds maximum allowed length",
+            .invalid_request,
+            self.allocator,
+        );
+        var mut_nack = nack;
+        defer mut_nack.deinit(self.allocator);
+
+        const json = try envelope.serializeEnvelope(mut_nack, self.allocator);
+        defer self.allocator.free(json);
+
+        var sender = self.pipe.serverSender();
+        try sender.write(json);
+        try sender.flush();
     }
 
     pub fn pumpServerOutbox(self: *Self) !usize {


### PR DESCRIPTION
## Summary

- Validates `model_ref` in execution_client.ts: max 512 chars, must contain `/` separator
- Validates `provider_id` and `model_id` in models_client.ts `resolve()`: max 256 chars each
- Throws `MakaiProtocolError` with `invalid_request` code on validation failure, before any transport I/O

## Test plan

- [x] Empty/oversized model_ref throws clear error before any network call
- [x] Invalid format (missing slash) throws clear error before any network call
- [x] Valid model_ref at boundary (511, 512 chars) passes through unchanged
- [x] provider_id and model_id at max length (256) accepted, 257 rejected
- [x] All existing tests continue to pass (138/138)