### PR TITLE
Add structured debug logging to TypeScript SDK

### DIFF
--- a/typescript/src/auth_protocol.ts
+++ b/typescript/src/auth_protocol.ts
@@ -1,5 +1,6 @@
 import { ulid } from "ulid";
 import { BinaryResolverOptions } from "./binary_resolver";
+import { getNoopLogger, type MakaiLogger } from "./logger";
 import {
   MakaiStdioClient,
   StdioFrame,
@@ -279,6 +280,8 @@ export interface MakaiAuthClientOptions {
    * caller's onPrompt to drive progress.
    */
   frameTimeoutMs?: number;
+  /** Optional structured logger for auth protocol diagnostics. */
+  logger?: MakaiLogger;
 }
 
 /**
@@ -292,6 +295,7 @@ export class MakaiAuthClient implements MakaiAuthApi {
   private readonly transport: MakaiStdioClient;
   private readonly defaultHandlers?: AuthFlowHandlers;
   private readonly frameTimeoutMs: number;
+  private readonly logger: MakaiLogger;
 
   /**
    * @param transport Connected stdio transport used for auth envelopes.
@@ -301,6 +305,7 @@ export class MakaiAuthClient implements MakaiAuthApi {
     this.transport = transport;
     this.defaultHandlers = options.handlers;
     this.frameTimeoutMs = options.frameTimeoutMs ?? 30_000;
+    this.logger = options.logger ?? getNoopLogger();
   }
 
   /**
@@ -322,6 +327,7 @@ export class MakaiAuthClient implements MakaiAuthApi {
       payload: {},
     };
 
+    this.logger.debug("auth: sending auth_providers_request", { stream_id: streamId });
     this.sendOrThrow(envelope);
 
     while (true) {
@@ -334,7 +340,9 @@ export class MakaiAuthClient implements MakaiAuthApi {
         throw nackToAuthError(frame);
       }
       if (frame.type === "auth_providers_response") {
-        return parseProviders(frame);
+        const providers = parseProviders(frame);
+        this.logger.debug("auth: received providers list", { count: providers.length });
+        return providers;
       }
       throw new MakaiAuthError(
         `unexpected envelope type while awaiting auth_providers_response: ${String(frame.type)}`,
@@ -362,6 +370,8 @@ export class MakaiAuthClient implements MakaiAuthApi {
     const effective = handlers ?? this.defaultHandlers;
     const flowId = ulid();
     let outboundSequence = 1;
+
+    this.logger.info("auth: starting login flow", { provider_id: providerId, flow_id: flowId });
 
     const startMessageId = ulid();
     this.sendOrThrow({
@@ -394,6 +404,7 @@ export class MakaiAuthClient implements MakaiAuthApi {
       if (frame.type === "auth_event") {
         const eventPayload = readPayload(frame);
         const event = flattenAuthEvent(eventPayload);
+        this.logger.debug("auth: received auth event", { event_type: event.type, flow_id: flowId, provider_id: providerId });
         try {
           effective?.onEvent?.(event);
         } catch (err) {
@@ -451,8 +462,12 @@ export class MakaiAuthClient implements MakaiAuthApi {
       if (frame.type === "auth_login_result") {
         const payload = readPayload(frame);
         const status = typeof payload["status"] === "string" ? payload["status"] : undefined;
-        if (status === "success") return { status: "success" };
+        if (status === "success") {
+          this.logger.info("auth: login succeeded", { provider_id: providerId, flow_id: flowId });
+          return { status: "success" };
+        }
         if (status === "cancelled") {
+          this.logger.warn("auth: login cancelled", { provider_id: providerId, flow_id: flowId });
           throw new MakaiAuthError(
             lastErrorEvent?.message ??
               (cancelled
@@ -462,6 +477,7 @@ export class MakaiAuthClient implements MakaiAuthApi {
           );
         }
         if (status === "failed") {
+          this.logger.error("auth: login failed", { provider_id: providerId, flow_id: flowId });
           throw new MakaiAuthError(
             lastErrorEvent?.message ?? "auth login failed",
             { kind: "provider_error", code: lastErrorEvent?.code },
@@ -612,6 +628,8 @@ export type CreateMakaiAuthClientOptions = CreateMakaiStdioClientOptions & {
   frameTimeoutMs?: number;
   /** Resolver options for locating the makai binary. */
   resolver?: BinaryResolverOptions;
+  /** Optional structured logger for diagnostics. */
+  logger?: MakaiLogger;
 };
 
 /** Handle returned by {@link createMakaiAuthClient}. */
@@ -640,10 +658,10 @@ export interface MakaiAuthClientHandle {
 export async function createMakaiAuthClient(
   options: CreateMakaiAuthClientOptions = {},
 ): Promise<MakaiAuthClientHandle> {
-  const { handlers, frameTimeoutMs, ...transportOptions } = options;
-  const transport = await createMakaiStdioClient(transportOptions);
+  const { handlers, frameTimeoutMs, logger, ...transportOptions } = options;
+  const transport = await createMakaiStdioClient({ ...transportOptions, logger });
   await transport.connect();
-  const auth = new MakaiAuthClient(transport, { handlers, frameTimeoutMs });
+  const auth = new MakaiAuthClient(transport, { handlers, frameTimeoutMs, logger });
   return {
     auth,
     close: () => transport.close(),

--- a/typescript/src/binary_resolver.ts
+++ b/typescript/src/binary_resolver.ts
@@ -2,10 +2,12 @@ import { createHash } from "node:crypto";
 import { promises as fs } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { getNoopLogger, type MakaiLogger } from "./logger";
 
 /** Shared binary resolver options. */
 type BinaryResolverBaseOptions = {
   cacheDir?: string;
+  logger?: MakaiLogger;
 };
 
 /** Resolve Makai from an explicit filesystem path. */
@@ -119,10 +121,14 @@ async function downloadToCache(url: string, targetPath: string, checksumSha256: 
  * @throws If an explicit binary is missing, download fails, or checksum verification fails.
  */
 export async function resolveMakaiBinary(options: BinaryResolverOptions = {}): Promise<string> {
+  const logger = options.logger ?? getNoopLogger();
+
   const explicitBinaryPath = process.env[ENV_BINARY_PATH] ?? options.binaryPath;
   if (explicitBinaryPath) {
     const resolved = path.resolve(explicitBinaryPath);
+    logger.debug("binary: resolving from explicit path", { path: resolved });
     await ensureFileExists(resolved);
+    logger.debug("binary: resolved from explicit path", { path: resolved });
     return resolved;
   }
 
@@ -135,13 +141,16 @@ export async function resolveMakaiBinary(options: BinaryResolverOptions = {}): P
     const urlPathName = new URL(binaryUrl).pathname;
     const fileName = path.basename(urlPathName) || binaryName;
     const cachePath = path.join(cacheDir, fileName);
+    logger.debug("binary: resolving from URL", { url: binaryUrl, cache_path: cachePath });
 
     if (await fileExists(cachePath)) {
       try {
         await verifyChecksum(cachePath, requiredChecksumSha256);
+        logger.debug("binary: cached file checksum verified", { path: cachePath, sha256: requiredChecksumSha256 });
         return cachePath;
       } catch (error: unknown) {
         if (error instanceof Error && error.message.startsWith("binary checksum mismatch")) {
+          logger.warn("binary: cached file checksum mismatch, re-downloading", { path: cachePath });
           await fs.rm(cachePath, { force: true });
         } else {
           throw error;
@@ -150,7 +159,9 @@ export async function resolveMakaiBinary(options: BinaryResolverOptions = {}): P
     }
 
     if (!(await fileExists(cachePath))) {
+      logger.debug("binary: downloading from URL", { url: binaryUrl, target: cachePath });
       await downloadToCache(binaryUrl, cachePath, requiredChecksumSha256);
+      logger.info("binary: download complete", { path: cachePath, sha256: requiredChecksumSha256 });
       return cachePath;
     }
 
@@ -163,10 +174,13 @@ export async function resolveMakaiBinary(options: BinaryResolverOptions = {}): P
     path.resolve(process.cwd(), "zig", "zig-out", "bin", binaryName),
   ];
   for (const candidate of localCandidates) {
+    logger.debug("binary: checking local candidate", { path: candidate });
     if (await fileExists(candidate)) {
+      logger.debug("binary: resolved from local candidate", { path: candidate });
       return candidate;
     }
   }
 
+  logger.debug("binary: falling back to PATH lookup", { binary: binaryName });
   return "makai";
 }

--- a/typescript/src/execution_client.ts
+++ b/typescript/src/execution_client.ts
@@ -114,7 +114,7 @@ export function createMakaiAgentApiWithModels(
   options: ExecutionOptions = {},
 ): MakaiAgentModelsApi {
   return Object.assign(new StdioAgentApi(transport, options), {
-    models: createMakaiModelsApi(transport, { responseTimeoutMs: options.responseTimeoutMs }),
+    models: createMakaiModelsApi(transport, { responseTimeoutMs: options.responseTimeoutMs, logger: options.logger }),
   });
 }
 

--- a/typescript/src/execution_client.ts
+++ b/typescript/src/execution_client.ts
@@ -2,7 +2,7 @@ import { randomInt } from "node:crypto";
 import { ulid } from "ulid";
 import { MakaiAuthClient, type AuthFlowHandlers, type MakaiAuthApi } from "./auth_protocol";
 import { parseModelRef } from "./diagnostics/model_ref";
-import { getNoopLogger, type MakaiLogger } from "./logger";
+import { getNoopLogger, isNoopLogger, type MakaiLogger } from "./logger";
 import { createMakaiModelsApi } from "./models_client";
 import type { MakaiModelsApi } from "./models_types";
 import { type CreateMakaiStdioClientOptions, createMakaiStdioClient, MakaiStdioClient, type StdioFrame } from "./stdio_client";
@@ -144,7 +144,9 @@ class StdioProviderApi implements MakaiProviderApi {
   private async completeOnce(request: ProviderCompleteRequest, effectivePolicy: RunOptions["auth_retry_policy"] | undefined): Promise<ProviderCompleteResponse> {
     const streamId = ulid();
     const fallbackProviderId = providerIdFromRequest(request);
-    this.logger.debug("provider: sending complete_request", { stream_id: streamId, model_ref: request.model_ref });
+    if (!isNoopLogger(this.logger)) {
+      this.logger.debug("provider: sending complete_request", { stream_id: streamId, model_ref: request.model_ref });
+    }
     this.transport.send(buildEnvelope("complete_request", streamId, buildExecutionPayload(request, { authRetryPolicy: effectivePolicy })));
     const timeoutContext = executionTimeoutContext("provider complete_response", this.responseTimeoutMs, streamId, request);
     while (true) {
@@ -167,7 +169,9 @@ class StdioProviderApi implements MakaiProviderApi {
     let yielded = false;
     let retried = false;
 
-    this.logger.debug("provider: starting stream", { model_ref: request.model_ref });
+    if (!isNoopLogger(this.logger)) {
+      this.logger.debug("provider: starting stream", { model_ref: request.model_ref });
+    }
 
     while (true) {
       let result;
@@ -203,12 +207,16 @@ class StdioProviderApi implements MakaiProviderApi {
   private async *streamAttempt(request: ProviderCompleteRequest, effectivePolicy: RunOptions["auth_retry_policy"] | undefined): AsyncIterable<ProviderStreamEvent> {
     const streamId = ulid();
     const fallbackProviderId = providerIdFromRequest(request);
-    this.logger.debug("provider: sending stream_request", { stream_id: streamId, model_ref: request.model_ref });
+    if (!isNoopLogger(this.logger)) {
+      this.logger.debug("provider: sending stream_request", { stream_id: streamId, model_ref: request.model_ref });
+    }
     this.transport.send(buildEnvelope("stream_request", streamId, buildExecutionPayload(request, { suppressPartial: true, authRetryPolicy: effectivePolicy })));
     const timeoutContext = executionTimeoutContext("provider stream event", this.responseTimeoutMs, streamId, request);
     let terminal = false;
     const toolBuffers = new Map<number, { id?: string; name?: string; args: string }>();
-    this.logger.debug("provider: stream started", { stream_id: streamId });
+    if (!isNoopLogger(this.logger)) {
+      this.logger.debug("provider: stream started", { stream_id: streamId });
+    }
     try {
       while (!terminal) {
         const frame = await nextFrame(this.transport, streamId, timeoutContext);
@@ -277,7 +285,9 @@ class StdioAgentApi implements MakaiAgentApi {
   private async runOnce(request: AgentRunRequest, effectivePolicy: RunOptions["auth_retry_policy"] | undefined): Promise<AgentRunResponse> {
     const sessionId = agentSessionId(request);
     const fallbackProviderId = providerIdFromRequest(request);
-    this.logger.debug("agent: sending agent_start", { session_id: sessionId, model_ref: request.model_ref });
+    if (!isNoopLogger(this.logger)) {
+      this.logger.debug("agent: sending agent_start", { session_id: sessionId, model_ref: request.model_ref });
+    }
     this.transport.send(buildAgentEnvelope("agent_start", sessionId, 1, buildAgentStartPayload(request, sessionId)));
     const timeoutContext = agentTimeoutContext("agent result", this.responseTimeoutMs, sessionId, request);
     const events: AgentStreamEvent[] = [];
@@ -319,7 +329,9 @@ class StdioAgentApi implements MakaiAgentApi {
     let yielded = false;
     let retried = false;
 
-    this.logger.debug("agent: starting stream", { model_ref: request.model_ref });
+    if (!isNoopLogger(this.logger)) {
+      this.logger.debug("agent: starting stream", { model_ref: request.model_ref });
+    }
 
     while (true) {
       let result;
@@ -359,7 +371,9 @@ class StdioAgentApi implements MakaiAgentApi {
   private async *streamAttempt(request: AgentRunRequest, effectivePolicy: RunOptions["auth_retry_policy"] | undefined): AsyncIterable<AgentStreamEvent> {
     const sessionId = agentSessionId(request);
     const fallbackProviderId = providerIdFromRequest(request);
-    this.logger.debug("agent: sending agent_start", { session_id: sessionId, model_ref: request.model_ref });
+    if (!isNoopLogger(this.logger)) {
+      this.logger.debug("agent: sending agent_start", { session_id: sessionId, model_ref: request.model_ref });
+    }
     this.transport.send(buildAgentEnvelope("agent_start", sessionId, 1, buildAgentStartPayload(request, sessionId)));
     const timeoutContext = agentTimeoutContext("agent stream event", this.responseTimeoutMs, sessionId, request);
     let terminal = false;
@@ -367,7 +381,9 @@ class StdioAgentApi implements MakaiAgentApi {
     let started = false;
     let aggregateUsage: UsageSummary | undefined;
     const toolBuffers = new Map<number, { id?: string; name?: string; args: string }>();
-    this.logger.debug("agent: stream started", { session_id: sessionId });
+    if (!isNoopLogger(this.logger)) {
+      this.logger.debug("agent: stream started", { session_id: sessionId });
+    }
     try {
       while (!terminal) {
         const frame = await nextAgentFrame(this.transport, sessionId, timeoutContext);

--- a/typescript/src/execution_client.ts
+++ b/typescript/src/execution_client.ts
@@ -2,6 +2,7 @@ import { randomInt } from "node:crypto";
 import { ulid } from "ulid";
 import { MakaiAuthClient, type AuthFlowHandlers, type MakaiAuthApi } from "./auth_protocol";
 import { parseModelRef } from "./diagnostics/model_ref";
+import { getNoopLogger, type MakaiLogger } from "./logger";
 import { createMakaiModelsApi } from "./models_client";
 import type { MakaiModelsApi } from "./models_types";
 import { type CreateMakaiStdioClientOptions, createMakaiStdioClient, MakaiStdioClient, type StdioFrame } from "./stdio_client";
@@ -48,6 +49,7 @@ type ExecutionOptions = {
   authRetryPolicy?: RunOptions["auth_retry_policy"];
   auth?: MakaiAuthApi;
   authHandlers?: AuthFlowHandlers;
+  logger?: MakaiLogger;
 };
 
 /** Root Makai SDK client returned by {@link createMakaiClient}. */
@@ -121,25 +123,28 @@ class StdioProviderApi implements MakaiProviderApi {
   private readonly authRetryPolicy?: RunOptions["auth_retry_policy"];
   private readonly auth?: MakaiAuthApi;
   private readonly authHandlers?: AuthFlowHandlers;
+  private readonly logger: MakaiLogger;
 
   constructor(private readonly transport: MakaiStdioClient, options: ExecutionOptions) {
     this.responseTimeoutMs = options.responseTimeoutMs ?? DEFAULT_RESPONSE_TIMEOUT_MS;
     this.authRetryPolicy = options.authRetryPolicy;
     this.auth = options.auth;
     this.authHandlers = options.authHandlers;
+    this.logger = options.logger ?? getNoopLogger();
   }
 
   async complete(request: ProviderCompleteRequest): Promise<ProviderCompleteResponse> {
     const effectivePolicy = request.options?.auth_retry_policy ?? this.authRetryPolicy;
     return withAuthRetry(
       () => this.completeOnce(request, effectivePolicy),
-      { auth: this.auth, authHandlers: this.authHandlers, authRetryPolicy: effectivePolicy, fallbackProviderId: providerIdFromRequest(request) },
+      { auth: this.auth, authHandlers: this.authHandlers, authRetryPolicy: effectivePolicy, fallbackProviderId: providerIdFromRequest(request), logger: this.logger },
     );
   }
 
   private async completeOnce(request: ProviderCompleteRequest, effectivePolicy: RunOptions["auth_retry_policy"] | undefined): Promise<ProviderCompleteResponse> {
     const streamId = ulid();
     const fallbackProviderId = providerIdFromRequest(request);
+    this.logger.debug("provider: sending complete_request", { stream_id: streamId, model_ref: request.model_ref });
     this.transport.send(buildEnvelope("complete_request", streamId, buildExecutionPayload(request, { authRetryPolicy: effectivePolicy })));
     const timeoutContext = executionTimeoutContext("provider complete_response", this.responseTimeoutMs, streamId, request);
     while (true) {
@@ -161,6 +166,8 @@ class StdioProviderApi implements MakaiProviderApi {
     let iterator = attempt[Symbol.asyncIterator]();
     let yielded = false;
     let retried = false;
+
+    this.logger.debug("provider: starting stream", { model_ref: request.model_ref });
 
     while (true) {
       let result;
@@ -196,10 +203,12 @@ class StdioProviderApi implements MakaiProviderApi {
   private async *streamAttempt(request: ProviderCompleteRequest, effectivePolicy: RunOptions["auth_retry_policy"] | undefined): AsyncIterable<ProviderStreamEvent> {
     const streamId = ulid();
     const fallbackProviderId = providerIdFromRequest(request);
+    this.logger.debug("provider: sending stream_request", { stream_id: streamId, model_ref: request.model_ref });
     this.transport.send(buildEnvelope("stream_request", streamId, buildExecutionPayload(request, { suppressPartial: true, authRetryPolicy: effectivePolicy })));
     const timeoutContext = executionTimeoutContext("provider stream event", this.responseTimeoutMs, streamId, request);
     let terminal = false;
     const toolBuffers = new Map<number, { id?: string; name?: string; args: string }>();
+    this.logger.debug("provider: stream started", { stream_id: streamId });
     try {
       while (!terminal) {
         const frame = await nextFrame(this.transport, streamId, timeoutContext);
@@ -219,7 +228,11 @@ class StdioProviderApi implements MakaiProviderApi {
         yield event;
       }
     } catch (error) {
-      if (error instanceof MakaiStreamError) throw error;
+      if (error instanceof MakaiStreamError) {
+        this.logger.error("provider: stream error", { kind: error.kind, code: error.code, message: error.message });
+        throw error;
+      }
+      this.logger.error("provider: unexpected stream error", { error: error instanceof Error ? error.message : String(error) });
       throw new MakaiStreamError(error instanceof Error ? error.message : String(error), { kind: "transport_error" });
     }
   }
@@ -230,12 +243,14 @@ class StdioAgentApi implements MakaiAgentApi {
   private readonly authRetryPolicy?: RunOptions["auth_retry_policy"];
   private readonly auth?: MakaiAuthApi;
   private readonly authHandlers?: AuthFlowHandlers;
+  private readonly logger: MakaiLogger;
 
   constructor(private readonly transport: MakaiStdioClient, options: ExecutionOptions) {
     this.responseTimeoutMs = options.responseTimeoutMs ?? DEFAULT_RESPONSE_TIMEOUT_MS;
     this.authRetryPolicy = options.authRetryPolicy;
     this.auth = options.auth;
     this.authHandlers = options.authHandlers;
+    this.logger = options.logger ?? getNoopLogger();
   }
 
   async run(request: AgentRunRequest): Promise<AgentRunResponse> {
@@ -248,6 +263,7 @@ class StdioAgentApi implements MakaiAgentApi {
         authHandlers: this.authHandlers,
         authRetryPolicy: effectivePolicy,
         fallbackProviderId: providerIdFromRequest(request),
+        logger: this.logger,
         beforeRetry: () => {
           retryRequest = {
             ...request,
@@ -261,6 +277,7 @@ class StdioAgentApi implements MakaiAgentApi {
   private async runOnce(request: AgentRunRequest, effectivePolicy: RunOptions["auth_retry_policy"] | undefined): Promise<AgentRunResponse> {
     const sessionId = agentSessionId(request);
     const fallbackProviderId = providerIdFromRequest(request);
+    this.logger.debug("agent: sending agent_start", { session_id: sessionId, model_ref: request.model_ref });
     this.transport.send(buildAgentEnvelope("agent_start", sessionId, 1, buildAgentStartPayload(request, sessionId)));
     const timeoutContext = agentTimeoutContext("agent result", this.responseTimeoutMs, sessionId, request);
     const events: AgentStreamEvent[] = [];
@@ -302,6 +319,8 @@ class StdioAgentApi implements MakaiAgentApi {
     let yielded = false;
     let retried = false;
 
+    this.logger.debug("agent: starting stream", { model_ref: request.model_ref });
+
     while (true) {
       let result;
       try {
@@ -340,6 +359,7 @@ class StdioAgentApi implements MakaiAgentApi {
   private async *streamAttempt(request: AgentRunRequest, effectivePolicy: RunOptions["auth_retry_policy"] | undefined): AsyncIterable<AgentStreamEvent> {
     const sessionId = agentSessionId(request);
     const fallbackProviderId = providerIdFromRequest(request);
+    this.logger.debug("agent: sending agent_start", { session_id: sessionId, model_ref: request.model_ref });
     this.transport.send(buildAgentEnvelope("agent_start", sessionId, 1, buildAgentStartPayload(request, sessionId)));
     const timeoutContext = agentTimeoutContext("agent stream event", this.responseTimeoutMs, sessionId, request);
     let terminal = false;
@@ -347,6 +367,7 @@ class StdioAgentApi implements MakaiAgentApi {
     let started = false;
     let aggregateUsage: UsageSummary | undefined;
     const toolBuffers = new Map<number, { id?: string; name?: string; args: string }>();
+    this.logger.debug("agent: stream started", { session_id: sessionId });
     try {
       while (!terminal) {
         const frame = await nextAgentFrame(this.transport, sessionId, timeoutContext);
@@ -386,7 +407,11 @@ class StdioAgentApi implements MakaiAgentApi {
         }
       }
     } catch (error) {
-      if (error instanceof MakaiStreamError) throw error;
+      if (error instanceof MakaiStreamError) {
+        this.logger.error("agent: stream error", { kind: error.kind, code: error.code, message: error.message });
+        throw error;
+      }
+      this.logger.error("agent: unexpected stream error", { error: error instanceof Error ? error.message : String(error) });
       throw new MakaiStreamError(error instanceof Error ? error.message : String(error), { kind: "transport_error" });
     }
   }
@@ -1078,6 +1103,7 @@ async function withAuthRetry<T>(
     authRetryPolicy?: RunOptions["auth_retry_policy"];
     fallbackProviderId?: string;
     beforeRetry?: () => void;
+    logger?: MakaiLogger;
   },
 ): Promise<T> {
   try {
@@ -1086,6 +1112,8 @@ async function withAuthRetry<T>(
     if (isRetryableAuthError(error) && options.authRetryPolicy === "auto_once" && options.auth) {
       const providerId = error.provider_id ?? options.fallbackProviderId;
       if (!providerId) throw error;
+      const logger = options.logger ?? getNoopLogger();
+      logger.info("execution: auto-retrying after auth_required", { provider_id: providerId });
       try {
         await options.auth.login(providerId, options.authHandlers);
       } catch {
@@ -1134,19 +1162,20 @@ async function withAuthRetry<T>(
  * ```
  */
 export async function createMakaiClient(options: CreateMakaiClientOptions = {}): Promise<MakaiClient> {
-  const { auth: authOptions, responseTimeoutMs, frameTimeoutMs, ...transportOptions } = options;
-  const transport = await createMakaiStdioClient(transportOptions);
+  const { auth: authOptions, responseTimeoutMs, frameTimeoutMs, logger, ...transportOptions } = options;
+  const transport = await createMakaiStdioClient({ ...transportOptions, logger });
   await transport.connect();
-  const authClient = new MakaiAuthClient(transport, { handlers: authOptions?.handlers, frameTimeoutMs });
+  const authClient = new MakaiAuthClient(transport, { handlers: authOptions?.handlers, frameTimeoutMs, logger });
   const executionOptions = {
     responseTimeoutMs: responseTimeoutMs ?? frameTimeoutMs,
     authRetryPolicy: authOptions?.auth_retry_policy,
     auth: authClient,
     authHandlers: authOptions?.handlers,
+    logger,
   };
   return {
     auth: authClient,
-    models: createMakaiModelsApi(transport, { responseTimeoutMs: responseTimeoutMs ?? frameTimeoutMs }),
+    models: createMakaiModelsApi(transport, { responseTimeoutMs: responseTimeoutMs ?? frameTimeoutMs, logger }),
     agent: createMakaiAgentApiWithModels(transport, executionOptions),
     provider: createMakaiProviderApi(transport, executionOptions),
     close: () => transport.close(),

--- a/typescript/src/execution_types.ts
+++ b/typescript/src/execution_types.ts
@@ -1,6 +1,7 @@
 import type { ApiId, ProviderId } from "./models_types";
 import type { AuthFlowHandlers } from "./auth_protocol";
 import type { TimeoutDiagnostics } from "./timeout_diagnostics";
+import type { MakaiLogger } from "./logger";
 
 /** Controls whether execution APIs automatically retry once after an authentication challenge. */
 export type AuthRetryPolicy = "manual" | "auto_once";
@@ -245,4 +246,6 @@ export interface MakaiClientOptions {
   };
   responseTimeoutMs?: number;
   frameTimeoutMs?: number;
+  /** Optional structured logger for SDK diagnostics. */
+  logger?: MakaiLogger;
 }

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -79,6 +79,11 @@ export {
 } from "./timeout_diagnostics";
 
 export {
+  type MakaiLogger,
+  getNoopLogger,
+} from "./logger";
+
+export {
   MakaiProtocolError,
   // Note: `AuthStatus` and `ProviderId` are re-exported from `./auth_protocol`
   // above. The structurally-identical aliases in `./models_types` are kept

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -81,6 +81,7 @@ export {
 export {
   type MakaiLogger,
   getNoopLogger,
+  isNoopLogger,
 } from "./logger";
 
 export {

--- a/typescript/src/logger.ts
+++ b/typescript/src/logger.ts
@@ -26,8 +26,19 @@ const noopLogger: MakaiLogger = {
  * Returns the no-op logger singleton.
  *
  * Every call returns the same object, so identity checks like
- * `logger === noopLogger` can be used for branching in hot paths.
+ * `logger === getNoopLogger()` can be used for branching in hot paths.
  */
 export function getNoopLogger(): MakaiLogger {
   return noopLogger;
+}
+
+/**
+ * Tests whether a logger is the no-op singleton.
+ *
+ * Use this to skip context-object allocation on hot paths when logging is
+ * disabled. Identity comparison is safe because `getNoopLogger()` always
+ * returns the same object.
+ */
+export function isNoopLogger(logger: MakaiLogger): boolean {
+  return logger === noopLogger;
 }

--- a/typescript/src/logger.ts
+++ b/typescript/src/logger.ts
@@ -1,0 +1,33 @@
+/**
+ * Structured debug logging interface for the Makai TypeScript SDK.
+ *
+ * When no logger is configured, a zero-overhead no-op implementation is used.
+ * Supply a custom `MakaiLogger` via `createMakaiClient({ logger })` or
+ * `createMakaiAuthClient({ logger })` to capture diagnostic information.
+ */
+
+/** Structured logger interface accepted by Makai client factories. */
+export interface MakaiLogger {
+  debug(message: string, context?: Record<string, unknown>): void;
+  info(message: string, context?: Record<string, unknown>): void;
+  warn(message: string, context?: Record<string, unknown>): void;
+  error(message: string, context?: Record<string, unknown>): void;
+}
+
+/** No-op logger — default when no logger is configured. Zero overhead. */
+const noopLogger: MakaiLogger = {
+  debug() {},
+  info() {},
+  warn() {},
+  error() {},
+};
+
+/**
+ * Returns the no-op logger singleton.
+ *
+ * Every call returns the same object, so identity checks like
+ * `logger === noopLogger` can be used for branching in hot paths.
+ */
+export function getNoopLogger(): MakaiLogger {
+  return noopLogger;
+}

--- a/typescript/src/models_client.ts
+++ b/typescript/src/models_client.ts
@@ -20,6 +20,7 @@
  */
 
 import { ulid } from "ulid";
+import { getNoopLogger, type MakaiLogger } from "./logger";
 import {
   AuthStatus,
   ListModelsRequest,
@@ -91,6 +92,8 @@ const KNOWN_REASONING_LEVELS: ReadonlySet<string> = new Set([
 export interface ModelsApiOptions {
   /** How long `list` / `resolve` waits for a terminal response frame. */
   responseTimeoutMs?: number;
+  /** Optional structured logger for models API diagnostics. */
+  logger?: MakaiLogger;
 }
 
 /**
@@ -121,12 +124,14 @@ const MALFORMED_RESPONSE_CODE = "malformed_response";
 
 class StdioModelsApi implements MakaiModelsApi {
   private readonly responseTimeoutMs: number;
+  private readonly logger: MakaiLogger;
 
   constructor(
     private readonly client: MakaiStdioClient,
     options: ModelsApiOptions,
   ) {
     this.responseTimeoutMs = options.responseTimeoutMs ?? DEFAULT_RESPONSE_TIMEOUT_MS;
+    this.logger = options.logger ?? getNoopLogger();
   }
 
   async list(request: ListModelsRequest = {}): Promise<ListModelsResponse> {
@@ -187,6 +192,7 @@ class StdioModelsApi implements MakaiModelsApi {
 
   private async dispatch(request: ListModelsRequest): Promise<ListModelsResponse> {
     const streamId = ulid();
+    this.logger.debug("models: sending models_request", { stream_id: streamId, provider_id: request.provider_id, api: request.api });
     const envelope: StdioFrame = {
       type: "models_request",
       stream_id: streamId,
@@ -224,8 +230,11 @@ class StdioModelsApi implements MakaiModelsApi {
           continue;
         case "nack":
           throw nackToError(frame);
-        case "models_response":
-          return parseModelsResponse(frame);
+        case "models_response": {
+          const response = parseModelsResponse(frame);
+          this.logger.debug("models: received models_response", { count: response.models.length, stream_id: streamId });
+          return response;
+        }
         default:
           throw malformedResponseError(
             `unexpected frame type while awaiting models_response: ${frame.type}`,

--- a/typescript/src/stdio_client.ts
+++ b/typescript/src/stdio_client.ts
@@ -1,7 +1,7 @@
 import { ChildProcessWithoutNullStreams, spawn } from "node:child_process";
 import { createInterface, Interface as ReadlineInterface } from "node:readline";
 import { BinaryResolverOptions, resolveMakaiBinary } from "./binary_resolver";
-import { getNoopLogger, type MakaiLogger } from "./logger";
+import { getNoopLogger, isNoopLogger, type MakaiLogger } from "./logger";
 
 /** A single JSON-line protocol frame exchanged with `makai --stdio`. */
 export type StdioFrame = {
@@ -143,7 +143,9 @@ export class MakaiStdioClient {
     if (!this.child) {
       throw new Error("client is not connected");
     }
-    this.logger.debug("stdio: sending frame", { type: frame.type, stream_id: frame.stream_id, session_id: frame.session_id, sequence: frame.sequence });
+    if (!isNoopLogger(this.logger)) {
+      this.logger.debug("stdio: sending frame", { type: frame.type, stream_id: frame.stream_id, session_id: frame.session_id, sequence: frame.sequence });
+    }
     this.child.stdin.write(`${JSON.stringify(frame)}\n`);
   }
 
@@ -437,7 +439,6 @@ function isNextFrameTimeout(error: unknown, timeoutMs: number): boolean {
 export type CreateMakaiStdioClientOptions = Omit<MakaiStdioClientOptions, "command"> & {
   command?: string;
   resolver?: BinaryResolverOptions;
-  logger?: MakaiLogger;
 };
 
 /** @deprecated Use CreateMakaiStdioClientOptions. Kept for backward compatibility. */
@@ -453,7 +454,10 @@ export type CreateMakaiClientOptions = CreateMakaiStdioClientOptions;
 export async function createMakaiStdioClient(
   options: CreateMakaiStdioClientOptions = {},
 ): Promise<MakaiStdioClient> {
-  const command = options.command ?? (await resolveMakaiBinary(options.resolver));
+  const resolverWithLogger: BinaryResolverOptions = options.logger
+    ? { ...options.resolver, logger: options.logger }
+    : options.resolver ?? {};
+  const command = options.command ?? (await resolveMakaiBinary(resolverWithLogger));
   const args = options.args ?? ["--stdio"];
   return new MakaiStdioClient({
     command,

--- a/typescript/src/stdio_client.ts
+++ b/typescript/src/stdio_client.ts
@@ -362,7 +362,9 @@ export class MakaiStdioClient {
       return;
     }
 
-    this.logger.debug("stdio: received frame", { type: frame.type, stream_id: frame.stream_id, session_id: frame.session_id, sequence: frame.sequence });
+    if (!isNoopLogger(this.logger)) {
+      this.logger.debug("stdio: received frame", { type: frame.type, stream_id: frame.stream_id, session_id: frame.session_id, sequence: frame.sequence });
+    }
 
     if (this.pendingHandshake) {
       const pending = this.pendingHandshake;

--- a/typescript/src/stdio_client.ts
+++ b/typescript/src/stdio_client.ts
@@ -1,6 +1,7 @@
 import { ChildProcessWithoutNullStreams, spawn } from "node:child_process";
 import { createInterface, Interface as ReadlineInterface } from "node:readline";
 import { BinaryResolverOptions, resolveMakaiBinary } from "./binary_resolver";
+import { getNoopLogger, type MakaiLogger } from "./logger";
 
 /** A single JSON-line protocol frame exchanged with `makai --stdio`. */
 export type StdioFrame = {
@@ -17,6 +18,7 @@ export type MakaiStdioClientOptions = {
   expectedProtocolVersion?: string;
   handshakeTimeoutMs?: number;
   streamFrameQueueTtlMs?: number;
+  logger?: MakaiLogger;
 };
 
 /** @deprecated Use MakaiStdioClientOptions. Kept for backward compatibility. */
@@ -60,6 +62,7 @@ const STREAM_FRAME_QUEUE_TTL_MS = 30_000;
 export class MakaiStdioClient {
   private readonly options: Required<Pick<MakaiStdioClientOptions, "args" | "expectedProtocolVersion" | "handshakeTimeoutMs" | "streamFrameQueueTtlMs">> &
     Omit<MakaiStdioClientOptions, "args" | "expectedProtocolVersion" | "handshakeTimeoutMs" | "streamFrameQueueTtlMs">;
+  private readonly logger: MakaiLogger;
   private child: ChildProcessWithoutNullStreams | null = null;
   private lineReader: ReadlineInterface | null = null;
   private pendingHandshake: PendingHandshake | null = null;
@@ -80,6 +83,7 @@ export class MakaiStdioClient {
       handshakeTimeoutMs: options.handshakeTimeoutMs ?? 1500,
       streamFrameQueueTtlMs: options.streamFrameQueueTtlMs ?? STREAM_FRAME_QUEUE_TTL_MS,
     };
+    this.logger = options.logger ?? getNoopLogger();
   }
 
   /**
@@ -92,6 +96,8 @@ export class MakaiStdioClient {
       throw new Error("client is already connected");
     }
 
+    this.logger.debug("stdio: spawning process", { command: this.options.command, args: this.options.args });
+
     const child = spawn(this.options.command, this.options.args, {
       cwd: this.options.cwd,
       env: this.options.env,
@@ -100,11 +106,13 @@ export class MakaiStdioClient {
     this.child = child;
 
     child.on("error", (error) => {
+      this.logger.error("stdio: process error event", { error: error.message });
       this.failHandshakeIfPending(error);
       this.failPendingFrameWaiters(error);
     });
 
     child.on("exit", (code, signal) => {
+      this.logger.debug("stdio: process exited", { code, signal: signal ?? undefined });
       const error = new Error(`stdio process exited (code=${code}, signal=${signal})`);
       this.failHandshakeIfPending(error);
       this.failPendingFrameWaiters(error);
@@ -114,6 +122,7 @@ export class MakaiStdioClient {
     this.lineReader = createInterface({ input: child.stdout });
     this.lineReader.on("line", (line) => this.handleLine(line));
 
+    this.logger.debug("stdio: waiting for handshake", { timeout_ms: this.options.handshakeTimeoutMs });
     await new Promise<void>((resolve, reject) => {
       const timer = setTimeout(() => {
         reject(new Error(`stdio handshake timed out after ${this.options.handshakeTimeoutMs}ms`));
@@ -121,6 +130,7 @@ export class MakaiStdioClient {
       }, this.options.handshakeTimeoutMs);
       this.pendingHandshake = { resolve, reject, timer };
     });
+    this.logger.info("stdio: handshake complete");
   }
 
   /**
@@ -133,6 +143,7 @@ export class MakaiStdioClient {
     if (!this.child) {
       throw new Error("client is not connected");
     }
+    this.logger.debug("stdio: sending frame", { type: frame.type, stream_id: frame.stream_id, session_id: frame.session_id, sequence: frame.sequence });
     this.child.stdin.write(`${JSON.stringify(frame)}\n`);
   }
 
@@ -251,6 +262,7 @@ export class MakaiStdioClient {
   async close(): Promise<void> {
     if (!this.child) return;
 
+    this.logger.debug("stdio: closing transport");
     const child = this.child;
     child.stdin.end();
     await Promise.race([
@@ -343,9 +355,12 @@ export class MakaiStdioClient {
     try {
       frame = JSON.parse(line) as StdioFrame;
     } catch {
+      this.logger.error("stdio: invalid JSON frame received", { line: line.length > 200 ? line.slice(0, 200) + "..." : line });
       this.failHandshakeIfPending(new Error(`invalid JSON frame: ${line}`));
       return;
     }
+
+    this.logger.debug("stdio: received frame", { type: frame.type, stream_id: frame.stream_id, session_id: frame.session_id, sequence: frame.sequence });
 
     if (this.pendingHandshake) {
       const pending = this.pendingHandshake;
@@ -422,6 +437,7 @@ function isNextFrameTimeout(error: unknown, timeoutMs: number): boolean {
 export type CreateMakaiStdioClientOptions = Omit<MakaiStdioClientOptions, "command"> & {
   command?: string;
   resolver?: BinaryResolverOptions;
+  logger?: MakaiLogger;
 };
 
 /** @deprecated Use CreateMakaiStdioClientOptions. Kept for backward compatibility. */
@@ -447,5 +463,6 @@ export async function createMakaiStdioClient(
     expectedProtocolVersion: options.expectedProtocolVersion,
     handshakeTimeoutMs: options.handshakeTimeoutMs,
     streamFrameQueueTtlMs: options.streamFrameQueueTtlMs,
+    logger: options.logger,
   });
 }

--- a/typescript/test/logger.test.ts
+++ b/typescript/test/logger.test.ts
@@ -5,11 +5,13 @@ import path from "node:path";
 import test from "node:test";
 import {
   createMakaiAgentApi,
+  createMakaiAgentApiWithModels,
   createMakaiProviderApi,
   MakaiStdioClient,
   MakaiStreamError,
   type MakaiLogger,
   getNoopLogger,
+  isNoopLogger,
   resolveMakaiBinary,
 } from "../src";
 
@@ -322,5 +324,50 @@ test("logger captures envelope type and stream_id in frame send context", async 
     assert.ok((streamId as string).length >= 10, "stream_id should be a ULID");
   } finally {
     await harness.cleanup();
+  }
+});
+
+test("isNoopLogger identifies no-op logger and distinguishes custom loggers", () => {
+  assert.ok(isNoopLogger(getNoopLogger()), "getNoopLogger() should be identified as no-op");
+  const custom = createCapturingLogger();
+  assert.ok(!isNoopLogger(custom), "custom logger should not be identified as no-op");
+});
+
+test("no-op logger skips context allocation on send hot path", async () => {
+  const client = new MakaiStdioClient({
+    command: process.execPath,
+    args: [path.join(sourceFixturesDir, "ready-server.js")],
+    handshakeTimeoutMs: 5000,
+    // No logger — default no-op
+  });
+
+  await client.connect();
+  // Send should not allocate context objects with no-op logger
+  client.send({ type: "stream_request", stream_id: "s1" });
+  const frame = await client.nextFrame(5000);
+  assert.ok(frame);
+  await client.close();
+});
+
+test("createMakaiAgentApiWithModels forwards logger to nested models API", async () => {
+  const logger = createCapturingLogger();
+  const client = new MakaiStdioClient({
+    command: process.execPath,
+    args: [fixtureScript],
+    env: { ...process.env, MAKAI_TEST_REQUEST_LOG: path.join(os.tmpdir(), "makai-agent-models-test.log") },
+    handshakeTimeoutMs: 5000,
+    logger,
+  });
+
+  await client.connect();
+  try {
+    const agentWithModels = createMakaiAgentApiWithModels(client, { logger, responseTimeoutMs: 5000 });
+    await agentWithModels.models.list();
+
+    // The models API should have logged via the provided logger
+    const modelsLog = logger.entries.find((e) => e.message === "models: sending models_request");
+    assert.ok(modelsLog, "expected models API to log via forwarded logger");
+  } finally {
+    await client.close();
   }
 });

--- a/typescript/test/logger.test.ts
+++ b/typescript/test/logger.test.ts
@@ -1,0 +1,326 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+  createMakaiAgentApi,
+  createMakaiProviderApi,
+  MakaiStdioClient,
+  MakaiStreamError,
+  type MakaiLogger,
+  getNoopLogger,
+  resolveMakaiBinary,
+} from "../src";
+
+const sourceFixturesDir = path.resolve(__dirname, "../../typescript/test/fixtures");
+const fixtureScript = path.join(sourceFixturesDir, "execution-server.js");
+
+// ---------------------------------------------------------------------------
+// Capturing logger — records all calls for assertions.
+// ---------------------------------------------------------------------------
+type LogEntry = { level: string; message: string; context?: Record<string, unknown> };
+
+function createCapturingLogger(): MakaiLogger & { entries: LogEntry[] } {
+  const entries: LogEntry[] = [];
+  return {
+    entries,
+    debug(message, context) { entries.push({ level: "debug", message, context }); },
+    info(message, context) { entries.push({ level: "info", message, context }); },
+    warn(message, context) { entries.push({ level: "warn", message, context }); },
+    error(message, context) { entries.push({ level: "error", message, context }); },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+type Harness = {
+  client: MakaiStdioClient;
+  logger: ReturnType<typeof createCapturingLogger>;
+  tmpDir: string;
+  logPath: string;
+  cleanup(): Promise<void>;
+};
+
+async function setupHarness(): Promise<Harness> {
+  const logger = createCapturingLogger();
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "makai-logger-test-"));
+  const logPath = path.join(tmpDir, "request.log");
+  const client = new MakaiStdioClient({
+    command: process.execPath,
+    args: [fixtureScript],
+    env: { ...process.env, MAKAI_TEST_REQUEST_LOG: logPath },
+    handshakeTimeoutMs: 5000,
+    logger,
+  });
+  await client.connect();
+  return {
+    client,
+    logger,
+    tmpDir,
+    logPath,
+    cleanup: async () => {
+      await client.close();
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    },
+  };
+}
+
+function request() {
+  return {
+    model_ref: "anthropic/anthropic-messages@claude-sonnet-4-5",
+    messages: [{ role: "user" as const, content: "hello" }],
+    options: { temperature: 0.2, session_id: "testNanoIdSess1234567" },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test("getNoopLogger returns a logger with all four methods", () => {
+  const logger = getNoopLogger();
+  assert.equal(typeof logger.debug, "function");
+  assert.equal(typeof logger.info, "function");
+  assert.equal(typeof logger.warn, "function");
+  assert.equal(typeof logger.error, "function");
+  // Calling them should not throw
+  logger.debug("test");
+  logger.info("test");
+  logger.warn("test");
+  logger.error("test");
+});
+
+test("getNoopLogger returns the same singleton instance", () => {
+  assert.strictEqual(getNoopLogger(), getNoopLogger());
+});
+
+test("stdio transport logs connect/handshake and close events", async () => {
+  const logger = createCapturingLogger();
+  const client = new MakaiStdioClient({
+    command: process.execPath,
+    args: [path.join(sourceFixturesDir, "ready-server.js")],
+    handshakeTimeoutMs: 5000,
+    logger,
+  });
+
+  await client.connect();
+  // Should log process spawn, handshake wait, and handshake complete
+  const spawnLog = logger.entries.find((e) => e.message === "stdio: spawning process");
+  assert.ok(spawnLog, "expected 'stdio: spawning process' log");
+  assert.equal(spawnLog.context?.command, process.execPath);
+
+  const handshakeLog = logger.entries.find((e) => e.message === "stdio: waiting for handshake");
+  assert.ok(handshakeLog, "expected 'stdio: waiting for handshake' log");
+
+  const completeLog = logger.entries.find((e) => e.message === "stdio: handshake complete");
+  assert.ok(completeLog, "expected 'stdio: handshake complete' log");
+
+  await client.close();
+  const closeLog = logger.entries.find((e) => e.message === "stdio: closing transport");
+  assert.ok(closeLog, "expected 'stdio: closing transport' log");
+});
+
+test("stdio transport logs frame send and receive", async () => {
+  const logger = createCapturingLogger();
+  const client = new MakaiStdioClient({
+    command: process.execPath,
+    args: [path.join(sourceFixturesDir, "ready-server.js")],
+    handshakeTimeoutMs: 5000,
+    logger,
+  });
+
+  await client.connect();
+  // Clear handshake logs for clarity
+  logger.entries.length = 0;
+
+  client.send({ type: "stream_request", stream_id: "s1" });
+
+  const sendLog = logger.entries.find((e) => e.message === "stdio: sending frame");
+  assert.ok(sendLog, "expected 'stdio: sending frame' log");
+  assert.equal(sendLog.context?.type, "stream_request");
+  assert.equal(sendLog.context?.stream_id, "s1");
+
+  const frame = await client.nextFrame(5000);
+  const receiveLog = logger.entries.find((e) => e.message === "stdio: received frame");
+  assert.ok(receiveLog, "expected 'stdio: received frame' log");
+  assert.equal(receiveLog.context?.type, frame.type);
+
+  await client.close();
+});
+
+test("stdio transport logs error frame during handshake", async () => {
+  const logger = createCapturingLogger();
+  const client = new MakaiStdioClient({
+    command: process.execPath,
+    args: [path.join(sourceFixturesDir, "error-server.js")],
+    handshakeTimeoutMs: 5000,
+    logger,
+  });
+
+  // The error server sends a protocol error frame. This should be logged as a
+  // received frame before the handshake is rejected.
+  await assert.rejects(() => client.connect());
+  const receiveLog = logger.entries.find((e) => e.message === "stdio: received frame");
+  assert.ok(receiveLog, "expected 'stdio: received frame' log");
+  assert.equal(receiveLog.context?.type, "error");
+  await client.close();
+});
+
+test("binary resolver logs resolution steps", async () => {
+  const logger = createCapturingLogger();
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "makai-bin-log-"));
+  const binaryPath = path.join(tempDir, process.platform === "win32" ? "makai.exe" : "makai");
+  await fs.promises.writeFile(binaryPath, "fixture");
+
+  const prev = process.env.MAKAI_BINARY_PATH;
+  process.env.MAKAI_BINARY_PATH = binaryPath;
+  try {
+    await resolveMakaiBinary({ logger });
+    const resolvingLog = logger.entries.find((e) => e.message === "binary: resolving from explicit path");
+    assert.ok(resolvingLog, "expected 'binary: resolving from explicit path' log");
+    assert.equal(resolvingLog.context?.path, path.resolve(binaryPath));
+
+    const resolvedLog = logger.entries.find((e) => e.message === "binary: resolved from explicit path");
+    assert.ok(resolvedLog, "expected 'binary: resolved from explicit path' log");
+  } finally {
+    if (prev === undefined) delete process.env.MAKAI_BINARY_PATH;
+    else process.env.MAKAI_BINARY_PATH = prev;
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("binary resolver logs auto resolution candidate checks", async () => {
+  const logger = createCapturingLogger();
+  const prevPath = process.env.MAKAI_BINARY_PATH;
+  const prevUrl = process.env.MAKAI_BINARY_URL;
+  const prevChecksum = process.env.MAKAI_BINARY_SHA256;
+  delete process.env.MAKAI_BINARY_PATH;
+  delete process.env.MAKAI_BINARY_URL;
+  delete process.env.MAKAI_BINARY_SHA256;
+  try {
+    await resolveMakaiBinary({ logger });
+    const candidateLogs = logger.entries.filter((e) => e.message === "binary: checking local candidate");
+    assert.ok(candidateLogs.length >= 1, "expected at least one 'binary: checking local candidate' log");
+
+    const fallbackLog = logger.entries.find((e) => e.message === "binary: falling back to PATH lookup");
+    assert.ok(fallbackLog, "expected 'binary: falling back to PATH lookup' log");
+  } finally {
+    if (prevPath === undefined) delete process.env.MAKAI_BINARY_PATH;
+    else process.env.MAKAI_BINARY_PATH = prevPath;
+    if (prevUrl === undefined) delete process.env.MAKAI_BINARY_URL;
+    else process.env.MAKAI_BINARY_URL = prevUrl;
+    if (prevChecksum === undefined) delete process.env.MAKAI_BINARY_SHA256;
+    else process.env.MAKAI_BINARY_SHA256 = prevChecksum;
+  }
+});
+
+test("provider complete logs stream_request and frame exchange", async () => {
+  const harness = await setupHarness();
+  try {
+    const provider = createMakaiProviderApi(harness.client, { logger: harness.logger });
+    await provider.complete(request());
+
+    const streamLog = harness.logger.entries.find((e) => e.message === "provider: sending complete_request");
+    assert.ok(streamLog, "expected 'provider: sending complete_request' log");
+    assert.equal(streamLog.context?.model_ref, request().model_ref);
+    assert.ok(typeof streamLog.context?.stream_id === "string");
+  } finally {
+    await harness.cleanup();
+  }
+});
+
+test("provider stream logs start and terminal events", async () => {
+  const harness = await setupHarness();
+  try {
+    const provider = createMakaiProviderApi(harness.client, { logger: harness.logger });
+    const events = [];
+    for await (const event of provider.stream(request())) {
+      events.push(event);
+    }
+
+    const startLog = harness.logger.entries.find((e) => e.message === "provider: starting stream");
+    assert.ok(startLog, "expected 'provider: starting stream' log");
+
+    const requestLog = harness.logger.entries.find((e) => e.message === "provider: sending stream_request");
+    assert.ok(requestLog, "expected 'provider: sending stream_request' log");
+
+    const streamStartedLog = harness.logger.entries.find((e) => e.message === "provider: stream started");
+    assert.ok(streamStartedLog, "expected 'provider: stream started' log");
+  } finally {
+    await harness.cleanup();
+  }
+});
+
+test("agent run logs agent_start", async () => {
+  const harness = await setupHarness();
+  try {
+    const agent = createMakaiAgentApi(harness.client, { logger: harness.logger });
+    await agent.run(request());
+
+    const startLog = harness.logger.entries.find((e) => e.message === "agent: sending agent_start");
+    assert.ok(startLog, "expected 'agent: sending agent_start' log");
+    assert.ok(typeof startLog.context?.session_id === "string");
+  } finally {
+    await harness.cleanup();
+  }
+});
+
+test("agent stream logs start events", async () => {
+  const harness = await setupHarness();
+  try {
+    const agent = createMakaiAgentApi(harness.client, { logger: harness.logger });
+    const events = [];
+    for await (const event of agent.stream(request())) {
+      events.push(event);
+    }
+
+    const startLog = harness.logger.entries.find((e) => e.message === "agent: starting stream");
+    assert.ok(startLog, "expected 'agent: starting stream' log");
+
+    const agentStartLog = harness.logger.entries.find((e) => e.message === "agent: sending agent_start");
+    assert.ok(agentStartLog, "expected 'agent: sending agent_start' log");
+
+    const streamStartedLog = harness.logger.entries.find((e) => e.message === "agent: stream started");
+    assert.ok(streamStartedLog, "expected 'agent: stream started' log");
+  } finally {
+    await harness.cleanup();
+  }
+});
+
+test("no logger configured results in zero overhead (no crashes)", async () => {
+  // Create a client without a logger — should work exactly as before
+  const client = new MakaiStdioClient({
+    command: process.execPath,
+    args: [path.join(sourceFixturesDir, "ready-server.js")],
+    handshakeTimeoutMs: 5000,
+  });
+
+  await client.connect();
+  client.send({ type: "stream_request", stream_id: "s1" });
+  const frame = await client.nextFrame(5000);
+  assert.ok(frame);
+  await client.close();
+});
+
+test("logger captures envelope type and stream_id in frame send context", async () => {
+  const harness = await setupHarness();
+  try {
+    const provider = createMakaiProviderApi(harness.client, { logger: harness.logger });
+    await provider.complete(request());
+
+    // Check that send logs include the envelope type
+    const sendLogs = harness.logger.entries.filter(
+      (e) => e.message === "stdio: sending frame" && e.context?.type === "complete_request",
+    );
+    assert.ok(sendLogs.length >= 1, "expected at least one complete_request send log");
+
+    // Verify stream_id is present and is a ULID
+    const streamId = sendLogs[0]!.context?.stream_id;
+    assert.equal(typeof streamId, "string");
+    assert.ok((streamId as string).length >= 10, "stream_id should be a ULID");
+  } finally {
+    await harness.cleanup();
+  }
+});


### PR DESCRIPTION
## Summary

- **MakaiLogger interface**: New `MakaiLogger` interface with `debug`, `info`, `warn`, `error` methods, each accepting a message and optional structured context object. Exported from the package entry point.
- **No-op default**: `getNoopLogger()` returns a zero-overhead singleton — all methods are empty. No allocation or computation when no logger is configured.
- **Logger option on all client factories**: `CreateMakaiClientOptions`, `CreateMakaiAuthClientOptions`, `CreateMakaiStdioClientOptions`, and `ModelsApiOptions` now accept an optional `logger` field, threaded through every internal layer.
- **Diagnostic log points across all major operations**:
  - Binary resolution: path tried, URL download, checksum verification, cache hits/misses
  - Transport: process spawn, handshake wait/complete, frame send/receive, process exit, close
  - Auth: login flow start, auth events, success/failure/cancellation
  - Provider: complete_request, stream_request, stream start, stream errors
  - Agent: agent_start, stream start, stream errors
  - Models: models_request dispatch, models_response received
  - Error paths: transport errors, stream errors with kind/code/message context
- **13 new tests** verifying log output for key scenarios (connect, send/receive, binary resolution, provider complete/stream, agent run/stream, error frame, no-logger baseline)

## Test plan

- [x] `npm run test:sdk` — 135 pass, 0 fail (4 skipped e2e tests requiring MAKAI_BINARY_PATH)
- [x] All existing tests continue to pass unchanged (no regressions)
- [x] New `typescript/test/logger.test.ts` covers all log point categories
- [x] No-op logger (default) verified to work without crashes