### PR TITLE
chore(release): prepare v0.1.0 with Zig packaging and TS SDK fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,12 +64,11 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/zig
-          key: ${{ runner.os }}-zig-${{ hashFiles('zig/build.zig.zon') }}
+          key: ${{ runner.os }}-zig-${{ hashFiles('build.zig.zon') }}
           restore-keys: |
             ${{ runner.os }}-zig-
 
       - name: Run ${{ matrix.group }} unit tests
-        working-directory: zig
         run: zig build test-unit-${{ matrix.group }}
 
   ts-sdk-e2e:
@@ -95,7 +94,6 @@ jobs:
         run: npm ci
 
       - name: Build makai binary for TS SDK E2E
-        working-directory: zig
         run: zig build install --prefix /tmp/makai-smoke
 
       - name: Run TS SDK unit + E2E tests
@@ -121,11 +119,10 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: ~/.cache/zig
-          key: ${{ runner.os }}-zig-${{ hashFiles('zig/build.zig.zon') }}
+          key: ${{ runner.os }}-zig-${{ hashFiles('build.zig.zon') }}
           restore-keys: |
             ${{ runner.os }}-zig-
       - name: Run Anthropic E2E tests
-        working-directory: zig
         run: zig build test-e2e-anthropic
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -145,11 +142,10 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: ~/.cache/zig
-          key: ${{ runner.os }}-zig-${{ hashFiles('zig/build.zig.zon') }}
+          key: ${{ runner.os }}-zig-${{ hashFiles('build.zig.zon') }}
           restore-keys: |
             ${{ runner.os }}-zig-
       - name: Run OpenAI E2E tests
-        working-directory: zig
         run: zig build test-e2e-openai
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
@@ -169,11 +165,10 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: ~/.cache/zig
-          key: ${{ runner.os }}-zig-${{ hashFiles('zig/build.zig.zon') }}
+          key: ${{ runner.os }}-zig-${{ hashFiles('build.zig.zon') }}
           restore-keys: |
             ${{ runner.os }}-zig-
       - name: Run Azure E2E tests
-        working-directory: zig
         run: zig build test-e2e-azure
         env:
           AZURE_OPENAI_API_KEY: ${{ secrets.AZURE_OPENAI_API_KEY }}
@@ -193,11 +188,10 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: ~/.cache/zig
-          key: ${{ runner.os }}-zig-${{ hashFiles('zig/build.zig.zon') }}
+          key: ${{ runner.os }}-zig-${{ hashFiles('build.zig.zon') }}
           restore-keys: |
             ${{ runner.os }}-zig-
       - name: Run Google E2E tests
-        working-directory: zig
         run: zig build test-e2e-google
         env:
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
@@ -216,11 +210,10 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: ~/.cache/zig
-          key: ${{ runner.os }}-zig-${{ hashFiles('zig/build.zig.zon') }}
+          key: ${{ runner.os }}-zig-${{ hashFiles('build.zig.zon') }}
           restore-keys: |
             ${{ runner.os }}-zig-
       - name: Run Ollama E2E tests
-        working-directory: zig
         run: zig build test-e2e-ollama
         env:
           OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
@@ -241,11 +234,10 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: ~/.cache/zig
-          key: ${{ runner.os }}-zig-${{ hashFiles('zig/build.zig.zon') }}
+          key: ${{ runner.os }}-zig-${{ hashFiles('build.zig.zon') }}
           restore-keys: |
             ${{ runner.os }}-zig-
       - name: Run GitHub Copilot E2E tests
-        working-directory: zig
         run: zig build test-e2e-github-copilot
         env:
           GH_COPILOT_REFRESH: ${{ secrets.GH_COPILOT_REFRESH }}
@@ -263,11 +255,10 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: ~/.cache/zig
-          key: ${{ runner.os }}-zig-${{ hashFiles('zig/build.zig.zon') }}
+          key: ${{ runner.os }}-zig-${{ hashFiles('build.zig.zon') }}
           restore-keys: |
             ${{ runner.os }}-zig-
       - name: Run Protocol E2E tests (mock-based)
-        working-directory: zig
         run: zig build test-e2e-protocol
 
   e2e-protocol-fullstack-ollama:
@@ -283,11 +274,10 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: ~/.cache/zig
-          key: ${{ runner.os }}-zig-${{ hashFiles('zig/build.zig.zon') }}
+          key: ${{ runner.os }}-zig-${{ hashFiles('build.zig.zon') }}
           restore-keys: |
             ${{ runner.os }}-zig-
       - name: Run Provider Protocol Fullstack E2E tests (Ollama)
-        working-directory: zig
         run: zig build test-e2e-provider-protocol-fullstack-ollama
         env:
           OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
@@ -308,11 +298,10 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: ~/.cache/zig
-          key: ${{ runner.os }}-zig-${{ hashFiles('zig/build.zig.zon') }}
+          key: ${{ runner.os }}-zig-${{ hashFiles('build.zig.zon') }}
           restore-keys: |
             ${{ runner.os }}-zig-
       - name: Run Provider Protocol Fullstack E2E tests (GitHub Copilot)
-        working-directory: zig
         run: zig build test-e2e-provider-protocol-fullstack-github
         env:
           GH_COPILOT_REFRESH: ${{ secrets.GH_COPILOT_REFRESH }}
@@ -333,11 +322,10 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: ~/.cache/zig
-          key: ${{ runner.os }}-zig-${{ hashFiles('zig/build.zig.zon') }}
+          key: ${{ runner.os }}-zig-${{ hashFiles('build.zig.zon') }}
           restore-keys: |
             ${{ runner.os }}-zig-
       - name: Run Distributed Fullstack E2E tests (GitHub Copilot)
-        working-directory: zig
         run: zig build test-e2e-distributed-fullstack-github
         env:
           GH_COPILOT_REFRESH: ${{ secrets.GH_COPILOT_REFRESH }}

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -134,7 +134,7 @@ jobs:
         run: |
           set -euo pipefail
           cd dist
-          sha256sum makai-* > SHA256SUMS.txt
+          sha256sum makai-*.tar.gz makai-*.zip > SHA256SUMS.txt
 
       - name: Upload checksums
         uses: actions/upload-artifact@v4
@@ -183,7 +183,7 @@ jobs:
         run: |
           set -euo pipefail
           TAG_VERSION="${GITHUB_REF_NAME#v}"
-          npm version "$TAG_VERSION" --no-git-tag-version
+          npm version "$TAG_VERSION" --no-git-tag-version --allow-same-version
 
       - name: Build TypeScript SDK
         run: npm run build:sdk

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -168,6 +168,18 @@ jobs:
         with:
           node-version: "22"
 
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Align main package version with tag
+        run: |
+          set -euo pipefail
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          npm version "$TAG_VERSION" --no-git-tag-version
+
+      - name: Build TypeScript SDK
+        run: npm run build:sdk
+
       - name: Download all binary artifacts
         uses: actions/download-artifact@v4
         with:
@@ -189,12 +201,6 @@ jobs:
 
       - name: Package npm packages
         run: npx tsx scripts/package-npm.ts --version "${GITHUB_REF_NAME#v}"
-
-      - name: Align main package version with tag
-        run: |
-          set -euo pipefail
-          TAG_VERSION="${GITHUB_REF_NAME#v}"
-          npm version "$TAG_VERSION" --no-git-tag-version
 
       - name: Upload npm packages
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -62,7 +62,6 @@ jobs:
         run: |
           set -euo pipefail
           OUT_ROOT="$GITHUB_WORKSPACE/dist-root/${{ matrix.os_name }}-${{ matrix.arch_name }}"
-          cd zig
           zig build install -Dtarget=${{ matrix.target }} -Doptimize=ReleaseSafe --prefix "$OUT_ROOT"
 
       - name: Package tar.gz

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -23,30 +23,35 @@ jobs:
             arch_name: arm64
             archive: tar.gz
             binary_name: makai
+            npm_target: darwin-arm64
           - runner: macos-latest
             target: x86_64-macos
             os_name: macos
             arch_name: x64
             archive: tar.gz
             binary_name: makai
+            npm_target: darwin-x64
           - runner: ubuntu-latest
             target: aarch64-linux
             os_name: linux
             arch_name: arm64
             archive: tar.gz
             binary_name: makai
+            npm_target: linux-arm64
           - runner: ubuntu-latest
             target: x86_64-linux
             os_name: linux
             arch_name: x64
             archive: tar.gz
             binary_name: makai
+            npm_target: linux-x64
           - runner: windows-latest
             target: x86_64-windows
             os_name: windows
             arch_name: x64
             archive: zip
             binary_name: makai.exe
+            npm_target: win32-x64
 
     steps:
       - name: Checkout code
@@ -99,6 +104,13 @@ jobs:
           path: dist/*
           if-no-files-found: error
 
+      - name: Upload binary for npm packaging
+        uses: actions/upload-artifact@v4
+        with:
+          name: npm-binary-${{ matrix.npm_target }}
+          path: dist-root/${{ matrix.os_name }}-${{ matrix.arch_name }}/bin/${{ matrix.binary_name }}
+          if-no-files-found: error
+
   checksums:
     name: Generate checksums
     runs-on: ubuntu-latest
@@ -142,11 +154,11 @@ jobs:
             dist/makai-*.zip
             dist/SHA256SUMS.txt
 
-  publish-npm:
-    name: Publish npm package
+  package-npm:
+    name: Package npm platforms
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
-    needs: [checksums]
+    needs: [build-binaries]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -155,21 +167,101 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "22"
-          registry-url: "https://registry.npmjs.org"
 
-      - name: Install dependencies
-        run: npm ci
+      - name: Download all binary artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist/bin
+          pattern: npm-binary-*
+          merge-multiple: true
 
-      - name: Build TypeScript SDK
-        run: npm run build:sdk
+      - name: Move binaries to expected locations
+        run: |
+          set -euo pipefail
+          mkdir -p dist/bin-flat
+          for f in dist/bin/*; do
+            binary=$(basename "$f")
+            mv "$f" "dist/bin-flat/$binary"
+            chmod +x "dist/bin-flat/$binary" 2>/dev/null || true
+          done
+          rm -rf dist/bin
+          mv dist/bin-flat dist/bin
 
-      - name: Align package version with tag
+      - name: Package npm packages
+        run: npx tsx scripts/package-npm.ts --version "${GITHUB_REF_NAME#v}"
+
+      - name: Align main package version with tag
         run: |
           set -euo pipefail
           TAG_VERSION="${GITHUB_REF_NAME#v}"
           npm version "$TAG_VERSION" --no-git-tag-version
 
-      - name: Publish package
-        run: npm publish --access public
+      - name: Upload npm packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: npm-packages
+          path: dist/npm/
+          if-no-files-found: error
+
+  publish-npm:
+    name: Publish npm packages
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    needs: [package-npm]
+    steps:
+      - name: Download npm packages
+        uses: actions/download-artifact@v4
+        with:
+          name: npm-packages
+          path: dist/npm
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Publish platform packages
+        run: |
+          set -euo pipefail
+          FAILED=0
+          for pkg in dist/npm/cli-*; do
+            PKG_NAME=$(basename "$pkg")
+            echo "Publishing $PKG_NAME..."
+            if OUTPUT=$(cd "$pkg" && npm publish --access public 2>&1); then
+              echo "$OUTPUT"
+              echo "$PKG_NAME published successfully"
+            else
+              echo "$OUTPUT"
+              if echo "$OUTPUT" | grep -qiE "previously published|cannot publish over|EPUBLISHCONFLICT"; then
+                echo "::warning::$PKG_NAME already published, skipping"
+              else
+                echo "::error::Failed to publish $PKG_NAME"
+                FAILED=1
+              fi
+            fi
+          done
+          if [ "$FAILED" -eq 1 ]; then
+            echo "One or more platform packages failed to publish"
+            exit 1
+          fi
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish main package
+        run: |
+          set -euo pipefail
+          if OUTPUT=$(cd dist/npm/makai && npm publish --access public 2>&1); then
+            echo "$OUTPUT"
+            echo "makai published successfully"
+          else
+            echo "$OUTPUT"
+            if echo "$OUTPUT" | grep -qiE "previously published|cannot publish over|EPUBLISHCONFLICT"; then
+              echo "::warning::makai already published, skipping"
+            else
+              echo "::error::Failed to publish makai"
+              exit 1
+            fi
+          fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -104,11 +104,19 @@ jobs:
           path: dist/*
           if-no-files-found: error
 
+      - name: Stage binary for npm packaging
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "$GITHUB_WORKSPACE/dist-npm-upload"
+          cp "$GITHUB_WORKSPACE/dist-root/${{ matrix.os_name }}-${{ matrix.arch_name }}/bin/${{ matrix.binary_name }}" \
+             "$GITHUB_WORKSPACE/dist-npm-upload/makai-${{ matrix.npm_target }}"
+
       - name: Upload binary for npm packaging
         uses: actions/upload-artifact@v4
         with:
           name: npm-binary-${{ matrix.npm_target }}
-          path: dist-root/${{ matrix.os_name }}-${{ matrix.arch_name }}/bin/${{ matrix.binary_name }}
+          path: dist-npm-upload/makai-${{ matrix.npm_target }}
           if-no-files-found: error
 
   checksums:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2026-05-16
+
+### Added
+
+- Initial release of Makai, a unified multi-provider AI streaming abstraction layer.
+- **Zig core library**: lock-free event queues, type-safe tagged unions, streaming JSON parser, SSE parser, and provider implementations for Anthropic, OpenAI (Completions & Responses), Google (Generative AI & Vertex), Azure OpenAI, AWS Bedrock (stub), and Ollama.
+- **Distributed protocol**: client-server wire protocol with envelope-based messaging, partial serialization/reconstruction, and in-process/stdio/SSE/WebSocket transports.
+- **Agent loop**: tool execution lifecycle with distributed runtime support.
+- **OAuth flows**: GitHub Copilot, Anthropic, Google, and OpenAI Codex OAuth with PKCE.
+- **TypeScript SDK**: stdio client transport, high-level APIs for provider completions, streaming, agent runs, auth flows, and model discovery.
+- **CLI**: `makai` binary with auth and stdio protocol support.
+
 ## Unreleased
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,0 +1,495 @@
+# Makai TypeScript SDK
+
+TypeScript SDK for Makai's stdio protocol. The SDK starts or connects to a `makai --stdio` runtime and exposes high-level namespaces for provider completions, streaming, agent runs, auth flows, and model discovery.
+
+## Installation
+
+The current package name is `makai`:
+
+```bash
+npm install makai
+```
+
+If you are consuming a scoped release, install the scope published by your registry instead, for example:
+
+```bash
+npm install @anthropic/makai
+```
+
+You also need access to the Makai runtime binary. By default the SDK looks for a local build under `zig-out/bin/makai` or `zig/zig-out/bin/makai`, then falls back to `makai` on `PATH`. See [Configuration](#configuration) for explicit binary resolver options.
+
+## Quick start
+
+Create a client, resolve a model, send one chat message, and print the assistant response.
+
+```ts
+import { createMakaiClient } from "makai";
+
+async function main(): Promise<void> {
+  const client = await createMakaiClient();
+
+  try {
+    const { model } = await client.models.resolve({
+      provider_id: "anthropic",
+      api: "anthropic-messages",
+      model_id: "claude-sonnet-4-5",
+    });
+
+    const response = await client.provider.complete({
+      model_ref: model.model_ref,
+      messages: [{ role: "user", content: "Write a haiku about streams." }],
+      options: { max_tokens: 128 },
+    });
+
+    const content = response.message.content;
+    console.log(typeof content === "string" ? content : JSON.stringify(content, null, 2));
+  } finally {
+    await client.close();
+  }
+}
+
+main().catch((error: unknown) => {
+  console.error(error);
+  process.exitCode = 1;
+});
+```
+
+## Streaming completions
+
+Use `client.provider.stream(...)` for provider-level streaming. It is the SDK's streaming form of `complete`; each `text_delta` contains newly generated text.
+
+```ts
+import { createMakaiClient } from "makai";
+
+async function main(): Promise<void> {
+  const client = await createMakaiClient();
+
+  try {
+    const { model } = await client.models.resolve({
+      provider_id: "anthropic",
+      api: "anthropic-messages",
+      model_id: "claude-sonnet-4-5",
+    });
+
+    for await (const event of client.provider.stream({
+      model_ref: model.model_ref,
+      messages: [{ role: "user", content: "Explain lock-free queues in one paragraph." }],
+      options: { max_tokens: 256 },
+    })) {
+      switch (event.type) {
+        case "message_start":
+          console.error(`Streaming ${event.provider_id ?? "provider"}/${event.model_id ?? "model"}`);
+          break;
+        case "text_delta":
+          process.stdout.write(event.delta);
+          break;
+        case "thinking_delta":
+          // Reasoning output is surfaced separately from normal text.
+          break;
+        case "tool_call":
+          console.error(`\nTool call requested: ${event.name}(${event.arguments_json})`);
+          break;
+        case "message_end":
+          process.stdout.write("\n");
+          console.error("Stop reason:", event.stop_reason);
+          break;
+        case "error":
+          throw new Error(event.message);
+      }
+    }
+  } finally {
+    await client.close();
+  }
+}
+
+void main();
+```
+
+If you are migrating from an API that used `client.complete({ stream: true })`, the equivalent Makai SDK call is `client.provider.stream(request)`; non-streaming calls use `client.provider.complete(request)`.
+
+## Agent loop with tools
+
+Use `client.agent.run(...)` when you want the Makai agent loop to manage provider turns and tool execution lifecycle. Tool definitions are JSON Schema strings. Tool execution is handled by the Makai runtime/tool protocol boundary; the TypeScript SDK sends tool schemas and receives the final assistant response plus streaming lifecycle events when using `agent.stream(...)`.
+
+```ts
+import { createMakaiClient, type ToolDefinition } from "makai";
+
+const tools: ToolDefinition[] = [
+  {
+    name: "get_weather",
+    description: "Get the current weather for a city.",
+    parameters_schema_json: JSON.stringify({
+      type: "object",
+      properties: {
+        city: { type: "string", description: "City and state or country." },
+      },
+      required: ["city"],
+      additionalProperties: false,
+    }),
+  },
+];
+
+async function main(): Promise<void> {
+  const client = await createMakaiClient();
+
+  try {
+    const { model } = await client.models.resolve({
+      provider_id: "anthropic",
+      api: "anthropic-messages",
+      model_id: "claude-sonnet-4-5",
+    });
+
+    const response = await client.agent.run({
+      model_ref: model.model_ref,
+      messages: [{ role: "user", content: "Should I bring an umbrella in San Francisco today?" }],
+      tools,
+      options: { max_tokens: 512, auth_retry_policy: "auto_once" },
+    });
+
+    console.log(response.message.content);
+  } finally {
+    await client.close();
+  }
+}
+
+void main();
+```
+
+For agent streaming, iterate over `client.agent.stream(request)` and handle `agent_start`, `turn_start`, `tool_execution_start`, `tool_execution_end`, provider deltas, and the terminal `agent_end` event.
+
+### Agent model discovery
+
+`client.agent.models` is a separate `MakaiModelsApi` instance that delegates to the same underlying model-discovery API over the shared transport as `client.models`. The two instances produce the same results but are not the same object (`client.agent.models !== client.models`).
+
+```ts
+// Both call the same underlying API and return the same results:
+const { models } = await client.models.list();
+const { models: agentModels } = await client.agent.models.list();
+```
+
+Prefer `client.models` when you only need model discovery. Use `client.agent.models` when chaining discovery with an agent call on the same namespace.
+
+## Auth
+
+Use `client.auth.listProviders()` to inspect auth state, and `client.auth.login(providerId, handlers)` to start an interactive login flow. Token material is owned by the runtime and is not exposed by the SDK.
+
+```ts
+import { createMakaiClient, type MakaiAuthEvent } from "makai";
+import { createInterface } from "node:readline/promises";
+import { stdin as input, stdout as output } from "node:process";
+
+async function main(): Promise<void> {
+  const client = await createMakaiClient();
+  const rl = createInterface({ input, output });
+
+  try {
+    const providers = await client.auth.listProviders();
+    const anthropic = providers.find((provider) => provider.id === "anthropic");
+
+    if (anthropic?.auth_status !== "authenticated") {
+      await client.auth.login("anthropic", {
+        onEvent(event: MakaiAuthEvent): void {
+          if (event.type === "auth_url") {
+            console.log(`Open ${event.url}`);
+            if (event.instructions) console.log(event.instructions);
+          } else if (event.type === "progress") {
+            console.log(event.message);
+          }
+        },
+        async onPrompt(prompt): Promise<string> {
+          return rl.question(`${prompt.message} `);
+        },
+      });
+    }
+  } finally {
+    rl.close();
+    await client.close();
+  }
+}
+
+void main();
+```
+
+You can also configure automatic one-shot auth retry for `provider` and `agent` calls:
+
+```ts
+import { createMakaiClient } from "makai";
+
+async function main(): Promise<void> {
+  const client = await createMakaiClient({
+    auth: {
+      auth_retry_policy: "auto_once",
+      handlers: {
+        onEvent: (event) => {
+          if (event.type === "auth_url") console.log(`Open ${event.url}`);
+        },
+        onPrompt: async (prompt) => prompt.allow_empty ? "" : process.env.MAKAI_AUTH_CODE ?? "",
+      },
+    },
+  });
+
+  try {
+    // Calls that hit auth_required can now trigger one login attempt automatically.
+  } finally {
+    await client.close();
+  }
+}
+
+void main();
+```
+
+## Models
+
+Models are discovered through `client.models`. Use `model_ref` from the returned descriptor in completion and agent requests. Treat `model_ref` as opaque; do not parse or construct it in application code.
+
+```ts
+import { createMakaiClient } from "makai";
+
+async function main(): Promise<void> {
+  const client = await createMakaiClient();
+
+  try {
+    const { models, fetched_at_ms, cache_max_age_ms } = await client.models.list({
+      provider_id: "anthropic",
+      include_login_required: true,
+    });
+
+    console.log(`Fetched ${models.length} models at ${new Date(fetched_at_ms).toISOString()}`);
+    console.log(`Cache max age: ${cache_max_age_ms}ms`);
+
+    for (const model of models) {
+      console.log(`${model.display_name}: ${model.model_ref} [${model.auth_status}]`);
+    }
+
+    const resolved = await client.models.resolve({
+      provider_id: "anthropic",
+      api: "anthropic-messages",
+      model_id: "claude-sonnet-4-5",
+    });
+
+    console.log("Use this model_ref:", resolved.model.model_ref);
+  } finally {
+    await client.close();
+  }
+}
+
+void main();
+```
+
+## Configuration
+
+`createMakaiClient(...)`, `createMakaiStdioClient(...)`, and `createMakaiAuthClient(...)` accept stdio transport options and binary resolver options.
+
+### Explicit binary path
+
+```ts
+import { createMakaiClient } from "makai";
+
+async function main(): Promise<void> {
+  const client = await createMakaiClient({
+    resolver: {
+      binaryPath: "/opt/makai/bin/makai",
+    },
+  });
+
+  try {
+    // Use client.provider, client.agent, client.auth, or client.models here.
+  } finally {
+    await client.close();
+  }
+}
+
+void main();
+```
+
+You can also set `MAKAI_BINARY_PATH=/opt/makai/bin/makai`.
+
+### Download from URL with checksum
+
+```ts
+import { createMakaiClient } from "makai";
+
+async function main(): Promise<void> {
+  const client = await createMakaiClient({
+    resolver: {
+      binaryUrl: "https://example.com/releases/makai-darwin-arm64",
+      checksumSha256: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      cacheDir: "/tmp/makai-bin-cache",
+    },
+  });
+
+  try {
+    // Use client.provider, client.agent, client.auth, or client.models here.
+  } finally {
+    await client.close();
+  }
+}
+
+void main();
+```
+
+Environment variable equivalents are `MAKAI_BINARY_URL` and `MAKAI_BINARY_SHA256`.
+
+### PATH lookup and local builds
+
+With no resolver options, Makai checks:
+
+1. `./zig-out/bin/makai` (or `makai.exe` on Windows)
+2. `./zig/zig-out/bin/makai`
+3. `makai` on `PATH`
+
+```ts
+import { createMakaiClient } from "makai";
+
+async function main(): Promise<void> {
+  const client = await createMakaiClient({
+    // Optional transport settings:
+    args: ["--stdio"],
+    cwd: process.cwd(),
+    env: { ...process.env, MAKAI_LOG: "info" },
+    handshakeTimeoutMs: 2_000,
+    responseTimeoutMs: 30_000,
+    frameTimeoutMs: 30_000,
+  });
+
+  try {
+    // Use client.provider, client.agent, client.auth, or client.models here.
+  } finally {
+    await client.close();
+  }
+}
+
+void main();
+```
+
+Close clients when done:
+
+```ts
+async function closeClient(client: { close(): Promise<void> }): Promise<void> {
+  await client.close();
+}
+```
+
+## Error handling
+
+The SDK exports error classes for common failure surfaces:
+
+- `MakaiStreamError` — provider, stream, transport, abort, or unknown failures while running `provider` or `agent` calls.
+- `MakaiAuthRequiredError` — specialized `MakaiStreamError` for `auth_required` failures. It includes `provider_id`.
+- `MakaiProtocolError` — models API protocol failures such as `invalid_request`, malformed responses, or request `nack`s.
+- `MakaiAuthError` — auth provider listing and login failures. The `kind` can be `provider_error`, `cancelled`, `transport_error`, or `unknown`.
+
+```ts
+import {
+  MakaiAuthError,
+  MakaiAuthRequiredError,
+  MakaiProtocolError,
+  MakaiStreamError,
+  createMakaiClient,
+} from "makai";
+
+async function run(): Promise<void> {
+  const client = await createMakaiClient();
+
+  try {
+    const { model } = await client.models.resolve({
+      provider_id: "anthropic",
+      api: "anthropic-messages",
+      model_id: "claude-sonnet-4-5",
+    });
+
+    await client.provider.complete({
+      model_ref: model.model_ref,
+      messages: [{ role: "user", content: "Hello" }],
+    });
+  } catch (error: unknown) {
+    if (error instanceof MakaiAuthRequiredError) {
+      console.error(`Login required for ${error.provider_id}`);
+    } else if (error instanceof MakaiStreamError) {
+      console.error(`Stream failed (${error.kind}/${error.code ?? "no-code"}): ${error.message}`);
+    } else if (error instanceof MakaiProtocolError) {
+      console.error(`Protocol failed (${error.code ?? "no-code"}): ${error.message}`);
+    } else if (error instanceof MakaiAuthError) {
+      console.error(`Auth failed (${error.kind}/${error.code ?? "no-code"}): ${error.message}`);
+    } else {
+      throw error;
+    }
+  } finally {
+    await client.close();
+  }
+}
+
+void run();
+```
+
+## TypeScript types
+
+Public types are exported from the package root and generated in `dist/src/index.d.ts` when you run `npm run build:sdk`. Key API types include:
+
+```ts
+import type {
+  AgentRunRequest,
+  AgentRunResponse,
+  AgentStreamEvent,
+  AuthFlowHandlers,
+  AuthStatus,
+  BinaryResolverOptions,
+  ChatMessage,
+  CompletionResponse,
+  ContentPart,
+  CreateMakaiClientOptions,
+  ListModelsRequest,
+  ListModelsResponse,
+  MakaiAgentApi,
+  MakaiAgentModelsApi,
+  MakaiAuthApi,
+  MakaiClient,
+  MakaiModelsApi,
+  MakaiProviderApi,
+  ModelDescriptor,
+  ProviderCompleteRequest,
+  ProviderCompleteResponse,
+  ProviderStreamEvent,
+  RunOptions,
+  ToolDefinition,
+  UsageSummary,
+} from "makai";
+```
+
+Most requests share this shape:
+
+```ts
+type ChatMessage = {
+  role: "system" | "developer" | "user" | "assistant" | "tool";
+  content: string | ContentPart[];
+  name?: string;
+  tool_call_id?: string;
+};
+
+type ToolDefinition = {
+  name: string;
+  description: string;
+  parameters_schema_json: string;
+};
+
+type RunOptions = {
+  temperature?: number;
+  max_tokens?: number;
+  reasoning_effort?: "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
+  auth_retry_policy?: "manual" | "auto_once";
+  session_id?: string;
+  metadata?: Record<string, string>;
+};
+```
+
+Core namespaces:
+
+```ts
+type MakaiClient = {
+  auth: MakaiAuthApi;
+  models: MakaiModelsApi;
+  agent: MakaiAgentModelsApi; // extends MakaiAgentApi with a `models` convenience alias
+  provider: MakaiProviderApi;
+  close(): Promise<void>;
+};
+```

--- a/bin/makai.js
+++ b/bin/makai.js
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+
+/**
+ * Makai CLI launcher.
+ * Detects the current platform and spawns the correct compiled binary
+ * from the matching @makai/cli-{platform} optional dependency.
+ */
+
+const { spawnSync } = require("child_process");
+
+const PLATFORM_MAP = {
+  "darwin-arm64": "@makai/cli-darwin-arm64",
+  "darwin-x64": "@makai/cli-darwin-x64",
+  "linux-arm64": "@makai/cli-linux-arm64",
+  "linux-x64": "@makai/cli-linux-x64",
+  "win32-x64": "@makai/cli-win32-x64",
+};
+
+const platformKey = `${process.platform}-${process.arch}`;
+const packageName = PLATFORM_MAP[platformKey];
+
+if (!packageName) {
+  console.error(
+    `Error: Makai does not support ${process.platform} ${process.arch}.\n` +
+      `Supported platforms: ${Object.keys(PLATFORM_MAP).join(", ")}`
+  );
+  process.exit(1);
+}
+
+let binaryPath;
+try {
+  binaryPath = require.resolve(`${packageName}/bin/makai`);
+} catch {
+  console.error(
+    `Error: Could not find Makai binary for ${platformKey}.\n` +
+      `The package ${packageName} may not be installed.\n` +
+      `Try reinstalling: npm install -g makai`
+  );
+  process.exit(1);
+}
+
+const result = spawnSync(binaryPath, process.argv.slice(2), {
+  stdio: "inherit",
+  env: process.env,
+});
+
+if (result.error) {
+  console.error(`Error: Failed to execute Makai binary: ${result.error.message}`);
+  process.exit(1);
+}
+
+process.exit(result.status ?? 1);

--- a/bin/makai.js
+++ b/bin/makai.js
@@ -29,7 +29,8 @@ if (!packageName) {
 
 let binaryPath;
 try {
-  binaryPath = require.resolve(`${packageName}/bin/makai`);
+  const binaryName = process.platform === "win32" ? "makai.exe" : "makai";
+  binaryPath = require.resolve(`${packageName}/bin/${binaryName}`);
 } catch {
   console.error(
     `Error: Could not find Makai binary for ${platformKey}.\n` +

--- a/build.zig
+++ b/build.zig
@@ -5,13 +5,13 @@ pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
 
     const ai_types_mod = b.createModule(.{
-        .root_source_file = b.path("src/ai_types.zig"),
+        .root_source_file = b.path("zig/src/ai_types.zig"),
         .target = target,
         .optimize = optimize,
     });
 
     const event_stream_mod = b.createModule(.{
-        .root_source_file = b.path("src/event_stream.zig"),
+        .root_source_file = b.path("zig/src/event_stream.zig"),
         .target = target,
         .optimize = optimize,
         .imports = &.{
@@ -23,19 +23,19 @@ pub fn build(b: *std.Build) void {
     ai_types_mod.addImport("event_stream", event_stream_mod);
 
     const sse_parser_mod = b.createModule(.{
-        .root_source_file = b.path("src/providers/sse_parser.zig"),
+        .root_source_file = b.path("zig/src/providers/sse_parser.zig"),
         .target = target,
         .optimize = optimize,
     });
 
     const json_writer_mod = b.createModule(.{
-        .root_source_file = b.path("src/json/writer.zig"),
+        .root_source_file = b.path("zig/src/json/writer.zig"),
         .target = target,
         .optimize = optimize,
     });
 
     const owned_slice_mod = b.createModule(.{
-        .root_source_file = b.path("src/owned_slice.zig"),
+        .root_source_file = b.path("zig/src/owned_slice.zig"),
         .target = target,
         .optimize = optimize,
     });
@@ -44,19 +44,19 @@ pub fn build(b: *std.Build) void {
     ai_types_mod.addImport("owned_slice", owned_slice_mod);
 
     const string_builder_mod = b.createModule(.{
-        .root_source_file = b.path("src/string_builder.zig"),
+        .root_source_file = b.path("zig/src/string_builder.zig"),
         .target = target,
         .optimize = optimize,
     });
 
     const hive_array_mod = b.createModule(.{
-        .root_source_file = b.path("src/hive_array.zig"),
+        .root_source_file = b.path("zig/src/hive_array.zig"),
         .target = target,
         .optimize = optimize,
     });
 
     const compat_mod = b.createModule(.{
-        .root_source_file = b.path("src/compat/mod.zig"),
+        .root_source_file = b.path("zig/src/compat/mod.zig"),
         .target = target,
         .optimize = optimize,
         .imports = &.{
@@ -65,13 +65,13 @@ pub fn build(b: *std.Build) void {
     });
 
     const streaming_json_mod = b.createModule(.{
-        .root_source_file = b.path("src/streaming_json.zig"),
+        .root_source_file = b.path("zig/src/streaming_json.zig"),
         .target = target,
         .optimize = optimize,
     });
 
     const tool_call_tracker_mod = b.createModule(.{
-        .root_source_file = b.path("src/tool_call_tracker.zig"),
+        .root_source_file = b.path("zig/src/tool_call_tracker.zig"),
         .target = target,
         .optimize = optimize,
         .imports = &.{
@@ -82,7 +82,7 @@ pub fn build(b: *std.Build) void {
     });
 
     const oauth_storage_mod = b.createModule(.{
-        .root_source_file = b.path("src/utils/oauth/storage.zig"),
+        .root_source_file = b.path("zig/src/utils/oauth/storage.zig"),
         .target = target,
         .optimize = optimize,
         .imports = &.{
@@ -91,7 +91,7 @@ pub fn build(b: *std.Build) void {
     });
 
     const refresh_lock_mod = b.createModule(.{
-        .root_source_file = b.path("src/utils/oauth/refresh_lock.zig"),
+        .root_source_file = b.path("zig/src/utils/oauth/refresh_lock.zig"),
         .target = target,
         .optimize = optimize,
         .imports = &.{
@@ -100,7 +100,7 @@ pub fn build(b: *std.Build) void {
     });
 
     const api_registry_mod = b.createModule(.{
-        .root_source_file = b.path("src/api_registry.zig"),
+        .root_source_file = b.path("zig/src/api_registry.zig"),
         .target = target,
         .optimize = optimize,
         .imports = &.{
@@ -111,7 +111,7 @@ pub fn build(b: *std.Build) void {
     });
 
     const github_copilot_mod = b.createModule(.{
-        .root_source_file = b.path("src/utils/oauth/github_copilot.zig"),
+        .root_source_file = b.path("zig/src/utils/oauth/github_copilot.zig"),
         .target = target,
         .optimize = optimize,
         .imports = &.{
@@ -121,7 +121,7 @@ pub fn build(b: *std.Build) void {
     });
 
     const oauth_utils_pkce_mod = b.createModule(.{
-        .root_source_file = b.path("src/utils/oauth/pkce.zig"),
+        .root_source_file = b.path("zig/src/utils/oauth/pkce.zig"),
         .target = target,
         .optimize = optimize,
         .imports = &.{
@@ -130,7 +130,7 @@ pub fn build(b: *std.Build) void {
     });
 
     const oauth_anthropic_mod = b.createModule(.{
-        .root_source_file = b.path("src/utils/oauth/anthropic.zig"),
+        .root_source_file = b.path("zig/src/utils/oauth/anthropic.zig"),
         .target = target,
         .optimize = optimize,
         .imports = &.{
@@ -141,7 +141,7 @@ pub fn build(b: *std.Build) void {
     });
 
     const auth_resolver_mod = b.createModule(.{
-        .root_source_file = b.path("src/utils/auth_resolver.zig"),
+        .root_source_file = b.path("zig/src/utils/auth_resolver.zig"),
         .target = target,
         .optimize = optimize,
         .imports = &.{
@@ -151,19 +151,19 @@ pub fn build(b: *std.Build) void {
     });
 
     const auth_provider_defs_mod = b.createModule(.{
-        .root_source_file = b.path("src/auth/providers.zig"),
+        .root_source_file = b.path("zig/src/auth/providers.zig"),
         .target = target,
         .optimize = optimize,
     });
 
     const provider_caps_mod = b.createModule(.{
-        .root_source_file = b.path("src/utils/provider_caps.zig"),
+        .root_source_file = b.path("zig/src/utils/provider_caps.zig"),
         .target = target,
         .optimize = optimize,
     });
 
     const overflow_mod = b.createModule(.{
-        .root_source_file = b.path("src/utils/overflow.zig"),
+        .root_source_file = b.path("zig/src/utils/overflow.zig"),
         .target = target,
         .optimize = optimize,
         .imports = &.{
@@ -172,7 +172,7 @@ pub fn build(b: *std.Build) void {
     });
 
     const retry_mod = b.createModule(.{
-        .root_source_file = b.path("src/utils/retry.zig"),
+        .root_source_file = b.path("zig/src/utils/retry.zig"),
         .target = target,
         .optimize = optimize,
         .imports = &.{
@@ -181,19 +181,19 @@ pub fn build(b: *std.Build) void {
     });
 
     const oom_mod = b.createModule(.{
-        .root_source_file = b.path("src/utils/oom.zig"),
+        .root_source_file = b.path("zig/src/utils/oom.zig"),
         .target = target,
         .optimize = optimize,
     });
 
     const sanitize_mod = b.createModule(.{
-        .root_source_file = b.path("src/utils/sanitize.zig"),
+        .root_source_file = b.path("zig/src/utils/sanitize.zig"),
         .target = target,
         .optimize = optimize,
     });
 
     const pre_transform_mod = b.createModule(.{
-        .root_source_file = b.path("src/utils/pre_transform.zig"),
+        .root_source_file = b.path("zig/src/utils/pre_transform.zig"),
         .target = target,
         .optimize = optimize,
         .imports = &.{
@@ -204,7 +204,7 @@ pub fn build(b: *std.Build) void {
     });
 
     const test_helpers_mod = b.createModule(.{
-        .root_source_file = b.path("test/e2e/test_helpers.zig"),
+        .root_source_file = b.path("zig/test/e2e/test_helpers.zig"),
         .target = target,
         .optimize = optimize,
         .imports = &.{
@@ -217,7 +217,7 @@ pub fn build(b: *std.Build) void {
     });
 
     const oauth_pkce_mod = b.createModule(.{
-        .root_source_file = b.path("src/oauth/pkce.zig"),
+        .root_source_file = b.path("zig/src/oauth/pkce.zig"),
         .target = target,
         .optimize = optimize,
         .imports = &.{
@@ -226,7 +226,7 @@ pub fn build(b: *std.Build) void {
     });
 
     const openai_completions_api_mod = b.createModule(.{
-        .root_source_file = b.path("src/providers/openai_completions_api.zig"),
+        .root_source_file = b.path("zig/src/providers/openai_completions_api.zig"),
         .target = target,
         .optimize = optimize,
         .imports = &.{
@@ -247,7 +247,7 @@ pub fn build(b: *std.Build) void {
     });
 
     const anthropic_messages_api_mod = b.createModule(.{
-        .root_source_file = b.path("src/providers/anthropic_messages_api.zig"),
+        .root_source_file = b.path("zig/src/providers/anthropic_messages_api.zig"),
         .target = target,
         .optimize = optimize,
         .imports = &.{
@@ -268,7 +268,7 @@ pub fn build(b: *std.Build) void {
     });
 
     const openai_responses_api_mod = b.createModule(.{
-        .root_source_file = b.path("src/providers/openai_responses_api.zig"),
+        .root_source_file = b.path("zig/src/providers/openai_responses_api.zig"),
         .target = target,
         .optimize = optimize,
         .imports = &.{
@@ -287,7 +287,7 @@ pub fn build(b: *std.Build) void {
     });
 
     const azure_openai_responses_api_mod = b.createModule(.{
-        .root_source_file = b.path("src/providers/azure_openai_responses_api.zig"),
+        .root_source_file = b.path("zig/src/providers/azure_openai_responses_api.zig"),
         .target = target,
         .optimize = optimize,
         .imports = &.{
@@ -301,7 +301,7 @@ pub fn build(b: *std.Build) void {
     });
 
     const google_generative_api_mod = b.createModule(.{
-        .root_source_file = b.path("src/providers/google_generative_api.zig"),
+        .root_source_file = b.path("zig/src/providers/google_generative_api.zig"),
         .target = target,
         .optimize = optimize,
         .imports = &.{
@@ -320,7 +320,7 @@ pub fn build(b: *std.Build) void {
     });
 
     const google_vertex_api_mod = b.createModule(.{
-        .root_source_file = b.path("src/providers/google_vertex_api.zig"),
+        .root_source_file = b.path("zig/src/providers/google_vertex_api.zig"),
         .target = target,
         .optimize = optimize,
         .imports = &.{
@@ -338,7 +338,7 @@ pub fn build(b: *std.Build) void {
     });
 
     const ollama_api_mod = b.createModule(.{
-        .root_source_file = b.path("src/providers/ollama_api.zig"),
+        .root_source_file = b.path("zig/src/providers/ollama_api.zig"),
         .target = target,
         .optimize = optimize,
         .imports = &.{
@@ -356,7 +356,7 @@ pub fn build(b: *std.Build) void {
     });
 
     const register_builtins_mod = b.createModule(.{
-        .root_source_file = b.path("src/register_builtins.zig"),
+        .root_source_file = b.path("zig/src/register_builtins.zig"),
         .target = target,
         .optimize = optimize,
         .imports = &.{
@@ -371,7 +371,7 @@ pub fn build(b: *std.Build) void {
     });
 
     const stream_mod = b.createModule(.{
-        .root_source_file = b.path("src/stream.zig"),
+        .root_source_file = b.path("zig/src/stream.zig"),
         .target = target,
         .optimize = optimize,
         .imports = &.{
@@ -382,7 +382,7 @@ pub fn build(b: *std.Build) void {
     });
 
     const transport_mod = b.createModule(.{
-        .root_source_file = b.path("src/transport.zig"),
+        .root_source_file = b.path("zig/src/transport.zig"),
         .target = target,
         .optimize = optimize,
         .imports = &.{
@@ -394,7 +394,7 @@ pub fn build(b: *std.Build) void {
     });
 
     const stdio_transport_mod = b.createModule(.{
-        .root_source_file = b.path("src/transports/stdio.zig"),
+        .root_source_file = b.path("zig/src/transports/stdio.zig"),
         .target = target,
         .optimize = optimize,
         .imports = &.{
@@ -404,7 +404,7 @@ pub fn build(b: *std.Build) void {
     });
 
     const sse_transport_mod = b.createModule(.{
-        .root_source_file = b.path("src/transports/sse.zig"),
+        .root_source_file = b.path("zig/src/transports/sse.zig"),
         .target = target,
         .optimize = optimize,
         .imports = &.{
@@ -415,7 +415,7 @@ pub fn build(b: *std.Build) void {
     });
 
     const websocket_transport_mod = b.createModule(.{
-        .root_source_file = b.path("src/transports/websocket.zig"),
+        .root_source_file = b.path("zig/src/transports/websocket.zig"),
         .target = target,
         .optimize = optimize,
         .imports = &.{
@@ -426,7 +426,7 @@ pub fn build(b: *std.Build) void {
     });
 
     const in_process_transport_mod = b.createModule(.{
-        .root_source_file = b.path("src/transports/in_process.zig"),
+        .root_source_file = b.path("zig/src/transports/in_process.zig"),
         .target = target,
         .optimize = optimize,
         .imports = &.{
@@ -439,7 +439,7 @@ pub fn build(b: *std.Build) void {
     });
 
     const transport_retry_mod = b.createModule(.{
-        .root_source_file = b.path("src/transports/transport_retry.zig"),
+        .root_source_file = b.path("zig/src/transports/transport_retry.zig"),
         .target = target,
         .optimize = optimize,
         .imports = &.{
@@ -452,12 +452,12 @@ pub fn build(b: *std.Build) void {
 
     // Standalone protocol helper modules (no runtime wiring in M-003 scope).
     const protocol_model_ref_mod = b.createModule(.{
-        .root_source_file = b.path("src/protocol/model_ref.zig"),
+        .root_source_file = b.path("zig/src/protocol/model_ref.zig"),
         .target = target,
         .optimize = optimize,
     });
     const protocol_model_catalog_types_mod = b.createModule(.{
-        .root_source_file = b.path("src/protocol/model_catalog_types.zig"),
+        .root_source_file = b.path("zig/src/protocol/model_catalog_types.zig"),
         .target = target,
         .optimize = optimize,
         .imports = &.{
@@ -469,7 +469,7 @@ pub fn build(b: *std.Build) void {
     // Protocol Provider Modules (protocol/provider/)
     // =========================================================================
     const content_partial_mod = b.createModule(.{
-        .root_source_file = b.path("src/protocol/provider/content_partial.zig"),
+        .root_source_file = b.path("zig/src/protocol/provider/content_partial.zig"),
         .target = target,
         .optimize = optimize,
         .imports = &.{
@@ -479,7 +479,7 @@ pub fn build(b: *std.Build) void {
     });
 
     const partial_serializer_mod = b.createModule(.{
-        .root_source_file = b.path("src/protocol/provider/partial_serializer.zig"),
+        .root_source_file = b.path("zig/src/protocol/provider/partial_serializer.zig"),
         .target = target,
         .optimize = optimize,
         .imports = &.{
@@ -491,7 +491,7 @@ pub fn build(b: *std.Build) void {
     });
 
     const protocol_types_mod = b.createModule(.{
-        .root_source_file = b.path("src/protocol/provider/types.zig"),
+        .root_source_file = b.path("zig/src/protocol/provider/types.zig"),
         .target = target,
         .optimize = optimize,
         .imports = &.{
@@ -503,7 +503,7 @@ pub fn build(b: *std.Build) void {
     });
 
     const protocol_envelope_mod = b.createModule(.{
-        .root_source_file = b.path("src/protocol/provider/envelope.zig"),
+        .root_source_file = b.path("zig/src/protocol/provider/envelope.zig"),
         .target = target,
         .optimize = optimize,
         .imports = &.{
@@ -516,7 +516,7 @@ pub fn build(b: *std.Build) void {
     });
 
     const partial_reconstructor_mod = b.createModule(.{
-        .root_source_file = b.path("src/protocol/provider/partial_reconstructor.zig"),
+        .root_source_file = b.path("zig/src/protocol/provider/partial_reconstructor.zig"),
         .target = target,
         .optimize = optimize,
         .imports = &.{
@@ -528,7 +528,7 @@ pub fn build(b: *std.Build) void {
     });
 
     const protocol_server_mod = b.createModule(.{
-        .root_source_file = b.path("src/protocol/provider/server.zig"),
+        .root_source_file = b.path("zig/src/protocol/provider/server.zig"),
         .target = target,
         .optimize = optimize,
         .imports = &.{
@@ -552,7 +552,7 @@ pub fn build(b: *std.Build) void {
     });
 
     const protocol_client_mod = b.createModule(.{
-        .root_source_file = b.path("src/protocol/provider/client.zig"),
+        .root_source_file = b.path("zig/src/protocol/provider/client.zig"),
         .target = target,
         .optimize = optimize,
         .imports = &.{
@@ -572,7 +572,7 @@ pub fn build(b: *std.Build) void {
     });
 
     const protocol_runtime_mod = b.createModule(.{
-        .root_source_file = b.path("src/protocol/provider/runtime.zig"),
+        .root_source_file = b.path("zig/src/protocol/provider/runtime.zig"),
         .target = target,
         .optimize = optimize,
         .imports = &.{
@@ -588,7 +588,7 @@ pub fn build(b: *std.Build) void {
     // Protocol Agent Modules (protocol/agent/)
     // =========================================================================
     const protocol_agent_types_mod = b.createModule(.{
-        .root_source_file = b.path("src/protocol/agent/types.zig"),
+        .root_source_file = b.path("zig/src/protocol/agent/types.zig"),
         .target = target,
         .optimize = optimize,
         .imports = &.{
@@ -599,7 +599,7 @@ pub fn build(b: *std.Build) void {
     });
 
     const protocol_agent_envelope_mod = b.createModule(.{
-        .root_source_file = b.path("src/protocol/agent/envelope.zig"),
+        .root_source_file = b.path("zig/src/protocol/agent/envelope.zig"),
         .target = target,
         .optimize = optimize,
         .imports = &.{
@@ -612,7 +612,7 @@ pub fn build(b: *std.Build) void {
     });
 
     const protocol_agent_server_mod = b.createModule(.{
-        .root_source_file = b.path("src/protocol/agent/server.zig"),
+        .root_source_file = b.path("zig/src/protocol/agent/server.zig"),
         .target = target,
         .optimize = optimize,
         .imports = &.{
@@ -623,7 +623,7 @@ pub fn build(b: *std.Build) void {
     });
 
     const protocol_agent_client_mod = b.createModule(.{
-        .root_source_file = b.path("src/protocol/agent/client.zig"),
+        .root_source_file = b.path("zig/src/protocol/agent/client.zig"),
         .target = target,
         .optimize = optimize,
         .imports = &.{
@@ -636,7 +636,7 @@ pub fn build(b: *std.Build) void {
     });
 
     const protocol_agent_runtime_mod = b.createModule(.{
-        .root_source_file = b.path("src/protocol/agent/runtime.zig"),
+        .root_source_file = b.path("zig/src/protocol/agent/runtime.zig"),
         .target = target,
         .optimize = optimize,
         .imports = &.{
@@ -651,7 +651,7 @@ pub fn build(b: *std.Build) void {
     // Protocol Auth Modules (protocol/auth/)
     // =========================================================================
     const protocol_auth_types_mod = b.createModule(.{
-        .root_source_file = b.path("src/protocol/auth/types.zig"),
+        .root_source_file = b.path("zig/src/protocol/auth/types.zig"),
         .target = target,
         .optimize = optimize,
         .imports = &.{
@@ -661,7 +661,7 @@ pub fn build(b: *std.Build) void {
     });
 
     const protocol_auth_envelope_mod = b.createModule(.{
-        .root_source_file = b.path("src/protocol/auth/envelope.zig"),
+        .root_source_file = b.path("zig/src/protocol/auth/envelope.zig"),
         .target = target,
         .optimize = optimize,
         .imports = &.{
@@ -673,7 +673,7 @@ pub fn build(b: *std.Build) void {
     });
 
     const protocol_auth_server_mod = b.createModule(.{
-        .root_source_file = b.path("src/protocol/auth/server.zig"),
+        .root_source_file = b.path("zig/src/protocol/auth/server.zig"),
         .target = target,
         .optimize = optimize,
         .imports = &.{
@@ -688,7 +688,7 @@ pub fn build(b: *std.Build) void {
     });
 
     const protocol_auth_runtime_mod = b.createModule(.{
-        .root_source_file = b.path("src/protocol/auth/runtime.zig"),
+        .root_source_file = b.path("zig/src/protocol/auth/runtime.zig"),
         .target = target,
         .optimize = optimize,
         .imports = &.{
@@ -702,7 +702,7 @@ pub fn build(b: *std.Build) void {
     // Protocol Tool Modules (protocol/tool/)
     // =========================================================================
     const protocol_tool_types_mod = b.createModule(.{
-        .root_source_file = b.path("src/protocol/tool/types.zig"),
+        .root_source_file = b.path("zig/src/protocol/tool/types.zig"),
         .target = target,
         .optimize = optimize,
         .imports = &.{
@@ -712,7 +712,7 @@ pub fn build(b: *std.Build) void {
     });
 
     const protocol_tool_envelope_mod = b.createModule(.{
-        .root_source_file = b.path("src/protocol/tool/envelope.zig"),
+        .root_source_file = b.path("zig/src/protocol/tool/envelope.zig"),
         .target = target,
         .optimize = optimize,
         .imports = &.{
@@ -724,7 +724,7 @@ pub fn build(b: *std.Build) void {
     });
 
     const protocol_tool_runtime_mod = b.createModule(.{
-        .root_source_file = b.path("src/protocol/tool/runtime.zig"),
+        .root_source_file = b.path("zig/src/protocol/tool/runtime.zig"),
         .target = target,
         .optimize = optimize,
         .imports = &.{
@@ -736,7 +736,7 @@ pub fn build(b: *std.Build) void {
 
     // Agent modules
     const agent_types_mod = b.createModule(.{
-        .root_source_file = b.path("src/agent/types.zig"),
+        .root_source_file = b.path("zig/src/agent/types.zig"),
         .target = target,
         .optimize = optimize,
         .imports = &.{
@@ -748,7 +748,7 @@ pub fn build(b: *std.Build) void {
     });
 
     const agent_loop_mod = b.createModule(.{
-        .root_source_file = b.path("src/agent/agent_loop.zig"),
+        .root_source_file = b.path("zig/src/agent/agent_loop.zig"),
         .target = target,
         .optimize = optimize,
         .imports = &.{
@@ -761,7 +761,7 @@ pub fn build(b: *std.Build) void {
     });
 
     const agent_mod = b.createModule(.{
-        .root_source_file = b.path("src/agent/mod.zig"),
+        .root_source_file = b.path("zig/src/agent/mod.zig"),
         .target = target,
         .optimize = optimize,
         .imports = &.{
@@ -779,7 +779,7 @@ pub fn build(b: *std.Build) void {
     });
 
     const agent_provider_protocol_bridge_mod = b.createModule(.{
-        .root_source_file = b.path("src/agent/provider_protocol_bridge.zig"),
+        .root_source_file = b.path("zig/src/agent/provider_protocol_bridge.zig"),
         .target = target,
         .optimize = optimize,
         .imports = &.{
@@ -811,7 +811,7 @@ pub fn build(b: *std.Build) void {
 
     const api_registry_test = b.addTest(.{
         .root_module = b.createModule(.{
-            .root_source_file = b.path("src/api_registry.zig"),
+            .root_source_file = b.path("zig/src/api_registry.zig"),
             .target = target,
             .optimize = optimize,
             .imports = &.{
@@ -824,7 +824,7 @@ pub fn build(b: *std.Build) void {
 
     const stream_test = b.addTest(.{
         .root_module = b.createModule(.{
-            .root_source_file = b.path("src/stream.zig"),
+            .root_source_file = b.path("zig/src/stream.zig"),
             .target = target,
             .optimize = optimize,
             .imports = &.{
@@ -868,7 +868,7 @@ pub fn build(b: *std.Build) void {
 
     const oauth_test = b.addTest(.{
         .root_module = b.createModule(.{
-            .root_source_file = b.path("src/oauth/mod.zig"),
+            .root_source_file = b.path("zig/src/oauth/mod.zig"),
             .target = target,
             .optimize = optimize,
             .imports = &.{
@@ -880,7 +880,7 @@ pub fn build(b: *std.Build) void {
 
     const e2e_anthropic_test = b.addTest(.{
         .root_module = b.createModule(.{
-            .root_source_file = b.path("test/e2e/anthropic_api.zig"),
+            .root_source_file = b.path("zig/test/e2e/anthropic_api.zig"),
             .target = target,
             .optimize = optimize,
             .imports = &.{
@@ -896,7 +896,7 @@ pub fn build(b: *std.Build) void {
 
     const e2e_openai_test = b.addTest(.{
         .root_module = b.createModule(.{
-            .root_source_file = b.path("test/e2e/openai_api.zig"),
+            .root_source_file = b.path("zig/test/e2e/openai_api.zig"),
             .target = target,
             .optimize = optimize,
             .imports = &.{
@@ -913,7 +913,7 @@ pub fn build(b: *std.Build) void {
 
     const e2e_azure_test = b.addTest(.{
         .root_module = b.createModule(.{
-            .root_source_file = b.path("test/e2e/azure_api.zig"),
+            .root_source_file = b.path("zig/test/e2e/azure_api.zig"),
             .target = target,
             .optimize = optimize,
             .imports = &.{
@@ -929,7 +929,7 @@ pub fn build(b: *std.Build) void {
 
     const e2e_google_test = b.addTest(.{
         .root_module = b.createModule(.{
-            .root_source_file = b.path("test/e2e/google_api.zig"),
+            .root_source_file = b.path("zig/test/e2e/google_api.zig"),
             .target = target,
             .optimize = optimize,
             .imports = &.{
@@ -945,7 +945,7 @@ pub fn build(b: *std.Build) void {
 
     const e2e_ollama_test = b.addTest(.{
         .root_module = b.createModule(.{
-            .root_source_file = b.path("test/e2e/ollama_api.zig"),
+            .root_source_file = b.path("zig/test/e2e/ollama_api.zig"),
             .target = target,
             .optimize = optimize,
             .imports = &.{
@@ -962,7 +962,7 @@ pub fn build(b: *std.Build) void {
     // Provider Protocol Fullstack E2E tests - Ollama
     const e2e_provider_protocol_fullstack_ollama_test = b.addTest(.{
         .root_module = b.createModule(.{
-            .root_source_file = b.path("test/e2e/provider_protocol_fullstack_ollama.zig"),
+            .root_source_file = b.path("zig/test/e2e/provider_protocol_fullstack_ollama.zig"),
             .target = target,
             .optimize = optimize,
             .imports = &.{
@@ -983,7 +983,7 @@ pub fn build(b: *std.Build) void {
     // Provider Protocol Fullstack E2E tests - GitHub Copilot
     const e2e_provider_protocol_fullstack_github_test = b.addTest(.{
         .root_module = b.createModule(.{
-            .root_source_file = b.path("test/e2e/provider_protocol_fullstack_github.zig"),
+            .root_source_file = b.path("zig/test/e2e/provider_protocol_fullstack_github.zig"),
             .target = target,
             .optimize = optimize,
             .imports = &.{
@@ -1005,7 +1005,7 @@ pub fn build(b: *std.Build) void {
     // Uses protocol_types as the root module to avoid conflict with server's local types.zig import
     const e2e_protocol_test = b.addTest(.{
         .root_module = b.createModule(.{
-            .root_source_file = b.path("test/e2e/protocol.zig"),
+            .root_source_file = b.path("zig/test/e2e/protocol.zig"),
             .target = target,
             .optimize = optimize,
             .imports = &.{
@@ -1021,7 +1021,7 @@ pub fn build(b: *std.Build) void {
 
     const e2e_distributed_fullstack_test = b.addTest(.{
         .root_module = b.createModule(.{
-            .root_source_file = b.path("test/e2e/distributed_fullstack.zig"),
+            .root_source_file = b.path("zig/test/e2e/distributed_fullstack.zig"),
             .target = target,
             .optimize = optimize,
             .imports = &.{
@@ -1046,7 +1046,7 @@ pub fn build(b: *std.Build) void {
 
     const e2e_distributed_fullstack_github_test = b.addTest(.{
         .root_module = b.createModule(.{
-            .root_source_file = b.path("test/e2e/distributed_fullstack_github.zig"),
+            .root_source_file = b.path("zig/test/e2e/distributed_fullstack_github.zig"),
             .target = target,
             .optimize = optimize,
             .imports = &.{
@@ -1130,7 +1130,7 @@ pub fn build(b: *std.Build) void {
 
     const agent_test = b.addTest(.{
         .root_module = b.createModule(.{
-            .root_source_file = b.path("test/unit/agent.zig"),
+            .root_source_file = b.path("zig/test/unit/agent.zig"),
             .target = target,
             .optimize = optimize,
             .imports = &.{
@@ -1145,7 +1145,7 @@ pub fn build(b: *std.Build) void {
 
     const agent_protocol_chain_test = b.addTest(.{
         .root_module = b.createModule(.{
-            .root_source_file = b.path("test/unit/agent_protocol_chain.zig"),
+            .root_source_file = b.path("zig/test/unit/agent_protocol_chain.zig"),
             .target = target,
             .optimize = optimize,
             .imports = &.{
@@ -1170,7 +1170,7 @@ pub fn build(b: *std.Build) void {
     // tests can exercise it with in-memory IO without dragging in the entire
     // `makai.zig` surface.
     const auth_cli_mod = b.createModule(.{
-        .root_source_file = b.path("src/tools/auth_cli.zig"),
+        .root_source_file = b.path("zig/src/tools/auth_cli.zig"),
         .target = target,
         .optimize = optimize,
         .imports = &.{
@@ -1184,7 +1184,7 @@ pub fn build(b: *std.Build) void {
     });
 
     const makai_cli_module = b.createModule(.{
-        .root_source_file = b.path("src/tools/makai.zig"),
+        .root_source_file = b.path("zig/src/tools/makai.zig"),
         .target = target,
         .optimize = optimize,
         .imports = &.{
@@ -1416,7 +1416,7 @@ pub fn build(b: *std.Build) void {
     // GitHub Copilot E2E tests
     const e2e_github_copilot_test = b.addTest(.{
         .root_module = b.createModule(.{
-            .root_source_file = b.path("test/e2e/github_copilot_api.zig"),
+            .root_source_file = b.path("zig/test/e2e/github_copilot_api.zig"),
             .target = target,
             .optimize = optimize,
             .imports = &.{
@@ -1459,4 +1459,14 @@ pub fn build(b: *std.Build) void {
 
     const test_protocol_types_step = b.step("test-protocol-types", "Run protocol types tests");
     test_protocol_types_step.dependOn(&b.addRunArtifact(protocol_types_test).step);
+
+    // Expose modules for consumers via `b.dependency("makai", .{}).module("...")`
+    b.modules.put(b.allocator, b.dupe("ai_types"), ai_types_mod) catch @panic("OOM");
+    b.modules.put(b.allocator, b.dupe("event_stream"), event_stream_mod) catch @panic("OOM");
+    b.modules.put(b.allocator, b.dupe("stream"), stream_mod) catch @panic("OOM");
+    b.modules.put(b.allocator, b.dupe("api_registry"), api_registry_mod) catch @panic("OOM");
+    b.modules.put(b.allocator, b.dupe("register_builtins"), register_builtins_mod) catch @panic("OOM");
+    b.modules.put(b.allocator, b.dupe("transport"), transport_mod) catch @panic("OOM");
+    b.modules.put(b.allocator, b.dupe("protocol_runtime"), protocol_runtime_mod) catch @panic("OOM");
+    b.modules.put(b.allocator, b.dupe("agent"), agent_mod) catch @panic("OOM");
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -7,6 +7,7 @@
         "build.zig.zon",
         "zig",
         "docs",
+        "CHANGELOG.md",
     },
     .fingerprint = 0x2810735ca1ee9efd,
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,0 +1,12 @@
+.{
+    .name = .makai,
+    .version = "0.1.0",
+    .dependencies = .{},
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "zig",
+        "docs",
+    },
+    .fingerprint = 0x2810735ca1ee9efd,
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,21 +1,46 @@
 {
   "name": "makai",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "makai",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "license": "ISC",
       "dependencies": {
         "nanoid": "^5.1.5",
         "ulid": "^3.0.2"
       },
+      "bin": {
+        "makai": "bin/makai.js"
+      },
       "devDependencies": {
         "@types/node": "^24.0.0",
         "typescript": "^5.8.3"
+      },
+      "optionalDependencies": {
+        "@makai/cli-darwin-arm64": "0.1.0",
+        "@makai/cli-darwin-x64": "0.1.0",
+        "@makai/cli-linux-arm64": "0.1.0",
+        "@makai/cli-linux-x64": "0.1.0",
+        "@makai/cli-win32-x64": "0.1.0"
       }
+    },
+    "node_modules/@makai/cli-darwin-arm64": {
+      "optional": true
+    },
+    "node_modules/@makai/cli-darwin-x64": {
+      "optional": true
+    },
+    "node_modules/@makai/cli-linux-arm64": {
+      "optional": true
+    },
+    "node_modules/@makai/cli-linux-x64": {
+      "optional": true
+    },
+    "node_modules/@makai/cli-win32-x64": {
+      "optional": true
     },
     "node_modules/@types/node": {
       "version": "24.10.13",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "type": "commonjs",
   "files": [
     "dist/src/**/*",
-    "typescript/README.md"
+    "README.md"
   ],
   "devDependencies": {
     "@types/node": "^24.0.0",

--- a/package.json
+++ b/package.json
@@ -19,10 +19,21 @@
   "author": "makai contributors",
   "license": "ISC",
   "type": "commonjs",
+  "bin": {
+    "makai": "bin/makai.js"
+  },
   "files": [
     "dist/src/**/*",
+    "bin/makai.js",
     "README.md"
   ],
+  "optionalDependencies": {
+    "@makai/cli-darwin-arm64": "0.1.0",
+    "@makai/cli-darwin-x64": "0.1.0",
+    "@makai/cli-linux-arm64": "0.1.0",
+    "@makai/cli-linux-x64": "0.1.0",
+    "@makai/cli-win32-x64": "0.1.0"
+  },
   "devDependencies": {
     "@types/node": "^24.0.0",
     "typescript": "^5.8.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "makai",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "TypeScript SDK for Makai stdio client transport",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -19,6 +19,10 @@
   "author": "makai contributors",
   "license": "ISC",
   "type": "commonjs",
+  "files": [
+    "dist/src/**/*",
+    "typescript/README.md"
+  ],
   "devDependencies": {
     "@types/node": "^24.0.0",
     "typescript": "^5.8.3"

--- a/scripts/package-npm.ts
+++ b/scripts/package-npm.ts
@@ -23,7 +23,7 @@ const PLATFORMS = [
   { target: "darwin-x64", os: "darwin", cpu: "x64", binary: "makai-darwin-x64" },
   { target: "linux-arm64", os: "linux", cpu: "arm64", binary: "makai-linux-arm64" },
   { target: "linux-x64", os: "linux", cpu: "x64", binary: "makai-linux-x64" },
-  { target: "win32-x64", os: "win32", cpu: "x64", binary: "makai.exe" },
+  { target: "win32-x64", os: "win32", cpu: "x64", binary: "makai-win32-x64" },
 ];
 
 console.log(`Packaging npm packages (version ${VERSION})...\n`);
@@ -38,14 +38,12 @@ for (const { target, os, cpu, binary } of PLATFORMS) {
   const srcBinary = join(BIN_DIR, binary);
   const destBinary = join(binDir, os === "win32" ? "makai.exe" : "makai");
 
-  try {
-    copyFileSync(srcBinary, destBinary);
-    if (os !== "win32") {
-      chmodSync(destBinary, 0o755);
-    }
-  } catch {
-    console.warn(`  Warning: Binary not found: ${srcBinary} (skipping ${pkgName})`);
-    continue;
+  if (!require("fs").existsSync(srcBinary)) {
+    throw new Error(`Binary not found: ${srcBinary} (required for ${pkgName})`);
+  }
+  copyFileSync(srcBinary, destBinary);
+  if (os !== "win32") {
+    chmodSync(destBinary, 0o755);
   }
 
   writeFileSync(
@@ -88,8 +86,16 @@ mkdirSync(destSrcDir, { recursive: true });
 
 // Read existing package.json and update for packaging
 const mainPkg = JSON.parse(readFileSync(join(ROOT, "package.json"), "utf-8"));
+mainPkg.version = VERSION;
 mainPkg.bin = { makai: "makai.js" };
 mainPkg.files = ["dist/src/", "makai.js", "README.md"];
+if (mainPkg.optionalDependencies) {
+  for (const dep of Object.keys(mainPkg.optionalDependencies)) {
+    if (dep.startsWith("@makai/cli-")) {
+      mainPkg.optionalDependencies[dep] = VERSION;
+    }
+  }
+}
 
 writeFileSync(
   join(mainDir, "package.json"),

--- a/scripts/package-npm.ts
+++ b/scripts/package-npm.ts
@@ -1,0 +1,124 @@
+/**
+ * Assembles npm packages from compiled binaries.
+ * Takes binaries from dist/bin/ and creates publishable packages in dist/npm/.
+ *
+ * Usage: node scripts/package-npm.ts [--version 0.1.0]
+ */
+
+import { mkdirSync, copyFileSync, writeFileSync, chmodSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const ROOT = process.cwd();
+const BIN_DIR = join(ROOT, "dist", "bin");
+const NPM_DIR = join(ROOT, "dist", "npm");
+
+const versionIdx = process.argv.indexOf("--version");
+const VERSION =
+  versionIdx !== -1
+    ? process.argv[versionIdx + 1]
+    : JSON.parse(readFileSync(join(ROOT, "package.json"), "utf-8")).version;
+
+const PLATFORMS = [
+  { target: "darwin-arm64", os: "darwin", cpu: "arm64", binary: "makai-darwin-arm64" },
+  { target: "darwin-x64", os: "darwin", cpu: "x64", binary: "makai-darwin-x64" },
+  { target: "linux-arm64", os: "linux", cpu: "arm64", binary: "makai-linux-arm64" },
+  { target: "linux-x64", os: "linux", cpu: "x64", binary: "makai-linux-x64" },
+  { target: "win32-x64", os: "win32", cpu: "x64", binary: "makai.exe" },
+];
+
+console.log(`Packaging npm packages (version ${VERSION})...\n`);
+
+for (const { target, os, cpu, binary } of PLATFORMS) {
+  const pkgName = `@makai/cli-${target}`;
+  const pkgDir = join(NPM_DIR, `cli-${target}`);
+  const binDir = join(pkgDir, "bin");
+
+  mkdirSync(binDir, { recursive: true });
+
+  const srcBinary = join(BIN_DIR, binary);
+  const destBinary = join(binDir, os === "win32" ? "makai.exe" : "makai");
+
+  try {
+    copyFileSync(srcBinary, destBinary);
+    if (os !== "win32") {
+      chmodSync(destBinary, 0o755);
+    }
+  } catch {
+    console.warn(`  Warning: Binary not found: ${srcBinary} (skipping ${pkgName})`);
+    continue;
+  }
+
+  writeFileSync(
+    join(pkgDir, "package.json"),
+    JSON.stringify(
+      {
+        name: pkgName,
+        version: VERSION,
+        description: `Makai binary for ${os} ${cpu}`,
+        os: [os],
+        cpu: [cpu],
+        bin: { makai: os === "win32" ? "bin/makai.exe" : "bin/makai" },
+        files: ["bin/"],
+        license: "ISC",
+        repository: {
+          type: "git",
+          url: "https://github.com/lsm/makai",
+        },
+      },
+      null,
+      2
+    )
+  );
+
+  console.log(`  Created ${pkgName}`);
+}
+
+// Create main makai package
+const mainDir = join(NPM_DIR, "makai");
+mkdirSync(mainDir, { recursive: true });
+
+// Copy launcher script
+copyFileSync(join(ROOT, "bin", "makai.js"), join(mainDir, "makai.js"));
+chmodSync(join(mainDir, "makai.js"), 0o755);
+
+// Copy SDK files
+const srcDir = join(ROOT, "dist", "src");
+const destSrcDir = join(mainDir, "dist", "src");
+mkdirSync(destSrcDir, { recursive: true });
+
+// Read existing package.json and update for packaging
+const mainPkg = JSON.parse(readFileSync(join(ROOT, "package.json"), "utf-8"));
+mainPkg.bin = { makai: "makai.js" };
+mainPkg.files = ["dist/src/", "makai.js", "README.md"];
+
+writeFileSync(
+  join(mainDir, "package.json"),
+  JSON.stringify(mainPkg, null, 2)
+);
+
+// Copy dist/src contents
+function copyDir(src: string, dest: string) {
+  mkdirSync(dest, { recursive: true });
+  for (const entry of require("fs").readdirSync(src, { withFileTypes: true })) {
+    const srcPath = join(src, entry.name);
+    const destPath = join(dest, entry.name);
+    if (entry.isDirectory()) {
+      copyDir(srcPath, destPath);
+    } else {
+      copyFileSync(srcPath, destPath);
+    }
+  }
+}
+copyDir(srcDir, destSrcDir);
+
+// Copy README
+copyFileSync(join(ROOT, "README.md"), join(mainDir, "README.md"));
+
+console.log(`  Created makai (main package)`);
+
+console.log(`\nAll packages created in ${NPM_DIR}`);
+console.log(`\nTo publish, run:`);
+for (const { target } of PLATFORMS) {
+  console.log(`  cd dist/npm/cli-${target} && npm publish --access public`);
+}
+console.log(`  cd dist/npm/makai && npm publish --access public`);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
+    "declaration": true,
     "types": ["node"],
     "rootDir": "typescript",
     "outDir": "dist"

--- a/typescript/src/binary_resolver.ts
+++ b/typescript/src/binary_resolver.ts
@@ -174,7 +174,8 @@ export async function resolveMakaiBinary(options: BinaryResolverOptions = {}): P
   const platformKey = `${process.platform}-${process.arch}`;
   const bundledPackage = `@makai/cli-${platformKey}`;
   try {
-    const bundledPath = require.resolve(`${bundledPackage}/bin/makai`);
+    const bundledBinaryName = process.platform === "win32" ? "makai.exe" : "makai";
+    const bundledPath = require.resolve(`${bundledPackage}/bin/${bundledBinaryName}`);
     logger.debug("binary: resolved from bundled package", { path: bundledPath, package: bundledPackage });
     return bundledPath;
   } catch {

--- a/typescript/src/binary_resolver.ts
+++ b/typescript/src/binary_resolver.ts
@@ -169,6 +169,18 @@ export async function resolveMakaiBinary(options: BinaryResolverOptions = {}): P
   }
 
   const binaryName = binaryNameForPlatform();
+
+  // Check bundled platform-specific package first
+  const platformKey = `${process.platform}-${process.arch}`;
+  const bundledPackage = `@makai/cli-${platformKey}`;
+  try {
+    const bundledPath = require.resolve(`${bundledPackage}/bin/makai`);
+    logger.debug("binary: resolved from bundled package", { path: bundledPath, package: bundledPackage });
+    return bundledPath;
+  } catch {
+    logger.debug("binary: bundled package not found", { package: bundledPackage });
+  }
+
   const localCandidates = [
     path.resolve(process.cwd(), "zig-out", "bin", binaryName),
     path.resolve(process.cwd(), "zig", "zig-out", "bin", binaryName),

--- a/zig/build.zig.zon
+++ b/zig/build.zig.zon
@@ -1,7 +1,0 @@
-.{
-    .name = .zig,
-    .version = "0.16.0",
-    .dependencies = .{},
-    .paths = .{""},
-    .fingerprint = 0xc1ce1081631dd09f,
-}


### PR DESCRIPTION
## Summary

Prepares makai for first release (v0.1.0) with fixes for both the Zig core library and TypeScript SDK.

### TypeScript SDK
- Added `files` field to `package.json` so npm only ships `dist/src/` and `typescript/README.md`
- Added `declaration: true` to `tsconfig.json` so `.d.ts` files are generated
- Bumped version to `0.1.0`
- Fixed release workflow npm steps to run from repo root (where `package.json` lives)

### Zig packaging
- Moved `build.zig` and `build.zig.zon` to repo root so `zig fetch` works with GitHub archive URLs
- Updated all `b.path()` references from `src/` to `zig/src/` and `test/` to `zig/test/`
- Exposed public modules for consumers: `ai_types`, `event_stream`, `stream`, `api_registry`, `register_builtins`, `transport`, `protocol_runtime`, `agent`
- Added `paths` to `build.zig.zon` to control what gets included in the package

### CI
- Updated `.github/workflows/ci.yml` to run `zig build` from repo root
- Updated `.github/workflows/release-binaries.yml` to build from repo root

### CHANGELOG
- Added v0.1.0 entry with release notes

## Test plan
- [x] `npm pack --dry-run` only includes compiled JS, types, and README
- [x] `npm publish --dry-run` succeeds
- [x] `zig build test` passes from repo root
- [x] `zig fetch` works with tarball and consumer can import `ai_types` module