### PR TITLE
Fix use-after-free in 6 provider streams by cloning model/context

### DIFF
--- a/zig/src/ai_types.zig
+++ b/zig/src/ai_types.zig
@@ -350,6 +350,36 @@ pub const AssistantMessage = struct {
     }
 };
 
+/// Free a built-up `AssistantContent` slice owned by the caller. Used by providers
+/// to clean up `content_blocks` when assembling a final `AssistantMessage` fails
+/// partway (e.g., a `model.api` duplicate triggers OOM). Mirrors the per-block
+/// cleanup in `AssistantMessage.deinit` but does not touch any metadata strings.
+pub fn deinitAssistantContent(allocator: std.mem.Allocator, blocks: []AssistantContent) void {
+    for (blocks) |block| {
+        switch (block) {
+            .text => |t| {
+                if (t.text.len > 0) allocator.free(t.text);
+                if (t.text_signature) |s| allocator.free(s);
+            },
+            .thinking => |t| {
+                if (t.thinking.len > 0) allocator.free(t.thinking);
+                if (t.thinking_signature) |s| allocator.free(s);
+            },
+            .tool_call => |tc| {
+                allocator.free(tc.id);
+                allocator.free(tc.name);
+                if (tc.arguments_json.len > 0) allocator.free(tc.arguments_json);
+                if (tc.thought_signature) |s| allocator.free(s);
+            },
+            .image => |img| {
+                allocator.free(img.data);
+                allocator.free(img.mime_type);
+            },
+        }
+    }
+    allocator.free(blocks);
+}
+
 pub const ToolResultMessage = struct {
     tool_call_id: []const u8,
     tool_name: []const u8,

--- a/zig/src/providers/anthropic_messages_api.zig
+++ b/zig/src/providers/anthropic_messages_api.zig
@@ -1041,6 +1041,7 @@ const ThreadCtx = struct {
     allocator: std.mem.Allocator,
     stream: *event_stream.AssistantMessageEventStream,
     model: ai_types.Model,
+    context: ai_types.Context,
     api_key: []u8,
     request_body: []u8,
     cancel_token: ?ai_types.CancelToken = null,
@@ -1048,6 +1049,17 @@ const ThreadCtx = struct {
     on_payload_ctx: ?*anyopaque = null,
     retry: ?ai_types.RetryConfig = null,
     ping_interval_ms: ?u64 = null,
+
+    /// Clean up all owned resources (model, context, api_key, request_body, self).
+    fn deinit(self: *ThreadCtx) void {
+        self.allocator.free(self.api_key);
+        self.allocator.free(self.request_body);
+        var mut_context = self.context;
+        mut_context.deinit(self.allocator);
+        var mut_model = self.model;
+        mut_model.deinit(self.allocator);
+        self.allocator.destroy(self);
+    }
 };
 
 const TestCancelStage = enum {
@@ -1126,9 +1138,7 @@ fn runThread(ctx: *ThreadCtx) void {
     // Check cancellation before sending
     if (cancel_token) |ct| {
         if (ct.isCancelled()) {
-            allocator.free(api_key);
-            allocator.free(request_body);
-            allocator.destroy(ctx);
+            ctx.deinit();
             stream.markThreadDone();
             stream.completeWithError("request cancelled");
             return;
@@ -1139,9 +1149,7 @@ fn runThread(ctx: *ThreadCtx) void {
     defer http_client.deinit();
 
     const url = buildUrlWithSuffix(allocator, model.base_url, "/v1/messages") catch {
-        allocator.free(api_key);
-        allocator.free(request_body);
-        allocator.destroy(ctx);
+        ctx.deinit();
         stream.markThreadDone();
         stream.completeWithError("oom building url");
         return;
@@ -1149,18 +1157,14 @@ fn runThread(ctx: *ThreadCtx) void {
     defer allocator.free(url);
 
     const uri = std.Uri.parse(url) catch {
-        allocator.free(api_key);
-        allocator.free(request_body);
-        allocator.destroy(ctx);
+        ctx.deinit();
         stream.markThreadDone();
         stream.completeWithError("invalid anthropic URL");
         return;
     };
 
     var header_set = buildAnthropicHeaders(allocator, api_key) catch {
-        allocator.free(api_key);
-        allocator.free(request_body);
-        allocator.destroy(ctx);
+        ctx.deinit();
         stream.markThreadDone();
         stream.completeWithError("oom headers");
         return;
@@ -1186,9 +1190,7 @@ fn runThread(ctx: *ThreadCtx) void {
         // Check cancellation before each attempt
         if (cancel_token) |ct| {
             if (ct.isCancelled()) {
-                allocator.free(api_key);
-                allocator.free(request_body);
-                allocator.destroy(ctx);
+                ctx.deinit();
                 stream.markThreadDone();
                 stream.completeWithError("request cancelled");
                 return;
@@ -1202,9 +1204,7 @@ fn runThread(ctx: *ThreadCtx) void {
         }
 
         if (testCancelAt(cancel_token, .connect_setup)) {
-            allocator.free(api_key);
-            allocator.free(request_body);
-            allocator.destroy(ctx);
+            ctx.deinit();
             stream.markThreadDone();
             stream.completeWithError("request cancelled");
             return;
@@ -1227,16 +1227,12 @@ fn runThread(ctx: *ThreadCtx) void {
                     continue;
                 }
                 // Sleep was cancelled
-                allocator.free(api_key);
-                allocator.free(request_body);
-                allocator.destroy(ctx);
+                ctx.deinit();
                 stream.markThreadDone();
                 stream.completeWithError("request cancelled");
                 return;
             }
-            allocator.free(api_key);
-            allocator.free(request_body);
-            allocator.destroy(ctx);
+            ctx.deinit();
             stream.markThreadDone();
             stream.completeWithError("request open failed");
             return;
@@ -1252,25 +1248,19 @@ fn runThread(ctx: *ThreadCtx) void {
                     continue;
                 }
                 // Sleep was cancelled
-                allocator.free(api_key);
-                allocator.free(request_body);
-                allocator.destroy(ctx);
+                ctx.deinit();
                 stream.markThreadDone();
                 stream.completeWithError("request cancelled");
                 return;
             }
-            allocator.free(api_key);
-            allocator.free(request_body);
-            allocator.destroy(ctx);
+            ctx.deinit();
             stream.markThreadDone();
             stream.completeWithError("request send failed");
             return;
         };
 
         if (testCancelAt(cancel_token, .response_headers)) {
-            allocator.free(api_key);
-            allocator.free(request_body);
-            allocator.destroy(ctx);
+            ctx.deinit();
             stream.markThreadDone();
             stream.completeWithError("request cancelled");
             return;
@@ -1285,16 +1275,12 @@ fn runThread(ctx: *ThreadCtx) void {
                     continue;
                 }
                 // Sleep was cancelled
-                allocator.free(api_key);
-                allocator.free(request_body);
-                allocator.destroy(ctx);
+                ctx.deinit();
                 stream.markThreadDone();
                 stream.completeWithError("request cancelled");
                 return;
             }
-            allocator.free(api_key);
-            allocator.free(request_body);
-            allocator.destroy(ctx);
+            ctx.deinit();
             stream.markThreadDone();
             stream.completeWithError("response failed");
             return;
@@ -1352,9 +1338,7 @@ fn runThread(ctx: *ThreadCtx) void {
             // Wait before retry
             if (!retry_util.sleepMs(delay, if (cancel_token) |ct| ct.cancelled else null)) {
                 // Sleep was cancelled
-                allocator.free(api_key);
-                allocator.free(request_body);
-                allocator.destroy(ctx);
+                ctx.deinit();
                 stream.markThreadDone();
                 stream.completeWithError("request cancelled");
                 return;
@@ -1377,9 +1361,7 @@ fn runThread(ctx: *ThreadCtx) void {
             if (status_code == 401) " (check ANTHROPIC_API_KEY is valid)" else "",
         }) catch null;
 
-        allocator.free(api_key);
-        allocator.free(request_body);
-        allocator.destroy(ctx);
+        ctx.deinit();
         stream.markThreadDone();
         stream.completeWithError(last_error orelse "anthropic request failed");
         return;
@@ -1457,9 +1439,7 @@ fn runThread(ctx: *ThreadCtx) void {
         // Check cancellation during streaming
         if (cancel_token) |ct| {
             if (ct.isCancelled()) {
-                allocator.free(api_key);
-                allocator.free(request_body);
-                allocator.destroy(ctx);
+                ctx.deinit();
                 stream.markThreadDone();
                 stream.completeWithError("request cancelled");
                 return;
@@ -1467,18 +1447,14 @@ fn runThread(ctx: *ThreadCtx) void {
         }
 
         if (testCancelAt(cancel_token, .between_sse_events)) {
-            allocator.free(api_key);
-            allocator.free(request_body);
-            allocator.destroy(ctx);
+            ctx.deinit();
             stream.markThreadDone();
             stream.completeWithError("request cancelled");
             return;
         }
 
         const n = compat.http.readResponse(reader, &read_buf) catch {
-            allocator.free(api_key);
-            allocator.free(request_body);
-            allocator.destroy(ctx);
+            ctx.deinit();
             stream.markThreadDone();
             stream.completeWithError("read error");
             return;
@@ -1486,9 +1462,7 @@ fn runThread(ctx: *ThreadCtx) void {
         if (n == 0) break;
 
         if (testCancelAt(cancel_token, .mid_event_payload)) {
-            allocator.free(api_key);
-            allocator.free(request_body);
-            allocator.destroy(ctx);
+            ctx.deinit();
             stream.markThreadDone();
             stream.completeWithError("request cancelled");
             return;
@@ -1501,9 +1475,7 @@ fn runThread(ctx: *ThreadCtx) void {
         }
 
         const events = parser.feed(read_buf[0..n]) catch {
-            allocator.free(api_key);
-            allocator.free(request_body);
-            allocator.destroy(ctx);
+            ctx.deinit();
             stream.markThreadDone();
             stream.completeWithError("sse parse error");
             return;
@@ -1511,9 +1483,7 @@ fn runThread(ctx: *ThreadCtx) void {
 
         for (events) |ev| {
             const result = parseAnthropicEventType(ev.data, allocator) catch {
-                allocator.free(api_key);
-                allocator.free(request_body);
-                allocator.destroy(ctx);
+                ctx.deinit();
                 stream.markThreadDone();
                 stream.completeWithError("event parse error");
                 return;
@@ -1612,9 +1582,7 @@ fn runThread(ctx: *ThreadCtx) void {
                             .text => {
                                 // Store the completed text block
                                 const text_copy = allocator.dupe(u8, current_text.items) catch {
-                                    allocator.free(api_key);
-                                    allocator.free(request_body);
-                                    allocator.destroy(ctx);
+                                    ctx.deinit();
                                     stream.markThreadDone();
                                     stream.completeWithError("oom text");
                                     return;
@@ -1626,9 +1594,7 @@ fn runThread(ctx: *ThreadCtx) void {
                             .thinking => {
                                 // Store the completed thinking block
                                 const thinking_copy = allocator.dupe(u8, current_thinking.items) catch {
-                                    allocator.free(api_key);
-                                    allocator.free(request_body);
-                                    allocator.destroy(ctx);
+                                    ctx.deinit();
                                     stream.markThreadDone();
                                     stream.completeWithError("oom thinking");
                                     return;
@@ -1675,9 +1641,7 @@ fn runThread(ctx: *ThreadCtx) void {
                 .message_stop => {},
                 .api_error => |err| {
                     defer allocator.free(err);
-                    allocator.free(api_key);
-                    allocator.free(request_body);
-                    allocator.destroy(ctx);
+                    ctx.deinit();
                     stream.markThreadDone();
                     stream.completeWithError(err);
                     return;
@@ -1697,9 +1661,7 @@ fn runThread(ctx: *ThreadCtx) void {
             switch (result) {
                 .api_error => |err| {
                     defer allocator.free(err);
-                    allocator.free(api_key);
-                    allocator.free(request_body);
-                    allocator.destroy(ctx);
+                    ctx.deinit();
                     stream.markThreadDone();
                     stream.completeWithError(err);
                     return;
@@ -1715,9 +1677,7 @@ fn runThread(ctx: *ThreadCtx) void {
     // If no content blocks were collected but we have text, create a text block
     if (content_blocks.items.len == 0 and current_text.items.len > 0) {
         const text_copy = allocator.dupe(u8, current_text.items) catch {
-            allocator.free(api_key);
-            allocator.free(request_body);
-            allocator.destroy(ctx);
+            ctx.deinit();
             stream.markThreadDone();
             stream.completeWithError("oom text");
             return;
@@ -1761,18 +1721,14 @@ fn runThread(ctx: *ThreadCtx) void {
             }
         }
 
-        allocator.free(api_key);
-        allocator.free(request_body);
-        allocator.destroy(ctx);
+        ctx.deinit();
         stream.markThreadDone();
         stream.completeWithError(err_text);
         return; // defer fires, freeing err_owned after completeWithError has duped err_text
     }
 
     const content_slice = content_blocks.toOwnedSlice(allocator) catch {
-        allocator.free(api_key);
-        allocator.free(request_body);
-        allocator.destroy(ctx);
+        ctx.deinit();
         stream.markThreadDone();
         stream.completeWithError("oom content");
         return;
@@ -1781,25 +1737,19 @@ fn runThread(ctx: *ThreadCtx) void {
     const out = ai_types.AssistantMessage{
         .content = content_slice,
         .api = allocator.dupe(u8, model.api) catch {
-            allocator.free(api_key);
-            allocator.free(request_body);
-            allocator.destroy(ctx);
+            ctx.deinit();
             stream.markThreadDone();
             stream.completeWithError("oom");
             return;
         },
         .provider = allocator.dupe(u8, model.provider) catch {
-            allocator.free(api_key);
-            allocator.free(request_body);
-            allocator.destroy(ctx);
+            ctx.deinit();
             stream.markThreadDone();
             stream.completeWithError("oom");
             return;
         },
         .model = allocator.dupe(u8, model.id) catch {
-            allocator.free(api_key);
-            allocator.free(request_body);
-            allocator.destroy(ctx);
+            ctx.deinit();
             stream.markThreadDone();
             stream.completeWithError("oom");
             return;
@@ -1813,9 +1763,7 @@ fn runThread(ctx: *ThreadCtx) void {
     stream.push(.{ .done = .{ .reason = stop_reason, .message = out } }) catch {};
 
     // Free ctx allocations before completing
-    allocator.free(api_key);
-    allocator.free(request_body);
-    allocator.destroy(ctx);
+    ctx.deinit();
 
     stream.markThreadDone();
     stream.complete(out);
@@ -1849,20 +1797,36 @@ pub fn streamAnthropicMessages(
     };
     errdefer allocator.free(api_key);
 
+    // Clone model to own the memory (background thread outlives caller's memory)
+    const owned_model = try ai_types.cloneModel(allocator, model);
+    errdefer {
+        var mut_m = owned_model;
+        mut_m.deinit(allocator);
+    }
+
+    // Clone context to own the memory (background thread outlives caller's memory)
+    const owned_context = try ai_types.cloneContext(allocator, context);
+    errdefer {
+        var mut_ctx = owned_context;
+        mut_ctx.deinit(allocator);
+    }
+
     const is_oauth = isOAuthToken(api_key);
-    const body = try buildRequestBody(model, context, o, allocator, is_oauth);
+    const body = try buildRequestBody(owned_model, owned_context, o, allocator, is_oauth);
     errdefer allocator.free(body);
 
     const s = try allocator.create(event_stream.AssistantMessageEventStream);
     errdefer allocator.destroy(s);
     s.* = event_stream.AssistantMessageEventStream.init(allocator);
+    s.wait_for_thread_on_deinit = true;
 
     const ctx = try allocator.create(ThreadCtx);
     errdefer allocator.destroy(ctx);
     ctx.* = .{
         .allocator = allocator,
         .stream = s,
-        .model = model,
+        .model = owned_model,
+        .context = owned_context,
         .api_key = api_key,
         .request_body = body,
         .cancel_token = o.cancel_token,

--- a/zig/src/providers/azure_openai_responses_api.zig
+++ b/zig/src/providers/azure_openai_responses_api.zig
@@ -220,20 +220,28 @@ const ThreadCtx = struct {
     allocator: std.mem.Allocator,
     stream: *event_stream.AssistantMessageEventStream,
     model: ai_types.Model,
+    context: ai_types.Context,
     api_key: []u8,
     base_url: []u8,
     body: []u8,
     cancel_token: ?ai_types.CancelToken = null,
     ping_interval_ms: ?u64 = null,
+
+    /// Clean up all owned resources (model, context, api_key, base_url, body, self).
+    fn deinit(self: *ThreadCtx) void {
+        self.allocator.free(self.api_key);
+        self.allocator.free(self.base_url);
+        self.allocator.free(self.body);
+        var mut_context = self.context;
+        mut_context.deinit(self.allocator);
+        var mut_model = self.model;
+        mut_model.deinit(self.allocator);
+        self.allocator.destroy(self);
+    }
 };
 
 fn runThread(ctx: *ThreadCtx) void {
-    defer {
-        ctx.allocator.free(ctx.api_key);
-        ctx.allocator.free(ctx.base_url);
-        ctx.allocator.free(ctx.body);
-        ctx.allocator.destroy(ctx);
-    }
+    defer ctx.deinit();
 
     if (ctx.cancel_token) |ct| {
         if (ct.isCancelled()) {
@@ -414,16 +422,31 @@ pub fn streamAzureOpenAIResponses(model: ai_types.Model, context: ai_types.Conte
     };
     errdefer allocator.free(base_url);
 
-    const body = try buildBody(model, context, o, allocator);
+    // Clone model to own the memory (background thread outlives caller's memory)
+    const owned_model = try ai_types.cloneModel(allocator, model);
+    errdefer {
+        var mut_m = owned_model;
+        mut_m.deinit(allocator);
+    }
+
+    // Clone context to own the memory (background thread outlives caller's memory)
+    const owned_context = try ai_types.cloneContext(allocator, context);
+    errdefer {
+        var mut_ctx = owned_context;
+        mut_ctx.deinit(allocator);
+    }
+
+    const body = try buildBody(owned_model, owned_context, o, allocator);
     errdefer allocator.free(body);
 
     const s = try allocator.create(event_stream.AssistantMessageEventStream);
     errdefer allocator.destroy(s);
     s.* = event_stream.AssistantMessageEventStream.init(allocator);
+    s.wait_for_thread_on_deinit = true;
 
     const ctx = try allocator.create(ThreadCtx);
     errdefer allocator.destroy(ctx);
-    ctx.* = .{ .allocator = allocator, .stream = s, .model = model, .api_key = api_key, .base_url = base_url, .body = body, .cancel_token = o.cancel_token, .ping_interval_ms = o.ping_interval_ms };
+    ctx.* = .{ .allocator = allocator, .stream = s, .model = owned_model, .context = owned_context, .api_key = api_key, .base_url = base_url, .body = body, .cancel_token = o.cancel_token, .ping_interval_ms = o.ping_interval_ms };
 
     const th = try std.Thread.spawn(.{}, runThread, .{ctx});
     th.detach();

--- a/zig/src/providers/google_generative_api.zig
+++ b/zig/src/providers/google_generative_api.zig
@@ -712,6 +712,7 @@ const ThreadCtx = struct {
     allocator: std.mem.Allocator,
     stream: *event_stream.AssistantMessageEventStream,
     model: ai_types.Model,
+    context: ai_types.Context,
     api_key: []u8,
     body: []u8,
     base_url: []u8,
@@ -721,6 +722,18 @@ const ThreadCtx = struct {
     on_payload_ctx: ?*anyopaque = null,
     retry_config: ?ai_types.RetryConfig = null,
     ping_interval_ms: ?u64 = null,
+
+    /// Clean up all owned resources (model, context, api_key, body, base_url, self).
+    fn deinit(self: *ThreadCtx) void {
+        self.allocator.free(self.base_url);
+        self.allocator.free(self.api_key);
+        self.allocator.free(self.body);
+        var mut_context = self.context;
+        mut_context.deinit(self.allocator);
+        var mut_model = self.model;
+        mut_model.deinit(self.allocator);
+        self.allocator.destroy(self);
+    }
 };
 
 fn runThread(ctx: *ThreadCtx) void {
@@ -745,10 +758,7 @@ fn runThread(ctx: *ThreadCtx) void {
     // Check cancellation before sending
     if (cancel_token) |ct| {
         if (ct.isCancelled()) {
-            allocator.free(base_url);
-            allocator.free(api_key);
-            allocator.free(body);
-            allocator.destroy(ctx);
+            ctx.deinit();
             stream.markThreadDone();
             stream.completeWithError("request cancelled");
             return;
@@ -759,10 +769,7 @@ fn runThread(ctx: *ThreadCtx) void {
     defer client.deinit();
 
     const url = buildStreamGenerateContentUrl(allocator, base_url, model.id, api_key) catch {
-        allocator.free(base_url);
-        allocator.free(api_key);
-        allocator.free(body);
-        allocator.destroy(ctx);
+        ctx.deinit();
         stream.markThreadDone();
         stream.completeWithError("oom url");
         return;
@@ -770,10 +777,7 @@ fn runThread(ctx: *ThreadCtx) void {
     defer allocator.free(url);
 
     const uri = std.Uri.parse(url) catch {
-        allocator.free(base_url);
-        allocator.free(api_key);
-        allocator.free(body);
-        allocator.destroy(ctx);
+        ctx.deinit();
         stream.markThreadDone();
         stream.completeWithError("invalid URL");
         return;
@@ -797,10 +801,7 @@ fn runThread(ctx: *ThreadCtx) void {
         // Check cancellation before each attempt
         if (cancel_token) |ct| {
             if (ct.isCancelled()) {
-                allocator.free(base_url);
-                allocator.free(api_key);
-                allocator.free(body);
-                allocator.destroy(ctx);
+                ctx.deinit();
                 stream.markThreadDone();
                 stream.completeWithError("request cancelled");
                 return;
@@ -822,18 +823,12 @@ fn runThread(ctx: *ThreadCtx) void {
                     continue;
                 }
                 // Sleep was cancelled
-                allocator.free(base_url);
-                allocator.free(api_key);
-                allocator.free(body);
-                allocator.destroy(ctx);
+                ctx.deinit();
                 stream.markThreadDone();
                 stream.completeWithError("request cancelled");
                 return;
             }
-            allocator.free(base_url);
-            allocator.free(api_key);
-            allocator.free(body);
-            allocator.destroy(ctx);
+            ctx.deinit();
             stream.markThreadDone();
             stream.completeWithError("request failed");
             return;
@@ -849,18 +844,12 @@ fn runThread(ctx: *ThreadCtx) void {
                     continue;
                 }
                 // Sleep was cancelled
-                allocator.free(base_url);
-                allocator.free(api_key);
-                allocator.free(body);
-                allocator.destroy(ctx);
+                ctx.deinit();
                 stream.markThreadDone();
                 stream.completeWithError("request cancelled");
                 return;
             }
-            allocator.free(base_url);
-            allocator.free(api_key);
-            allocator.free(body);
-            allocator.destroy(ctx);
+            ctx.deinit();
             stream.markThreadDone();
             stream.completeWithError("send failed");
             return;
@@ -875,18 +864,12 @@ fn runThread(ctx: *ThreadCtx) void {
                     continue;
                 }
                 // Sleep was cancelled
-                allocator.free(base_url);
-                allocator.free(api_key);
-                allocator.free(body);
-                allocator.destroy(ctx);
+                ctx.deinit();
                 stream.markThreadDone();
                 stream.completeWithError("request cancelled");
                 return;
             }
-            allocator.free(base_url);
-            allocator.free(api_key);
-            allocator.free(body);
-            allocator.destroy(ctx);
+            ctx.deinit();
             stream.markThreadDone();
             stream.completeWithError("receive failed");
             return;
@@ -944,10 +927,7 @@ fn runThread(ctx: *ThreadCtx) void {
             // Wait before retry
             if (!retry_util.sleepMs(delay, if (cancel_token) |ct| ct.cancelled else null)) {
                 // Sleep was cancelled
-                allocator.free(base_url);
-                allocator.free(api_key);
-                allocator.free(body);
-                allocator.destroy(ctx);
+                ctx.deinit();
                 stream.markThreadDone();
                 stream.completeWithError("request cancelled");
                 return;
@@ -963,10 +943,7 @@ fn runThread(ctx: *ThreadCtx) void {
 
     // After retry loop, check final status
     if (response.head.status != .ok) {
-        allocator.free(base_url);
-        allocator.free(api_key);
-        allocator.free(body);
-        allocator.destroy(ctx);
+        ctx.deinit();
         stream.markThreadDone();
         stream.completeWithError("google request failed");
         return;
@@ -1017,10 +994,7 @@ fn runThread(ctx: *ThreadCtx) void {
         // Check cancellation during streaming
         if (cancel_token) |ct| {
             if (ct.isCancelled()) {
-                allocator.free(base_url);
-                allocator.free(api_key);
-                allocator.free(body);
-                allocator.destroy(ctx);
+                ctx.deinit();
                 stream.markThreadDone();
                 stream.completeWithError("request cancelled");
                 return;
@@ -1028,10 +1002,7 @@ fn runThread(ctx: *ThreadCtx) void {
         }
 
         const n = compat.http.readResponse(reader, &read_buf) catch {
-            allocator.free(base_url);
-            allocator.free(api_key);
-            allocator.free(body);
-            allocator.destroy(ctx);
+            ctx.deinit();
             stream.markThreadDone();
             stream.completeWithError("read failed");
             return;
@@ -1039,10 +1010,7 @@ fn runThread(ctx: *ThreadCtx) void {
         if (n == 0) break;
 
         const events = parser.feed(read_buf[0..n]) catch {
-            allocator.free(base_url);
-            allocator.free(api_key);
-            allocator.free(body);
-            allocator.destroy(ctx);
+            ctx.deinit();
             stream.markThreadDone();
             stream.completeWithError("parse failed");
             return;
@@ -1360,10 +1328,7 @@ fn runThread(ctx: *ThreadCtx) void {
     }
 
     const content_slice = content_blocks.toOwnedSlice(allocator) catch {
-        allocator.free(base_url);
-        allocator.free(api_key);
-        allocator.free(body);
-        allocator.destroy(ctx);
+        ctx.deinit();
         stream.markThreadDone();
         stream.completeWithError("oom content");
         return;
@@ -1382,10 +1347,7 @@ fn runThread(ctx: *ThreadCtx) void {
     stream.push(.{ .done = .{ .reason = stop_reason, .message = out } }) catch {};
 
     // Free ctx allocations before completing
-    allocator.free(base_url);
-    allocator.free(api_key);
-    allocator.free(body);
-    allocator.destroy(ctx);
+    ctx.deinit();
 
     stream.markThreadDone();
     stream.complete(out);
@@ -1410,19 +1372,35 @@ pub fn streamGoogleGenerativeAI(model: ai_types.Model, context: ai_types.Context
     };
     errdefer allocator.free(base_url);
 
-    const body = try buildBody(context, o, model, allocator);
+    // Clone model to own the memory (background thread outlives caller's memory)
+    const owned_model = try ai_types.cloneModel(allocator, model);
+    errdefer {
+        var mut_m = owned_model;
+        mut_m.deinit(allocator);
+    }
+
+    // Clone context to own the memory (background thread outlives caller's memory)
+    const owned_context = try ai_types.cloneContext(allocator, context);
+    errdefer {
+        var mut_ctx = owned_context;
+        mut_ctx.deinit(allocator);
+    }
+
+    const body = try buildBody(owned_context, o, owned_model, allocator);
     errdefer allocator.free(body);
 
     const s = try allocator.create(event_stream.AssistantMessageEventStream);
     errdefer allocator.destroy(s);
     s.* = event_stream.AssistantMessageEventStream.init(allocator);
+    s.wait_for_thread_on_deinit = true;
 
     const ctx = try allocator.create(ThreadCtx);
     errdefer allocator.destroy(ctx);
     ctx.* = .{
         .allocator = allocator,
         .stream = s,
-        .model = model,
+        .model = owned_model,
+        .context = owned_context,
         .api_key = api_key,
         .body = body,
         .base_url = base_url,

--- a/zig/src/providers/google_generative_api.zig
+++ b/zig/src/providers/google_generative_api.zig
@@ -1336,17 +1336,33 @@ fn runThread(ctx: *ThreadCtx) void {
 
     const out = ai_types.AssistantMessage{
         .content = content_slice,
-        .api = model.api,
-        .provider = model.provider,
-        .model = model.id,
+        .api = allocator.dupe(u8, model.api) catch {
+            ctx.deinit();
+            stream.markThreadDone();
+            stream.completeWithError("oom");
+            return;
+        },
+        .provider = allocator.dupe(u8, model.provider) catch {
+            ctx.deinit();
+            stream.markThreadDone();
+            stream.completeWithError("oom");
+            return;
+        },
+        .model = allocator.dupe(u8, model.id) catch {
+            ctx.deinit();
+            stream.markThreadDone();
+            stream.completeWithError("oom");
+            return;
+        },
         .usage = usage,
         .stop_reason = stop_reason,
         .timestamp = compat.time.nowMillis(),
+        .is_owned = true, // Strings were duped above
     };
 
     stream.push(.{ .done = .{ .reason = stop_reason, .message = out } }) catch {};
 
-    // Free ctx allocations before completing
+    // Free ctx allocations before completing (out owns its strings, no UAF)
     ctx.deinit();
 
     stream.markThreadDone();

--- a/zig/src/providers/google_generative_api.zig
+++ b/zig/src/providers/google_generative_api.zig
@@ -1334,26 +1334,38 @@ fn runThread(ctx: *ThreadCtx) void {
         return;
     };
 
+    // Dupe metadata strings BEFORE composing `out` so a mid-dupe OOM can cascade-free
+    // both content_slice and any prior successful dupes without leaking.
+    const api_dup = allocator.dupe(u8, model.api) catch {
+        ai_types.deinitAssistantContent(allocator, content_slice);
+        ctx.deinit();
+        stream.markThreadDone();
+        stream.completeWithError("oom");
+        return;
+    };
+    const provider_dup = allocator.dupe(u8, model.provider) catch {
+        allocator.free(api_dup);
+        ai_types.deinitAssistantContent(allocator, content_slice);
+        ctx.deinit();
+        stream.markThreadDone();
+        stream.completeWithError("oom");
+        return;
+    };
+    const model_dup = allocator.dupe(u8, model.id) catch {
+        allocator.free(provider_dup);
+        allocator.free(api_dup);
+        ai_types.deinitAssistantContent(allocator, content_slice);
+        ctx.deinit();
+        stream.markThreadDone();
+        stream.completeWithError("oom");
+        return;
+    };
+
     const out = ai_types.AssistantMessage{
         .content = content_slice,
-        .api = allocator.dupe(u8, model.api) catch {
-            ctx.deinit();
-            stream.markThreadDone();
-            stream.completeWithError("oom");
-            return;
-        },
-        .provider = allocator.dupe(u8, model.provider) catch {
-            ctx.deinit();
-            stream.markThreadDone();
-            stream.completeWithError("oom");
-            return;
-        },
-        .model = allocator.dupe(u8, model.id) catch {
-            ctx.deinit();
-            stream.markThreadDone();
-            stream.completeWithError("oom");
-            return;
-        },
+        .api = api_dup,
+        .provider = provider_dup,
+        .model = model_dup,
         .usage = usage,
         .stop_reason = stop_reason,
         .timestamp = compat.time.nowMillis(),

--- a/zig/src/providers/google_vertex_api.zig
+++ b/zig/src/providers/google_vertex_api.zig
@@ -1255,26 +1255,38 @@ fn runThread(ctx: *ThreadCtx) void {
         return;
     };
 
+    // Dupe metadata strings BEFORE composing `out` so a mid-dupe OOM can cascade-free
+    // both content_slice and any prior successful dupes without leaking.
+    const api_dup = allocator.dupe(u8, model.api) catch {
+        ai_types.deinitAssistantContent(allocator, content_slice);
+        ctx.deinit();
+        stream.markThreadDone();
+        stream.completeWithError("oom");
+        return;
+    };
+    const provider_dup = allocator.dupe(u8, model.provider) catch {
+        allocator.free(api_dup);
+        ai_types.deinitAssistantContent(allocator, content_slice);
+        ctx.deinit();
+        stream.markThreadDone();
+        stream.completeWithError("oom");
+        return;
+    };
+    const model_dup = allocator.dupe(u8, model.id) catch {
+        allocator.free(provider_dup);
+        allocator.free(api_dup);
+        ai_types.deinitAssistantContent(allocator, content_slice);
+        ctx.deinit();
+        stream.markThreadDone();
+        stream.completeWithError("oom");
+        return;
+    };
+
     const out = ai_types.AssistantMessage{
         .content = content_slice,
-        .api = allocator.dupe(u8, model.api) catch {
-            ctx.deinit();
-            stream.markThreadDone();
-            stream.completeWithError("oom");
-            return;
-        },
-        .provider = allocator.dupe(u8, model.provider) catch {
-            ctx.deinit();
-            stream.markThreadDone();
-            stream.completeWithError("oom");
-            return;
-        },
-        .model = allocator.dupe(u8, model.id) catch {
-            ctx.deinit();
-            stream.markThreadDone();
-            stream.completeWithError("oom");
-            return;
-        },
+        .api = api_dup,
+        .provider = provider_dup,
+        .model = model_dup,
         .usage = usage,
         .stop_reason = stop_reason,
         .timestamp = compat.time.nowMillis(),

--- a/zig/src/providers/google_vertex_api.zig
+++ b/zig/src/providers/google_vertex_api.zig
@@ -692,6 +692,7 @@ const ThreadCtx = struct {
     allocator: std.mem.Allocator,
     stream: *event_stream.AssistantMessageEventStream,
     model: ai_types.Model,
+    context: ai_types.Context,
     api_key: []u8,
     body: []u8,
     project: []u8,
@@ -700,6 +701,19 @@ const ThreadCtx = struct {
     retry_config: ?ai_types.RetryConfig = null,
     cancel_token: ?ai_types.CancelToken = null,
     ping_interval_ms: ?u64 = null,
+
+    /// Clean up all owned resources (model, context, api_key, body, project, location, self).
+    fn deinit(self: *ThreadCtx) void {
+        self.allocator.free(self.project);
+        self.allocator.free(self.location);
+        self.allocator.free(self.api_key);
+        self.allocator.free(self.body);
+        var mut_context = self.context;
+        mut_context.deinit(self.allocator);
+        var mut_model = self.model;
+        mut_model.deinit(self.allocator);
+        self.allocator.destroy(self);
+    }
 };
 
 fn runThread(ctx: *ThreadCtx) void {
@@ -716,11 +730,7 @@ fn runThread(ctx: *ThreadCtx) void {
 
     if (cancel_token) |ct| {
         if (ct.isCancelled()) {
-            allocator.free(project);
-            allocator.free(location);
-            allocator.free(api_key);
-            allocator.free(body);
-            allocator.destroy(ctx);
+            ctx.deinit();
             stream.markThreadDone();
             stream.completeWithError("request cancelled");
             return;
@@ -733,11 +743,7 @@ fn runThread(ctx: *ThreadCtx) void {
     // Vertex AI URL structure:
     // https://<location>-aiplatform.googleapis.com/v1/projects/<project>/locations/<location>/publishers/google/models/<model>:streamGenerateContent?alt=sse
     const url = buildVertexStreamUrl(allocator, location, project, model.id, api_key) catch {
-        allocator.free(project);
-        allocator.free(location);
-        allocator.free(api_key);
-        allocator.free(body);
-        allocator.destroy(ctx);
+        ctx.deinit();
         stream.markThreadDone();
         stream.completeWithError("oom url");
         return;
@@ -745,11 +751,7 @@ fn runThread(ctx: *ThreadCtx) void {
     defer allocator.free(url);
 
     const uri = std.Uri.parse(url) catch {
-        allocator.free(project);
-        allocator.free(location);
-        allocator.free(api_key);
-        allocator.free(body);
-        allocator.destroy(ctx);
+        ctx.deinit();
         stream.markThreadDone();
         stream.completeWithError("invalid URL");
         return;
@@ -784,20 +786,12 @@ fn runThread(ctx: *ThreadCtx) void {
                     retry_attempt += 1;
                     continue;
                 }
-                allocator.free(project);
-                allocator.free(location);
-                allocator.free(api_key);
-                allocator.free(body);
-                allocator.destroy(ctx);
+                ctx.deinit();
                 stream.markThreadDone();
                 stream.completeWithError("request failed");
                 return;
             }
-            allocator.free(project);
-            allocator.free(location);
-            allocator.free(api_key);
-            allocator.free(body);
-            allocator.destroy(ctx);
+            ctx.deinit();
             stream.markThreadDone();
             stream.completeWithError("request failed");
             return;
@@ -812,20 +806,12 @@ fn runThread(ctx: *ThreadCtx) void {
                     retry_attempt += 1;
                     continue;
                 }
-                allocator.free(project);
-                allocator.free(location);
-                allocator.free(api_key);
-                allocator.free(body);
-                allocator.destroy(ctx);
+                ctx.deinit();
                 stream.markThreadDone();
                 stream.completeWithError("send failed");
                 return;
             }
-            allocator.free(project);
-            allocator.free(location);
-            allocator.free(api_key);
-            allocator.free(body);
-            allocator.destroy(ctx);
+            ctx.deinit();
             stream.markThreadDone();
             stream.completeWithError("send failed");
             return;
@@ -839,20 +825,12 @@ fn runThread(ctx: *ThreadCtx) void {
                     retry_attempt += 1;
                     continue;
                 }
-                allocator.free(project);
-                allocator.free(location);
-                allocator.free(api_key);
-                allocator.free(body);
-                allocator.destroy(ctx);
+                ctx.deinit();
                 stream.markThreadDone();
                 stream.completeWithError("receive failed");
                 return;
             }
-            allocator.free(project);
-            allocator.free(location);
-            allocator.free(api_key);
-            allocator.free(body);
-            allocator.destroy(ctx);
+            ctx.deinit();
             stream.markThreadDone();
             stream.completeWithError("receive failed");
             return;
@@ -909,11 +887,7 @@ fn runThread(ctx: *ThreadCtx) void {
 
             // Wait before retry
             if (!retry_util.sleepMs(delay, null)) {
-                allocator.free(project);
-                allocator.free(location);
-                allocator.free(api_key);
-                allocator.free(body);
-                allocator.destroy(ctx);
+                ctx.deinit();
                 stream.markThreadDone();
                 stream.completeWithError("vertex request failed");
                 return;
@@ -929,11 +903,7 @@ fn runThread(ctx: *ThreadCtx) void {
 
     // After retry loop, check final status
     if (response.head.status != .ok) {
-        allocator.free(project);
-        allocator.free(location);
-        allocator.free(api_key);
-        allocator.free(body);
-        allocator.destroy(ctx);
+        ctx.deinit();
         stream.markThreadDone();
         stream.completeWithError("vertex request failed");
         return;
@@ -981,11 +951,7 @@ fn runThread(ctx: *ThreadCtx) void {
         }
 
         const n = compat.http.readResponse(reader, &read_buf) catch {
-            allocator.free(project);
-            allocator.free(location);
-            allocator.free(api_key);
-            allocator.free(body);
-            allocator.destroy(ctx);
+            ctx.deinit();
             stream.markThreadDone();
             stream.completeWithError("read failed");
             return;
@@ -993,11 +959,7 @@ fn runThread(ctx: *ThreadCtx) void {
         if (n == 0) break;
 
         const events = parser.feed(read_buf[0..n]) catch {
-            allocator.free(project);
-            allocator.free(location);
-            allocator.free(api_key);
-            allocator.free(body);
-            allocator.destroy(ctx);
+            ctx.deinit();
             stream.markThreadDone();
             stream.completeWithError("parse failed");
             return;
@@ -1287,11 +1249,7 @@ fn runThread(ctx: *ThreadCtx) void {
     }
 
     const content_slice = content_blocks.toOwnedSlice(allocator) catch {
-        allocator.free(project);
-        allocator.free(location);
-        allocator.free(api_key);
-        allocator.free(body);
-        allocator.destroy(ctx);
+        ctx.deinit();
         stream.markThreadDone();
         stream.completeWithError("oom content");
         return;
@@ -1309,11 +1267,7 @@ fn runThread(ctx: *ThreadCtx) void {
 
     stream.push(.{ .done = .{ .reason = stop_reason, .message = out } }) catch {};
 
-    allocator.free(project);
-    allocator.free(location);
-    allocator.free(api_key);
-    allocator.free(body);
-    allocator.destroy(ctx);
+    ctx.deinit();
 
     stream.markThreadDone();
     stream.complete(out);
@@ -1369,10 +1323,28 @@ pub fn streamGoogleVertex(
     };
     errdefer allocator.free(api_key);
 
-    const body = buildBody(context, o, model, allocator) catch {
+    // Clone model to own the memory (background thread outlives caller's memory)
+    const owned_model = ai_types.cloneModel(allocator, model) catch return error.OutOfMemory;
+    errdefer {
+        var mut_m = owned_model;
+        mut_m.deinit(allocator);
+    }
+
+    // Clone context to own the memory (background thread outlives caller's memory)
+    const owned_context = ai_types.cloneContext(allocator, context) catch return error.OutOfMemory;
+    errdefer {
+        var mut_ctx = owned_context;
+        mut_ctx.deinit(allocator);
+    }
+
+    const body = buildBody(owned_context, o, owned_model, allocator) catch {
         allocator.free(project);
         allocator.free(location);
         allocator.free(api_key);
+        var mut_ctx_in = owned_context;
+        mut_ctx_in.deinit(allocator);
+        var mut_m_in = owned_model;
+        mut_m_in.deinit(allocator);
         return error.InvalidConfiguration;
     };
     errdefer allocator.free(body);
@@ -1382,10 +1354,15 @@ pub fn streamGoogleVertex(
         allocator.free(location);
         allocator.free(api_key);
         allocator.free(body);
+        var mut_ctx_in = owned_context;
+        mut_ctx_in.deinit(allocator);
+        var mut_m_in = owned_model;
+        mut_m_in.deinit(allocator);
         return error.InvalidConfiguration;
     };
     errdefer allocator.destroy(s);
     s.* = event_stream.AssistantMessageEventStream.init(allocator);
+    s.wait_for_thread_on_deinit = true;
 
     const ctx = allocator.create(ThreadCtx) catch {
         allocator.free(project);
@@ -1393,13 +1370,18 @@ pub fn streamGoogleVertex(
         allocator.free(api_key);
         allocator.free(body);
         allocator.destroy(s);
+        var mut_ctx_in = owned_context;
+        mut_ctx_in.deinit(allocator);
+        var mut_m_in = owned_model;
+        mut_m_in.deinit(allocator);
         return error.InvalidConfiguration;
     };
     errdefer allocator.destroy(ctx);
     ctx.* = .{
         .allocator = allocator,
         .stream = s,
-        .model = model,
+        .model = owned_model,
+        .context = owned_context,
         .api_key = api_key,
         .body = body,
         .project = project,
@@ -1411,11 +1393,7 @@ pub fn streamGoogleVertex(
     };
 
     const th = std.Thread.spawn(.{}, runThread, .{ctx}) catch {
-        allocator.free(project);
-        allocator.free(location);
-        allocator.free(api_key);
-        allocator.free(body);
-        allocator.destroy(ctx);
+        ctx.deinit();
         allocator.destroy(s);
         return error.InvalidConfiguration;
     };

--- a/zig/src/providers/google_vertex_api.zig
+++ b/zig/src/providers/google_vertex_api.zig
@@ -1257,16 +1257,33 @@ fn runThread(ctx: *ThreadCtx) void {
 
     const out = ai_types.AssistantMessage{
         .content = content_slice,
-        .api = model.api,
-        .provider = model.provider,
-        .model = model.id,
+        .api = allocator.dupe(u8, model.api) catch {
+            ctx.deinit();
+            stream.markThreadDone();
+            stream.completeWithError("oom");
+            return;
+        },
+        .provider = allocator.dupe(u8, model.provider) catch {
+            ctx.deinit();
+            stream.markThreadDone();
+            stream.completeWithError("oom");
+            return;
+        },
+        .model = allocator.dupe(u8, model.id) catch {
+            ctx.deinit();
+            stream.markThreadDone();
+            stream.completeWithError("oom");
+            return;
+        },
         .usage = usage,
         .stop_reason = stop_reason,
         .timestamp = compat.time.nowMillis(),
+        .is_owned = true, // Strings were duped above
     };
 
     stream.push(.{ .done = .{ .reason = stop_reason, .message = out } }) catch {};
 
+    // Free ctx allocations before completing (out owns its strings, no UAF)
     ctx.deinit();
 
     stream.markThreadDone();
@@ -1301,12 +1318,10 @@ pub fn streamGoogleVertex(
         if (ct.isCancelled()) break :blk try allocator.dupe(u8, "us-central1");
         break :blk try resolveLocation(null, allocator) orelse {
             std.log.err("Vertex AI requires a location. Set GOOGLE_CLOUD_LOCATION environment variable.", .{});
-            allocator.free(project);
             return error.MissingLocation;
         };
     } else try resolveLocation(null, allocator) orelse {
         std.log.err("Vertex AI requires a location. Set GOOGLE_CLOUD_LOCATION environment variable.", .{});
-        allocator.free(project);
         return error.MissingLocation;
     };
     errdefer allocator.free(location);
@@ -1317,8 +1332,6 @@ pub fn streamGoogleVertex(
         const e = env(allocator, "GOOGLE_API_KEY");
         if (e) |k| break :blk @constCast(k);
         std.log.err("Vertex AI requires an API key. Set GOOGLE_API_KEY environment variable or pass api_key in options.", .{});
-        allocator.free(project);
-        allocator.free(location);
         return error.MissingApiKey;
     };
     errdefer allocator.free(api_key);
@@ -1337,45 +1350,15 @@ pub fn streamGoogleVertex(
         mut_ctx.deinit(allocator);
     }
 
-    const body = buildBody(owned_context, o, owned_model, allocator) catch {
-        allocator.free(project);
-        allocator.free(location);
-        allocator.free(api_key);
-        var mut_ctx_in = owned_context;
-        mut_ctx_in.deinit(allocator);
-        var mut_m_in = owned_model;
-        mut_m_in.deinit(allocator);
-        return error.InvalidConfiguration;
-    };
+    const body = buildBody(owned_context, o, owned_model, allocator) catch return error.InvalidConfiguration;
     errdefer allocator.free(body);
 
-    const s = allocator.create(event_stream.AssistantMessageEventStream) catch {
-        allocator.free(project);
-        allocator.free(location);
-        allocator.free(api_key);
-        allocator.free(body);
-        var mut_ctx_in = owned_context;
-        mut_ctx_in.deinit(allocator);
-        var mut_m_in = owned_model;
-        mut_m_in.deinit(allocator);
-        return error.InvalidConfiguration;
-    };
+    const s = allocator.create(event_stream.AssistantMessageEventStream) catch return error.InvalidConfiguration;
     errdefer allocator.destroy(s);
     s.* = event_stream.AssistantMessageEventStream.init(allocator);
     s.wait_for_thread_on_deinit = true;
 
-    const ctx = allocator.create(ThreadCtx) catch {
-        allocator.free(project);
-        allocator.free(location);
-        allocator.free(api_key);
-        allocator.free(body);
-        allocator.destroy(s);
-        var mut_ctx_in = owned_context;
-        mut_ctx_in.deinit(allocator);
-        var mut_m_in = owned_model;
-        mut_m_in.deinit(allocator);
-        return error.InvalidConfiguration;
-    };
+    const ctx = allocator.create(ThreadCtx) catch return error.InvalidConfiguration;
     errdefer allocator.destroy(ctx);
     ctx.* = .{
         .allocator = allocator,
@@ -1392,11 +1375,7 @@ pub fn streamGoogleVertex(
         .ping_interval_ms = o.ping_interval_ms,
     };
 
-    const th = std.Thread.spawn(.{}, runThread, .{ctx}) catch {
-        ctx.deinit();
-        allocator.destroy(s);
-        return error.InvalidConfiguration;
-    };
+    const th = std.Thread.spawn(.{}, runThread, .{ctx}) catch return error.InvalidConfiguration;
     th.detach();
     return s;
 }

--- a/zig/src/providers/ollama_api.zig
+++ b/zig/src/providers/ollama_api.zig
@@ -1166,17 +1166,33 @@ fn runThread(ctx: *ThreadCtx) void {
 
     const out = ai_types.AssistantMessage{
         .content = content_slice,
-        .api = model.api,
-        .provider = model.provider,
-        .model = model.id,
+        .api = allocator.dupe(u8, model.api) catch {
+            ctx.deinit();
+            stream.markThreadDone();
+            stream.completeWithError("oom");
+            return;
+        },
+        .provider = allocator.dupe(u8, model.provider) catch {
+            ctx.deinit();
+            stream.markThreadDone();
+            stream.completeWithError("oom");
+            return;
+        },
+        .model = allocator.dupe(u8, model.id) catch {
+            ctx.deinit();
+            stream.markThreadDone();
+            stream.completeWithError("oom");
+            return;
+        },
         .usage = usage,
         .stop_reason = stop_reason,
         .timestamp = compat.time.nowMillis(),
+        .is_owned = true, // Strings were duped above
     };
 
     stream.push(.{ .done = .{ .reason = stop_reason, .message = out } }) catch {};
 
-    // Free ctx allocations before completing
+    // Free ctx allocations before completing (out owns its strings, no UAF)
     ctx.deinit();
 
     stream.markThreadDone();

--- a/zig/src/providers/ollama_api.zig
+++ b/zig/src/providers/ollama_api.zig
@@ -523,6 +523,7 @@ const ThreadCtx = struct {
     allocator: std.mem.Allocator,
     stream: *event_stream.AssistantMessageEventStream,
     model: ai_types.Model,
+    context: ai_types.Context,
     base_url: []u8,
     api_key: ?[]u8,
     body: []u8,
@@ -531,6 +532,18 @@ const ThreadCtx = struct {
     on_payload_ctx: ?*anyopaque = null,
     retry_config: ?ai_types.RetryConfig = null,
     ping_interval_ms: ?u64 = null,
+
+    /// Clean up all owned resources (model, context, base_url, api_key, body, self).
+    fn deinit(self: *ThreadCtx) void {
+        self.allocator.free(self.base_url);
+        if (self.api_key) |k| self.allocator.free(k);
+        self.allocator.free(self.body);
+        var mut_context = self.context;
+        mut_context.deinit(self.allocator);
+        var mut_model = self.model;
+        mut_model.deinit(self.allocator);
+        self.allocator.destroy(self);
+    }
 };
 
 /// Create a partial message for events (references model strings directly, no allocation)
@@ -567,10 +580,7 @@ fn runThread(ctx: *ThreadCtx) void {
     // Check cancellation before sending
     if (cancel_token) |ct| {
         if (ct.isCancelled()) {
-            allocator.free(base_url);
-            if (api_key) |k| allocator.free(k);
-            allocator.free(body);
-            allocator.destroy(ctx);
+            ctx.deinit();
             stream.markThreadDone();
             stream.completeWithError("request cancelled");
             return;
@@ -581,10 +591,7 @@ fn runThread(ctx: *ThreadCtx) void {
     defer client.deinit();
 
     const url = buildUrlWithSuffix(allocator, base_url, "/api/chat") catch {
-        allocator.free(base_url);
-        if (api_key) |k| allocator.free(k);
-        allocator.free(body);
-        allocator.destroy(ctx);
+        ctx.deinit();
         stream.markThreadDone();
         stream.completeWithError("oom url");
         return;
@@ -592,10 +599,7 @@ fn runThread(ctx: *ThreadCtx) void {
     defer allocator.free(url);
 
     const uri = std.Uri.parse(url) catch {
-        allocator.free(base_url);
-        if (api_key) |k| allocator.free(k);
-        allocator.free(body);
-        allocator.destroy(ctx);
+        ctx.deinit();
         stream.markThreadDone();
         stream.completeWithError("invalid URL");
         return;
@@ -604,10 +608,7 @@ fn runThread(ctx: *ThreadCtx) void {
     var headers: std.ArrayList(std.http.Header) = .empty;
     defer headers.deinit(allocator);
     headers.append(allocator, .{ .name = "content-type", .value = "application/json" }) catch {
-        allocator.free(base_url);
-        if (api_key) |k| allocator.free(k);
-        allocator.free(body);
-        allocator.destroy(ctx);
+        ctx.deinit();
         stream.markThreadDone();
         stream.completeWithError("oom headers");
         return;
@@ -618,19 +619,13 @@ fn runThread(ctx: *ThreadCtx) void {
 
     if (api_key) |k| {
         auth_value = buildBearerAuthValue(allocator, k) catch {
-            allocator.free(base_url);
-            allocator.free(k);
-            allocator.free(body);
-            allocator.destroy(ctx);
+            ctx.deinit();
             stream.markThreadDone();
             stream.completeWithError("oom auth header");
             return;
         };
         headers.append(allocator, .{ .name = "authorization", .value = auth_value.? }) catch {
-            allocator.free(base_url);
-            allocator.free(k);
-            allocator.free(body);
-            allocator.destroy(ctx);
+            ctx.deinit();
             stream.markThreadDone();
             stream.completeWithError("oom headers");
             return;
@@ -653,10 +648,7 @@ fn runThread(ctx: *ThreadCtx) void {
         // Check cancellation before each attempt
         if (cancel_token) |ct| {
             if (ct.isCancelled()) {
-                allocator.free(base_url);
-                if (api_key) |k| allocator.free(k);
-                allocator.free(body);
-                allocator.destroy(ctx);
+                ctx.deinit();
                 stream.markThreadDone();
                 stream.completeWithError("request cancelled");
                 return;
@@ -678,18 +670,12 @@ fn runThread(ctx: *ThreadCtx) void {
                     continue;
                 }
                 // Sleep was cancelled
-                allocator.free(base_url);
-                if (api_key) |k| allocator.free(k);
-                allocator.free(body);
-                allocator.destroy(ctx);
+                ctx.deinit();
                 stream.markThreadDone();
                 stream.completeWithError("request cancelled");
                 return;
             }
-            allocator.free(base_url);
-            if (api_key) |k| allocator.free(k);
-            allocator.free(body);
-            allocator.destroy(ctx);
+            ctx.deinit();
             stream.markThreadDone();
             stream.completeWithError("request failed");
             return;
@@ -705,18 +691,12 @@ fn runThread(ctx: *ThreadCtx) void {
                     continue;
                 }
                 // Sleep was cancelled
-                allocator.free(base_url);
-                if (api_key) |k| allocator.free(k);
-                allocator.free(body);
-                allocator.destroy(ctx);
+                ctx.deinit();
                 stream.markThreadDone();
                 stream.completeWithError("request cancelled");
                 return;
             }
-            allocator.free(base_url);
-            if (api_key) |k| allocator.free(k);
-            allocator.free(body);
-            allocator.destroy(ctx);
+            ctx.deinit();
             stream.markThreadDone();
             stream.completeWithError("send failed");
             return;
@@ -731,18 +711,12 @@ fn runThread(ctx: *ThreadCtx) void {
                     continue;
                 }
                 // Sleep was cancelled
-                allocator.free(base_url);
-                if (api_key) |k| allocator.free(k);
-                allocator.free(body);
-                allocator.destroy(ctx);
+                ctx.deinit();
                 stream.markThreadDone();
                 stream.completeWithError("request cancelled");
                 return;
             }
-            allocator.free(base_url);
-            if (api_key) |k| allocator.free(k);
-            allocator.free(body);
-            allocator.destroy(ctx);
+            ctx.deinit();
             stream.markThreadDone();
             stream.completeWithError("receive failed");
             return;
@@ -800,10 +774,7 @@ fn runThread(ctx: *ThreadCtx) void {
             // Wait before retry
             if (!retry_util.sleepMs(delay, if (cancel_token) |ct| ct.cancelled else null)) {
                 // Sleep was cancelled
-                allocator.free(base_url);
-                if (api_key) |k| allocator.free(k);
-                allocator.free(body);
-                allocator.destroy(ctx);
+                ctx.deinit();
                 stream.markThreadDone();
                 stream.completeWithError("request cancelled");
                 return;
@@ -819,10 +790,7 @@ fn runThread(ctx: *ThreadCtx) void {
 
     // After retry loop, check final status
     if (response.head.status != .ok) {
-        allocator.free(base_url);
-        if (api_key) |k| allocator.free(k);
-        allocator.free(body);
-        allocator.destroy(ctx);
+        ctx.deinit();
         stream.markThreadDone();
         stream.completeWithError("ollama request failed");
         return;
@@ -867,10 +835,7 @@ fn runThread(ctx: *ThreadCtx) void {
         // Check cancellation during streaming
         if (cancel_token) |ct| {
             if (ct.isCancelled()) {
-                allocator.free(base_url);
-                if (api_key) |k| allocator.free(k);
-                allocator.free(body);
-                allocator.destroy(ctx);
+                ctx.deinit();
                 stream.markThreadDone();
                 stream.completeWithError("request cancelled");
                 return;
@@ -878,10 +843,7 @@ fn runThread(ctx: *ThreadCtx) void {
         }
 
         const n = compat.http.readResponse(reader, &read_buf) catch {
-            allocator.free(base_url);
-            if (api_key) |k| allocator.free(k);
-            allocator.free(body);
-            allocator.destroy(ctx);
+            ctx.deinit();
             stream.markThreadDone();
             stream.completeWithError("read failed");
             return;
@@ -1024,10 +986,7 @@ fn runThread(ctx: *ThreadCtx) void {
                 line.clearRetainingCapacity();
             } else {
                 line.append(allocator, ch) catch {
-                    allocator.free(base_url);
-                    if (api_key) |k| allocator.free(k);
-                    allocator.free(body);
-                    allocator.destroy(ctx);
+                    ctx.deinit();
                     stream.markThreadDone();
                     stream.completeWithError("oom line");
                     return;
@@ -1199,10 +1158,7 @@ fn runThread(ctx: *ThreadCtx) void {
     }
 
     const content_slice = content_blocks.toOwnedSlice(allocator) catch {
-        allocator.free(base_url);
-        if (api_key) |k| allocator.free(k);
-        allocator.free(body);
-        allocator.destroy(ctx);
+        ctx.deinit();
         stream.markThreadDone();
         stream.completeWithError("oom content");
         return;
@@ -1221,10 +1177,7 @@ fn runThread(ctx: *ThreadCtx) void {
     stream.push(.{ .done = .{ .reason = stop_reason, .message = out } }) catch {};
 
     // Free ctx allocations before completing
-    allocator.free(base_url);
-    if (api_key) |k| allocator.free(k);
-    allocator.free(body);
-    allocator.destroy(ctx);
+    ctx.deinit();
 
     stream.markThreadDone();
     stream.complete(out);
@@ -1258,19 +1211,35 @@ pub fn streamOllama(
     };
     errdefer allocator.free(base_url);
 
-    const body = try buildBody(model, context, o, allocator);
+    // Clone model to own the memory (background thread outlives caller's memory)
+    const owned_model = try ai_types.cloneModel(allocator, model);
+    errdefer {
+        var mut_m = owned_model;
+        mut_m.deinit(allocator);
+    }
+
+    // Clone context to own the memory (background thread outlives caller's memory)
+    const owned_context = try ai_types.cloneContext(allocator, context);
+    errdefer {
+        var mut_ctx = owned_context;
+        mut_ctx.deinit(allocator);
+    }
+
+    const body = try buildBody(owned_model, owned_context, o, allocator);
     errdefer allocator.free(body);
 
     const s = try allocator.create(event_stream.AssistantMessageEventStream);
     errdefer allocator.destroy(s);
     s.* = event_stream.AssistantMessageEventStream.init(allocator);
+    s.wait_for_thread_on_deinit = true;
 
     const ctx = try allocator.create(ThreadCtx);
     errdefer allocator.destroy(ctx);
     ctx.* = .{
         .allocator = allocator,
         .stream = s,
-        .model = model,
+        .model = owned_model,
+        .context = owned_context,
         .base_url = base_url,
         .api_key = api_key,
         .body = body,

--- a/zig/src/providers/ollama_api.zig
+++ b/zig/src/providers/ollama_api.zig
@@ -1164,26 +1164,38 @@ fn runThread(ctx: *ThreadCtx) void {
         return;
     };
 
+    // Dupe metadata strings BEFORE composing `out` so a mid-dupe OOM can cascade-free
+    // both content_slice and any prior successful dupes without leaking.
+    const api_dup = allocator.dupe(u8, model.api) catch {
+        ai_types.deinitAssistantContent(allocator, content_slice);
+        ctx.deinit();
+        stream.markThreadDone();
+        stream.completeWithError("oom");
+        return;
+    };
+    const provider_dup = allocator.dupe(u8, model.provider) catch {
+        allocator.free(api_dup);
+        ai_types.deinitAssistantContent(allocator, content_slice);
+        ctx.deinit();
+        stream.markThreadDone();
+        stream.completeWithError("oom");
+        return;
+    };
+    const model_dup = allocator.dupe(u8, model.id) catch {
+        allocator.free(provider_dup);
+        allocator.free(api_dup);
+        ai_types.deinitAssistantContent(allocator, content_slice);
+        ctx.deinit();
+        stream.markThreadDone();
+        stream.completeWithError("oom");
+        return;
+    };
+
     const out = ai_types.AssistantMessage{
         .content = content_slice,
-        .api = allocator.dupe(u8, model.api) catch {
-            ctx.deinit();
-            stream.markThreadDone();
-            stream.completeWithError("oom");
-            return;
-        },
-        .provider = allocator.dupe(u8, model.provider) catch {
-            ctx.deinit();
-            stream.markThreadDone();
-            stream.completeWithError("oom");
-            return;
-        },
-        .model = allocator.dupe(u8, model.id) catch {
-            ctx.deinit();
-            stream.markThreadDone();
-            stream.completeWithError("oom");
-            return;
-        },
+        .api = api_dup,
+        .provider = provider_dup,
+        .model = model_dup,
         .usage = usage,
         .stop_reason = stop_reason,
         .timestamp = compat.time.nowMillis(),

--- a/zig/src/providers/openai_completions_api.zig
+++ b/zig/src/providers/openai_completions_api.zig
@@ -1781,6 +1781,7 @@ pub fn streamOpenAICompletions(
     const s = try allocator.create(event_stream.AssistantMessageEventStream);
     errdefer allocator.destroy(s);
     s.* = event_stream.AssistantMessageEventStream.init(allocator);
+    s.wait_for_thread_on_deinit = true;
 
     const ctx = try allocator.create(ThreadCtx);
     errdefer {

--- a/zig/src/providers/openai_responses_api.zig
+++ b/zig/src/providers/openai_responses_api.zig
@@ -1291,9 +1291,10 @@ fn runThread(ctx: *ThreadCtx) void {
     const content_count: usize = if (has_thinking) 1 else 0;
     const content_count_final = content_count + if (has_text) @as(usize, 1) else @as(usize, 0) + tool_call_count;
 
+    // Build content slice first (single empty text block when no content was streamed).
+    var content_slice: []ai_types.AssistantContent = undefined;
     if (content_count_final == 0) {
-        // No content - create empty text block
-        var content = allocator.alloc(ai_types.AssistantContent, 1) catch {
+        content_slice = allocator.alloc(ai_types.AssistantContent, 1) catch {
             allocator.free(auth);
             allocator.free(url);
             ctx.deinit();
@@ -1301,103 +1302,100 @@ fn runThread(ctx: *ThreadCtx) void {
             stream.completeWithError("oom result");
             return;
         };
-        content[0] = .{ .text = .{ .text = "" } };
-        const out = ai_types.AssistantMessage{
-            .content = content,
-            .api = model.api,
-            .provider = model.provider,
-            .model = model.id,
-            .usage = usage,
-            .stop_reason = stop_reason,
-            .timestamp = compat.time.nowMillis(),
+        content_slice[0] = .{ .text = .{ .text = "" } };
+    } else {
+        content_slice = allocator.alloc(ai_types.AssistantContent, content_count_final) catch {
+            allocator.free(auth);
+            allocator.free(url);
+            ctx.deinit();
+            stream.markThreadDone();
+            stream.completeWithError("oom building result");
+            return;
         };
-        allocator.free(auth);
-        allocator.free(url);
-        ctx.deinit();
-        stream.markThreadDone();
-        stream.complete(out);
-        return;
-    }
+        var idx: usize = 0;
 
-    var content = allocator.alloc(ai_types.AssistantContent, content_count_final) catch {
-        allocator.free(auth);
-        allocator.free(url);
-        ctx.deinit();
-        stream.markThreadDone();
-        stream.completeWithError("oom building result");
-        return;
-    };
-    var idx: usize = 0;
-
-    if (has_thinking) {
-        content[idx] = .{ .thinking = .{
-            .thinking = allocator.dupe(u8, thinking.items) catch {
-                allocator.free(content);
-                allocator.free(auth);
-                allocator.free(url);
-                ctx.deinit();
-                stream.markThreadDone();
-                stream.completeWithError("oom building thinking");
-                return;
-            },
-        } };
-        idx += 1;
-    }
-
-    if (has_text) {
-        content[idx] = .{
-            .text = .{
-                .text = allocator.dupe(u8, text.items) catch {
-                    // Free previously allocated content
-                    for (content[0..idx]) |*block| {
-                        switch (block.*) {
-                            .thinking => |t| allocator.free(t.thinking),
-                            else => {},
-                        }
-                    }
-                    allocator.free(content);
+        if (has_thinking) {
+            content_slice[idx] = .{ .thinking = .{
+                .thinking = allocator.dupe(u8, thinking.items) catch {
+                    allocator.free(content_slice);
                     allocator.free(auth);
                     allocator.free(url);
                     ctx.deinit();
                     stream.markThreadDone();
-                    stream.completeWithError("oom building text");
+                    stream.completeWithError("oom building thinking");
                     return;
                 },
-            },
-        };
-        idx += 1;
+            } };
+            idx += 1;
+        }
+
+        if (has_text) {
+            content_slice[idx] = .{
+                .text = .{
+                    .text = allocator.dupe(u8, text.items) catch {
+                        // Free previously allocated content
+                        for (content_slice[0..idx]) |*block| {
+                            switch (block.*) {
+                                .thinking => |t| allocator.free(t.thinking),
+                                else => {},
+                            }
+                        }
+                        allocator.free(content_slice);
+                        allocator.free(auth);
+                        allocator.free(url);
+                        ctx.deinit();
+                        stream.markThreadDone();
+                        stream.completeWithError("oom building text");
+                        return;
+                    },
+                },
+            };
+            idx += 1;
+        }
+
+        // Note: tool calls are already emitted via toolcall_end events during streaming
+        // and completed in the tracker. We don't need to iterate again here since
+        // output_item_done events already handled them.
     }
 
-    // Note: tool calls are already emitted via toolcall_end events during streaming
-    // and completed in the tracker. We don't need to iterate again here since
-    // output_item_done events already handled them.
+    // Dupe metadata strings BEFORE composing `out` so a mid-dupe OOM can cascade-free
+    // both content_slice and any prior successful dupes without leaking.
+    const api_dup = allocator.dupe(u8, model.api) catch {
+        ai_types.deinitAssistantContent(allocator, content_slice);
+        allocator.free(auth);
+        allocator.free(url);
+        ctx.deinit();
+        stream.markThreadDone();
+        stream.completeWithError("oom");
+        return;
+    };
+    const provider_dup = allocator.dupe(u8, model.provider) catch {
+        allocator.free(api_dup);
+        ai_types.deinitAssistantContent(allocator, content_slice);
+        allocator.free(auth);
+        allocator.free(url);
+        ctx.deinit();
+        stream.markThreadDone();
+        stream.completeWithError("oom");
+        return;
+    };
+    const model_dup = allocator.dupe(u8, model.id) catch {
+        allocator.free(provider_dup);
+        allocator.free(api_dup);
+        ai_types.deinitAssistantContent(allocator, content_slice);
+        allocator.free(auth);
+        allocator.free(url);
+        ctx.deinit();
+        stream.markThreadDone();
+        stream.completeWithError("oom");
+        return;
+    };
 
     const out = ai_types.AssistantMessage{
-        .content = content,
-        .api = allocator.dupe(u8, model.api) catch {
-            allocator.free(auth);
-            allocator.free(url);
-            ctx.deinit();
-            stream.markThreadDone();
-            stream.completeWithError("oom");
-            return;
-        },
-        .provider = allocator.dupe(u8, model.provider) catch {
-            allocator.free(auth);
-            allocator.free(url);
-            ctx.deinit();
-            stream.markThreadDone();
-            stream.completeWithError("oom");
-            return;
-        },
-        .model = allocator.dupe(u8, model.id) catch {
-            allocator.free(auth);
-            allocator.free(url);
-            ctx.deinit();
-            stream.markThreadDone();
-            stream.completeWithError("oom");
-            return;
-        },
+        .content = content_slice,
+        .api = api_dup,
+        .provider = provider_dup,
+        .model = model_dup,
         .usage = usage,
         .stop_reason = stop_reason,
         .timestamp = compat.time.nowMillis(),

--- a/zig/src/providers/openai_responses_api.zig
+++ b/zig/src/providers/openai_responses_api.zig
@@ -1374,15 +1374,37 @@ fn runThread(ctx: *ThreadCtx) void {
 
     const out = ai_types.AssistantMessage{
         .content = content,
-        .api = model.api,
-        .provider = model.provider,
-        .model = model.id,
+        .api = allocator.dupe(u8, model.api) catch {
+            allocator.free(auth);
+            allocator.free(url);
+            ctx.deinit();
+            stream.markThreadDone();
+            stream.completeWithError("oom");
+            return;
+        },
+        .provider = allocator.dupe(u8, model.provider) catch {
+            allocator.free(auth);
+            allocator.free(url);
+            ctx.deinit();
+            stream.markThreadDone();
+            stream.completeWithError("oom");
+            return;
+        },
+        .model = allocator.dupe(u8, model.id) catch {
+            allocator.free(auth);
+            allocator.free(url);
+            ctx.deinit();
+            stream.markThreadDone();
+            stream.completeWithError("oom");
+            return;
+        },
         .usage = usage,
         .stop_reason = stop_reason,
         .timestamp = compat.time.nowMillis(),
+        .is_owned = true, // Strings were duped above
     };
 
-    // Free ctx allocations before completing
+    // Free ctx allocations before completing (out owns its strings, no UAF)
     allocator.free(auth);
     allocator.free(url);
     ctx.deinit();

--- a/zig/src/providers/openai_responses_api.zig
+++ b/zig/src/providers/openai_responses_api.zig
@@ -933,7 +933,6 @@ fn runThread(ctx: *ThreadCtx) void {
     }
 
     var next_content_index: usize = 0;
-    var tool_call_count: usize = 0;
     var thinking_started = false;
     var thinking_content_index: ?usize = null;
     var text_content_index: ?usize = null;
@@ -1066,7 +1065,6 @@ fn runThread(ctx: *ThreadCtx) void {
 
                         const content_index = next_content_index;
                         next_content_index += 1;
-                        tool_call_count += 1;
 
                         // Store mapping from item_id to content_index
                         const duped_item_id = allocator.dupe(u8, item_id) catch {
@@ -1285,15 +1283,20 @@ fn runThread(ctx: *ThreadCtx) void {
         usage.cost.total *= tier_multiplier;
     }
 
-    // Build content blocks - thinking first if present, then text, then tool calls
+    // Build content blocks - thinking first if present, then text.
+    // Tool calls are NOT included here: they're emitted via toolcall_end events
+    // during streaming and completed in the tracker; the final AssistantMessage
+    // content slice only carries thinking + text. Sizing the alloc to the actual
+    // number of filled slots prevents uninitialized union entries from being
+    // dereferenced by `deinitAssistantContent` on the OOM cleanup paths below.
     const has_thinking = thinking.items.len > 0;
     const has_text = text.items.len > 0;
-    const content_count: usize = if (has_thinking) 1 else 0;
-    const content_count_final = content_count + if (has_text) @as(usize, 1) else @as(usize, 0) + tool_call_count;
+    const filled_count: usize = (if (has_thinking) @as(usize, 1) else @as(usize, 0)) +
+        (if (has_text) @as(usize, 1) else @as(usize, 0));
 
     // Build content slice first (single empty text block when no content was streamed).
     var content_slice: []ai_types.AssistantContent = undefined;
-    if (content_count_final == 0) {
+    if (filled_count == 0) {
         content_slice = allocator.alloc(ai_types.AssistantContent, 1) catch {
             allocator.free(auth);
             allocator.free(url);
@@ -1304,7 +1307,7 @@ fn runThread(ctx: *ThreadCtx) void {
         };
         content_slice[0] = .{ .text = .{ .text = "" } };
     } else {
-        content_slice = allocator.alloc(ai_types.AssistantContent, content_count_final) catch {
+        content_slice = allocator.alloc(ai_types.AssistantContent, filled_count) catch {
             allocator.free(auth);
             allocator.free(url);
             ctx.deinit();
@@ -1353,9 +1356,7 @@ fn runThread(ctx: *ThreadCtx) void {
             idx += 1;
         }
 
-        // Note: tool calls are already emitted via toolcall_end events during streaming
-        // and completed in the tracker. We don't need to iterate again here since
-        // output_item_done events already handled them.
+        std.debug.assert(idx == filled_count);
     }
 
     // Dupe metadata strings BEFORE composing `out` so a mid-dupe OOM can cascade-free

--- a/zig/src/providers/openai_responses_api.zig
+++ b/zig/src/providers/openai_responses_api.zig
@@ -604,6 +604,7 @@ const ThreadCtx = struct {
     allocator: std.mem.Allocator,
     stream: *event_stream.AssistantMessageEventStream,
     model: ai_types.Model,
+    context: ai_types.Context,
     api_key: []u8,
     body: []u8,
     service_tier: ?ai_types.ServiceTier,
@@ -612,6 +613,17 @@ const ThreadCtx = struct {
     on_payload_ctx: ?*anyopaque = null,
     retry_config: ?ai_types.RetryConfig = null,
     ping_interval_ms: ?u64 = null,
+
+    /// Clean up all owned resources (model, context, api_key, body, self).
+    fn deinit(self: *ThreadCtx) void {
+        self.allocator.free(self.api_key);
+        self.allocator.free(self.body);
+        var mut_context = self.context;
+        mut_context.deinit(self.allocator);
+        var mut_model = self.model;
+        mut_model.deinit(self.allocator);
+        self.allocator.destroy(self);
+    }
 };
 
 fn runThread(ctx: *ThreadCtx) void {
@@ -635,9 +647,7 @@ fn runThread(ctx: *ThreadCtx) void {
     // Check cancellation before sending
     if (cancel_token) |ct| {
         if (ct.isCancelled()) {
-            allocator.free(api_key);
-            allocator.free(body);
-            allocator.destroy(ctx);
+            ctx.deinit();
             stream.markThreadDone();
             stream.completeWithError("request cancelled");
             return;
@@ -648,9 +658,7 @@ fn runThread(ctx: *ThreadCtx) void {
     defer client.deinit();
 
     const url = buildUrlWithSuffix(allocator, model.base_url, "/v1/responses") catch {
-        allocator.free(api_key);
-        allocator.free(body);
-        allocator.destroy(ctx);
+        ctx.deinit();
         stream.markThreadDone();
         stream.completeWithError("oom url");
         return;
@@ -658,9 +666,7 @@ fn runThread(ctx: *ThreadCtx) void {
 
     const auth = buildBearerAuthValue(allocator, api_key) catch {
         allocator.free(url);
-        allocator.free(api_key);
-        allocator.free(body);
-        allocator.destroy(ctx);
+        ctx.deinit();
         stream.markThreadDone();
         stream.completeWithError("oom auth");
         return;
@@ -669,9 +675,7 @@ fn runThread(ctx: *ThreadCtx) void {
     const uri = std.Uri.parse(url) catch {
         allocator.free(auth);
         allocator.free(url);
-        allocator.free(api_key);
-        allocator.free(body);
-        allocator.destroy(ctx);
+        ctx.deinit();
         stream.markThreadDone();
         stream.completeWithError("invalid URL");
         return;
@@ -682,9 +686,7 @@ fn runThread(ctx: *ThreadCtx) void {
     headers.append(allocator, .{ .name = "authorization", .value = auth }) catch {
         allocator.free(auth);
         allocator.free(url);
-        allocator.free(api_key);
-        allocator.free(body);
-        allocator.destroy(ctx);
+        ctx.deinit();
         stream.markThreadDone();
         stream.completeWithError("oom headers");
         return;
@@ -692,9 +694,7 @@ fn runThread(ctx: *ThreadCtx) void {
     headers.append(allocator, .{ .name = "content-type", .value = "application/json" }) catch {
         allocator.free(auth);
         allocator.free(url);
-        allocator.free(api_key);
-        allocator.free(body);
-        allocator.destroy(ctx);
+        ctx.deinit();
         stream.markThreadDone();
         stream.completeWithError("oom headers");
         return;
@@ -718,9 +718,7 @@ fn runThread(ctx: *ThreadCtx) void {
             if (ct.isCancelled()) {
                 allocator.free(auth);
                 allocator.free(url);
-                allocator.free(api_key);
-                allocator.free(body);
-                allocator.destroy(ctx);
+                ctx.deinit();
                 stream.markThreadDone();
                 stream.completeWithError("request cancelled");
                 return;
@@ -744,18 +742,14 @@ fn runThread(ctx: *ThreadCtx) void {
                 // Sleep was cancelled
                 allocator.free(auth);
                 allocator.free(url);
-                allocator.free(api_key);
-                allocator.free(body);
-                allocator.destroy(ctx);
+                ctx.deinit();
                 stream.markThreadDone();
                 stream.completeWithError("request cancelled");
                 return;
             }
             allocator.free(auth);
             allocator.free(url);
-            allocator.free(api_key);
-            allocator.free(body);
-            allocator.destroy(ctx);
+            ctx.deinit();
             stream.markThreadDone();
             stream.completeWithError("request failed");
             return;
@@ -773,18 +767,14 @@ fn runThread(ctx: *ThreadCtx) void {
                 // Sleep was cancelled
                 allocator.free(auth);
                 allocator.free(url);
-                allocator.free(api_key);
-                allocator.free(body);
-                allocator.destroy(ctx);
+                ctx.deinit();
                 stream.markThreadDone();
                 stream.completeWithError("request cancelled");
                 return;
             }
             allocator.free(auth);
             allocator.free(url);
-            allocator.free(api_key);
-            allocator.free(body);
-            allocator.destroy(ctx);
+            ctx.deinit();
             stream.markThreadDone();
             stream.completeWithError("send failed");
             return;
@@ -801,18 +791,14 @@ fn runThread(ctx: *ThreadCtx) void {
                 // Sleep was cancelled
                 allocator.free(auth);
                 allocator.free(url);
-                allocator.free(api_key);
-                allocator.free(body);
-                allocator.destroy(ctx);
+                ctx.deinit();
                 stream.markThreadDone();
                 stream.completeWithError("request cancelled");
                 return;
             }
             allocator.free(auth);
             allocator.free(url);
-            allocator.free(api_key);
-            allocator.free(body);
-            allocator.destroy(ctx);
+            ctx.deinit();
             stream.markThreadDone();
             stream.completeWithError("receive failed");
             return;
@@ -872,9 +858,7 @@ fn runThread(ctx: *ThreadCtx) void {
                 // Sleep was cancelled
                 allocator.free(auth);
                 allocator.free(url);
-                allocator.free(api_key);
-                allocator.free(body);
-                allocator.destroy(ctx);
+                ctx.deinit();
                 stream.markThreadDone();
                 stream.completeWithError("request cancelled");
                 return;
@@ -903,9 +887,7 @@ fn runThread(ctx: *ThreadCtx) void {
 
         allocator.free(auth);
         allocator.free(url);
-        allocator.free(api_key);
-        allocator.free(body);
-        allocator.destroy(ctx);
+        ctx.deinit();
         stream.markThreadDone();
         stream.completeWithError("responses request failed");
         return;
@@ -991,9 +973,7 @@ fn runThread(ctx: *ThreadCtx) void {
             if (ct.isCancelled()) {
                 allocator.free(auth);
                 allocator.free(url);
-                allocator.free(api_key);
-                allocator.free(body);
-                allocator.destroy(ctx);
+                ctx.deinit();
                 stream.markThreadDone();
                 stream.completeWithError("request cancelled");
                 return;
@@ -1003,9 +983,7 @@ fn runThread(ctx: *ThreadCtx) void {
         const n = compat.http.readResponse(reader, &read_buf) catch {
             allocator.free(auth);
             allocator.free(url);
-            allocator.free(api_key);
-            allocator.free(body);
-            allocator.destroy(ctx);
+            ctx.deinit();
             stream.markThreadDone();
             stream.completeWithError("read failed");
             return;
@@ -1015,9 +993,7 @@ fn runThread(ctx: *ThreadCtx) void {
         const events = parser.feed(read_buf[0..n]) catch {
             allocator.free(auth);
             allocator.free(url);
-            allocator.free(api_key);
-            allocator.free(body);
-            allocator.destroy(ctx);
+            ctx.deinit();
             stream.markThreadDone();
             stream.completeWithError("parse failed");
             return;
@@ -1082,9 +1058,7 @@ fn runThread(ctx: *ThreadCtx) void {
                         const compound_id = buildCompoundId(allocator, call_id, item_id) catch {
                             allocator.free(auth);
                             allocator.free(url);
-                            allocator.free(api_key);
-                            allocator.free(body);
-                            allocator.destroy(ctx);
+                            ctx.deinit();
                             stream.markThreadDone();
                             stream.completeWithError("oom compound id");
                             return;
@@ -1099,9 +1073,7 @@ fn runThread(ctx: *ThreadCtx) void {
                             allocator.free(compound_id);
                             allocator.free(auth);
                             allocator.free(url);
-                            allocator.free(api_key);
-                            allocator.free(body);
-                            allocator.destroy(ctx);
+                            ctx.deinit();
                             stream.markThreadDone();
                             stream.completeWithError("oom item_id");
                             return;
@@ -1111,9 +1083,7 @@ fn runThread(ctx: *ThreadCtx) void {
                             allocator.free(compound_id);
                             allocator.free(auth);
                             allocator.free(url);
-                            allocator.free(api_key);
-                            allocator.free(body);
-                            allocator.destroy(ctx);
+                            ctx.deinit();
                             stream.markThreadDone();
                             stream.completeWithError("oom item map");
                             return;
@@ -1124,9 +1094,7 @@ fn runThread(ctx: *ThreadCtx) void {
                             allocator.free(compound_id);
                             allocator.free(auth);
                             allocator.free(url);
-                            allocator.free(api_key);
-                            allocator.free(body);
-                            allocator.destroy(ctx);
+                            ctx.deinit();
                             stream.markThreadDone();
                             stream.completeWithError("oom compound map");
                             return;
@@ -1134,9 +1102,7 @@ fn runThread(ctx: *ThreadCtx) void {
                             allocator.free(compound_id);
                             allocator.free(auth);
                             allocator.free(url);
-                            allocator.free(api_key);
-                            allocator.free(body);
-                            allocator.destroy(ctx);
+                            ctx.deinit();
                             stream.markThreadDone();
                             stream.completeWithError("oom compound map");
                             return;
@@ -1146,9 +1112,7 @@ fn runThread(ctx: *ThreadCtx) void {
                         _ = tool_call_tracker_instance.startCall(content_index, content_index, compound_id, name) catch {
                             allocator.free(auth);
                             allocator.free(url);
-                            allocator.free(api_key);
-                            allocator.free(body);
-                            allocator.destroy(ctx);
+                            ctx.deinit();
                             stream.markThreadDone();
                             stream.completeWithError("oom tool call start");
                             return;
@@ -1332,9 +1296,7 @@ fn runThread(ctx: *ThreadCtx) void {
         var content = allocator.alloc(ai_types.AssistantContent, 1) catch {
             allocator.free(auth);
             allocator.free(url);
-            allocator.free(api_key);
-            allocator.free(body);
-            allocator.destroy(ctx);
+            ctx.deinit();
             stream.markThreadDone();
             stream.completeWithError("oom result");
             return;
@@ -1351,9 +1313,7 @@ fn runThread(ctx: *ThreadCtx) void {
         };
         allocator.free(auth);
         allocator.free(url);
-        allocator.free(api_key);
-        allocator.free(body);
-        allocator.destroy(ctx);
+        ctx.deinit();
         stream.markThreadDone();
         stream.complete(out);
         return;
@@ -1362,9 +1322,7 @@ fn runThread(ctx: *ThreadCtx) void {
     var content = allocator.alloc(ai_types.AssistantContent, content_count_final) catch {
         allocator.free(auth);
         allocator.free(url);
-        allocator.free(api_key);
-        allocator.free(body);
-        allocator.destroy(ctx);
+        ctx.deinit();
         stream.markThreadDone();
         stream.completeWithError("oom building result");
         return;
@@ -1377,9 +1335,7 @@ fn runThread(ctx: *ThreadCtx) void {
                 allocator.free(content);
                 allocator.free(auth);
                 allocator.free(url);
-                allocator.free(api_key);
-                allocator.free(body);
-                allocator.destroy(ctx);
+                ctx.deinit();
                 stream.markThreadDone();
                 stream.completeWithError("oom building thinking");
                 return;
@@ -1402,9 +1358,7 @@ fn runThread(ctx: *ThreadCtx) void {
                     allocator.free(content);
                     allocator.free(auth);
                     allocator.free(url);
-                    allocator.free(api_key);
-                    allocator.free(body);
-                    allocator.destroy(ctx);
+                    ctx.deinit();
                     stream.markThreadDone();
                     stream.completeWithError("oom building text");
                     return;
@@ -1431,9 +1385,7 @@ fn runThread(ctx: *ThreadCtx) void {
     // Free ctx allocations before completing
     allocator.free(auth);
     allocator.free(url);
-    allocator.free(api_key);
-    allocator.free(body);
-    allocator.destroy(ctx);
+    ctx.deinit();
 
     stream.markThreadDone();
     stream.complete(out);
@@ -1450,19 +1402,35 @@ pub fn streamOpenAIResponses(model: ai_types.Model, context: ai_types.Context, o
     };
     errdefer allocator.free(api_key);
 
-    const body = try buildRequestBody(model, context, o, allocator);
+    // Clone model to own the memory (background thread outlives caller's memory)
+    const owned_model = try ai_types.cloneModel(allocator, model);
+    errdefer {
+        var mut_m = owned_model;
+        mut_m.deinit(allocator);
+    }
+
+    // Clone context to own the memory (background thread outlives caller's memory)
+    const owned_context = try ai_types.cloneContext(allocator, context);
+    errdefer {
+        var mut_ctx = owned_context;
+        mut_ctx.deinit(allocator);
+    }
+
+    const body = try buildRequestBody(owned_model, owned_context, o, allocator);
     errdefer allocator.free(body);
 
     const s = try allocator.create(event_stream.AssistantMessageEventStream);
     errdefer allocator.destroy(s);
     s.* = event_stream.AssistantMessageEventStream.init(allocator);
+    s.wait_for_thread_on_deinit = true;
 
     const ctx = try allocator.create(ThreadCtx);
     errdefer allocator.destroy(ctx);
     ctx.* = .{
         .allocator = allocator,
         .stream = s,
-        .model = model,
+        .model = owned_model,
+        .context = owned_context,
         .api_key = api_key,
         .body = body,
         .service_tier = o.service_tier,


### PR DESCRIPTION
## Summary

- Clones `model` and `context` with `ai_types.cloneModel` /
  `ai_types.cloneContext` before spawning the streaming worker thread in
  six providers that previously passed the caller's borrowed structs by
  value: `anthropic_messages_api.zig`, `azure_openai_responses_api.zig`,
  `google_generative_api.zig`, `google_vertex_api.zig`, `ollama_api.zig`,
  and `openai_responses_api.zig`.
- Stores the owned copies on `ThreadCtx` and frees them in a new
  `ThreadCtx.deinit()` helper. Replaces the open-coded
  `allocator.free(api_key); ... allocator.destroy(ctx);` cleanup blocks
  across each `runThread` with a single `ctx.deinit()` call so
  model/context cleanup cannot be missed in any error path.
- Sets `s.wait_for_thread_on_deinit = true` on every provider's stream so
  `EventStream.deinit` blocks until the worker calls
  `markThreadDone()`, preventing the detached thread from running past
  the stream's lifetime when the caller drops the stream early. The
  `openai_completions_api.zig` reference already cloned model/context but
  was missing this thread-join setting; it is added here for
  consistency.

## Why

The detached background thread reads `model.api`, `model.provider`,
`model.id`, `model.base_url`, and (in some providers) `context.messages`
/ `context.tools` / `context.system_prompt` long after the caller has
returned, so the original borrowed slices/arrays are use-after-free.
`createPartialMessage(model)` and `buildRequestBody`/`buildBody` are
called on every SSE batch from the worker, so the race is easy to hit.

Detached threads with no join also leak past stream `deinit()`, which can
manifest as use-after-free on the stream and ring buffer.

## Test plan

- [x] `zig build test` (full unit test matrix passes locally)
- [x] `zig build test-unit-providers` (provider-specific tests pass
  locally)
- [x] `scripts/check-zig-patterns.sh` passes