### PR TITLE
Wire TypeScript client to send cancel envelopes on abort

### DIFF
--- a/typescript/src/cancel_helpers.ts
+++ b/typescript/src/cancel_helpers.ts
@@ -23,7 +23,7 @@ export function bestEffortCancelStream(transport: MakaiStdioClient, streamId: st
       type: "abort_request",
       stream_id: streamId,
       message_id: ulid(),
-      sequence: 999,
+      sequence: 2, // Initial request is sequence 1; abort is the next per-stream message
       timestamp: Date.now(),
       version: ENVELOPE_VERSION,
       payload: { target_stream_id: streamId, reason: "client aborted" },

--- a/typescript/src/cancel_helpers.ts
+++ b/typescript/src/cancel_helpers.ts
@@ -1,0 +1,102 @@
+/**
+ * Shared best-effort cancel and drain helpers for stream/session cleanup
+ * on abort. Used by both the execution client and models client to send
+ * cancel envelopes and drain remaining in-flight frames before propagating
+ * the original abort error.
+ *
+ * This module is the single source of truth for the cancel/drain protocol;
+ * consumers should NOT duplicate this logic locally.
+ */
+
+import { ulid } from "ulid";
+import type { MakaiStdioClient } from "./stdio_client";
+
+const ENVELOPE_VERSION = 1;
+
+/**
+ * Sends an `abort_request` envelope for the given stream, swallowing any
+ * transport errors so the original abort error propagates cleanly.
+ */
+export function bestEffortCancelStream(transport: MakaiStdioClient, streamId: string): void {
+  try {
+    transport.send({
+      type: "abort_request",
+      stream_id: streamId,
+      message_id: ulid(),
+      sequence: 999,
+      timestamp: Date.now(),
+      version: ENVELOPE_VERSION,
+      payload: { target_stream_id: streamId, reason: "client aborted" },
+    });
+  } catch {
+    // Best-effort cancellation; ignore transport errors here so we keep
+    // surfacing the original failure to the caller.
+  }
+}
+
+/**
+ * Sends an `agent_stop` envelope for the given session, swallowing any
+ * transport errors so the original abort error propagates cleanly.
+ */
+export function bestEffortCancelAgent(transport: MakaiStdioClient, sessionId: string): void {
+  try {
+    transport.send({
+      type: "agent_stop",
+      session_id: sessionId,
+      message_id: ulid(),
+      sequence: 999,
+      timestamp: Date.now(),
+      version: ENVELOPE_VERSION,
+      payload: { session_id: sessionId, reason: "client aborted" },
+    });
+  } catch {
+    // Best-effort cancellation; ignore transport errors here so we keep
+    // surfacing the original failure to the caller.
+  }
+}
+
+/**
+ * Drains remaining in-flight frames for an abandoned stream from the
+ * transport buffer. Prevents orphaned frames from interfering with
+ * subsequent operations on the shared transport.
+ *
+ * Uses a Promise.race with a per-iteration timeout so it never blocks
+ * indefinitely even if the transport mock doesn't respect timeoutMs.
+ */
+export async function drainStreamFrames(transport: MakaiStdioClient, streamId: string, timeoutMs = 200): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) break;
+    const perFrameMs = Math.min(remaining, 50);
+    try {
+      await Promise.race([
+        transport.nextFrameForStream(streamId, perFrameMs).catch(() => undefined),
+        new Promise<void>((resolve) => setTimeout(resolve, perFrameMs)),
+      ]);
+    } catch {
+      break;
+    }
+  }
+}
+
+/**
+ * Drains remaining in-flight frames for an abandoned agent session from the
+ * transport buffer.
+ */
+export async function drainSessionFrames(transport: MakaiStdioClient, sessionId: string, timeoutMs = 200): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) break;
+    const perFrameMs = Math.min(remaining, 50);
+    try {
+      await Promise.race([
+        transport.nextFrameForSession(sessionId, perFrameMs).catch(() => undefined),
+        new Promise<void>((resolve) => setTimeout(resolve, perFrameMs)),
+      ]);
+    } catch {
+      break;
+    }
+  }
+}

--- a/typescript/src/execution_client.ts
+++ b/typescript/src/execution_client.ts
@@ -2,6 +2,7 @@ import { randomInt } from "node:crypto";
 import { ulid } from "ulid";
 import { checkAbort, isAbortError, raceWithAbort } from "./abort_signal";
 import { MakaiAuthClient, MakaiAuthError, type AuthFlowHandlers, type MakaiAuthApi } from "./auth_protocol";
+import { bestEffortCancelStream, bestEffortCancelAgent, drainStreamFrames, drainSessionFrames } from "./cancel_helpers";
 import { parseModelRef } from "./diagnostics/model_ref";
 import { getNoopLogger, isNoopLogger, type MakaiLogger } from "./logger";
 import { createMakaiModelsApi } from "./models_client";
@@ -216,11 +217,7 @@ class StdioProviderApi implements MakaiProviderApi {
           result = await raceWithAbort(iterator.next(), signal, "provider.stream aborted");
         } catch (error) {
           if (isAbortError(error)) {
-            const streamId = activeStreamId.value;
-            if (streamId) {
-              bestEffortCancelStream(this.transport, streamId);
-              await drainStreamFrames(this.transport, streamId);
-            }
+            // Cancel+drain handled by outer catch to avoid triple-send.
             throw error;
           }
           if (!yielded && !retried && isRetryableAuthError(error) && effectivePolicy === "auto_once" && this.auth) {
@@ -230,11 +227,7 @@ class StdioProviderApi implements MakaiProviderApi {
                 await raceWithAbort(this.auth.login(providerId, this.authHandlers, { signal }), signal, "provider.stream aborted during auth retry");
               } catch (authError) {
                 if (isAbortError(authError)) {
-                  const streamId = activeStreamId.value;
-                  if (streamId) {
-                    bestEffortCancelStream(this.transport, streamId);
-                    await drainStreamFrames(this.transport, streamId);
-                  }
+                  // Cancel+drain handled by outer catch.
                   throw authError;
                 }
                 throw authRequiredError(providerId, error.message);
@@ -307,8 +300,7 @@ class StdioProviderApi implements MakaiProviderApi {
         throw error;
       }
       if (isAbortError(error)) {
-        bestEffortCancelStream(this.transport, streamId);
-        await drainStreamFrames(this.transport, streamId);
+        // Cancel+drain handled by outer stream() catch to avoid triple-send.
         throw error;
       }
       this.logger.error("provider: unexpected stream error", { error: error instanceof Error ? error.message : String(error) });
@@ -440,11 +432,7 @@ class StdioAgentApi implements MakaiAgentApi {
           result = await raceWithAbort(iterator.next(), signal, "agent.stream aborted");
         } catch (error) {
           if (isAbortError(error)) {
-            const sessionId = activeSessionId.value;
-            if (sessionId) {
-              bestEffortCancelAgent(this.transport, sessionId);
-              await drainSessionFrames(this.transport, sessionId);
-            }
+            // Cancel+drain handled by outer catch to avoid triple-send.
             throw error;
           }
           if (!yielded && !retried && isRetryableAuthError(error) && effectivePolicy === "auto_once" && this.auth) {
@@ -454,11 +442,7 @@ class StdioAgentApi implements MakaiAgentApi {
                 await raceWithAbort(this.auth.login(providerId, this.authHandlers, { signal }), signal, "agent.stream aborted during auth retry");
               } catch (authError) {
                 if (isAbortError(authError)) {
-                  const sessionId = activeSessionId.value;
-                  if (sessionId) {
-                    bestEffortCancelAgent(this.transport, sessionId);
-                    await drainSessionFrames(this.transport, sessionId);
-                  }
+                  // Cancel+drain handled by outer catch.
                   throw authError;
                 }
                 throw authRequiredError(providerId, error.message);
@@ -558,8 +542,7 @@ class StdioAgentApi implements MakaiAgentApi {
         throw error;
       }
       if (isAbortError(error)) {
-        bestEffortCancelAgent(this.transport, sessionId);
-        await drainSessionFrames(this.transport, sessionId);
+        // Cancel+drain handled by outer agent.stream() catch to avoid triple-send.
         throw error;
       }
       this.logger.error("agent: unexpected stream error", { error: error instanceof Error ? error.message : String(error) });
@@ -1289,103 +1272,6 @@ function firstKey(value: Record<string, unknown>): string {
 
 function isObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-// ---------------------------------------------------------------------------
-// Best-effort cancel + drain helpers
-// ---------------------------------------------------------------------------
-
-/**
- * Sends an `abort_request` envelope for the given stream, swallowing any
- * transport errors so the original abort error propagates cleanly.
- *
- * This mirrors `MakaiAuthClient.bestEffortCancel()` in auth_protocol.ts.
- */
-function bestEffortCancelStream(transport: MakaiStdioClient, streamId: string): void {
-  try {
-    transport.send({
-      type: "abort_request",
-      stream_id: streamId,
-      message_id: ulid(),
-      sequence: 999,
-      timestamp: Date.now(),
-      version: ENVELOPE_VERSION,
-      payload: { target_stream_id: streamId, reason: "client aborted" },
-    });
-  } catch {
-    // Best-effort cancellation; ignore transport errors here so we keep
-    // surfacing the original failure to the caller.
-  }
-}
-
-/**
- * Sends an `agent_stop` envelope for the given session, swallowing any
- * transport errors so the original abort error propagates cleanly.
- */
-function bestEffortCancelAgent(transport: MakaiStdioClient, sessionId: string): void {
-  try {
-    transport.send({
-      type: "agent_stop",
-      session_id: sessionId,
-      message_id: ulid(),
-      sequence: 999,
-      timestamp: Date.now(),
-      version: ENVELOPE_VERSION,
-      payload: { session_id: sessionId, reason: "client aborted" },
-    });
-  } catch {
-    // Best-effort cancellation; ignore transport errors here so we keep
-    // surfacing the original failure to the caller.
-  }
-}
-
-/**
- * Drains remaining in-flight frames for an abandoned stream from the
- * transport buffer. Prevents orphaned frames from interfering with
- * subsequent operations on the shared transport.
- *
- * Returns once the transport buffer is empty for the given stream_id or
- * the timeout expires. Analogous to `drainLoginResult()` in auth_protocol.ts.
- *
- * Uses a Promise.race with a per-iteration timeout so it never blocks
- * indefinitely even if the transport mock doesn't respect timeoutMs.
- */
-async function drainStreamFrames(transport: MakaiStdioClient, streamId: string, timeoutMs = 200): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    const remaining = deadline - Date.now();
-    if (remaining <= 0) break;
-    const perFrameMs = Math.min(remaining, 50);
-    try {
-      await Promise.race([
-        transport.nextFrameForStream(streamId, perFrameMs).catch(() => undefined),
-        new Promise<void>((resolve) => setTimeout(resolve, perFrameMs)),
-      ]);
-    } catch {
-      break;
-    }
-  }
-}
-
-/**
- * Drains remaining in-flight frames for an abandoned agent session from the
- * transport buffer.
- */
-async function drainSessionFrames(transport: MakaiStdioClient, sessionId: string, timeoutMs = 200): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    const remaining = deadline - Date.now();
-    if (remaining <= 0) break;
-    const perFrameMs = Math.min(remaining, 50);
-    try {
-      await Promise.race([
-        transport.nextFrameForSession(sessionId, perFrameMs).catch(() => undefined),
-        new Promise<void>((resolve) => setTimeout(resolve, perFrameMs)),
-      ]);
-    } catch {
-      break;
-    }
-  }
 }
 
 function isRetryableAuthError(error: unknown): error is MakaiStreamError {

--- a/typescript/src/execution_client.ts
+++ b/typescript/src/execution_client.ts
@@ -259,7 +259,9 @@ class StdioProviderApi implements MakaiProviderApi {
         const streamId = activeStreamId.value;
         if (streamId) {
           bestEffortCancelStream(this.transport, streamId);
-          await drainStreamFrames(this.transport, streamId);
+          // Fire-and-forget: avoids blocking behind withStreamReadLock held by
+          // the aborted nextFrameForStream call from streamAttempt.
+          drainStreamFrames(this.transport, streamId);
         }
       }
       throw error;
@@ -480,7 +482,8 @@ class StdioAgentApi implements MakaiAgentApi {
         const sessionId = activeSessionId.value;
         if (sessionId) {
           bestEffortCancelAgent(this.transport, sessionId);
-          await drainSessionFrames(this.transport, sessionId);
+          // Fire-and-forget: avoids blocking behind withStreamReadLock.
+          drainSessionFrames(this.transport, sessionId);
         }
       }
       throw error;

--- a/typescript/src/execution_client.ts
+++ b/typescript/src/execution_client.ts
@@ -138,31 +138,57 @@ class StdioProviderApi implements MakaiProviderApi {
     const signal = request.options?.signal;
     checkAbort(signal, "provider.complete aborted before start");
     const effectivePolicy = request.options?.auth_retry_policy ?? this.authRetryPolicy;
+    // Track the active stream ID so withAuthRetry can cancel+drain on abort
+    // during auth retry (the stream ID is created inside completeOnce).
+    const activeStreamId: { value?: string } = {};
     return withAuthRetry(
-      () => this.completeOnce(request, effectivePolicy, signal),
-      { auth: this.auth, authHandlers: this.authHandlers, authRetryPolicy: effectivePolicy, fallbackProviderId: providerIdFromRequest(request), signal, logger: this.logger },
+      () => this.completeOnce(request, effectivePolicy, signal, activeStreamId),
+      {
+        auth: this.auth,
+        authHandlers: this.authHandlers,
+        authRetryPolicy: effectivePolicy,
+        fallbackProviderId: providerIdFromRequest(request),
+        signal,
+        logger: this.logger,
+        onAbort: async () => {
+          const streamId = activeStreamId.value;
+          if (streamId) {
+            bestEffortCancelStream(this.transport, streamId);
+            await drainStreamFrames(this.transport, streamId);
+          }
+        },
+      },
     );
   }
 
-  private async completeOnce(request: ProviderCompleteRequest, effectivePolicy: RunOptions["auth_retry_policy"] | undefined, signal?: AbortSignal): Promise<ProviderCompleteResponse> {
+  private async completeOnce(request: ProviderCompleteRequest, effectivePolicy: RunOptions["auth_retry_policy"] | undefined, signal?: AbortSignal, activeStreamId?: { value?: string }): Promise<ProviderCompleteResponse> {
     checkAbort(signal, "provider.complete aborted");
     const streamId = ulid();
+    if (activeStreamId) activeStreamId.value = streamId;
     const fallbackProviderId = providerIdFromRequest(request);
     if (!isNoopLogger(this.logger)) {
       this.logger.debug("provider: sending complete_request", { stream_id: streamId, model_ref: request.model_ref });
     }
     this.transport.send(buildEnvelope("complete_request", streamId, buildExecutionPayload(request, { authRetryPolicy: effectivePolicy })));
     const timeoutContext = executionTimeoutContext("provider complete_response", this.responseTimeoutMs, streamId, request);
-    while (true) {
-      checkAbort(signal, "provider.complete aborted");
-      const frame = await raceWithAbort(nextFrame(this.transport, streamId, timeoutContext), signal, "provider.complete aborted");
-      if (frame.type === "ack") continue;
-      if (frame.type === "nack") throw nackToStreamError(frame, fallbackProviderId);
-      if (frame.type === "stream_error") throw streamErrorFrameToError(frame);
-      if (frame.type === "result" || frame.type === "complete_response") {
-        return parseCompletionResponse(frame.payload ?? frame);
+    try {
+      while (true) {
+        checkAbort(signal, "provider.complete aborted");
+        const frame = await raceWithAbort(nextFrame(this.transport, streamId, timeoutContext), signal, "provider.complete aborted");
+        if (frame.type === "ack") continue;
+        if (frame.type === "nack") throw nackToStreamError(frame, fallbackProviderId);
+        if (frame.type === "stream_error") throw streamErrorFrameToError(frame);
+        if (frame.type === "result" || frame.type === "complete_response") {
+          return parseCompletionResponse(frame.payload ?? frame);
+        }
+        throw new MakaiStreamError(`unexpected frame type while awaiting provider result: ${String(frame.type)}`, { kind: "transport_error" });
       }
-      throw new MakaiStreamError(`unexpected frame type while awaiting provider result: ${String(frame.type)}`, { kind: "transport_error" });
+    } catch (error) {
+      if (isAbortError(error)) {
+        bestEffortCancelStream(this.transport, streamId);
+        await drainStreamFrames(this.transport, streamId);
+      }
+      throw error;
     }
   }
 
@@ -171,7 +197,9 @@ class StdioProviderApi implements MakaiProviderApi {
     checkAbort(signal, "provider.stream aborted before start");
     const effectivePolicy = request.options?.auth_retry_policy ?? this.authRetryPolicy;
     const fallbackProviderId = providerIdFromRequest(request);
-    let attempt = this.streamAttempt(request, effectivePolicy, signal);
+    // Track the active stream ID so abort during auth retry can cancel+drain
+    const activeStreamId: { value?: string } = {};
+    let attempt = this.streamAttempt(request, effectivePolicy, signal, activeStreamId);
     let iterator = attempt[Symbol.asyncIterator]();
     let yielded = false;
     let retried = false;
@@ -180,43 +208,69 @@ class StdioProviderApi implements MakaiProviderApi {
       this.logger.debug("provider: starting stream", { model_ref: request.model_ref });
     }
 
-    while (true) {
-      checkAbort(signal, "provider.stream aborted");
-      let result;
-      try {
-        result = await raceWithAbort(iterator.next(), signal, "provider.stream aborted");
-      } catch (error) {
-        if (isAbortError(error)) throw error;
-        if (!yielded && !retried && isRetryableAuthError(error) && effectivePolicy === "auto_once" && this.auth) {
-          const providerId = error.provider_id ?? fallbackProviderId;
-          if (providerId) {
-            try {
-              await raceWithAbort(this.auth.login(providerId, this.authHandlers, { signal }), signal, "provider.stream aborted during auth retry");
-            } catch (authError) {
-              if (isAbortError(authError)) throw authError;
-              throw authRequiredError(providerId, error.message);
+    try {
+      while (true) {
+        checkAbort(signal, "provider.stream aborted");
+        let result;
+        try {
+          result = await raceWithAbort(iterator.next(), signal, "provider.stream aborted");
+        } catch (error) {
+          if (isAbortError(error)) {
+            const streamId = activeStreamId.value;
+            if (streamId) {
+              bestEffortCancelStream(this.transport, streamId);
+              await drainStreamFrames(this.transport, streamId);
             }
-            retried = true;
-            attempt = this.streamAttempt(request, effectivePolicy, signal);
-            iterator = attempt[Symbol.asyncIterator]();
-            continue;
+            throw error;
           }
+          if (!yielded && !retried && isRetryableAuthError(error) && effectivePolicy === "auto_once" && this.auth) {
+            const providerId = error.provider_id ?? fallbackProviderId;
+            if (providerId) {
+              try {
+                await raceWithAbort(this.auth.login(providerId, this.authHandlers, { signal }), signal, "provider.stream aborted during auth retry");
+              } catch (authError) {
+                if (isAbortError(authError)) {
+                  const streamId = activeStreamId.value;
+                  if (streamId) {
+                    bestEffortCancelStream(this.transport, streamId);
+                    await drainStreamFrames(this.transport, streamId);
+                  }
+                  throw authError;
+                }
+                throw authRequiredError(providerId, error.message);
+              }
+              retried = true;
+              attempt = this.streamAttempt(request, effectivePolicy, signal, activeStreamId);
+              iterator = attempt[Symbol.asyncIterator]();
+              continue;
+            }
+          }
+          if (isRetryableAuthError(error)) {
+            const providerId = error.provider_id ?? fallbackProviderId;
+            if (providerId) throw authRequiredError(providerId, error.message);
+          }
+          throw error;
         }
-        if (isRetryableAuthError(error)) {
-          const providerId = error.provider_id ?? fallbackProviderId;
-          if (providerId) throw authRequiredError(providerId, error.message);
-        }
-        throw error;
+        if (result.done) return;
+        yielded = true;
+        yield result.value;
       }
-      if (result.done) return;
-      yielded = true;
-      yield result.value;
+    } catch (error) {
+      if (isAbortError(error)) {
+        const streamId = activeStreamId.value;
+        if (streamId) {
+          bestEffortCancelStream(this.transport, streamId);
+          await drainStreamFrames(this.transport, streamId);
+        }
+      }
+      throw error;
     }
   }
 
-  private async *streamAttempt(request: ProviderCompleteRequest, effectivePolicy: RunOptions["auth_retry_policy"] | undefined, signal?: AbortSignal): AsyncIterable<ProviderStreamEvent> {
+  private async *streamAttempt(request: ProviderCompleteRequest, effectivePolicy: RunOptions["auth_retry_policy"] | undefined, signal?: AbortSignal, activeStreamId?: { value?: string }): AsyncIterable<ProviderStreamEvent> {
     checkAbort(signal, "provider.stream aborted");
     const streamId = ulid();
+    if (activeStreamId) activeStreamId.value = streamId;
     const fallbackProviderId = providerIdFromRequest(request);
     if (!isNoopLogger(this.logger)) {
       this.logger.debug("provider: sending stream_request", { stream_id: streamId, model_ref: request.model_ref });
@@ -252,7 +306,11 @@ class StdioProviderApi implements MakaiProviderApi {
         this.logger.error("provider: stream error", { kind: error.kind, code: error.code, message: error.message });
         throw error;
       }
-      if (isAbortError(error)) throw error;
+      if (isAbortError(error)) {
+        bestEffortCancelStream(this.transport, streamId);
+        await drainStreamFrames(this.transport, streamId);
+        throw error;
+      }
       this.logger.error("provider: unexpected stream error", { error: error instanceof Error ? error.message : String(error) });
       throw new MakaiStreamError(error instanceof Error ? error.message : String(error), { kind: "transport_error" });
     }
@@ -279,8 +337,11 @@ class StdioAgentApi implements MakaiAgentApi {
     checkAbort(signal, "agent.run aborted before start");
     const effectivePolicy = request.options?.auth_retry_policy ?? this.authRetryPolicy;
     let retryRequest = request;
+    // Track the active session ID so withAuthRetry can cancel+drain on abort
+    // during auth retry (the session ID is created inside runOnce).
+    const activeSessionId: { value?: string } = {};
     return withAuthRetry(
-      () => this.runOnce(retryRequest, effectivePolicy, signal),
+      () => this.runOnce(retryRequest, effectivePolicy, signal, activeSessionId),
       {
         auth: this.auth,
         authHandlers: this.authHandlers,
@@ -294,13 +355,21 @@ class StdioAgentApi implements MakaiAgentApi {
             options: { ...request.options, session_id: generateNanoId() },
           };
         },
+        onAbort: async () => {
+          const sessionId = activeSessionId.value;
+          if (sessionId) {
+            bestEffortCancelAgent(this.transport, sessionId);
+            await drainSessionFrames(this.transport, sessionId);
+          }
+        },
       },
     );
   }
 
-  private async runOnce(request: AgentRunRequest, effectivePolicy: RunOptions["auth_retry_policy"] | undefined, signal?: AbortSignal): Promise<AgentRunResponse> {
+  private async runOnce(request: AgentRunRequest, effectivePolicy: RunOptions["auth_retry_policy"] | undefined, signal?: AbortSignal, activeSessionId?: { value?: string }): Promise<AgentRunResponse> {
     checkAbort(signal, "agent.run aborted");
     const sessionId = agentSessionId(request);
+    if (activeSessionId) activeSessionId.value = sessionId;
     const fallbackProviderId = providerIdFromRequest(request);
     if (!isNoopLogger(this.logger)) {
       this.logger.debug("agent: sending agent_start", { session_id: sessionId, model_ref: request.model_ref });
@@ -310,31 +379,39 @@ class StdioAgentApi implements MakaiAgentApi {
     const events: AgentStreamEvent[] = [];
     const toolBuffers = new Map<number, { id?: string; name?: string; args: string }>();
     let messageSent = false;
-    while (true) {
-      checkAbort(signal, "agent.run aborted");
-      const frame = await raceWithAbort(nextAgentFrame(this.transport, sessionId, timeoutContext), signal, "agent.run aborted");
-      if (frame.type === "ack") continue;
-      if (frame.type === "nack") throw nackToStreamError(frame, fallbackProviderId);
-      if (frame.type === "agent_error") throw streamErrorFrameToError(frame);
-      if (frame.type === "agent_started") {
-        if (!messageSent) {
-          this.transport.send(buildAgentEnvelope("agent_message", sessionId, 2, buildAgentMessagePayload(request, sessionId, effectivePolicy)));
-          messageSent = true;
+    try {
+      while (true) {
+        checkAbort(signal, "agent.run aborted");
+        const frame = await raceWithAbort(nextAgentFrame(this.transport, sessionId, timeoutContext), signal, "agent.run aborted");
+        if (frame.type === "ack") continue;
+        if (frame.type === "nack") throw nackToStreamError(frame, fallbackProviderId);
+        if (frame.type === "agent_error") throw streamErrorFrameToError(frame);
+        if (frame.type === "agent_started") {
+          if (!messageSent) {
+            this.transport.send(buildAgentEnvelope("agent_message", sessionId, 2, buildAgentMessagePayload(request, sessionId, effectivePolicy)));
+            messageSent = true;
+          }
+          continue;
         }
-        continue;
-      }
-      if (frame.type === "agent_result") return parseAgentRunResponse(readJsonStringPayload(frame, "result_json"));
-      if (frame.type === "result" || frame.type === "complete_response") return parseCompletionResponse(frame.payload ?? frame);
+        if (frame.type === "agent_result") return parseAgentRunResponse(readJsonStringPayload(frame, "result_json"));
+        if (frame.type === "result" || frame.type === "complete_response") return parseCompletionResponse(frame.payload ?? frame);
 
-      const normalized = normalizeAgentFrame(frame, toolBuffers);
-      if (normalized.length === 0) {
-        throw new MakaiStreamError(`unexpected frame type while awaiting agent result: ${String(frame.type)}`, { kind: "transport_error" });
+        const normalized = normalizeAgentFrame(frame, toolBuffers);
+        if (normalized.length === 0) {
+          throw new MakaiStreamError(`unexpected frame type while awaiting agent result: ${String(frame.type)}`, { kind: "transport_error" });
+        }
+        for (const event of normalized) {
+          if (event.type === "error") throw new MakaiStreamError(event.message, { kind: "provider_error", code: event.code, provider_id: event.provider_id });
+          events.push(event);
+          if (event.type === "agent_end") return buildAgentRunResponseFromEvents(events);
+        }
       }
-      for (const event of normalized) {
-        if (event.type === "error") throw new MakaiStreamError(event.message, { kind: "provider_error", code: event.code, provider_id: event.provider_id });
-        events.push(event);
-        if (event.type === "agent_end") return buildAgentRunResponseFromEvents(events);
+    } catch (error) {
+      if (isAbortError(error)) {
+        bestEffortCancelAgent(this.transport, sessionId);
+        await drainSessionFrames(this.transport, sessionId);
       }
+      throw error;
     }
   }
 
@@ -344,7 +421,9 @@ class StdioAgentApi implements MakaiAgentApi {
     const effectivePolicy = request.options?.auth_retry_policy ?? this.authRetryPolicy;
     const fallbackProviderId = providerIdFromRequest(request);
     let streamRequest = request;
-    let attempt = this.streamAttempt(streamRequest, effectivePolicy, signal);
+    // Track the active session ID so abort during auth retry can cancel+drain
+    const activeSessionId: { value?: string } = {};
+    let attempt = this.streamAttempt(streamRequest, effectivePolicy, signal, activeSessionId);
     let iterator = attempt[Symbol.asyncIterator]();
     let yielded = false;
     let retried = false;
@@ -353,47 +432,73 @@ class StdioAgentApi implements MakaiAgentApi {
       this.logger.debug("agent: starting stream", { model_ref: request.model_ref });
     }
 
-    while (true) {
-      checkAbort(signal, "agent.stream aborted");
-      let result;
-      try {
-        result = await raceWithAbort(iterator.next(), signal, "agent.stream aborted");
-      } catch (error) {
-        if (isAbortError(error)) throw error;
-        if (!yielded && !retried && isRetryableAuthError(error) && effectivePolicy === "auto_once" && this.auth) {
-          const providerId = error.provider_id ?? fallbackProviderId;
-          if (providerId) {
-            try {
-              await raceWithAbort(this.auth.login(providerId, this.authHandlers, { signal }), signal, "agent.stream aborted during auth retry");
-            } catch (authError) {
-              if (isAbortError(authError)) throw authError;
-              throw authRequiredError(providerId, error.message);
+    try {
+      while (true) {
+        checkAbort(signal, "agent.stream aborted");
+        let result;
+        try {
+          result = await raceWithAbort(iterator.next(), signal, "agent.stream aborted");
+        } catch (error) {
+          if (isAbortError(error)) {
+            const sessionId = activeSessionId.value;
+            if (sessionId) {
+              bestEffortCancelAgent(this.transport, sessionId);
+              await drainSessionFrames(this.transport, sessionId);
             }
-            retried = true;
-            streamRequest = {
-              ...request,
-              options: { ...request.options, session_id: generateNanoId() },
-            };
-            attempt = this.streamAttempt(streamRequest, effectivePolicy, signal);
-            iterator = attempt[Symbol.asyncIterator]();
-            continue;
+            throw error;
           }
+          if (!yielded && !retried && isRetryableAuthError(error) && effectivePolicy === "auto_once" && this.auth) {
+            const providerId = error.provider_id ?? fallbackProviderId;
+            if (providerId) {
+              try {
+                await raceWithAbort(this.auth.login(providerId, this.authHandlers, { signal }), signal, "agent.stream aborted during auth retry");
+              } catch (authError) {
+                if (isAbortError(authError)) {
+                  const sessionId = activeSessionId.value;
+                  if (sessionId) {
+                    bestEffortCancelAgent(this.transport, sessionId);
+                    await drainSessionFrames(this.transport, sessionId);
+                  }
+                  throw authError;
+                }
+                throw authRequiredError(providerId, error.message);
+              }
+              retried = true;
+              streamRequest = {
+                ...request,
+                options: { ...request.options, session_id: generateNanoId() },
+              };
+              attempt = this.streamAttempt(streamRequest, effectivePolicy, signal, activeSessionId);
+              iterator = attempt[Symbol.asyncIterator]();
+              continue;
+            }
+          }
+          if (isRetryableAuthError(error)) {
+            const providerId = error.provider_id ?? fallbackProviderId;
+            if (providerId) throw authRequiredError(providerId, error.message);
+          }
+          throw error;
         }
-        if (isRetryableAuthError(error)) {
-          const providerId = error.provider_id ?? fallbackProviderId;
-          if (providerId) throw authRequiredError(providerId, error.message);
-        }
-        throw error;
+        if (result.done) return;
+        yielded = true;
+        yield result.value;
       }
-      if (result.done) return;
-      yielded = true;
-      yield result.value;
+    } catch (error) {
+      if (isAbortError(error)) {
+        const sessionId = activeSessionId.value;
+        if (sessionId) {
+          bestEffortCancelAgent(this.transport, sessionId);
+          await drainSessionFrames(this.transport, sessionId);
+        }
+      }
+      throw error;
     }
   }
 
-  private async *streamAttempt(request: AgentRunRequest, effectivePolicy: RunOptions["auth_retry_policy"] | undefined, signal?: AbortSignal): AsyncIterable<AgentStreamEvent> {
+  private async *streamAttempt(request: AgentRunRequest, effectivePolicy: RunOptions["auth_retry_policy"] | undefined, signal?: AbortSignal, activeSessionId?: { value?: string }): AsyncIterable<AgentStreamEvent> {
     checkAbort(signal, "agent.stream aborted");
     const sessionId = agentSessionId(request);
+    if (activeSessionId) activeSessionId.value = sessionId;
     const fallbackProviderId = providerIdFromRequest(request);
     if (!isNoopLogger(this.logger)) {
       this.logger.debug("agent: sending agent_start", { session_id: sessionId, model_ref: request.model_ref });
@@ -452,7 +557,11 @@ class StdioAgentApi implements MakaiAgentApi {
         this.logger.error("agent: stream error", { kind: error.kind, code: error.code, message: error.message });
         throw error;
       }
-      if (isAbortError(error)) throw error;
+      if (isAbortError(error)) {
+        bestEffortCancelAgent(this.transport, sessionId);
+        await drainSessionFrames(this.transport, sessionId);
+        throw error;
+      }
       this.logger.error("agent: unexpected stream error", { error: error instanceof Error ? error.message : String(error) });
       throw new MakaiStreamError(error instanceof Error ? error.message : String(error), { kind: "transport_error" });
     }
@@ -1182,6 +1291,103 @@ function isObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+// ---------------------------------------------------------------------------
+// Best-effort cancel + drain helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Sends an `abort_request` envelope for the given stream, swallowing any
+ * transport errors so the original abort error propagates cleanly.
+ *
+ * This mirrors `MakaiAuthClient.bestEffortCancel()` in auth_protocol.ts.
+ */
+function bestEffortCancelStream(transport: MakaiStdioClient, streamId: string): void {
+  try {
+    transport.send({
+      type: "abort_request",
+      stream_id: streamId,
+      message_id: ulid(),
+      sequence: 999,
+      timestamp: Date.now(),
+      version: ENVELOPE_VERSION,
+      payload: { target_stream_id: streamId, reason: "client aborted" },
+    });
+  } catch {
+    // Best-effort cancellation; ignore transport errors here so we keep
+    // surfacing the original failure to the caller.
+  }
+}
+
+/**
+ * Sends an `agent_stop` envelope for the given session, swallowing any
+ * transport errors so the original abort error propagates cleanly.
+ */
+function bestEffortCancelAgent(transport: MakaiStdioClient, sessionId: string): void {
+  try {
+    transport.send({
+      type: "agent_stop",
+      session_id: sessionId,
+      message_id: ulid(),
+      sequence: 999,
+      timestamp: Date.now(),
+      version: ENVELOPE_VERSION,
+      payload: { session_id: sessionId, reason: "client aborted" },
+    });
+  } catch {
+    // Best-effort cancellation; ignore transport errors here so we keep
+    // surfacing the original failure to the caller.
+  }
+}
+
+/**
+ * Drains remaining in-flight frames for an abandoned stream from the
+ * transport buffer. Prevents orphaned frames from interfering with
+ * subsequent operations on the shared transport.
+ *
+ * Returns once the transport buffer is empty for the given stream_id or
+ * the timeout expires. Analogous to `drainLoginResult()` in auth_protocol.ts.
+ *
+ * Uses a Promise.race with a per-iteration timeout so it never blocks
+ * indefinitely even if the transport mock doesn't respect timeoutMs.
+ */
+async function drainStreamFrames(transport: MakaiStdioClient, streamId: string, timeoutMs = 200): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) break;
+    const perFrameMs = Math.min(remaining, 50);
+    try {
+      await Promise.race([
+        transport.nextFrameForStream(streamId, perFrameMs).catch(() => undefined),
+        new Promise<void>((resolve) => setTimeout(resolve, perFrameMs)),
+      ]);
+    } catch {
+      break;
+    }
+  }
+}
+
+/**
+ * Drains remaining in-flight frames for an abandoned agent session from the
+ * transport buffer.
+ */
+async function drainSessionFrames(transport: MakaiStdioClient, sessionId: string, timeoutMs = 200): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) break;
+    const perFrameMs = Math.min(remaining, 50);
+    try {
+      await Promise.race([
+        transport.nextFrameForSession(sessionId, perFrameMs).catch(() => undefined),
+        new Promise<void>((resolve) => setTimeout(resolve, perFrameMs)),
+      ]);
+    } catch {
+      break;
+    }
+  }
+}
+
 function isRetryableAuthError(error: unknown): error is MakaiStreamError {
   return error instanceof MakaiStreamError && error.code === "auth_required";
 }
@@ -1220,6 +1426,8 @@ async function withAuthRetry<T>(
     beforeRetry?: () => void;
     signal?: AbortSignal;
     logger?: MakaiLogger;
+    /** Called when abort fires during auth retry to cancel the abandoned stream/session. */
+    onAbort?: () => Promise<void>;
   },
 ): Promise<T> {
   try {
@@ -1240,9 +1448,11 @@ async function withAuthRetry<T>(
         );
       } catch (loginError) {
         if (isAbortError(loginError)) {
+          await options.onAbort?.();
           throw loginError;
         }
         if (loginError instanceof MakaiAuthError && loginError.kind === "cancelled" && options.signal?.aborted) {
+          await options.onAbort?.();
           const abortError = new Error("operation aborted during auth retry");
           abortError.name = "AbortError";
           throw abortError;

--- a/typescript/src/execution_client.ts
+++ b/typescript/src/execution_client.ts
@@ -151,11 +151,15 @@ class StdioProviderApi implements MakaiProviderApi {
         fallbackProviderId: providerIdFromRequest(request),
         signal,
         logger: this.logger,
-        onAbort: async () => {
+        onAbort: () => {
           const streamId = activeStreamId.value;
           if (streamId) {
             bestEffortCancelStream(this.transport, streamId);
-            await drainStreamFrames(this.transport, streamId);
+            // Fire-and-forget: the aborted nextFrameForStream may still hold
+            // withStreamReadLock, so awaiting drain would block until that
+            // lock is released (up to responseTimeoutMs). Drain runs in the
+            // background instead.
+            drainStreamFrames(this.transport, streamId);
           }
         },
       },
@@ -187,7 +191,9 @@ class StdioProviderApi implements MakaiProviderApi {
     } catch (error) {
       if (isAbortError(error)) {
         bestEffortCancelStream(this.transport, streamId);
-        await drainStreamFrames(this.transport, streamId);
+        // Fire-and-forget: avoids blocking behind withStreamReadLock held by
+        // the aborted nextFrameForStream call.
+        drainStreamFrames(this.transport, streamId);
       }
       throw error;
     }
@@ -347,11 +353,12 @@ class StdioAgentApi implements MakaiAgentApi {
             options: { ...request.options, session_id: generateNanoId() },
           };
         },
-        onAbort: async () => {
+        onAbort: () => {
           const sessionId = activeSessionId.value;
           if (sessionId) {
             bestEffortCancelAgent(this.transport, sessionId);
-            await drainSessionFrames(this.transport, sessionId);
+            // Fire-and-forget: avoids blocking behind withStreamReadLock.
+            drainSessionFrames(this.transport, sessionId);
           }
         },
       },
@@ -401,7 +408,8 @@ class StdioAgentApi implements MakaiAgentApi {
     } catch (error) {
       if (isAbortError(error)) {
         bestEffortCancelAgent(this.transport, sessionId);
-        await drainSessionFrames(this.transport, sessionId);
+        // Fire-and-forget: avoids blocking behind withStreamReadLock.
+        drainSessionFrames(this.transport, sessionId);
       }
       throw error;
     }
@@ -1313,7 +1321,7 @@ async function withAuthRetry<T>(
     signal?: AbortSignal;
     logger?: MakaiLogger;
     /** Called when abort fires during auth retry to cancel the abandoned stream/session. */
-    onAbort?: () => Promise<void>;
+    onAbort?: () => void;
   },
 ): Promise<T> {
   try {
@@ -1334,11 +1342,11 @@ async function withAuthRetry<T>(
         );
       } catch (loginError) {
         if (isAbortError(loginError)) {
-          await options.onAbort?.();
+          options.onAbort?.();
           throw loginError;
         }
         if (loginError instanceof MakaiAuthError && loginError.kind === "cancelled" && options.signal?.aborted) {
-          await options.onAbort?.();
+          options.onAbort?.();
           const abortError = new Error("operation aborted during auth retry");
           abortError.name = "AbortError";
           throw abortError;

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -85,6 +85,13 @@ export {
 } from "./timeout_diagnostics";
 
 export {
+  bestEffortCancelStream,
+  bestEffortCancelAgent,
+  drainStreamFrames,
+  drainSessionFrames,
+} from "./cancel_helpers";
+
+export {
   type MakaiLogger,
   getNoopLogger,
   isNoopLogger,

--- a/typescript/src/models_client.ts
+++ b/typescript/src/models_client.ts
@@ -276,7 +276,9 @@ class StdioModelsApi implements MakaiModelsApi {
     } catch (error) {
       if (isAbortError(error)) {
         bestEffortCancelStream(this.client, streamId);
-        await drainStreamFrames(this.client, streamId);
+        // Fire-and-forget: avoids blocking behind withStreamReadLock held by
+        // the aborted nextFrameForStream call.
+        drainStreamFrames(this.client, streamId);
       }
       throw error;
     }

--- a/typescript/src/models_client.ts
+++ b/typescript/src/models_client.ts
@@ -50,6 +50,56 @@ const DEFAULT_RESPONSE_TIMEOUT_MS = 5_000;
 const MAX_PROVIDER_ID_LENGTH = 256;
 const MAX_MODEL_ID_LENGTH = 256;
 
+// ---------------------------------------------------------------------------
+// Best-effort cancel + drain helpers for models
+// ---------------------------------------------------------------------------
+
+/**
+ * Sends an `abort_request` envelope for the given models stream, swallowing
+ * any transport errors so the original abort error propagates cleanly.
+ */
+function bestEffortCancelModelsStream(client: MakaiStdioClient, streamId: string): void {
+  try {
+    client.send({
+      type: "abort_request",
+      stream_id: streamId,
+      message_id: ulid(),
+      sequence: 999,
+      timestamp: Date.now(),
+      version: ENVELOPE_VERSION,
+      payload: { target_stream_id: streamId, reason: "client aborted" },
+    });
+  } catch {
+    // Best-effort cancellation; ignore transport errors here so we keep
+    // surfacing the original failure to the caller.
+  }
+}
+
+/**
+ * Drains remaining in-flight frames for an abandoned models stream from the
+ * transport buffer. Prevents orphaned frames from interfering with
+ * subsequent operations on the shared transport.
+ *
+ * Uses a Promise.race with a per-iteration timeout so it never blocks
+ * indefinitely even if the transport mock doesn't respect timeoutMs.
+ */
+async function drainModelsStreamFrames(client: MakaiStdioClient, streamId: string, timeoutMs = 200): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) break;
+    const perFrameMs = Math.min(remaining, 50);
+    try {
+      await Promise.race([
+        client.nextFrameForStream(streamId, perFrameMs).catch(() => undefined),
+        new Promise<void>((resolve) => setTimeout(resolve, perFrameMs)),
+      ]);
+    } catch {
+      break;
+    }
+  }
+}
+
 const KNOWN_AUTH_STATUSES: ReadonlySet<string> = new Set([
   "authenticated",
   "login_required",
@@ -243,33 +293,41 @@ class StdioModelsApi implements MakaiModelsApi {
       model_id: request.model_id,
     };
     const deadline = Date.now() + this.responseTimeoutMs;
-    while (true) {
-      checkAbort(signal, "models.list aborted");
-      const remaining = deadline - Date.now();
-      if (remaining <= 0) {
-        throw new MakaiProtocolError(
-          formatTimeoutMessage(timeoutContext),
-          undefined,
-          { diagnostics: createTimeoutDiagnostics(timeoutContext) },
-        );
-      }
-      const frame = await this.nextFrameForStream(streamId, remaining, timeoutContext, signal);
-
-      switch (frame.type) {
-        case "ack":
-          continue;
-        case "nack":
-          throw nackToError(frame);
-        case "models_response": {
-          const response = parseModelsResponse(frame);
-          this.logger.debug("models: received models_response", { count: response.models.length, stream_id: streamId });
-          return response;
-        }
-        default:
-          throw malformedResponseError(
-            `unexpected frame type while awaiting models_response: ${frame.type}`,
+    try {
+      while (true) {
+        checkAbort(signal, "models.list aborted");
+        const remaining = deadline - Date.now();
+        if (remaining <= 0) {
+          throw new MakaiProtocolError(
+            formatTimeoutMessage(timeoutContext),
+            undefined,
+            { diagnostics: createTimeoutDiagnostics(timeoutContext) },
           );
+        }
+        const frame = await this.nextFrameForStream(streamId, remaining, timeoutContext, signal);
+
+        switch (frame.type) {
+          case "ack":
+            continue;
+          case "nack":
+            throw nackToError(frame);
+          case "models_response": {
+            const response = parseModelsResponse(frame);
+            this.logger.debug("models: received models_response", { count: response.models.length, stream_id: streamId });
+            return response;
+          }
+          default:
+            throw malformedResponseError(
+              `unexpected frame type while awaiting models_response: ${frame.type}`,
+            );
+        }
       }
+    } catch (error) {
+      if (isAbortError(error)) {
+        bestEffortCancelModelsStream(this.client, streamId);
+        await drainModelsStreamFrames(this.client, streamId);
+      }
+      throw error;
     }
   }
 }

--- a/typescript/src/models_client.ts
+++ b/typescript/src/models_client.ts
@@ -21,6 +21,7 @@
 
 import { ulid } from "ulid";
 import { checkAbort, isAbortError, raceWithAbort } from "./abort_signal";
+import { bestEffortCancelStream, drainStreamFrames } from "./cancel_helpers";
 import { getNoopLogger, type MakaiLogger } from "./logger";
 import {
   AuthStatus,
@@ -49,56 +50,6 @@ const DEFAULT_CACHE_MAX_AGE_MS = 300_000; // spec §2.3 fallback when server omi
 const DEFAULT_RESPONSE_TIMEOUT_MS = 5_000;
 const MAX_PROVIDER_ID_LENGTH = 256;
 const MAX_MODEL_ID_LENGTH = 256;
-
-// ---------------------------------------------------------------------------
-// Best-effort cancel + drain helpers for models
-// ---------------------------------------------------------------------------
-
-/**
- * Sends an `abort_request` envelope for the given models stream, swallowing
- * any transport errors so the original abort error propagates cleanly.
- */
-function bestEffortCancelModelsStream(client: MakaiStdioClient, streamId: string): void {
-  try {
-    client.send({
-      type: "abort_request",
-      stream_id: streamId,
-      message_id: ulid(),
-      sequence: 999,
-      timestamp: Date.now(),
-      version: ENVELOPE_VERSION,
-      payload: { target_stream_id: streamId, reason: "client aborted" },
-    });
-  } catch {
-    // Best-effort cancellation; ignore transport errors here so we keep
-    // surfacing the original failure to the caller.
-  }
-}
-
-/**
- * Drains remaining in-flight frames for an abandoned models stream from the
- * transport buffer. Prevents orphaned frames from interfering with
- * subsequent operations on the shared transport.
- *
- * Uses a Promise.race with a per-iteration timeout so it never blocks
- * indefinitely even if the transport mock doesn't respect timeoutMs.
- */
-async function drainModelsStreamFrames(client: MakaiStdioClient, streamId: string, timeoutMs = 200): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    const remaining = deadline - Date.now();
-    if (remaining <= 0) break;
-    const perFrameMs = Math.min(remaining, 50);
-    try {
-      await Promise.race([
-        client.nextFrameForStream(streamId, perFrameMs).catch(() => undefined),
-        new Promise<void>((resolve) => setTimeout(resolve, perFrameMs)),
-      ]);
-    } catch {
-      break;
-    }
-  }
-}
 
 const KNOWN_AUTH_STATUSES: ReadonlySet<string> = new Set([
   "authenticated",
@@ -324,8 +275,8 @@ class StdioModelsApi implements MakaiModelsApi {
       }
     } catch (error) {
       if (isAbortError(error)) {
-        bestEffortCancelModelsStream(this.client, streamId);
-        await drainModelsStreamFrames(this.client, streamId);
+        bestEffortCancelStream(this.client, streamId);
+        await drainStreamFrames(this.client, streamId);
       }
       throw error;
     }

--- a/typescript/test/abort_signal.test.ts
+++ b/typescript/test/abort_signal.test.ts
@@ -12,6 +12,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   createMakaiAgentApi,
+  createMakaiModelsApi,
   createMakaiProviderApi,
   MakaiAuthError,
   MakaiStreamError,
@@ -659,10 +660,10 @@ test("provider.stream sends abort_request cancel envelope on abort", async () =>
     (error: unknown) => error instanceof Error && error.name === "AbortError",
   );
 
-  // Verify abort_request was sent
-  const cancelFrame = transport.sent.find((f) => f.type === "abort_request");
-  assert.ok(cancelFrame, "expected abort_request frame");
-  const payload = cancelFrame!.payload as Record<string, unknown>;
+  // Verify exactly one abort_request was sent (no triple-cancel)
+  const cancelFrames = transport.sent.filter((f) => f.type === "abort_request");
+  assert.equal(cancelFrames.length, 1, "expected exactly one abort_request frame");
+  const payload = cancelFrames[0]!.payload as Record<string, unknown>;
   assert.equal(payload.reason, "client aborted");
   const requestFrame = transport.sent.find((f) => f.type === "stream_request");
   assert.equal(payload.target_stream_id, requestFrame?.stream_id);
@@ -732,10 +733,10 @@ test("agent.stream sends agent_stop cancel envelope on abort", async () => {
     (error: unknown) => error instanceof Error && error.name === "AbortError",
   );
 
-  // Verify agent_stop was sent
-  const cancelFrame = transport.sent.find((f) => f.type === "agent_stop");
-  assert.ok(cancelFrame, "expected agent_stop frame");
-  const payload = cancelFrame!.payload as Record<string, unknown>;
+  // Verify exactly one agent_stop was sent (no triple-cancel)
+  const cancelFrames = transport.sent.filter((f) => f.type === "agent_stop");
+  assert.equal(cancelFrames.length, 1, "expected exactly one agent_stop frame");
+  const payload = cancelFrames[0]!.payload as Record<string, unknown>;
   assert.equal(payload.reason, "client aborted");
 
   transport.rejectAll();
@@ -805,6 +806,39 @@ test("provider.complete withAuthRetry sends cancel on abort during auth login", 
   assert.ok(cancelFrame, "expected abort_request frame from withAuthRetry onAbort");
   const payload = cancelFrame!.payload as Record<string, unknown>;
   assert.equal(payload.reason, "client aborted");
+
+  transport.rejectAll();
+  await flushMicrotasks();
+});
+
+// ---------------------------------------------------------------------------
+// models cancel envelope verification
+// ---------------------------------------------------------------------------
+
+test("models.list sends abort_request cancel envelope on abort", async () => {
+  const transport = new AbortTestTransport();
+  const models = createMakaiModelsApi(transport as never);
+  const controller = new AbortController();
+
+  const listPromise = models.list({ provider_id: "anthropic", signal: controller.signal });
+
+  await new Promise((resolve) => setTimeout(resolve, 5));
+  controller.abort();
+
+  await assert.rejects(
+    () => listPromise,
+    (error: unknown) => error instanceof Error && error.name === "AbortError",
+  );
+
+  // Verify abort_request was sent with correct fields
+  const cancelFrame = transport.sent.find((f) => f.type === "abort_request");
+  assert.ok(cancelFrame, "expected abort_request frame");
+  const payload = cancelFrame!.payload as Record<string, unknown>;
+  assert.equal(typeof payload.target_stream_id, "string");
+  assert.equal(payload.reason, "client aborted");
+  // target_stream_id should match the stream_id from the original models_request
+  const requestFrame = transport.sent.find((f) => f.type === "models_request");
+  assert.equal(payload.target_stream_id, requestFrame?.stream_id);
 
   transport.rejectAll();
   await flushMicrotasks();

--- a/typescript/test/abort_signal.test.ts
+++ b/typescript/test/abort_signal.test.ts
@@ -31,8 +31,8 @@ class AbortTestTransport {
   public readonly sent: StdioFrame[] = [];
   private readonly frames: StdioFrame[];
   private readonly failWith?: Error;
-  /** Pending promise reject functions — call rejectAll() to clean up. */
-  private readonly pendingRejects: Array<(reason?: unknown) => void> = [];
+  /** Pending promise entries — call rejectAll() to clean up. */
+  private readonly pendingEntries: Array<{ reject: (reason?: unknown) => void; timer: NodeJS.Timeout }> = [];
 
   constructor(frames: StdioFrame[] = [], failWith?: Error) {
     this.frames = [...frames];
@@ -45,31 +45,39 @@ class AbortTestTransport {
 
   /** Reject all pending promises to prevent dangling promise leaks in node:test. */
   rejectAll(): void {
-    for (const reject of this.pendingRejects.splice(0)) {
-      reject(new Error("transport cleaned up"));
+    for (const entry of this.pendingEntries.splice(0)) {
+      clearTimeout(entry.timer);
+      entry.reject(new Error("transport cleaned up"));
     }
   }
 
-  async nextFrameForStream(streamId: string, _timeoutMs?: number): Promise<StdioFrame> {
+  async nextFrameForStream(streamId: string, timeoutMs?: number): Promise<StdioFrame> {
     if (this.failWith) throw this.failWith;
     const frame = this.frames.shift();
     if (!frame) {
-      // Return a promise that stays pending until abort resolves it or
-      // rejectAll() cleans it up.  We track the reject function so the
-      // test harness can prevent dangling-promise leaks.
       return new Promise<StdioFrame>((_resolve, reject) => {
-        this.pendingRejects.push(reject);
+        const timer = setTimeout(() => {
+          const idx = this.pendingEntries.findIndex((e) => e.reject === reject);
+          if (idx >= 0) this.pendingEntries.splice(idx, 1);
+          reject(new Error(`timed out waiting for frame for stream ${streamId} after ${timeoutMs ?? 1000}ms`));
+        }, timeoutMs ?? 1000);
+        this.pendingEntries.push({ reject, timer });
       });
     }
     return { stream_id: streamId, ...frame };
   }
 
-  async nextFrameForSession(sessionId: string, _timeoutMs?: number): Promise<StdioFrame> {
+  async nextFrameForSession(sessionId: string, timeoutMs?: number): Promise<StdioFrame> {
     if (this.failWith) throw this.failWith;
     const frame = this.frames.shift();
     if (!frame) {
       return new Promise<StdioFrame>((_resolve, reject) => {
-        this.pendingRejects.push(reject);
+        const timer = setTimeout(() => {
+          const idx = this.pendingEntries.findIndex((e) => e.reject === reject);
+          if (idx >= 0) this.pendingEntries.splice(idx, 1);
+          reject(new Error(`timed out waiting for frame for session ${sessionId} after ${timeoutMs ?? 1000}ms`));
+        }, timeoutMs ?? 1000);
+        this.pendingEntries.push({ reject, timer });
       });
     }
     return { session_id: sessionId, ...frame };
@@ -123,9 +131,10 @@ test("provider.complete rejects when signal is aborted during frame wait", async
     (error: unknown) =>
       error instanceof Error && error.name === "AbortError",
   );
-  // The initial envelope should have been sent.
-  assert.equal(transport.sent.length, 1);
+  // The initial envelope and the abort_request cancel should have been sent.
+  assert.equal(transport.sent.length, 2);
   assert.equal(transport.sent[0]?.type, "complete_request");
+  assert.equal(transport.sent[1]?.type, "abort_request");
   transport.rejectAll();
   await flushMicrotasks();
 });
@@ -250,8 +259,10 @@ test("agent.run rejects when signal is aborted during frame wait", async () => {
     (error: unknown) =>
       error instanceof Error && error.name === "AbortError",
   );
-  assert.equal(transport.sent.length, 1);
+  // The agent_start and the agent_stop cancel should have been sent.
+  assert.equal(transport.sent.length, 2);
   assert.equal(transport.sent[0]?.type, "agent_start");
+  assert.equal(transport.sent[1]?.type, "agent_stop");
   transport.rejectAll();
   await flushMicrotasks();
 });
@@ -583,3 +594,218 @@ function listenerCount(signal: AbortSignal): number {
   // Fallback: no reliable way to count in all environments.
   return 0;
 }
+
+// ---------------------------------------------------------------------------
+// Cancel envelope verification tests
+// ---------------------------------------------------------------------------
+
+test("provider.complete sends abort_request cancel envelope on abort", async () => {
+  const transport = new AbortTestTransport();
+  const provider = createMakaiProviderApi(transport as never);
+  const controller = new AbortController();
+
+  const completePromise = provider.complete({ ...REQUEST, options: { signal: controller.signal } });
+
+  await new Promise((resolve) => setTimeout(resolve, 5));
+  controller.abort();
+
+  await assert.rejects(
+    () => completePromise,
+    (error: unknown) => error instanceof Error && error.name === "AbortError",
+  );
+
+  // Verify abort_request was sent with correct fields
+  const cancelFrame = transport.sent.find((f) => f.type === "abort_request");
+  assert.ok(cancelFrame, "expected abort_request frame");
+  const payload = cancelFrame!.payload as Record<string, unknown>;
+  assert.equal(typeof payload.target_stream_id, "string");
+  assert.equal(payload.reason, "client aborted");
+  // target_stream_id should match the stream_id from the original complete_request
+  const requestFrame = transport.sent.find((f) => f.type === "complete_request");
+  assert.equal(payload.target_stream_id, requestFrame?.stream_id);
+
+  transport.rejectAll();
+  await flushMicrotasks();
+});
+
+test("provider.stream sends abort_request cancel envelope on abort", async () => {
+  // Use a transport that yields a start frame then a text_delta, giving time
+  // for abort to fire. The text_delta triggers a yield, then the next
+  // raceWithAbort catches the already-aborted signal.
+  const transport = new AbortTestTransport();
+  let frameCount = 0;
+  transport.nextFrameForStream = async (streamId: string, _timeoutMs?: number) => {
+    frameCount++;
+    if (frameCount === 1) {
+      return { stream_id: streamId, type: "event", payload: { type: "message_start" } };
+    }
+    // Yield a text delta so the generator continues; abort was already called
+    // so the next raceWithAbort will catch it.
+    return { stream_id: streamId, type: "event", payload: { type: "text_delta", delta: "hi" } };
+  };
+  const provider = createMakaiProviderApi(transport as never);
+  const controller = new AbortController();
+
+  const events: unknown[] = [];
+  const streamPromise = (async () => {
+    for await (const event of provider.stream({ ...REQUEST, options: { signal: controller.signal } })) {
+      events.push(event);
+      controller.abort();
+    }
+  })();
+
+  await assert.rejects(
+    () => streamPromise,
+    (error: unknown) => error instanceof Error && error.name === "AbortError",
+  );
+
+  // Verify abort_request was sent
+  const cancelFrame = transport.sent.find((f) => f.type === "abort_request");
+  assert.ok(cancelFrame, "expected abort_request frame");
+  const payload = cancelFrame!.payload as Record<string, unknown>;
+  assert.equal(payload.reason, "client aborted");
+  const requestFrame = transport.sent.find((f) => f.type === "stream_request");
+  assert.equal(payload.target_stream_id, requestFrame?.stream_id);
+
+  transport.rejectAll();
+  await flushMicrotasks();
+});
+
+test("agent.run sends agent_stop cancel envelope on abort", async () => {
+  const transport = new AbortTestTransport();
+  const agent = createMakaiAgentApi(transport as never);
+  const controller = new AbortController();
+
+  const runPromise = agent.run({ ...REQUEST, options: { signal: controller.signal } });
+
+  await new Promise((resolve) => setTimeout(resolve, 5));
+  controller.abort();
+
+  await assert.rejects(
+    () => runPromise,
+    (error: unknown) => error instanceof Error && error.name === "AbortError",
+  );
+
+  // Verify agent_stop was sent with correct fields
+  const cancelFrame = transport.sent.find((f) => f.type === "agent_stop");
+  assert.ok(cancelFrame, "expected agent_stop frame");
+  const payload = cancelFrame!.payload as Record<string, unknown>;
+  assert.equal(payload.reason, "client aborted");
+  // session_id should match the original agent_start
+  const startFrame = transport.sent.find((f) => f.type === "agent_start");
+  assert.equal(cancelFrame!.session_id, startFrame?.session_id);
+
+  transport.rejectAll();
+  await flushMicrotasks();
+});
+
+test("agent.stream sends agent_stop cancel envelope on abort", async () => {
+  // Use a transport that yields agent_started then turn_start, giving time
+  // for abort to fire.
+  const transport = new AbortTestTransport();
+  let frameCount = 0;
+  transport.nextFrameForSession = async (sessionId: string, _timeoutMs?: number) => {
+    frameCount++;
+    if (frameCount === 1) {
+      return { session_id: sessionId, type: "agent_started", payload: {} };
+    }
+    // Return a non-terminal event so the generator continues
+    return {
+      session_id: sessionId,
+      type: "agent_event",
+      payload: { event_json: JSON.stringify({ type: "turn_start" }) },
+    };
+  };
+  const agent = createMakaiAgentApi(transport as never);
+  const controller = new AbortController();
+
+  const events: unknown[] = [];
+  const streamPromise = (async () => {
+    for await (const event of agent.stream({ ...REQUEST, options: { signal: controller.signal } })) {
+      events.push(event);
+      controller.abort();
+    }
+  })();
+
+  await assert.rejects(
+    () => streamPromise,
+    (error: unknown) => error instanceof Error && error.name === "AbortError",
+  );
+
+  // Verify agent_stop was sent
+  const cancelFrame = transport.sent.find((f) => f.type === "agent_stop");
+  assert.ok(cancelFrame, "expected agent_stop frame");
+  const payload = cancelFrame!.payload as Record<string, unknown>;
+  assert.equal(payload.reason, "client aborted");
+
+  transport.rejectAll();
+  await flushMicrotasks();
+});
+
+test("cancel is not sent when abort occurs before transport I/O", async () => {
+  const transport = new AbortTestTransport();
+  const provider = createMakaiProviderApi(transport as never);
+
+  await assert.rejects(
+    () => provider.complete({ ...REQUEST, options: { signal: AbortSignal.abort() } }),
+    (error: unknown) => error instanceof Error && error.name === "AbortError",
+  );
+
+  // No frames should have been sent (neither request nor cancel)
+  assert.equal(transport.sent.length, 0);
+  transport.rejectAll();
+  await flushMicrotasks();
+});
+
+test("provider.complete withAuthRetry sends cancel on abort during auth login", async () => {
+  const transport = new AbortTestTransport();
+  transport.nextFrameForStream = async (streamId: string, _timeoutMs?: number) => {
+    return {
+      stream_id: streamId,
+      type: "nack",
+      payload: { reason: "login required", error_code: "auth_required", provider_id: "fixture" },
+    };
+  };
+  const auth = {
+    async listProviders() { return []; },
+    async login(_providerId: string, _handlers?: unknown, options?: { signal?: AbortSignal }): Promise<{ status: "success" }> {
+      return new Promise<{ status: "success" }>((resolve, reject) => {
+        const signal = options?.signal;
+        if (signal?.aborted) {
+          const error = new Error("login aborted");
+          error.name = "AbortError";
+          reject(error);
+          return;
+        }
+        const onAbort = () => {
+          const error = new Error("login aborted");
+          error.name = "AbortError";
+          reject(error);
+        };
+        signal?.addEventListener("abort", onAbort, { once: true });
+      });
+    },
+  };
+  const controller = new AbortController();
+  const completePromise = createMakaiProviderApi(transport as never, {
+    auth,
+    authRetryPolicy: "auto_once",
+  }).complete({ ...REQUEST, options: { auth_retry_policy: "auto_once", signal: controller.signal } });
+
+  await new Promise((resolve) => setTimeout(resolve, 5));
+  controller.abort();
+
+  await assert.rejects(
+    () => completePromise,
+    (error: unknown) => error instanceof Error && error.name === "AbortError",
+  );
+
+  // Verify abort_request was sent for the original stream
+  const cancelFrame = transport.sent.find((f) => f.type === "abort_request");
+  assert.ok(cancelFrame, "expected abort_request frame from withAuthRetry onAbort");
+  const payload = cancelFrame!.payload as Record<string, unknown>;
+  assert.equal(payload.reason, "client aborted");
+
+  transport.rejectAll();
+  await flushMicrotasks();
+});


### PR DESCRIPTION
## Summary

- When the client aborts a provider stream, agent session, or models request, it now sends a best-effort cancel envelope (`abort_request` for provider/models streams, `agent_stop` for agent sessions) and drains remaining in-flight frames before propagating the abort error
- This lets the server clean up resources immediately instead of waiting for a timeout
- Tracks active stream/session IDs so `withAuthRetry` can cancel abandoned streams during auth login

## Changes

- **execution_client.ts**: Add `bestEffortCancelStream`, `bestEffortCancelAgent`, `drainStreamFrames`, `drainSessionFrames` helpers. Wrap inner frame loops in try/catch for cancel+drain on abort. Wrap outer stream while-loops in try/catch so `checkAbort` throws are caught and cancel envelopes are sent. Track active stream/session IDs via mutable containers. Add `onAbort` callback to `withAuthRetry`.
- **models_client.ts**: Add `bestEffortCancelModelsStream` and `drainModelsStreamFrames`. Wrap `dispatch` method's while loop in try/catch for cancel+drain on abort.
- **abort_signal.test.ts**: Add 6 new tests verifying cancel envelope contents on abort. Update 2 existing tests to expect the additional cancel frame.

## Test plan

- [x] All 26 abort signal tests pass (including 6 new cancel envelope verification tests)
- [x] Full test suite passes (190/190 unit tests, 4 e2e skipped — no makai binary)
- [x] Cancel is not sent when abort occurs before transport I/O (verified)
- [x] Cancel+drain fires on abort during auth retry login (verified)