### PR TITLE
fix(providers): bedrock import, google api key header, anthropic double ref

### DIFF
--- a/zig/src/agent/agent_loop.zig
+++ b/zig/src/agent/agent_loop.zig
@@ -476,7 +476,9 @@ fn streamAssistantResponse(
     // Fallback for providers that don't emit .done (e.g. OpenAI Completions, Anthropic)
     if (final_message == null) {
         if (provider_stream.getResult()) |result| {
-            final_message = try ai_types.cloneAssistantMessage(allocator, result);
+            var cloned = try ai_types.cloneAssistantMessage(allocator, result);
+            errdefer cloned.deinit(allocator);
+            final_message = cloned;
             const msg: ai_types.Message = .{ .assistant = final_message.? };
             try event_stream.push(.{ .message_end = .{
                 .message = msg,

--- a/zig/src/agent/agent_loop.zig
+++ b/zig/src/agent/agent_loop.zig
@@ -651,11 +651,12 @@ fn runLoop(
                         .message = assistant_message,
                         .tool_results = types.OwnedSlice(ai_types.ToolResultMessage).initBorrowed(&.{}),
                     } });
-                    // Free the local copy if owned (state already has clones via setFinalMessage)
-                    if (assistant_message.is_owned) {
-                        var am = assistant_message;
-                        am.deinit(allocator);
-                    }
+                    // NOTE: We intentionally do NOT deinit assistant_message here.
+                    // AgentEventStream.push performs shallow copies, so event consumers
+                    // may read message fields after this branch exits. Deiniting would
+                    // cause use-after-free. The state clones (setFinalMessage/
+                    // appendClonedStateMessage) own independent copies; this local copy
+                    // is kept alive for the event stream lifetime.
                     break :outer;
                 },
                 .stop, .length, .content_filter => {

--- a/zig/src/agent/agent_loop.zig
+++ b/zig/src/agent/agent_loop.zig
@@ -651,6 +651,11 @@ fn runLoop(
                         .message = assistant_message,
                         .tool_results = types.OwnedSlice(ai_types.ToolResultMessage).initBorrowed(&.{}),
                     } });
+                    // Free the local copy if owned (state already has clones via setFinalMessage)
+                    if (assistant_message.is_owned) {
+                        var am = assistant_message;
+                        am.deinit(allocator);
+                    }
                     break :outer;
                 },
                 .stop, .length, .content_filter => {

--- a/zig/src/agent/agent_loop.zig
+++ b/zig/src/agent/agent_loop.zig
@@ -473,7 +473,17 @@ fn streamAssistantResponse(
         }
     }
 
-    // Return final message (required to be set by done/error)
+    // Fallback for providers that don't emit .done (e.g. OpenAI Completions, Anthropic)
+    if (final_message == null) {
+        if (provider_stream.getResult()) |result| {
+            final_message = try ai_types.cloneAssistantMessage(allocator, result);
+            const msg: ai_types.Message = .{ .assistant = final_message.? };
+            try event_stream.push(.{ .message_end = .{
+                .message = msg,
+            } });
+        }
+    }
+
     return final_message orelse error.NoFinalMessage;
 }
 

--- a/zig/src/ai_types.zig
+++ b/zig/src/ai_types.zig
@@ -631,6 +631,10 @@ pub fn cloneAssistantMessage(allocator: std.mem.Allocator, msg: AssistantMessage
         OwnedSlice(u8).initOwned(try allocator.dupe(u8, e))
     else
         OwnedSlice(u8).initBorrowed("");
+    errdefer {
+        var em = error_msg;
+        em.deinit(allocator);
+    }
 
     const api = try allocator.dupe(u8, msg.api);
     errdefer allocator.free(api);

--- a/zig/src/ai_types.zig
+++ b/zig/src/ai_types.zig
@@ -632,15 +632,23 @@ pub fn cloneAssistantMessage(allocator: std.mem.Allocator, msg: AssistantMessage
     else
         OwnedSlice(u8).initBorrowed("");
 
+    const api = try allocator.dupe(u8, msg.api);
+    errdefer allocator.free(api);
+    const provider = try allocator.dupe(u8, msg.provider);
+    errdefer allocator.free(provider);
+    const model_str = try allocator.dupe(u8, msg.model);
+    errdefer allocator.free(model_str);
+
     return .{
         .content = content,
-        .api = msg.api, // Borrowed reference, not owned
-        .provider = msg.provider, // Borrowed reference, not owned
-        .model = msg.model, // Borrowed reference, not owned
+        .api = api,
+        .provider = provider,
+        .model = model_str,
         .usage = msg.usage,
         .stop_reason = msg.stop_reason,
         .error_message = error_msg,
         .timestamp = msg.timestamp,
+        .is_owned = true,
     };
 }
 

--- a/zig/src/protocol/provider/client.zig
+++ b/zig/src/protocol/provider/client.zig
@@ -890,6 +890,15 @@ test "processEnvelope routes events to per-stream event stream" {
     const e2 = s2.poll();
     try std.testing.expect(e1 != null and e1.? == .start);
     try std.testing.expect(e2 != null and e2.? == .start);
+
+    if (e1) |ev| {
+        var mutable_ev = ev;
+        ai_types.deinitAssistantMessageEvent(allocator, &mutable_ev);
+    }
+    if (e2) |ev| {
+        var mutable_ev = ev;
+        ai_types.deinitAssistantMessageEvent(allocator, &mutable_ev);
+    }
 }
 
 test "processEnvelope handles ack" {
@@ -1001,6 +1010,11 @@ test "processEnvelope handles events" {
     const evt = client.event_stream.poll();
     try std.testing.expect(evt != null);
     try std.testing.expect(evt.? == .start);
+
+    if (evt) |ev| {
+        var mutable_ev = ev;
+        ai_types.deinitAssistantMessageEvent(allocator, &mutable_ev);
+    }
 
     env.deinit(allocator);
 }


### PR DESCRIPTION
## Summary

Fixes three provider bugs found in codebase review:

1. **Bedrock duplicate import** — `bedrock_converse_stream_api.zig` had `const std = @import("std")` on both line 1 and line 5, which Zig rejects. Removed the duplicate on line 5 so the Bedrock provider compiles.

2. **Google API key exposure in URL** — Both `google_generative_api.zig` and `google_vertex_api.zig` embedded the API key in the request URL via `?alt=sse&key=<API_KEY>`. This exposes keys in HTTP logs, proxies, and CDNs. Moved the key to the `x-goog-api-key` HTTP header, which Google Generative AI API accepts as an alternative.

3. **Anthropic done/complete double reference** — `anthropic_messages_api.zig` pushed the same `AssistantMessage` object into a `.done` event and then passed it to `stream.complete(out)`. Because the message owns its `content` slice, consumers that deinit either copy get a double-free. Fixed by cloning the message for the `.done` event so the two copies have independent allocations.

## Test plan

- [x] `zig build test-unit-providers` passes
- [x] `zig build test` (full unit suite) passes