### PR TITLE
feat(agent): spawn agent loop in background thread

### DIFF
--- a/zig/src/agent/agent.zig
+++ b/zig/src/agent/agent.zig
@@ -793,7 +793,11 @@ pub const Agent = struct {
         }
 
         // Surface background-loop errors so callers do not receive ok when the
-        // agent loop aborted.
+        // agent loop aborted. completeWithError sets err_msg; complete(result)
+        // with an error stop_reason is checked via getResult().
+        if (stream.getError() != null) {
+            return error.AgentLoopFailed;
+        }
         if (stream.getResult()) |result| {
             if (result.final_message.stop_reason == .@"error") {
                 return error.AgentLoopFailed;

--- a/zig/src/agent/agent.zig
+++ b/zig/src/agent/agent.zig
@@ -687,6 +687,10 @@ pub const Agent = struct {
         var cancelled = std.atomic.Value(bool).init(false);
         self._cancel_token = .{ .cancelled = &cancelled };
         self._state.is_streaming = true;
+        errdefer {
+            self._state.is_streaming = false;
+            self._cancel_token = null;
+        }
         self._state.stream_message = null;
         self._state.error_message.deinit(self._allocator);
         self._state.error_message = types.OwnedSlice(u8).initBorrowed("");

--- a/zig/src/agent/agent.zig
+++ b/zig/src/agent/agent.zig
@@ -798,7 +798,9 @@ pub const Agent = struct {
 
         // Surface background-loop errors so callers do not receive ok when the
         // agent loop aborted. completeWithError sets err_msg; complete(result)
-        // with an error stop_reason is checked via getResult().
+        // with an error stop_reason is checked via getResult(); a completed
+        // stream with neither result nor error (e.g., OOM in completeWithError)
+        // is also treated as failure.
         if (stream.getError() != null) {
             return error.AgentLoopFailed;
         }
@@ -806,6 +808,8 @@ pub const Agent = struct {
             if (result.final_message.stop_reason == .@"error") {
                 return error.AgentLoopFailed;
             }
+        } else if (stream.isDone()) {
+            return error.AgentLoopFailed;
         }
 
         self._state.is_streaming = false;

--- a/zig/src/agent/agent.zig
+++ b/zig/src/agent/agent.zig
@@ -731,6 +731,10 @@ pub const Agent = struct {
             .get_api_key_ctx = self._get_api_key_ctx,
         };
 
+        // Track how many messages context has before the loop so we can tell
+        // whether any prompts were actually consumed.
+        const initial_message_count = context.messages.items.len;
+
         // Run loop
         const stream = if (messages.*) |msgs|
             try agent_loop.agentLoop(self._allocator, msgs, &context, config)
@@ -780,11 +784,20 @@ pub const Agent = struct {
             self.emit(event);
         }
 
-        // Transfer ownership only if the stream completed successfully.
-        // If runLoop failed before consuming all prompts, the caller retains
-        // ownership and its cleanup path will free them.
-        if (stream.getError() == null) {
+        // Transfer ownership if any prompts were actually consumed (appended to
+        // context). This avoids a double-free when consumed prompts were
+        // shallow-copied into context, while still letting the caller clean up
+        // unconsumed prompts on early failure.
+        if (context.messages.items.len > initial_message_count) {
             messages.* = null;
+        }
+
+        // Surface background-loop errors so callers do not receive ok when the
+        // agent loop aborted.
+        if (stream.getResult()) |result| {
+            if (result.final_message.stop_reason == .@"error") {
+                return error.AgentLoopFailed;
+            }
         }
 
         self._state.is_streaming = false;

--- a/zig/src/agent/agent.zig
+++ b/zig/src/agent/agent.zig
@@ -737,11 +737,6 @@ pub const Agent = struct {
         else
             try agent_loop.agentLoopContinue(self._allocator, &context, config);
 
-        // agentLoop has successfully copied the prompt payloads into its result
-        // stream. The caller no longer owns the per-message payloads and should
-        // only release the outer slice container.
-        messages.* = null;
-
         defer {
             stream.deinit();
             self._allocator.destroy(stream);
@@ -783,6 +778,13 @@ pub const Agent = struct {
 
             // Emit to listeners
             self.emit(event);
+        }
+
+        // Transfer ownership only if the stream completed successfully.
+        // If runLoop failed before consuming all prompts, the caller retains
+        // ownership and its cleanup path will free them.
+        if (stream.getError() == null) {
+            messages.* = null;
         }
 
         self._state.is_streaming = false;

--- a/zig/src/agent/agent_loop.zig
+++ b/zig/src/agent/agent_loop.zig
@@ -841,6 +841,10 @@ pub fn agentLoop(
         if (owned_api_key) |key| allocator.free(key);
         return err;
     };
+    errdefer {
+        if (owned_api_key) |key| allocator.free(key);
+        if (owned_session_id) |sid| allocator.free(sid);
+    }
 
     const stream = try allocator.create(AgentEventStream);
     errdefer allocator.destroy(stream);
@@ -880,6 +884,10 @@ pub fn agentLoopContinue(
         if (owned_api_key) |key| allocator.free(key);
         return err;
     };
+    errdefer {
+        if (owned_api_key) |key| allocator.free(key);
+        if (owned_session_id) |sid| allocator.free(sid);
+    }
 
     const stream = try allocator.create(AgentEventStream);
     errdefer allocator.destroy(stream);

--- a/zig/src/agent/agent_loop.zig
+++ b/zig/src/agent/agent_loop.zig
@@ -760,37 +760,88 @@ fn runLoop(
 }
 
 /// Thread context for background agent loop execution.
-/// Caller must keep prompts and config data alive until the stream completes.
+///
+/// Lifetime requirements on the caller:
+/// - `prompts` and the strings inside each Message must stay alive until the
+///   stream completes (they are shallow-copied into context.messages).
+/// - `config.model` string fields must stay alive until the stream completes.
+/// - `config.tools` slice and the string fields inside each AgentTool must stay
+///   alive until the stream completes.
+/// - All `config.*_ctx` callback context pointers must stay valid until the
+///   stream completes.
+/// - `api_key` and `session_id` are cloned into owned memory by agentLoop and
+///   freed automatically by the background thread; the caller may free its
+///   copies immediately after the call returns.
 const RunLoopThreadCtx = struct {
     allocator: std.mem.Allocator,
     prompts: ?[]const ai_types.Message,
     context: *AgentContext,
     config: AgentLoopConfig,
     stream: *AgentEventStream,
+    owned_api_key: ?[]u8 = null,
+    owned_session_id: ?[]u8 = null,
 };
 
 /// Background thread entry point for the agent loop.
 fn runLoopThread(ctx: *RunLoopThreadCtx) void {
+    const allocator = ctx.allocator;
     const stream = ctx.stream;
 
-    runLoop(ctx.allocator, ctx.prompts, ctx.context, ctx.config, stream) catch |err| {
+    runLoop(allocator, ctx.prompts, ctx.context, ctx.config, stream) catch |err| {
         stream.completeWithError(@errorName(err));
     };
 
+    if (ctx.owned_api_key) |key| allocator.free(key);
+    if (ctx.owned_session_id) |sid| allocator.free(sid);
+
+    allocator.destroy(ctx);
     stream.markThreadDone();
-    ctx.allocator.destroy(ctx);
+}
+
+/// Clone config string fields that are commonly borrowed by callers.
+fn cloneConfigStrings(
+    allocator: std.mem.Allocator,
+    config: AgentLoopConfig,
+    out_owned_api_key: *?[]u8,
+    out_owned_session_id: *?[]u8,
+) !AgentLoopConfig {
+    var cloned = config;
+    if (config.api_key) |key| {
+        out_owned_api_key.* = try allocator.dupe(u8, key);
+        cloned.api_key = out_owned_api_key.*;
+    }
+    if (config.session_id) |sid| {
+        out_owned_session_id.* = try allocator.dupe(u8, sid);
+        cloned.session_id = out_owned_session_id.*;
+    }
+    return cloned;
 }
 
 /// Start an agent loop with new prompt messages.
 /// Returns an event stream that emits events during execution.
 /// Caller owns the returned stream and must call deinit().
-/// Caller must keep prompts alive until the stream completes.
+///
+/// Lifetime: the caller must keep `prompts` and all borrowed fields inside
+/// `config` alive until the stream completes. Specifically:
+/// - `prompts` messages (shallow-copied into context)
+/// - `config.model` strings
+/// - `config.tools` slice and tool string fields
+/// - `config.*_ctx` callback context pointers
+/// `api_key` and `session_id` are cloned internally and may be freed by the
+/// caller immediately after this call returns.
 pub fn agentLoop(
     allocator: std.mem.Allocator,
     prompts: []const ai_types.Message,
     context: *AgentContext,
     config: AgentLoopConfig,
 ) !*AgentEventStream {
+    var owned_api_key: ?[]u8 = null;
+    var owned_session_id: ?[]u8 = null;
+    const thread_config = cloneConfigStrings(allocator, config, &owned_api_key, &owned_session_id) catch |err| {
+        if (owned_api_key) |key| allocator.free(key);
+        return err;
+    };
+
     const stream = try allocator.create(AgentEventStream);
     errdefer allocator.destroy(stream);
     stream.* = AgentEventStream.init(allocator);
@@ -802,8 +853,10 @@ pub fn agentLoop(
         .allocator = allocator,
         .prompts = prompts,
         .context = context,
-        .config = config,
+        .config = thread_config,
         .stream = stream,
+        .owned_api_key = owned_api_key,
+        .owned_session_id = owned_session_id,
     };
 
     const th = try std.Thread.spawn(.{}, runLoopThread, .{ctx});
@@ -814,11 +867,20 @@ pub fn agentLoop(
 
 /// Continue an agent loop from the current context without adding new messages.
 /// Used for retries - context already has user message or tool results.
+///
+/// Lifetime: same borrowed-field rules as agentLoop apply.
 pub fn agentLoopContinue(
     allocator: std.mem.Allocator,
     context: *AgentContext,
     config: AgentLoopConfig,
 ) !*AgentEventStream {
+    var owned_api_key: ?[]u8 = null;
+    var owned_session_id: ?[]u8 = null;
+    const thread_config = cloneConfigStrings(allocator, config, &owned_api_key, &owned_session_id) catch |err| {
+        if (owned_api_key) |key| allocator.free(key);
+        return err;
+    };
+
     const stream = try allocator.create(AgentEventStream);
     errdefer allocator.destroy(stream);
     stream.* = AgentEventStream.init(allocator);
@@ -830,8 +892,10 @@ pub fn agentLoopContinue(
         .allocator = allocator,
         .prompts = null,
         .context = context,
-        .config = config,
+        .config = thread_config,
         .stream = stream,
+        .owned_api_key = owned_api_key,
+        .owned_session_id = owned_session_id,
     };
 
     const th = try std.Thread.spawn(.{}, runLoopThread, .{ctx});

--- a/zig/src/agent/agent_loop.zig
+++ b/zig/src/agent/agent_loop.zig
@@ -759,9 +759,32 @@ fn runLoop(
     event_stream.complete(result);
 }
 
+/// Thread context for background agent loop execution.
+/// Caller must keep prompts and config data alive until the stream completes.
+const RunLoopThreadCtx = struct {
+    allocator: std.mem.Allocator,
+    prompts: ?[]const ai_types.Message,
+    context: *AgentContext,
+    config: AgentLoopConfig,
+    stream: *AgentEventStream,
+};
+
+/// Background thread entry point for the agent loop.
+fn runLoopThread(ctx: *RunLoopThreadCtx) void {
+    const stream = ctx.stream;
+
+    runLoop(ctx.allocator, ctx.prompts, ctx.context, ctx.config, stream) catch |err| {
+        stream.completeWithError(@errorName(err));
+    };
+
+    stream.markThreadDone();
+    ctx.allocator.destroy(ctx);
+}
+
 /// Start an agent loop with new prompt messages.
 /// Returns an event stream that emits events during execution.
 /// Caller owns the returned stream and must call deinit().
+/// Caller must keep prompts alive until the stream completes.
 pub fn agentLoop(
     allocator: std.mem.Allocator,
     prompts: []const ai_types.Message,
@@ -769,10 +792,22 @@ pub fn agentLoop(
     config: AgentLoopConfig,
 ) !*AgentEventStream {
     const stream = try allocator.create(AgentEventStream);
+    errdefer allocator.destroy(stream);
     stream.* = AgentEventStream.init(allocator);
+    stream.wait_for_thread_on_deinit = true;
 
-    // Run the loop (in a real implementation, this would be async/threaded)
-    try runLoop(allocator, prompts, context, config, stream);
+    const ctx = try allocator.create(RunLoopThreadCtx);
+    errdefer allocator.destroy(ctx);
+    ctx.* = .{
+        .allocator = allocator,
+        .prompts = prompts,
+        .context = context,
+        .config = config,
+        .stream = stream,
+    };
+
+    const th = try std.Thread.spawn(.{}, runLoopThread, .{ctx});
+    th.detach();
 
     return stream;
 }
@@ -785,10 +820,22 @@ pub fn agentLoopContinue(
     config: AgentLoopConfig,
 ) !*AgentEventStream {
     const stream = try allocator.create(AgentEventStream);
+    errdefer allocator.destroy(stream);
     stream.* = AgentEventStream.init(allocator);
+    stream.wait_for_thread_on_deinit = true;
 
-    // Run the loop without initial prompts
-    try runLoop(allocator, null, context, config, stream);
+    const ctx = try allocator.create(RunLoopThreadCtx);
+    errdefer allocator.destroy(ctx);
+    ctx.* = .{
+        .allocator = allocator,
+        .prompts = null,
+        .context = context,
+        .config = config,
+        .stream = stream,
+    };
+
+    const th = try std.Thread.spawn(.{}, runLoopThread, .{ctx});
+    th.detach();
 
     return stream;
 }

--- a/zig/test/unit/agent.zig
+++ b/zig/test/unit/agent.zig
@@ -104,6 +104,13 @@ const MockProtocolState = struct {
     stop_reason: ai_types.StopReason = .stop,
     call_count: usize = 0,
     last_options: ?ProtocolOptions = null,
+
+    pub fn deinit(self: *MockProtocolState, allocator: std.mem.Allocator) void {
+        if (self.last_options) |opts| {
+            if (opts.api_key) |k| allocator.free(k);
+            if (opts.session_id) |s| allocator.free(s);
+        }
+    }
 };
 
 fn createModel() ai_types.Model {
@@ -153,7 +160,15 @@ fn mockProtocolStream(
 
     const state: *MockProtocolState = @ptrCast(@alignCast(ctx));
     state.call_count += 1;
-    state.last_options = options;
+    state.last_options = .{
+        .api_key = if (options.api_key) |k| try allocator.dupe(u8, k) else null,
+        .session_id = if (options.session_id) |s| try allocator.dupe(u8, s) else null,
+        .cancel_token = options.cancel_token,
+        .thinking_budgets = options.thinking_budgets,
+        .max_retry_delay_ms = options.max_retry_delay_ms,
+        .temperature = options.temperature,
+        .max_tokens = options.max_tokens,
+    };
 
     const stream = try allocator.create(event_stream.AssistantMessageEventStream);
     stream.* = event_stream.AssistantMessageEventStream.init(allocator);
@@ -365,6 +380,7 @@ test "ProtocolOptions: passed through to protocol client" {
     const allocator = testing.allocator;
 
     var state = MockProtocolState{ .mode = .done, .text = "options" };
+    defer state.deinit(allocator);
 
     var ctx = AgentContext.init(allocator);
     defer ctx.deinit();


### PR DESCRIPTION
## Summary

`agentLoop()` previously called `runLoop()` synchronously. The entire agent loop (multiple LLM round trips, tool executions, streaming) completed before `agentLoop()` returned, meaning the returned `AgentEventStream` was already complete — no events to poll in real time.

This change makes `agentLoop()` and `agentLoopContinue()` spawn `runLoop()` in a detached background thread, matching the provider streaming pattern.

## Changes

- Add `RunLoopThreadCtx` to pass allocator, prompts, context, config, and stream to the background thread
- `agentLoop()` / `agentLoopContinue()` now:
  1. Create an `AgentEventStream` with `wait_for_thread_on_deinit = true`
  2. Spawn `runLoopThread` via `std.Thread.spawn`
  3. Detach the thread and return the live stream immediately
- `runLoopThread` calls `runLoop()`, then `markThreadDone()` and cleans up its context
- Stream `deinit()` waits for thread completion (no resource leak)

## Test Plan

- [x] `zig build test-unit-agent` passes
- [x] `zig build test` (full suite) passes