### PR TITLE
[codex] add token efficiency telemetry primitives

### DIFF
--- a/zig/src/agent/agent.zig
+++ b/zig/src/agent/agent.zig
@@ -598,22 +598,106 @@ pub const Agent = struct {
 
     fn cloneToolResultMessage(self: *Agent, msg: ai_types.ToolResultMessage) !ai_types.ToolResultMessage {
         var content = try self._allocator.alloc(ai_types.UserContentPart, msg.content.len);
+        var initialized: usize = 0;
+        errdefer {
+            for (content[0..initialized]) |*part| part.deinit(self._allocator);
+            self._allocator.free(content);
+        }
         for (msg.content, 0..) |c, i| {
             content[i] = .{ .text = .{ .text = try self._allocator.dupe(u8, c.text.text) } };
+            initialized += 1;
         }
 
         const details_json = if (msg.getDetailsJson()) |d|
             ai_types.OwnedSlice(u8).initOwned(try self._allocator.dupe(u8, d))
         else
             ai_types.OwnedSlice(u8).initBorrowed("");
+        errdefer {
+            var mutable = details_json;
+            mutable.deinit(self._allocator);
+        }
+
+        const artifacts = try self.cloneArtifactReferences(msg.artifacts.slice());
+        errdefer {
+            var mutable = ai_types.OwnedSlice(ai_types.ArtifactReference).initOwned(artifacts);
+            mutable.deinit(self._allocator);
+        }
+
+        const tool_call_id = try self._allocator.dupe(u8, msg.tool_call_id);
+        errdefer self._allocator.free(tool_call_id);
+        const tool_name = try self._allocator.dupe(u8, msg.tool_name);
+        errdefer self._allocator.free(tool_name);
 
         return .{
-            .tool_call_id = try self._allocator.dupe(u8, msg.tool_call_id),
-            .tool_name = try self._allocator.dupe(u8, msg.tool_name),
+            .tool_call_id = tool_call_id,
+            .tool_name = tool_name,
             .content = content,
             .details_json = details_json,
+            .artifacts = ai_types.OwnedSlice(ai_types.ArtifactReference).initOwned(artifacts),
             .is_error = msg.is_error,
             .timestamp = msg.timestamp,
+        };
+    }
+
+    fn cloneArtifactReferences(self: *Agent, artifacts: []const ai_types.ArtifactReference) ![]ai_types.ArtifactReference {
+        const cloned = try self._allocator.alloc(ai_types.ArtifactReference, artifacts.len);
+        var initialized: usize = 0;
+        errdefer {
+            for (cloned[0..initialized]) |*artifact| artifact.deinit(self._allocator);
+            self._allocator.free(cloned);
+        }
+
+        for (artifacts, 0..) |artifact, i| {
+            cloned[i] = try self.cloneArtifactReference(artifact);
+            initialized += 1;
+        }
+
+        return cloned;
+    }
+
+    fn cloneArtifactReference(self: *Agent, artifact: ai_types.ArtifactReference) !ai_types.ArtifactReference {
+        const artifact_id = try self._allocator.dupe(u8, artifact.artifact_id);
+        errdefer self._allocator.free(artifact_id);
+
+        const uri = if (artifact.getUri()) |value|
+            ai_types.OwnedSlice(u8).initOwned(try self._allocator.dupe(u8, value))
+        else
+            ai_types.OwnedSlice(u8).initBorrowed("");
+        errdefer {
+            var mutable = uri;
+            mutable.deinit(self._allocator);
+        }
+
+        const mime_type = if (artifact.getMimeType()) |value|
+            ai_types.OwnedSlice(u8).initOwned(try self._allocator.dupe(u8, value))
+        else
+            ai_types.OwnedSlice(u8).initBorrowed("");
+        errdefer {
+            var mutable = mime_type;
+            mutable.deinit(self._allocator);
+        }
+
+        const sha256 = if (artifact.getSha256()) |value|
+            ai_types.OwnedSlice(u8).initOwned(try self._allocator.dupe(u8, value))
+        else
+            ai_types.OwnedSlice(u8).initBorrowed("");
+        errdefer {
+            var mutable = sha256;
+            mutable.deinit(self._allocator);
+        }
+
+        const description = if (artifact.getDescription()) |value|
+            ai_types.OwnedSlice(u8).initOwned(try self._allocator.dupe(u8, value))
+        else
+            ai_types.OwnedSlice(u8).initBorrowed("");
+
+        return .{
+            .artifact_id = artifact_id,
+            .uri = uri,
+            .mime_type = mime_type,
+            .byte_size = artifact.byte_size,
+            .sha256 = sha256,
+            .description = description,
         };
     }
 

--- a/zig/src/agent/agent_loop.zig
+++ b/zig/src/agent/agent_loop.zig
@@ -16,6 +16,194 @@ pub const AgentToolResult = types.AgentToolResult;
 pub const ProtocolClient = types.ProtocolClient;
 pub const ProtocolOptions = types.ProtocolOptions;
 
+const ByteTokenEstimate = struct {
+    bytes: u64 = 0,
+    estimated_tokens: u64 = 0,
+};
+
+const ToolResultUsage = struct {
+    result_bytes: u64 = 0,
+    details_bytes: u64 = 0,
+    total_bytes: u64 = 0,
+    estimated_tokens: u64 = 0,
+    artifact_count: u32 = 0,
+};
+
+const ContextUsage = struct {
+    system_prompt: ByteTokenEstimate = .{},
+    messages: ByteTokenEstimate = .{},
+    tools: ByteTokenEstimate = .{},
+
+    fn totalBytes(self: ContextUsage) u64 {
+        return self.system_prompt.bytes + self.messages.bytes + self.tools.bytes;
+    }
+
+    fn totalEstimatedTokens(self: ContextUsage) u64 {
+        return self.system_prompt.estimated_tokens + self.messages.estimated_tokens + self.tools.estimated_tokens;
+    }
+};
+
+fn estimateTextTokens(len: usize) u64 {
+    if (len == 0) return 0;
+    return @intCast((len + 3) / 4);
+}
+
+fn addText(est: *ByteTokenEstimate, text: []const u8) void {
+    est.bytes += text.len;
+    est.estimated_tokens += estimateTextTokens(text.len);
+}
+
+fn addImage(est: *ByteTokenEstimate, image: ai_types.ImageContent) void {
+    est.bytes += image.data.len + image.mime_type.len;
+    est.estimated_tokens += 850;
+}
+
+fn estimateUserContentPart(part: ai_types.UserContentPart) ByteTokenEstimate {
+    var est: ByteTokenEstimate = .{};
+    switch (part) {
+        .text => |text| addText(&est, text.text),
+        .image => |image| addImage(&est, image),
+    }
+    return est;
+}
+
+fn estimateUserContentParts(parts: []const ai_types.UserContentPart) ByteTokenEstimate {
+    var est: ByteTokenEstimate = .{};
+    for (parts) |part| {
+        const part_est = estimateUserContentPart(part);
+        est.bytes += part_est.bytes;
+        est.estimated_tokens += part_est.estimated_tokens;
+    }
+    return est;
+}
+
+fn estimateAssistantContent(block: ai_types.AssistantContent) ByteTokenEstimate {
+    var est: ByteTokenEstimate = .{};
+    switch (block) {
+        .text => |text| addText(&est, text.text),
+        .thinking => |thinking| addText(&est, thinking.thinking),
+        .image => |image| addImage(&est, image),
+        .tool_call => |tool_call| {
+            addText(&est, tool_call.id);
+            addText(&est, tool_call.name);
+            addText(&est, tool_call.arguments_json);
+            est.estimated_tokens += 50;
+        },
+    }
+    return est;
+}
+
+fn estimateMessage(message: ai_types.Message) ByteTokenEstimate {
+    var est: ByteTokenEstimate = .{ .estimated_tokens = 5 };
+    switch (message) {
+        .user => |user| switch (user.content) {
+            .text => |text| addText(&est, text),
+            .parts => |parts| {
+                const parts_est = estimateUserContentParts(parts);
+                est.bytes += parts_est.bytes;
+                est.estimated_tokens += parts_est.estimated_tokens;
+            },
+        },
+        .assistant => |assistant| {
+            for (assistant.content) |block| {
+                const block_est = estimateAssistantContent(block);
+                est.bytes += block_est.bytes;
+                est.estimated_tokens += block_est.estimated_tokens;
+            }
+        },
+        .tool_result => |tool_result| {
+            addText(&est, tool_result.tool_call_id);
+            addText(&est, tool_result.tool_name);
+            const parts_est = estimateUserContentParts(tool_result.content);
+            est.bytes += parts_est.bytes;
+            est.estimated_tokens += parts_est.estimated_tokens;
+            if (tool_result.getDetailsJson()) |details| addText(&est, details);
+        },
+    }
+    return est;
+}
+
+fn estimateMessages(messages: []const ai_types.Message) ByteTokenEstimate {
+    var est: ByteTokenEstimate = .{};
+    for (messages) |message| {
+        const msg_est = estimateMessage(message);
+        est.bytes += msg_est.bytes;
+        est.estimated_tokens += msg_est.estimated_tokens;
+    }
+    return est;
+}
+
+fn estimateToolDefinitions(tools: ?[]const ai_types.Tool) ByteTokenEstimate {
+    var est: ByteTokenEstimate = .{};
+    const defs = tools orelse return est;
+    for (defs) |tool| {
+        addText(&est, tool.name);
+        addText(&est, tool.description);
+        addText(&est, tool.parameters_schema_json);
+        est.estimated_tokens += 12;
+    }
+    return est;
+}
+
+fn estimateContextUsage(context: ai_types.Context) ContextUsage {
+    const system_prompt = context.getSystemPrompt() orelse "";
+    return .{
+        .system_prompt = .{
+            .bytes = system_prompt.len,
+            .estimated_tokens = estimateTextTokens(system_prompt.len),
+        },
+        .messages = estimateMessages(context.messages),
+        .tools = estimateToolDefinitions(context.tools),
+    };
+}
+
+fn emitContextUsage(event_stream: *AgentEventStream, context: ai_types.Context) !void {
+    const usage = estimateContextUsage(context);
+    const system_prompt: []const u8 = context.getSystemPrompt() orelse "";
+    try event_stream.push(.{ .prompt_segment_usage = .{
+        .segment = .system_prompt,
+        .cache_role = .stable,
+        .bytes = usage.system_prompt.bytes,
+        .estimated_tokens = usage.system_prompt.estimated_tokens,
+        .item_count = if (system_prompt.len > 0) 1 else 0,
+    } });
+    try event_stream.push(.{ .prompt_segment_usage = .{
+        .segment = .tool_definitions,
+        .cache_role = .stable,
+        .bytes = usage.tools.bytes,
+        .estimated_tokens = usage.tools.estimated_tokens,
+        .item_count = if (context.tools) |tools| @intCast(tools.len) else 0,
+    } });
+    try event_stream.push(.{ .prompt_segment_usage = .{
+        .segment = .message_history,
+        .cache_role = .dynamic,
+        .bytes = usage.messages.bytes,
+        .estimated_tokens = usage.messages.estimated_tokens,
+        .item_count = @intCast(context.messages.len),
+    } });
+    try event_stream.push(.{ .context_usage = .{
+        .system_prompt_bytes = usage.system_prompt.bytes,
+        .message_bytes = usage.messages.bytes,
+        .tool_definition_bytes = usage.tools.bytes,
+        .total_bytes = usage.totalBytes(),
+        .estimated_tokens = usage.totalEstimatedTokens(),
+        .message_count = @intCast(context.messages.len),
+        .tool_count = if (context.tools) |tools| @intCast(tools.len) else 0,
+    } });
+}
+
+fn measureToolResult(result: AgentToolResult) ToolResultUsage {
+    const content = estimateUserContentParts(result.content.slice());
+    const details_bytes: u64 = if (result.getDetailsJson()) |details| details.len else 0;
+    return .{
+        .result_bytes = content.bytes,
+        .details_bytes = details_bytes,
+        .total_bytes = content.bytes + details_bytes,
+        .estimated_tokens = content.estimated_tokens + estimateTextTokens(@intCast(details_bytes)),
+        .artifact_count = @intCast(result.artifacts.slice().len),
+    };
+}
+
 /// Build tool definitions array for LLM request
 fn buildToolsArray(
     allocator: std.mem.Allocator,
@@ -90,12 +278,22 @@ fn createToolResultMessage(
             ai_types.OwnedSlice(u8).initOwned(try allocator.dupe(u8, details))
     else
         ai_types.OwnedSlice(u8).initBorrowed("");
+    errdefer {
+        var mutable = details_json;
+        mutable.deinit(allocator);
+    }
+
+    const artifacts = if (result.artifacts.is_owned)
+        ai_types.OwnedSlice(ai_types.ArtifactReference).initOwned(@constCast(result.artifacts.slice()))
+    else
+        ai_types.OwnedSlice(ai_types.ArtifactReference).initBorrowed(result.artifacts.slice());
 
     return .{
         .tool_call_id = try allocator.dupe(u8, tool_call.id),
         .tool_name = try allocator.dupe(u8, tool_call.name),
         .content = result.content.slice(),
         .details_json = details_json,
+        .artifacts = artifacts,
         .is_error = is_error,
         .timestamp = compat.time.nowMillis(),
     };
@@ -162,6 +360,55 @@ fn skipToolCall(
     };
 }
 
+fn finalizeToolExecution(
+    allocator: std.mem.Allocator,
+    config: AgentLoopConfig,
+    event_stream: *AgentEventStream,
+    results: *std.ArrayList(ai_types.ToolResultMessage),
+    tool_call: ai_types.ToolCall,
+    args_json: []const u8,
+    result: *AgentToolResult,
+    is_error: bool,
+) !void {
+    const raw_usage = measureToolResult(result.*);
+
+    if (config.tool_output_middleware_fn) |middleware| {
+        try middleware(config.tool_output_middleware_ctx, .{
+            .tool_call_id = tool_call.id,
+            .tool_name = tool_call.name,
+            .args_json = args_json,
+            .is_error = is_error,
+            .raw_result_bytes = raw_usage.result_bytes,
+            .raw_details_bytes = raw_usage.details_bytes,
+            .raw_total_bytes = raw_usage.total_bytes,
+        }, result, allocator);
+    }
+
+    const returned_usage = measureToolResult(result.*);
+    const result_json = result.getDetailsJson() orelse "null";
+    const args_bytes: u64 = @intCast(args_json.len);
+
+    try event_stream.push(.{ .tool_execution_end = .{
+        .tool_call_id = tool_call.id,
+        .tool_name = tool_call.name,
+        .result_json = result_json,
+        .is_error = is_error,
+        .args_bytes = args_bytes,
+        .raw_result_bytes = raw_usage.result_bytes,
+        .returned_result_bytes = returned_usage.result_bytes,
+        .raw_details_bytes = raw_usage.details_bytes,
+        .returned_details_bytes = returned_usage.details_bytes,
+        .raw_total_bytes = raw_usage.total_bytes + args_bytes,
+        .returned_total_bytes = returned_usage.total_bytes + args_bytes,
+        .estimated_returned_tokens = returned_usage.estimated_tokens + estimateTextTokens(args_json.len),
+        .artifact_count = returned_usage.artifact_count,
+        .artifacts = result.artifacts.slice(),
+    } });
+
+    const tool_result_msg = try createToolResultMessage(allocator, tool_call, result.*, is_error);
+    try results.append(allocator, tool_result_msg);
+}
+
 /// Result from tool execution phase
 const ToolExecutionResult = struct {
     tool_results: []ai_types.ToolResultMessage,
@@ -215,24 +462,17 @@ fn executeToolCalls(
 
         var result: AgentToolResult = undefined;
         var is_error = false;
+        var execution_args = tool_call.arguments_json;
 
         if (tool) |t| {
             // Validate tool arguments against schema
             const validated_args = validateToolArguments(allocator, t, tool_call.arguments_json) catch |err| {
                 result = try createErrorResult(allocator, err);
                 is_error = true;
-                // Still need to emit end event even on validation error
-                const result_json = result.getDetailsJson() orelse "null";
-                try event_stream.push(.{ .tool_execution_end = .{
-                    .tool_call_id = tool_call.id,
-                    .tool_name = tool_call.name,
-                    .result_json = result_json,
-                    .is_error = is_error,
-                } });
-                const tool_result_msg = try createToolResultMessage(allocator, tool_call, result, is_error);
-                try results.append(allocator, tool_result_msg);
+                try finalizeToolExecution(allocator, config, event_stream, &results, tool_call, execution_args, &result, is_error);
                 continue;
             };
+            execution_args = validated_args;
 
             // Create context for tool update callback
             var update_ctx = ToolUpdateContext{
@@ -278,20 +518,7 @@ fn executeToolCalls(
             is_error = true;
         }
 
-        // Build result JSON for event
-        const result_json = result.getDetailsJson() orelse "null";
-
-        // Emit end event
-        try event_stream.push(.{ .tool_execution_end = .{
-            .tool_call_id = tool_call.id,
-            .tool_name = tool_call.name,
-            .result_json = result_json,
-            .is_error = is_error,
-        } });
-
-        // Create tool result message
-        const tool_result_msg = try createToolResultMessage(allocator, tool_call, result, is_error);
-        try results.append(allocator, tool_result_msg);
+        try finalizeToolExecution(allocator, config, event_stream, &results, tool_call, execution_args, &result, is_error);
 
         // Check for steering messages - skip remaining tools if any
         if (config.get_steering_messages_fn) |get_steering| {
@@ -361,6 +588,7 @@ fn streamAssistantResponse(
         .tools = tools,
         .is_owned = false,
     };
+    try emitContextUsage(event_stream, llm_context);
 
     // Build protocol options
     const options = ProtocolOptions{
@@ -995,6 +1223,115 @@ test "createErrorResult creates valid result" {
     try std.testing.expect(result.content.slice()[0] == .text);
 }
 
+fn mockContextUsageStream(
+    ctx: ?*anyopaque,
+    model: ai_types.Model,
+    context: ai_types.Context,
+    options: ProtocolOptions,
+    allocator: std.mem.Allocator,
+) anyerror!*event_stream_module.AssistantMessageEventStream {
+    _ = ctx;
+    _ = model;
+    _ = context;
+    _ = options;
+
+    const stream = try allocator.create(event_stream_module.AssistantMessageEventStream);
+    stream.* = event_stream_module.AssistantMessageEventStream.init(allocator);
+
+    const content = try allocator.alloc(ai_types.AssistantContent, 1);
+    content[0] = .{ .text = .{ .text = try allocator.dupe(u8, "ok") } };
+    stream.complete(.{
+        .content = content,
+        .api = "test-api",
+        .provider = "test-provider",
+        .model = "test-model",
+        .usage = .{},
+        .stop_reason = .stop,
+        .timestamp = 0,
+    });
+
+    return stream;
+}
+
+test "streamAssistantResponse emits context and prompt segment usage" {
+    const allocator = std.testing.allocator;
+
+    var context = AgentContext.init(allocator);
+    defer context.deinit();
+    context.system_prompt = types.OwnedSlice(u8).initOwned(try allocator.dupe(u8, "stable system prompt"));
+
+    const user_text = try allocator.dupe(u8, "dynamic user prompt");
+    try context.appendMessage(.{ .user = .{
+        .content = .{ .text = user_text },
+        .timestamp = 0,
+    } });
+
+    const tools = [_]AgentTool{.{
+        .label = "Search",
+        .name = "search",
+        .description = "Search indexed artifacts",
+        .parameters_schema_json = "{\"type\":\"object\"}",
+        .execute = undefined,
+    }};
+    context.tools = &tools;
+
+    const model = ai_types.Model{
+        .id = "test-model",
+        .name = "Test",
+        .api = "test-api",
+        .provider = "test-provider",
+        .base_url = "",
+        .reasoning = false,
+        .input = &.{"text"},
+        .cost = .{ .input = 0, .output = 0, .cache_read = 0, .cache_write = 0 },
+        .context_window = 1024,
+        .max_tokens = 256,
+    };
+
+    var agent_events = AgentEventStream.init(allocator);
+    defer agent_events.deinit();
+
+    var final = try streamAssistantResponse(
+        allocator,
+        &context,
+        .{
+            .model = model,
+            .protocol = .{ .stream_fn = mockContextUsageStream },
+        },
+        &agent_events,
+    );
+    defer final.deinit(allocator);
+
+    var saw_context_usage = false;
+    var segment_count: usize = 0;
+    while (agent_events.poll()) |evt| {
+        switch (evt) {
+            .context_usage => |usage| {
+                saw_context_usage = true;
+                try std.testing.expectEqual(@as(u32, 1), usage.message_count);
+                try std.testing.expectEqual(@as(u32, 1), usage.tool_count);
+                try std.testing.expect(usage.system_prompt_bytes > 0);
+                try std.testing.expect(usage.message_bytes > 0);
+                try std.testing.expect(usage.tool_definition_bytes > 0);
+                try std.testing.expect(usage.estimated_tokens > 0);
+            },
+            .prompt_segment_usage => |segment| {
+                segment_count += 1;
+                if (segment.segment == .system_prompt or segment.segment == .tool_definitions) {
+                    try std.testing.expectEqual(types.PromptSegmentCacheRole.stable, segment.cache_role);
+                }
+                if (segment.segment == .message_history) {
+                    try std.testing.expectEqual(types.PromptSegmentCacheRole.dynamic, segment.cache_role);
+                }
+            },
+            else => {},
+        }
+    }
+
+    try std.testing.expect(saw_context_usage);
+    try std.testing.expectEqual(@as(usize, 3), segment_count);
+}
+
 const MockProtocolToolContext = struct {
     call_count: usize = 0,
     saw_update: bool = false,
@@ -1051,6 +1388,69 @@ fn mockProtocolExecuteCancelled(
         if (token.isCancelled()) return error.Cancelled;
     }
     return error.Cancelled;
+}
+
+fn mockLargeOutputTool(
+    tool_call_id: []const u8,
+    args_json: []const u8,
+    cancel_token: ?ai_types.CancelToken,
+    on_update_ctx: ?*anyopaque,
+    on_update: ?types.ToolUpdateCallback,
+    allocator: std.mem.Allocator,
+) anyerror!AgentToolResult {
+    _ = tool_call_id;
+    _ = args_json;
+    _ = cancel_token;
+    _ = on_update_ctx;
+    _ = on_update;
+
+    const content = try allocator.alloc(ai_types.UserContentPart, 1);
+    content[0] = .{ .text = .{
+        .text = try allocator.dupe(u8, "raw log line 1\nraw log line 2\nraw log line 3"),
+    } };
+    return .{
+        .content = types.OwnedSlice(ai_types.UserContentPart).initOwned(content),
+        .details_json = types.OwnedSlice(u8).initOwned(try allocator.dupe(u8, "{\"raw\":true,\"lines\":3}")),
+    };
+}
+
+const MiddlewareRecorder = struct {
+    raw_total_bytes: u64 = 0,
+    call_count: usize = 0,
+};
+
+fn compactToolOutputMiddleware(
+    ctx: ?*anyopaque,
+    input: types.ToolOutputMiddlewareInput,
+    result: *AgentToolResult,
+    allocator: std.mem.Allocator,
+) anyerror!void {
+    const recorder: *MiddlewareRecorder = @ptrCast(@alignCast(ctx.?));
+    recorder.raw_total_bytes = input.raw_total_bytes;
+    recorder.call_count += 1;
+
+    result.content.deinit(allocator);
+    result.details_json.deinit(allocator);
+
+    const content = try allocator.alloc(ai_types.UserContentPart, 1);
+    content[0] = .{ .text = .{
+        .text = try allocator.dupe(u8, "3 raw log lines stored as artifact"),
+    } };
+
+    const artifacts = try allocator.alloc(ai_types.ArtifactReference, 1);
+    artifacts[0] = .{
+        .artifact_id = try allocator.dupe(u8, "artifact-log-1"),
+        .uri = types.OwnedSlice(u8).initOwned(try allocator.dupe(u8, "makai-artifact://artifact-log-1")),
+        .mime_type = types.OwnedSlice(u8).initOwned(try allocator.dupe(u8, "text/plain")),
+        .byte_size = input.raw_total_bytes,
+        .description = types.OwnedSlice(u8).initOwned(try allocator.dupe(u8, "raw tool output")),
+    };
+
+    result.* = .{
+        .content = types.OwnedSlice(ai_types.UserContentPart).initOwned(content),
+        .details_json = types.OwnedSlice(u8).initOwned(try allocator.dupe(u8, "{\"summary\":true}")),
+        .artifacts = types.OwnedSlice(ai_types.ArtifactReference).initOwned(artifacts),
+    };
 }
 
 test "executeToolCalls uses protocol executor when configured" {
@@ -1125,6 +1525,87 @@ test "executeToolCalls uses protocol executor when configured" {
     }
     try std.testing.expect(protocol_ctx.saw_update);
     try std.testing.expect(saw_update);
+}
+
+test "executeToolCalls applies output middleware and reports byte telemetry" {
+    const allocator = std.testing.allocator;
+
+    const tools = [_]AgentTool{
+        .{
+            .label = "Logs",
+            .name = "logs",
+            .description = "Collect logs",
+            .parameters_schema_json = "{}",
+            .execute = mockLargeOutputTool,
+        },
+    };
+
+    const assistant_content = [_]ai_types.AssistantContent{
+        .{ .tool_call = .{
+            .id = "call_logs",
+            .name = "logs",
+            .arguments_json = "{\"path\":\"server.log\"}",
+        } },
+    };
+    const assistant_message = ai_types.AssistantMessage{
+        .content = &assistant_content,
+        .api = "test-api",
+        .provider = "test-provider",
+        .model = "test-model",
+        .usage = .{},
+        .stop_reason = .tool_use,
+        .timestamp = 0,
+    };
+
+    const model = ai_types.Model{
+        .id = "test-model",
+        .name = "Test",
+        .api = "test-api",
+        .provider = "test-provider",
+        .base_url = "",
+        .reasoning = false,
+        .input = &.{"text"},
+        .cost = .{ .input = 0, .output = 0, .cache_read = 0, .cache_write = 0 },
+        .context_window = 1024,
+        .max_tokens = 256,
+    };
+
+    var recorder = MiddlewareRecorder{};
+    var agent_events = AgentEventStream.init(allocator);
+    defer agent_events.deinit();
+
+    var tool_result = try executeToolCalls(
+        allocator,
+        assistant_message,
+        .{
+            .model = model,
+            .protocol = .{ .stream_fn = undefined },
+            .tools = &tools,
+            .tool_output_middleware_fn = compactToolOutputMiddleware,
+            .tool_output_middleware_ctx = &recorder,
+        },
+        &agent_events,
+    );
+    defer tool_result.deinit(allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), recorder.call_count);
+    try std.testing.expect(recorder.raw_total_bytes > 0);
+    try std.testing.expectEqual(@as(usize, 1), tool_result.tool_results.len);
+    try std.testing.expectEqualStrings("3 raw log lines stored as artifact", tool_result.tool_results[0].content[0].text.text);
+    try std.testing.expectEqual(@as(usize, 1), tool_result.tool_results[0].artifacts.slice().len);
+    try std.testing.expectEqualStrings("artifact-log-1", tool_result.tool_results[0].artifacts.slice()[0].artifact_id);
+
+    var saw_end = false;
+    while (agent_events.poll()) |evt| {
+        if (evt == .tool_execution_end) {
+            saw_end = true;
+            try std.testing.expect(evt.tool_execution_end.raw_total_bytes > evt.tool_execution_end.returned_total_bytes);
+            try std.testing.expectEqual(@as(u32, 1), evt.tool_execution_end.artifact_count);
+            try std.testing.expectEqual(@as(usize, 1), evt.tool_execution_end.artifacts.len);
+            try std.testing.expectEqualStrings("artifact-log-1", evt.tool_execution_end.artifacts[0].artifact_id);
+        }
+    }
+    try std.testing.expect(saw_end);
 }
 
 test "executeToolCalls emits terminal events on protocol cancellation" {

--- a/zig/src/agent/types.zig
+++ b/zig/src/agent/types.zig
@@ -5,6 +5,7 @@ const event_stream = @import("event_stream");
 const owned_slice_mod = @import("owned_slice");
 
 pub const OwnedSlice = owned_slice_mod.OwnedSlice;
+pub const ArtifactReference = ai_types.ArtifactReference;
 
 // ============================================================================
 // Agent Event Types
@@ -49,6 +50,37 @@ pub const MessageEndPayload = struct {
     message: ai_types.Message,
 };
 
+/// Aggregate byte/token pressure for one provider request context.
+pub const ContextUsagePayload = struct {
+    system_prompt_bytes: u64 = 0,
+    message_bytes: u64 = 0,
+    tool_definition_bytes: u64 = 0,
+    total_bytes: u64 = 0,
+    estimated_tokens: u64 = 0,
+    message_count: u32 = 0,
+    tool_count: u32 = 0,
+};
+
+pub const PromptSegmentKind = enum {
+    system_prompt,
+    message_history,
+    tool_definitions,
+};
+
+pub const PromptSegmentCacheRole = enum {
+    stable,
+    dynamic,
+};
+
+/// Cache-aware prompt segment accounting for TUI context-pressure views.
+pub const PromptSegmentUsagePayload = struct {
+    segment: PromptSegmentKind,
+    cache_role: PromptSegmentCacheRole,
+    bytes: u64 = 0,
+    estimated_tokens: u64 = 0,
+    item_count: u32 = 0,
+};
+
 /// Payload for tool_execution_start event
 pub const ToolExecutionStartPayload = struct {
     tool_call_id: []const u8,
@@ -70,6 +102,16 @@ pub const ToolExecutionEndPayload = struct {
     tool_name: []const u8,
     result_json: []const u8,
     is_error: bool,
+    args_bytes: u64 = 0,
+    raw_result_bytes: u64 = 0,
+    returned_result_bytes: u64 = 0,
+    raw_details_bytes: u64 = 0,
+    returned_details_bytes: u64 = 0,
+    raw_total_bytes: u64 = 0,
+    returned_total_bytes: u64 = 0,
+    estimated_returned_tokens: u64 = 0,
+    artifact_count: u32 = 0,
+    artifacts: []const ArtifactReference = &.{},
 };
 
 /// Agent event types emitted during execution
@@ -86,6 +128,8 @@ pub const AgentEvent = union(enum) {
     message_start: MessageStartPayload,
     message_update: MessageUpdatePayload,
     message_end: MessageEndPayload,
+    context_usage: ContextUsagePayload,
+    prompt_segment_usage: PromptSegmentUsagePayload,
 
     // Tool execution lifecycle
     tool_execution_start: ToolExecutionStartPayload,
@@ -101,6 +145,7 @@ pub const AgentEvent = union(enum) {
 pub const AgentToolResult = struct {
     content: OwnedSlice(ai_types.UserContentPart) = OwnedSlice(ai_types.UserContentPart).initBorrowed(&.{}),
     details_json: OwnedSlice(u8) = OwnedSlice(u8).initBorrowed(""),
+    artifacts: OwnedSlice(ArtifactReference) = OwnedSlice(ArtifactReference).initBorrowed(&.{}),
 
     pub fn getDetailsJson(self: *const AgentToolResult) ?[]const u8 {
         const details = self.details_json.slice();
@@ -110,6 +155,7 @@ pub const AgentToolResult = struct {
     pub fn deinit(self: *AgentToolResult, allocator: std.mem.Allocator) void {
         self.content.deinit(allocator);
         self.details_json.deinit(allocator);
+        self.artifacts.deinit(allocator);
     }
 };
 
@@ -142,6 +188,28 @@ pub const ToolProtocolExecuteFn = *const fn (
     on_update: ?ToolUpdateCallback,
     allocator: std.mem.Allocator,
 ) anyerror!AgentToolResult;
+
+pub const ToolOutputMiddlewareInput = struct {
+    tool_call_id: []const u8,
+    tool_name: []const u8,
+    args_json: []const u8,
+    is_error: bool,
+    raw_result_bytes: u64,
+    raw_details_bytes: u64,
+    raw_total_bytes: u64,
+};
+
+/// Hook point for reversible tool-output filtering/artifact backing.
+///
+/// Implementations may mutate `result` in place, for example by replacing a
+/// large text payload with a compact summary plus `ArtifactReference` entries.
+/// The hook owns any memory it puts into `result`.
+pub const ToolOutputMiddlewareFn = *const fn (
+    ctx: ?*anyopaque,
+    input: ToolOutputMiddlewareInput,
+    result: *AgentToolResult,
+    allocator: std.mem.Allocator,
+) anyerror!void;
 
 /// Agent tool definition
 pub const AgentTool = struct {
@@ -274,6 +342,8 @@ pub const AgentLoopConfig = struct {
     tools: ?[]const AgentTool = null,
     execute_tool_via_protocol_fn: ?ToolProtocolExecuteFn = null,
     execute_tool_via_protocol_ctx: ?*anyopaque = null,
+    tool_output_middleware_fn: ?ToolOutputMiddlewareFn = null,
+    tool_output_middleware_ctx: ?*anyopaque = null,
 
     // Streaming options (passed through to protocol)
     temperature: ?f32 = null,

--- a/zig/src/ai_types.zig
+++ b/zig/src/ai_types.zig
@@ -296,6 +296,44 @@ pub const UserMessage = struct {
     }
 };
 
+/// Reference to raw data stored outside the model transcript.
+pub const ArtifactReference = struct {
+    artifact_id: []const u8,
+    uri: OwnedSlice(u8) = OwnedSlice(u8).initBorrowed(""),
+    mime_type: OwnedSlice(u8) = OwnedSlice(u8).initBorrowed(""),
+    byte_size: ?u64 = null,
+    sha256: OwnedSlice(u8) = OwnedSlice(u8).initBorrowed(""),
+    description: OwnedSlice(u8) = OwnedSlice(u8).initBorrowed(""),
+
+    pub fn getUri(self: *const ArtifactReference) ?[]const u8 {
+        const value = self.uri.slice();
+        return if (value.len > 0) value else null;
+    }
+
+    pub fn getMimeType(self: *const ArtifactReference) ?[]const u8 {
+        const value = self.mime_type.slice();
+        return if (value.len > 0) value else null;
+    }
+
+    pub fn getSha256(self: *const ArtifactReference) ?[]const u8 {
+        const value = self.sha256.slice();
+        return if (value.len > 0) value else null;
+    }
+
+    pub fn getDescription(self: *const ArtifactReference) ?[]const u8 {
+        const value = self.description.slice();
+        return if (value.len > 0) value else null;
+    }
+
+    pub fn deinit(self: *ArtifactReference, allocator: std.mem.Allocator) void {
+        allocator.free(self.artifact_id);
+        self.uri.deinit(allocator);
+        self.mime_type.deinit(allocator);
+        self.sha256.deinit(allocator);
+        self.description.deinit(allocator);
+    }
+};
+
 pub const AssistantMessage = struct {
     content: []const AssistantContent,
     api: []const u8,
@@ -385,6 +423,7 @@ pub const ToolResultMessage = struct {
     tool_name: []const u8,
     content: []const UserContentPart,
     details_json: OwnedSlice(u8) = OwnedSlice(u8).initBorrowed(""),
+    artifacts: OwnedSlice(ArtifactReference) = OwnedSlice(ArtifactReference).initBorrowed(&.{}),
     is_error: bool,
     timestamp: i64,
 
@@ -404,6 +443,7 @@ pub const ToolResultMessage = struct {
         }
         allocator.free(self.content);
         self.details_json.deinit(allocator);
+        self.artifacts.deinit(allocator);
     }
 };
 
@@ -911,6 +951,12 @@ fn cloneToolResultMessage(allocator: std.mem.Allocator, tr: ToolResultMessage) !
         OwnedSlice(u8).initBorrowed("");
     errdefer details_json.deinit(allocator);
 
+    const cloned_artifacts = try cloneArtifactReferences(allocator, tr.artifacts.slice());
+    errdefer {
+        var artifacts = OwnedSlice(ArtifactReference).initOwned(cloned_artifacts);
+        artifacts.deinit(allocator);
+    }
+
     const tool_call_id = try allocator.dupe(u8, tr.tool_call_id);
     errdefer allocator.free(tool_call_id);
     const tool_name = try allocator.dupe(u8, tr.tool_name);
@@ -921,8 +967,75 @@ fn cloneToolResultMessage(allocator: std.mem.Allocator, tr: ToolResultMessage) !
         .tool_name = tool_name,
         .content = cloned_content,
         .details_json = details_json,
+        .artifacts = OwnedSlice(ArtifactReference).initOwned(cloned_artifacts),
         .is_error = tr.is_error,
         .timestamp = tr.timestamp,
+    };
+}
+
+fn cloneArtifactReferences(allocator: std.mem.Allocator, artifacts: []const ArtifactReference) ![]ArtifactReference {
+    const cloned = try allocator.alloc(ArtifactReference, artifacts.len);
+    var initialized: usize = 0;
+    errdefer {
+        for (cloned[0..initialized]) |*artifact| artifact.deinit(allocator);
+        allocator.free(cloned);
+    }
+
+    for (artifacts, 0..) |artifact, i| {
+        cloned[i] = try cloneArtifactReference(allocator, artifact);
+        initialized += 1;
+    }
+
+    return cloned;
+}
+
+fn cloneArtifactReference(allocator: std.mem.Allocator, artifact: ArtifactReference) !ArtifactReference {
+    const artifact_id = try allocator.dupe(u8, artifact.artifact_id);
+    errdefer allocator.free(artifact_id);
+
+    const uri = if (artifact.getUri()) |value|
+        OwnedSlice(u8).initOwned(try allocator.dupe(u8, value))
+    else
+        OwnedSlice(u8).initBorrowed("");
+    errdefer {
+        var mutable = uri;
+        mutable.deinit(allocator);
+    }
+
+    const mime_type = if (artifact.getMimeType()) |value|
+        OwnedSlice(u8).initOwned(try allocator.dupe(u8, value))
+    else
+        OwnedSlice(u8).initBorrowed("");
+    errdefer {
+        var mutable = mime_type;
+        mutable.deinit(allocator);
+    }
+
+    const sha256 = if (artifact.getSha256()) |value|
+        OwnedSlice(u8).initOwned(try allocator.dupe(u8, value))
+    else
+        OwnedSlice(u8).initBorrowed("");
+    errdefer {
+        var mutable = sha256;
+        mutable.deinit(allocator);
+    }
+
+    const description = if (artifact.getDescription()) |value|
+        OwnedSlice(u8).initOwned(try allocator.dupe(u8, value))
+    else
+        OwnedSlice(u8).initBorrowed("");
+    errdefer {
+        var mutable = description;
+        mutable.deinit(allocator);
+    }
+
+    return .{
+        .artifact_id = artifact_id,
+        .uri = uri,
+        .mime_type = mime_type,
+        .byte_size = artifact.byte_size,
+        .sha256 = sha256,
+        .description = description,
     };
 }
 

--- a/zig/src/protocol/tool/envelope.zig
+++ b/zig/src/protocol/tool/envelope.zig
@@ -96,6 +96,14 @@ fn serializePayload(w: *json_writer.JsonWriter, payload: tool_types.Payload, all
             try w.writeBoolField("is_error", res.is_error);
             if (res.getErrorMessage()) |msg| try w.writeStringField("error_message", msg);
             if (res.getDetailsJson()) |details| try w.writeStringField("details_json", details);
+            if (res.artifacts.slice().len > 0) {
+                try w.writeKey("artifacts");
+                try w.beginArray();
+                for (res.artifacts.slice()) |artifact| {
+                    try serializeArtifactReference(w, artifact);
+                }
+                try w.endArray();
+            }
             try w.writeIntField("duration_ms", res.duration_ms);
         },
         .tool_cancel => |req| {
@@ -130,6 +138,72 @@ fn serializePayload(w: *json_writer.JsonWriter, payload: tool_types.Payload, all
             try w.writeIntField("started_at", info.started_at);
             if (info.completed_at) |completed_at| try w.writeIntField("completed_at", completed_at);
         },
+        .artifact_retrieve => |req| {
+            try w.writeStringField("artifact_id", req.artifact_id);
+            if (req.byte_offset) |offset| try w.writeIntField("byte_offset", offset);
+            if (req.byte_limit) |limit| try w.writeIntField("byte_limit", limit);
+        },
+        .artifact_retrieved => |res| {
+            try w.writeKey("artifact");
+            try serializeArtifactReference(w, res.artifact);
+            if (res.getContentJson()) |content_json| try w.writeStringField("content_json", content_json);
+        },
+        .artifact_search => |req| {
+            try w.writeStringField("query", req.query);
+            if (req.limit) |limit| try w.writeIntField("limit", limit);
+        },
+        .artifact_search_result => |res| {
+            try w.writeKey("results");
+            try w.beginArray();
+            for (res.results) |result| {
+                try w.beginObject();
+                try w.writeKey("artifact");
+                try serializeArtifactReference(w, result.artifact);
+                if (result.getSnippet()) |snippet| try w.writeStringField("snippet", snippet);
+                if (result.score) |score| {
+                    try w.writeKey("score");
+                    try w.writeFloat(score);
+                }
+                try w.endObject();
+            }
+            try w.endArray();
+        },
+        .hashline_read => |req| {
+            try w.writeStringField("path", req.path);
+            try w.writeBoolField("feature_enabled", req.feature_enabled);
+            if (req.byte_limit) |limit| try w.writeIntField("byte_limit", limit);
+        },
+        .hashline_read_result => |res| {
+            try w.writeStringField("path", res.path);
+            try w.writeKey("lines");
+            try w.beginArray();
+            for (res.lines) |line| {
+                try w.beginObject();
+                try w.writeIntField("line", line.line);
+                try w.writeStringField("hash", line.hash);
+                try w.writeStringField("text", line.text);
+                try w.endObject();
+            }
+            try w.endArray();
+        },
+        .hashline_edit => |req| {
+            try w.writeStringField("path", req.path);
+            try w.writeStringField("operation", @tagName(req.operation));
+            try w.writeIntField("start_line", req.start_line);
+            try w.writeStringField("start_hash", req.start_hash);
+            if (req.end_line) |line| try w.writeIntField("end_line", line);
+            if (req.getEndHash()) |hash| try w.writeStringField("end_hash", hash);
+            if (req.getReplacement()) |replacement| try w.writeStringField("replacement", replacement);
+            try w.writeBoolField("feature_enabled", req.feature_enabled);
+        },
+        .hashline_edit_result => |res| {
+            try w.writeStringField("path", res.path);
+            try w.writeBoolField("applied", res.applied);
+            if (res.new_artifact) |artifact| {
+                try w.writeKey("new_artifact");
+                try serializeArtifactReference(w, artifact);
+            }
+        },
         .ping => {},
         .pong => |pong| try w.writeStringField("ping_id", pong.ping_id.slice()),
         .goodbye => |goodbye| {
@@ -137,6 +211,17 @@ fn serializePayload(w: *json_writer.JsonWriter, payload: tool_types.Payload, all
         },
     }
 
+    try w.endObject();
+}
+
+fn serializeArtifactReference(w: *json_writer.JsonWriter, artifact: tool_types.ArtifactReference) !void {
+    try w.beginObject();
+    try w.writeStringField("artifact_id", artifact.artifact_id);
+    if (artifact.getUri()) |uri| try w.writeStringField("uri", uri);
+    if (artifact.getMimeType()) |mime_type| try w.writeStringField("mime_type", mime_type);
+    if (artifact.byte_size) |byte_size| try w.writeIntField("byte_size", byte_size);
+    if (artifact.getSha256()) |sha256| try w.writeStringField("sha256", sha256);
+    if (artifact.getDescription()) |description| try w.writeStringField("description", description);
     try w.endObject();
 }
 
@@ -191,6 +276,37 @@ pub fn deserializeEnvelope(json: []const u8, allocator: std.mem.Allocator) !tool
 
 fn parseUlidRequired(str: []const u8) !tool_types.Ulid {
     return tool_types.parseUlid(str) orelse error.InvalidUlid;
+}
+
+fn deserializeArtifactReference(obj: std.json.ObjectMap, allocator: std.mem.Allocator) !tool_types.ArtifactReference {
+    var artifact = tool_types.ArtifactReference{
+        .artifact_id = try allocator.dupe(u8, obj.get("artifact_id").?.string),
+    };
+    errdefer artifact.deinit(allocator);
+
+    if (obj.get("uri")) |v| artifact.uri = OwnedSlice(u8).initOwned(try allocator.dupe(u8, v.string));
+    if (obj.get("mime_type")) |v| artifact.mime_type = OwnedSlice(u8).initOwned(try allocator.dupe(u8, v.string));
+    if (obj.get("byte_size")) |v| artifact.byte_size = @as(u64, @intCast(v.integer));
+    if (obj.get("sha256")) |v| artifact.sha256 = OwnedSlice(u8).initOwned(try allocator.dupe(u8, v.string));
+    if (obj.get("description")) |v| artifact.description = OwnedSlice(u8).initOwned(try allocator.dupe(u8, v.string));
+
+    return artifact;
+}
+
+fn deserializeArtifactReferences(array: std.json.Array, allocator: std.mem.Allocator) ![]tool_types.ArtifactReference {
+    const artifacts = try allocator.alloc(tool_types.ArtifactReference, array.items.len);
+    var initialized: usize = 0;
+    errdefer {
+        for (artifacts[0..initialized]) |*artifact| artifact.deinit(allocator);
+        allocator.free(artifacts);
+    }
+
+    for (array.items, 0..) |item, i| {
+        artifacts[i] = try deserializeArtifactReference(item.object, allocator);
+        initialized += 1;
+    }
+
+    return artifacts;
 }
 
 fn deserializePayload(type_str: []const u8, payload: std.json.ObjectMap, allocator: std.mem.Allocator) !tool_types.Payload {
@@ -265,6 +381,7 @@ fn deserializePayload(type_str: []const u8, payload: std.json.ObjectMap, allocat
         };
         if (payload.get("error_message")) |v| result.error_message = OwnedSlice(u8).initOwned(try allocator.dupe(u8, v.string));
         if (payload.get("details_json")) |v| result.details_json = OwnedSlice(u8).initOwned(try allocator.dupe(u8, v.string));
+        if (payload.get("artifacts")) |v| result.artifacts = OwnedSlice(tool_types.ArtifactReference).initOwned(try deserializeArtifactReferences(v.array, allocator));
         return .{ .tool_result = result };
     }
     if (std.mem.eql(u8, type_str, "tool_cancel")) {
@@ -299,6 +416,117 @@ fn deserializePayload(type_str: []const u8, payload: std.json.ObjectMap, allocat
             .started_at = payload.get("started_at").?.integer,
             .completed_at = if (payload.get("completed_at")) |v| v.integer else null,
         } };
+    }
+    if (std.mem.eql(u8, type_str, "artifact_retrieve")) {
+        return .{ .artifact_retrieve = .{
+            .artifact_id = try allocator.dupe(u8, payload.get("artifact_id").?.string),
+            .byte_offset = if (payload.get("byte_offset")) |v| @as(u64, @intCast(v.integer)) else null,
+            .byte_limit = if (payload.get("byte_limit")) |v| @as(u64, @intCast(v.integer)) else null,
+        } };
+    }
+    if (std.mem.eql(u8, type_str, "artifact_retrieved")) {
+        var res = tool_types.ArtifactRetrieveResponse{
+            .artifact = try deserializeArtifactReference(payload.get("artifact").?.object, allocator),
+        };
+        errdefer res.deinit(allocator);
+        if (payload.get("content_json")) |v| res.content_json = OwnedSlice(u8).initOwned(try allocator.dupe(u8, v.string));
+        return .{ .artifact_retrieved = res };
+    }
+    if (std.mem.eql(u8, type_str, "artifact_search")) {
+        return .{ .artifact_search = .{
+            .query = try allocator.dupe(u8, payload.get("query").?.string),
+            .limit = if (payload.get("limit")) |v| @as(u32, @intCast(v.integer)) else null,
+        } };
+    }
+    if (std.mem.eql(u8, type_str, "artifact_search_result")) {
+        const values = payload.get("results").?.array;
+        const results = try allocator.alloc(tool_types.ArtifactSearchResult, values.items.len);
+        var initialized: usize = 0;
+        errdefer {
+            for (results[0..initialized]) |*result| result.deinit(allocator);
+            allocator.free(results);
+        }
+        for (values.items, 0..) |item, i| {
+            const obj = item.object;
+            results[i] = blk: {
+                var result = tool_types.ArtifactSearchResult{
+                    .artifact = try deserializeArtifactReference(obj.get("artifact").?.object, allocator),
+                };
+                errdefer result.deinit(allocator);
+                if (obj.get("snippet")) |v| result.snippet = OwnedSlice(u8).initOwned(try allocator.dupe(u8, v.string));
+                if (obj.get("score")) |v| result.score = switch (v) {
+                    .float => |f| @floatCast(f),
+                    .integer => |n| @floatFromInt(n),
+                    else => null,
+                };
+                break :blk result;
+            };
+            initialized += 1;
+        }
+        return .{ .artifact_search_result = .{ .results = results } };
+    }
+    if (std.mem.eql(u8, type_str, "hashline_read")) {
+        return .{ .hashline_read = .{
+            .path = try allocator.dupe(u8, payload.get("path").?.string),
+            .feature_enabled = if (payload.get("feature_enabled")) |v| v.bool else false,
+            .byte_limit = if (payload.get("byte_limit")) |v| @as(u64, @intCast(v.integer)) else null,
+        } };
+    }
+    if (std.mem.eql(u8, type_str, "hashline_read_result")) {
+        const values = payload.get("lines").?.array;
+        const lines = try allocator.alloc(tool_types.HashlineLine, values.items.len);
+        var initialized: usize = 0;
+        errdefer {
+            for (lines[0..initialized]) |*line| line.deinit(allocator);
+            allocator.free(lines);
+        }
+        for (values.items, 0..) |item, i| {
+            const obj = item.object;
+            lines[i] = blk: {
+                const hash = try allocator.dupe(u8, obj.get("hash").?.string);
+                errdefer allocator.free(hash);
+                const text = try allocator.dupe(u8, obj.get("text").?.string);
+                errdefer allocator.free(text);
+                break :blk .{
+                    .line = @as(u32, @intCast(obj.get("line").?.integer)),
+                    .hash = hash,
+                    .text = text,
+                };
+            };
+            initialized += 1;
+        }
+        return .{ .hashline_read_result = .{
+            .path = try allocator.dupe(u8, payload.get("path").?.string),
+            .lines = lines,
+        } };
+    }
+    if (std.mem.eql(u8, type_str, "hashline_edit")) {
+        var req = tool_types.HashlineEditRequest{
+            .path = try allocator.dupe(u8, payload.get("path").?.string),
+            .operation = std.meta.stringToEnum(tool_types.HashlineEditOperation, payload.get("operation").?.string) orelse return error.InvalidPayloadType,
+            .start_line = @as(u32, @intCast(payload.get("start_line").?.integer)),
+            .start_hash = try allocator.dupe(u8, payload.get("start_hash").?.string),
+            .feature_enabled = if (payload.get("feature_enabled")) |v| v.bool else false,
+        };
+        errdefer {
+            allocator.free(req.path);
+            allocator.free(req.start_hash);
+            req.end_hash.deinit(allocator);
+            req.replacement.deinit(allocator);
+        }
+        if (payload.get("end_line")) |v| req.end_line = @as(u32, @intCast(v.integer));
+        if (payload.get("end_hash")) |v| req.end_hash = OwnedSlice(u8).initOwned(try allocator.dupe(u8, v.string));
+        if (payload.get("replacement")) |v| req.replacement = OwnedSlice(u8).initOwned(try allocator.dupe(u8, v.string));
+        return .{ .hashline_edit = req };
+    }
+    if (std.mem.eql(u8, type_str, "hashline_edit_result")) {
+        var res = tool_types.HashlineEditResponse{
+            .path = try allocator.dupe(u8, payload.get("path").?.string),
+            .applied = payload.get("applied").?.bool,
+        };
+        errdefer res.deinit(allocator);
+        if (payload.get("new_artifact")) |v| res.new_artifact = try deserializeArtifactReference(v.object, allocator);
+        return .{ .hashline_edit_result = res };
     }
     if (std.mem.eql(u8, type_str, "ping")) return .ping;
     if (std.mem.eql(u8, type_str, "pong")) {
@@ -440,4 +668,113 @@ test "tool envelope negative timeout error" {
 
     try std.testing.expect(env.payload == .tool_error);
     try std.testing.expectEqual(tool_types.ToolErrorCode.tool_timeout, env.payload.tool_error.code);
+}
+
+test "tool envelope roundtrip artifact search response" {
+    const allocator = std.testing.allocator;
+
+    const results = try allocator.alloc(tool_types.ArtifactSearchResult, 1);
+    results[0] = .{
+        .artifact = .{
+            .artifact_id = try allocator.dupe(u8, "artifact-1"),
+            .uri = OwnedSlice(u8).initOwned(try allocator.dupe(u8, "makai-artifact://artifact-1")),
+            .mime_type = OwnedSlice(u8).initOwned(try allocator.dupe(u8, "text/plain")),
+            .byte_size = 128,
+            .description = OwnedSlice(u8).initOwned(try allocator.dupe(u8, "raw logs")),
+        },
+        .snippet = OwnedSlice(u8).initOwned(try allocator.dupe(u8, "error line")),
+        .score = 0.75,
+    };
+
+    var env = tool_types.Envelope{
+        .server_id = tool_types.generateUlid(),
+        .message_id = tool_types.generateUlid(),
+        .sequence = 3,
+        .timestamp = compat.time.nowMillis(),
+        .payload = .{ .artifact_search_result = .{ .results = results } },
+    };
+    defer env.deinit(allocator);
+
+    const json = try serializeEnvelope(env, allocator);
+    defer allocator.free(json);
+
+    var parsed = try deserializeEnvelope(json, allocator);
+    defer parsed.deinit(allocator);
+
+    try std.testing.expect(parsed.payload == .artifact_search_result);
+    try std.testing.expectEqual(@as(usize, 1), parsed.payload.artifact_search_result.results.len);
+    try std.testing.expectEqualStrings("artifact-1", parsed.payload.artifact_search_result.results[0].artifact.artifact_id);
+    try std.testing.expectEqualStrings("error line", parsed.payload.artifact_search_result.results[0].snippet.slice());
+}
+
+test "tool envelope roundtrip tool result artifacts" {
+    const allocator = std.testing.allocator;
+
+    const artifacts = try allocator.alloc(tool_types.ArtifactReference, 1);
+    artifacts[0] = .{
+        .artifact_id = try allocator.dupe(u8, "artifact-tool-output"),
+        .uri = OwnedSlice(u8).initOwned(try allocator.dupe(u8, "makai-artifact://artifact-tool-output")),
+        .mime_type = OwnedSlice(u8).initOwned(try allocator.dupe(u8, "application/json")),
+        .byte_size = 4096,
+    };
+
+    var env = tool_types.Envelope{
+        .server_id = tool_types.generateUlid(),
+        .message_id = tool_types.generateUlid(),
+        .sequence = 4,
+        .timestamp = compat.time.nowMillis(),
+        .payload = .{ .tool_result = .{
+            .execution_id = tool_types.generateUlid(),
+            .tool_call_id = try allocator.dupe(u8, "call_1"),
+            .result_json = try allocator.dupe(u8, "[{\"type\":\"text\",\"text\":\"summary\"}]"),
+            .details_json = OwnedSlice(u8).initOwned(try allocator.dupe(u8, "{\"summary\":true}")),
+            .artifacts = OwnedSlice(tool_types.ArtifactReference).initOwned(artifacts),
+            .duration_ms = 25,
+        } },
+    };
+    defer env.deinit(allocator);
+
+    const json = try serializeEnvelope(env, allocator);
+    defer allocator.free(json);
+
+    var parsed = try deserializeEnvelope(json, allocator);
+    defer parsed.deinit(allocator);
+
+    try std.testing.expect(parsed.payload == .tool_result);
+    try std.testing.expectEqual(@as(usize, 1), parsed.payload.tool_result.artifacts.slice().len);
+    try std.testing.expectEqualStrings("artifact-tool-output", parsed.payload.tool_result.artifacts.slice()[0].artifact_id);
+}
+
+test "tool envelope roundtrip hashline edit" {
+    const allocator = std.testing.allocator;
+
+    var env = tool_types.Envelope{
+        .server_id = tool_types.generateUlid(),
+        .message_id = tool_types.generateUlid(),
+        .sequence = 5,
+        .timestamp = compat.time.nowMillis(),
+        .payload = .{ .hashline_edit = .{
+            .path = try allocator.dupe(u8, "src/main.zig"),
+            .operation = .replace_range,
+            .start_line = 10,
+            .start_hash = try allocator.dupe(u8, "a1b2"),
+            .end_line = 12,
+            .end_hash = OwnedSlice(u8).initOwned(try allocator.dupe(u8, "c3d4")),
+            .replacement = OwnedSlice(u8).initOwned(try allocator.dupe(u8, "const x = 1;")),
+            .feature_enabled = true,
+        } },
+    };
+    defer env.deinit(allocator);
+
+    const json = try serializeEnvelope(env, allocator);
+    defer allocator.free(json);
+
+    var parsed = try deserializeEnvelope(json, allocator);
+    defer parsed.deinit(allocator);
+
+    try std.testing.expect(parsed.payload == .hashline_edit);
+    try std.testing.expect(parsed.payload.hashline_edit.feature_enabled);
+    try std.testing.expectEqual(tool_types.HashlineEditOperation.replace_range, parsed.payload.hashline_edit.operation);
+    try std.testing.expectEqualStrings("a1b2", parsed.payload.hashline_edit.start_hash);
+    try std.testing.expectEqualStrings("const x = 1;", parsed.payload.hashline_edit.replacement.slice());
 }

--- a/zig/src/protocol/tool/envelope.zig
+++ b/zig/src/protocol/tool/envelope.zig
@@ -303,6 +303,14 @@ fn parseRequiredJsonString(obj: std.json.ObjectMap, key: []const u8) ![]const u8
     return parseJsonString(obj.get(key) orelse return error.InvalidPayloadType);
 }
 
+fn parseRequiredJsonArray(obj: std.json.ObjectMap, key: []const u8) !std.json.Array {
+    return parseJsonArray(obj.get(key) orelse return error.InvalidPayloadType);
+}
+
+fn parseRequiredJsonObject(obj: std.json.ObjectMap, key: []const u8) !std.json.ObjectMap {
+    return parseJsonObject(obj.get(key) orelse return error.InvalidPayloadType);
+}
+
 fn parseUnsignedJsonInteger(comptime T: type, value: std.json.Value) !T {
     return switch (value) {
         .integer => |n| std.math.cast(T, n) orelse error.InvalidPayloadType,
@@ -462,7 +470,7 @@ fn deserializePayload(type_str: []const u8, payload: std.json.ObjectMap, allocat
     }
     if (std.mem.eql(u8, type_str, "artifact_retrieve")) {
         var req = tool_types.ArtifactRetrieveRequest{
-            .artifact_id = try allocator.dupe(u8, payload.get("artifact_id").?.string),
+            .artifact_id = try allocator.dupe(u8, try parseRequiredJsonString(payload, "artifact_id")),
         };
         errdefer allocator.free(req.artifact_id);
 
@@ -472,7 +480,7 @@ fn deserializePayload(type_str: []const u8, payload: std.json.ObjectMap, allocat
     }
     if (std.mem.eql(u8, type_str, "artifact_retrieved")) {
         var res = tool_types.ArtifactRetrieveResponse{
-            .artifact = try deserializeArtifactReference(payload.get("artifact").?.object, allocator),
+            .artifact = try deserializeArtifactReference(try parseRequiredJsonObject(payload, "artifact"), allocator),
         };
         errdefer res.deinit(allocator);
         if (payload.get("content_json")) |v| res.content_json = OwnedSlice(u8).initOwned(try allocator.dupe(u8, try parseJsonString(v)));
@@ -480,7 +488,7 @@ fn deserializePayload(type_str: []const u8, payload: std.json.ObjectMap, allocat
     }
     if (std.mem.eql(u8, type_str, "artifact_search")) {
         var req = tool_types.ArtifactSearchRequest{
-            .query = try allocator.dupe(u8, payload.get("query").?.string),
+            .query = try allocator.dupe(u8, try parseRequiredJsonString(payload, "query")),
         };
         errdefer allocator.free(req.query);
 
@@ -488,7 +496,7 @@ fn deserializePayload(type_str: []const u8, payload: std.json.ObjectMap, allocat
         return .{ .artifact_search = req };
     }
     if (std.mem.eql(u8, type_str, "artifact_search_result")) {
-        const values = payload.get("results").?.array;
+        const values = try parseRequiredJsonArray(payload, "results");
         const results = try allocator.alloc(tool_types.ArtifactSearchResult, values.items.len);
         var initialized: usize = 0;
         errdefer {
@@ -496,13 +504,13 @@ fn deserializePayload(type_str: []const u8, payload: std.json.ObjectMap, allocat
             allocator.free(results);
         }
         for (values.items, 0..) |item, i| {
-            const obj = item.object;
+            const obj = try parseJsonObject(item);
             results[i] = blk: {
                 var result = tool_types.ArtifactSearchResult{
-                    .artifact = try deserializeArtifactReference(obj.get("artifact").?.object, allocator),
+                    .artifact = try deserializeArtifactReference(try parseRequiredJsonObject(obj, "artifact"), allocator),
                 };
                 errdefer result.deinit(allocator);
-                if (obj.get("snippet")) |v| result.snippet = OwnedSlice(u8).initOwned(try allocator.dupe(u8, v.string));
+                if (obj.get("snippet")) |v| result.snippet = OwnedSlice(u8).initOwned(try allocator.dupe(u8, try parseJsonString(v)));
                 if (obj.get("score")) |v| result.score = switch (v) {
                     .float => |f| @floatCast(f),
                     .integer => |n| @floatFromInt(n),
@@ -516,7 +524,7 @@ fn deserializePayload(type_str: []const u8, payload: std.json.ObjectMap, allocat
     }
     if (std.mem.eql(u8, type_str, "hashline_read")) {
         var req = tool_types.HashlineReadRequest{
-            .path = try allocator.dupe(u8, payload.get("path").?.string),
+            .path = try allocator.dupe(u8, try parseRequiredJsonString(payload, "path")),
             .feature_enabled = if (payload.get("feature_enabled")) |v| v.bool else false,
         };
         errdefer allocator.free(req.path);
@@ -525,7 +533,7 @@ fn deserializePayload(type_str: []const u8, payload: std.json.ObjectMap, allocat
         return .{ .hashline_read = req };
     }
     if (std.mem.eql(u8, type_str, "hashline_read_result")) {
-        const values = payload.get("lines").?.array;
+        const values = try parseRequiredJsonArray(payload, "lines");
         const lines = try allocator.alloc(tool_types.HashlineLine, values.items.len);
         var initialized: usize = 0;
         errdefer {
@@ -533,12 +541,12 @@ fn deserializePayload(type_str: []const u8, payload: std.json.ObjectMap, allocat
             allocator.free(lines);
         }
         for (values.items, 0..) |item, i| {
-            const obj = item.object;
+            const obj = try parseJsonObject(item);
             lines[i] = blk: {
-                const line = try parseUnsignedJsonInteger(u32, obj.get("line").?);
-                const hash = try allocator.dupe(u8, obj.get("hash").?.string);
+                const line = try parseUnsignedJsonInteger(u32, obj.get("line") orelse return error.InvalidPayloadType);
+                const hash = try allocator.dupe(u8, try parseRequiredJsonString(obj, "hash"));
                 errdefer allocator.free(hash);
-                const text = try allocator.dupe(u8, obj.get("text").?.string);
+                const text = try allocator.dupe(u8, try parseRequiredJsonString(obj, "text"));
                 errdefer allocator.free(text);
                 break :blk .{
                     .line = line,
@@ -549,13 +557,13 @@ fn deserializePayload(type_str: []const u8, payload: std.json.ObjectMap, allocat
             initialized += 1;
         }
         return .{ .hashline_read_result = .{
-            .path = try allocator.dupe(u8, payload.get("path").?.string),
+            .path = try allocator.dupe(u8, try parseRequiredJsonString(payload, "path")),
             .lines = lines,
         } };
     }
     if (std.mem.eql(u8, type_str, "hashline_edit")) {
         var req = tool_types.HashlineEditRequest{
-            .path = try allocator.dupe(u8, payload.get("path").?.string),
+            .path = try allocator.dupe(u8, try parseRequiredJsonString(payload, "path")),
             .operation = undefined,
             .start_line = undefined,
             .start_hash = "",
@@ -568,22 +576,22 @@ fn deserializePayload(type_str: []const u8, payload: std.json.ObjectMap, allocat
             req.end_hash.deinit(allocator);
             req.replacement.deinit(allocator);
         }
-        req.operation = std.meta.stringToEnum(tool_types.HashlineEditOperation, payload.get("operation").?.string) orelse return error.InvalidPayloadType;
-        req.start_line = try parseUnsignedJsonInteger(u32, payload.get("start_line").?);
-        req.start_hash = try allocator.dupe(u8, payload.get("start_hash").?.string);
+        req.operation = std.meta.stringToEnum(tool_types.HashlineEditOperation, try parseRequiredJsonString(payload, "operation")) orelse return error.InvalidPayloadType;
+        req.start_line = try parseUnsignedJsonInteger(u32, payload.get("start_line") orelse return error.InvalidPayloadType);
+        req.start_hash = try allocator.dupe(u8, try parseRequiredJsonString(payload, "start_hash"));
         owns_start_hash = true;
         if (payload.get("end_line")) |v| req.end_line = try parseUnsignedJsonInteger(u32, v);
-        if (payload.get("end_hash")) |v| req.end_hash = OwnedSlice(u8).initOwned(try allocator.dupe(u8, v.string));
-        if (payload.get("replacement")) |v| req.replacement = OwnedSlice(u8).initOwned(try allocator.dupe(u8, v.string));
+        if (payload.get("end_hash")) |v| req.end_hash = OwnedSlice(u8).initOwned(try allocator.dupe(u8, try parseJsonString(v)));
+        if (payload.get("replacement")) |v| req.replacement = OwnedSlice(u8).initOwned(try allocator.dupe(u8, try parseJsonString(v)));
         return .{ .hashline_edit = req };
     }
     if (std.mem.eql(u8, type_str, "hashline_edit_result")) {
         var res = tool_types.HashlineEditResponse{
-            .path = try allocator.dupe(u8, payload.get("path").?.string),
+            .path = try allocator.dupe(u8, try parseRequiredJsonString(payload, "path")),
             .applied = payload.get("applied").?.bool,
         };
         errdefer res.deinit(allocator);
-        if (payload.get("new_artifact")) |v| res.new_artifact = try deserializeArtifactReference(v.object, allocator);
+        if (payload.get("new_artifact")) |v| res.new_artifact = try deserializeArtifactReference(try parseJsonObject(v), allocator);
         return .{ .hashline_edit_result = res };
     }
     if (std.mem.eql(u8, type_str, "ping")) return .ping;
@@ -854,9 +862,15 @@ test "tool envelope rejects malformed hashline edit without leaks" {
         "{\"type\":\"hashline_edit\",\"server_id\":\"00000000000000000000000001\",\"message_id\":\"00000000000000000000000002\",\"sequence\":1,\"timestamp\":1,\"version\":1,\"payload\":{\"path\":\"src/main.zig\",\"operation\":\"invalid\",\"start_line\":1,\"start_hash\":\"a1b2\"}}";
     const negative_start_line =
         "{\"type\":\"hashline_edit\",\"server_id\":\"00000000000000000000000001\",\"message_id\":\"00000000000000000000000002\",\"sequence\":1,\"timestamp\":1,\"version\":1,\"payload\":{\"path\":\"src/main.zig\",\"operation\":\"replace_range\",\"start_line\":-1,\"start_hash\":\"a1b2\"}}";
+    const non_string_end_hash =
+        "{\"type\":\"hashline_edit\",\"server_id\":\"00000000000000000000000001\",\"message_id\":\"00000000000000000000000002\",\"sequence\":1,\"timestamp\":1,\"version\":1,\"payload\":{\"path\":\"src/main.zig\",\"operation\":\"replace_range\",\"start_line\":1,\"start_hash\":\"a1b2\",\"end_hash\":42}}";
+    const non_string_replacement =
+        "{\"type\":\"hashline_edit\",\"server_id\":\"00000000000000000000000001\",\"message_id\":\"00000000000000000000000002\",\"sequence\":1,\"timestamp\":1,\"version\":1,\"payload\":{\"path\":\"src/main.zig\",\"operation\":\"replace_range\",\"start_line\":1,\"start_hash\":\"a1b2\",\"replacement\":42}}";
 
     try std.testing.expectError(error.InvalidPayloadType, deserializeEnvelope(invalid_operation, allocator));
     try std.testing.expectError(error.InvalidPayloadType, deserializeEnvelope(negative_start_line, allocator));
+    try std.testing.expectError(error.InvalidPayloadType, deserializeEnvelope(non_string_end_hash, allocator));
+    try std.testing.expectError(error.InvalidPayloadType, deserializeEnvelope(non_string_replacement, allocator));
 }
 
 test "tool envelope rejects malformed artifact references without leaks" {
@@ -896,4 +910,32 @@ test "tool envelope rejects remaining negative unsigned fields without leaks" {
     try std.testing.expectError(error.InvalidPayloadType, deserializeEnvelope(negative_search_limit, allocator));
     try std.testing.expectError(error.InvalidPayloadType, deserializeEnvelope(negative_read_limit, allocator));
     try std.testing.expectError(error.InvalidPayloadType, deserializeEnvelope(negative_result_line, allocator));
+}
+
+test "tool envelope rejects malformed artifact search results without leaks" {
+    const allocator = std.testing.allocator;
+    const missing_artifact =
+        "{\"type\":\"artifact_search_result\",\"server_id\":\"00000000000000000000000001\",\"message_id\":\"00000000000000000000000002\",\"sequence\":1,\"timestamp\":1,\"version\":1,\"payload\":{\"results\":[{\"snippet\":\"hit\"}]}}";
+    const non_object_artifact =
+        "{\"type\":\"artifact_search_result\",\"server_id\":\"00000000000000000000000001\",\"message_id\":\"00000000000000000000000002\",\"sequence\":1,\"timestamp\":1,\"version\":1,\"payload\":{\"results\":[{\"artifact\":\"artifact-1\"}]}}";
+    const non_object_result =
+        "{\"type\":\"artifact_search_result\",\"server_id\":\"00000000000000000000000001\",\"message_id\":\"00000000000000000000000002\",\"sequence\":1,\"timestamp\":1,\"version\":1,\"payload\":{\"results\":[42]}}";
+
+    try std.testing.expectError(error.InvalidPayloadType, deserializeEnvelope(missing_artifact, allocator));
+    try std.testing.expectError(error.InvalidPayloadType, deserializeEnvelope(non_object_artifact, allocator));
+    try std.testing.expectError(error.InvalidPayloadType, deserializeEnvelope(non_object_result, allocator));
+}
+
+test "tool envelope rejects malformed hashline read results without leaks" {
+    const allocator = std.testing.allocator;
+    const non_object_line =
+        "{\"type\":\"hashline_read_result\",\"server_id\":\"00000000000000000000000001\",\"message_id\":\"00000000000000000000000002\",\"sequence\":1,\"timestamp\":1,\"version\":1,\"payload\":{\"path\":\"src/main.zig\",\"lines\":[42]}}";
+    const non_string_hash =
+        "{\"type\":\"hashline_read_result\",\"server_id\":\"00000000000000000000000001\",\"message_id\":\"00000000000000000000000002\",\"sequence\":1,\"timestamp\":1,\"version\":1,\"payload\":{\"path\":\"src/main.zig\",\"lines\":[{\"line\":1,\"hash\":42,\"text\":\"bad\"}]}}";
+    const non_string_text =
+        "{\"type\":\"hashline_read_result\",\"server_id\":\"00000000000000000000000001\",\"message_id\":\"00000000000000000000000002\",\"sequence\":1,\"timestamp\":1,\"version\":1,\"payload\":{\"path\":\"src/main.zig\",\"lines\":[{\"line\":1,\"hash\":\"abc\",\"text\":42}]}}";
+
+    try std.testing.expectError(error.InvalidPayloadType, deserializeEnvelope(non_object_line, allocator));
+    try std.testing.expectError(error.InvalidPayloadType, deserializeEnvelope(non_string_hash, allocator));
+    try std.testing.expectError(error.InvalidPayloadType, deserializeEnvelope(non_string_text, allocator));
 }

--- a/zig/src/protocol/tool/envelope.zig
+++ b/zig/src/protocol/tool/envelope.zig
@@ -299,6 +299,10 @@ fn parseJsonObject(value: std.json.Value) !std.json.ObjectMap {
     };
 }
 
+fn parseRequiredJsonString(obj: std.json.ObjectMap, key: []const u8) ![]const u8 {
+    return parseJsonString(obj.get(key) orelse return error.InvalidPayloadType);
+}
+
 fn parseUnsignedJsonInteger(comptime T: type, value: std.json.Value) !T {
     return switch (value) {
         .integer => |n| std.math.cast(T, n) orelse error.InvalidPayloadType,
@@ -312,7 +316,7 @@ fn parseOptionalUnsignedJsonInteger(comptime T: type, value: ?std.json.Value) !?
 
 fn deserializeArtifactReference(obj: std.json.ObjectMap, allocator: std.mem.Allocator) !tool_types.ArtifactReference {
     var artifact = tool_types.ArtifactReference{
-        .artifact_id = try allocator.dupe(u8, try parseJsonString(obj.get("artifact_id").?)),
+        .artifact_id = try allocator.dupe(u8, try parseRequiredJsonString(obj, "artifact_id")),
     };
     errdefer artifact.deinit(allocator);
 
@@ -471,7 +475,7 @@ fn deserializePayload(type_str: []const u8, payload: std.json.ObjectMap, allocat
             .artifact = try deserializeArtifactReference(payload.get("artifact").?.object, allocator),
         };
         errdefer res.deinit(allocator);
-        if (payload.get("content_json")) |v| res.content_json = OwnedSlice(u8).initOwned(try allocator.dupe(u8, v.string));
+        if (payload.get("content_json")) |v| res.content_json = OwnedSlice(u8).initOwned(try allocator.dupe(u8, try parseJsonString(v)));
         return .{ .artifact_retrieved = res };
     }
     if (std.mem.eql(u8, type_str, "artifact_search")) {
@@ -857,13 +861,19 @@ test "tool envelope rejects malformed hashline edit without leaks" {
 
 test "tool envelope rejects malformed artifact references without leaks" {
     const allocator = std.testing.allocator;
+    const missing_artifact_id =
+        "{\"type\":\"artifact_retrieved\",\"server_id\":\"00000000000000000000000001\",\"message_id\":\"00000000000000000000000002\",\"sequence\":1,\"timestamp\":1,\"version\":1,\"payload\":{\"artifact\":{\"uri\":\"makai-artifact://artifact-1\"}}}";
     const negative_byte_size =
         "{\"type\":\"artifact_retrieved\",\"server_id\":\"00000000000000000000000001\",\"message_id\":\"00000000000000000000000002\",\"sequence\":1,\"timestamp\":1,\"version\":1,\"payload\":{\"artifact\":{\"artifact_id\":\"artifact-1\",\"byte_size\":-1}}}";
     const non_string_uri =
         "{\"type\":\"artifact_retrieved\",\"server_id\":\"00000000000000000000000001\",\"message_id\":\"00000000000000000000000002\",\"sequence\":1,\"timestamp\":1,\"version\":1,\"payload\":{\"artifact\":{\"artifact_id\":\"artifact-1\",\"uri\":42}}}";
+    const non_string_content_json =
+        "{\"type\":\"artifact_retrieved\",\"server_id\":\"00000000000000000000000001\",\"message_id\":\"00000000000000000000000002\",\"sequence\":1,\"timestamp\":1,\"version\":1,\"payload\":{\"artifact\":{\"artifact_id\":\"artifact-1\"},\"content_json\":42}}";
 
+    try std.testing.expectError(error.InvalidPayloadType, deserializeEnvelope(missing_artifact_id, allocator));
     try std.testing.expectError(error.InvalidPayloadType, deserializeEnvelope(negative_byte_size, allocator));
     try std.testing.expectError(error.InvalidPayloadType, deserializeEnvelope(non_string_uri, allocator));
+    try std.testing.expectError(error.InvalidPayloadType, deserializeEnvelope(non_string_content_json, allocator));
 }
 
 test "tool envelope rejects non-array tool result artifacts without leaks" {

--- a/zig/src/protocol/tool/envelope.zig
+++ b/zig/src/protocol/tool/envelope.zig
@@ -299,6 +299,13 @@ fn parseJsonObject(value: std.json.Value) !std.json.ObjectMap {
     };
 }
 
+fn parseJsonBool(value: std.json.Value) !bool {
+    return switch (value) {
+        .bool => |b| b,
+        else => error.InvalidPayloadType,
+    };
+}
+
 fn parseRequiredJsonString(obj: std.json.ObjectMap, key: []const u8) ![]const u8 {
     return parseJsonString(obj.get(key) orelse return error.InvalidPayloadType);
 }
@@ -309,6 +316,10 @@ fn parseRequiredJsonArray(obj: std.json.ObjectMap, key: []const u8) !std.json.Ar
 
 fn parseRequiredJsonObject(obj: std.json.ObjectMap, key: []const u8) !std.json.ObjectMap {
     return parseJsonObject(obj.get(key) orelse return error.InvalidPayloadType);
+}
+
+fn parseRequiredJsonBool(obj: std.json.ObjectMap, key: []const u8) !bool {
+    return parseJsonBool(obj.get(key) orelse return error.InvalidPayloadType);
 }
 
 fn parseUnsignedJsonInteger(comptime T: type, value: std.json.Value) !T {
@@ -523,9 +534,10 @@ fn deserializePayload(type_str: []const u8, payload: std.json.ObjectMap, allocat
         return .{ .artifact_search_result = .{ .results = results } };
     }
     if (std.mem.eql(u8, type_str, "hashline_read")) {
+        const feature_enabled = if (payload.get("feature_enabled")) |v| try parseJsonBool(v) else false;
         var req = tool_types.HashlineReadRequest{
             .path = try allocator.dupe(u8, try parseRequiredJsonString(payload, "path")),
-            .feature_enabled = if (payload.get("feature_enabled")) |v| v.bool else false,
+            .feature_enabled = feature_enabled,
         };
         errdefer allocator.free(req.path);
 
@@ -562,12 +574,13 @@ fn deserializePayload(type_str: []const u8, payload: std.json.ObjectMap, allocat
         } };
     }
     if (std.mem.eql(u8, type_str, "hashline_edit")) {
+        const feature_enabled = if (payload.get("feature_enabled")) |v| try parseJsonBool(v) else false;
         var req = tool_types.HashlineEditRequest{
             .path = try allocator.dupe(u8, try parseRequiredJsonString(payload, "path")),
             .operation = undefined,
             .start_line = undefined,
             .start_hash = "",
-            .feature_enabled = if (payload.get("feature_enabled")) |v| v.bool else false,
+            .feature_enabled = feature_enabled,
         };
         var owns_start_hash = false;
         errdefer {
@@ -586,9 +599,10 @@ fn deserializePayload(type_str: []const u8, payload: std.json.ObjectMap, allocat
         return .{ .hashline_edit = req };
     }
     if (std.mem.eql(u8, type_str, "hashline_edit_result")) {
+        const applied = try parseRequiredJsonBool(payload, "applied");
         var res = tool_types.HashlineEditResponse{
             .path = try allocator.dupe(u8, try parseRequiredJsonString(payload, "path")),
-            .applied = payload.get("applied").?.bool,
+            .applied = applied,
         };
         errdefer res.deinit(allocator);
         if (payload.get("new_artifact")) |v| res.new_artifact = try deserializeArtifactReference(try parseJsonObject(v), allocator);
@@ -866,11 +880,14 @@ test "tool envelope rejects malformed hashline edit without leaks" {
         "{\"type\":\"hashline_edit\",\"server_id\":\"00000000000000000000000001\",\"message_id\":\"00000000000000000000000002\",\"sequence\":1,\"timestamp\":1,\"version\":1,\"payload\":{\"path\":\"src/main.zig\",\"operation\":\"replace_range\",\"start_line\":1,\"start_hash\":\"a1b2\",\"end_hash\":42}}";
     const non_string_replacement =
         "{\"type\":\"hashline_edit\",\"server_id\":\"00000000000000000000000001\",\"message_id\":\"00000000000000000000000002\",\"sequence\":1,\"timestamp\":1,\"version\":1,\"payload\":{\"path\":\"src/main.zig\",\"operation\":\"replace_range\",\"start_line\":1,\"start_hash\":\"a1b2\",\"replacement\":42}}";
+    const non_bool_feature_enabled =
+        "{\"type\":\"hashline_edit\",\"server_id\":\"00000000000000000000000001\",\"message_id\":\"00000000000000000000000002\",\"sequence\":1,\"timestamp\":1,\"version\":1,\"payload\":{\"path\":\"src/main.zig\",\"operation\":\"replace_range\",\"start_line\":1,\"start_hash\":\"a1b2\",\"feature_enabled\":\"yes\"}}";
 
     try std.testing.expectError(error.InvalidPayloadType, deserializeEnvelope(invalid_operation, allocator));
     try std.testing.expectError(error.InvalidPayloadType, deserializeEnvelope(negative_start_line, allocator));
     try std.testing.expectError(error.InvalidPayloadType, deserializeEnvelope(non_string_end_hash, allocator));
     try std.testing.expectError(error.InvalidPayloadType, deserializeEnvelope(non_string_replacement, allocator));
+    try std.testing.expectError(error.InvalidPayloadType, deserializeEnvelope(non_bool_feature_enabled, allocator));
 }
 
 test "tool envelope rejects malformed artifact references without leaks" {
@@ -938,4 +955,23 @@ test "tool envelope rejects malformed hashline read results without leaks" {
     try std.testing.expectError(error.InvalidPayloadType, deserializeEnvelope(non_object_line, allocator));
     try std.testing.expectError(error.InvalidPayloadType, deserializeEnvelope(non_string_hash, allocator));
     try std.testing.expectError(error.InvalidPayloadType, deserializeEnvelope(non_string_text, allocator));
+}
+
+test "tool envelope rejects malformed hashline read request feature flag without leaks" {
+    const allocator = std.testing.allocator;
+    const non_bool_feature_enabled =
+        "{\"type\":\"hashline_read\",\"server_id\":\"00000000000000000000000001\",\"message_id\":\"00000000000000000000000002\",\"sequence\":1,\"timestamp\":1,\"version\":1,\"payload\":{\"path\":\"src/main.zig\",\"feature_enabled\":\"yes\"}}";
+
+    try std.testing.expectError(error.InvalidPayloadType, deserializeEnvelope(non_bool_feature_enabled, allocator));
+}
+
+test "tool envelope rejects malformed hashline edit results without leaks" {
+    const allocator = std.testing.allocator;
+    const missing_applied =
+        "{\"type\":\"hashline_edit_result\",\"server_id\":\"00000000000000000000000001\",\"message_id\":\"00000000000000000000000002\",\"sequence\":1,\"timestamp\":1,\"version\":1,\"payload\":{\"path\":\"src/main.zig\"}}";
+    const non_bool_applied =
+        "{\"type\":\"hashline_edit_result\",\"server_id\":\"00000000000000000000000001\",\"message_id\":\"00000000000000000000000002\",\"sequence\":1,\"timestamp\":1,\"version\":1,\"payload\":{\"path\":\"src/main.zig\",\"applied\":\"yes\"}}";
+
+    try std.testing.expectError(error.InvalidPayloadType, deserializeEnvelope(missing_applied, allocator));
+    try std.testing.expectError(error.InvalidPayloadType, deserializeEnvelope(non_bool_applied, allocator));
 }

--- a/zig/src/protocol/tool/envelope.zig
+++ b/zig/src/protocol/tool/envelope.zig
@@ -278,6 +278,27 @@ fn parseUlidRequired(str: []const u8) !tool_types.Ulid {
     return tool_types.parseUlid(str) orelse error.InvalidUlid;
 }
 
+fn parseJsonString(value: std.json.Value) ![]const u8 {
+    return switch (value) {
+        .string => |s| s,
+        else => error.InvalidPayloadType,
+    };
+}
+
+fn parseJsonArray(value: std.json.Value) !std.json.Array {
+    return switch (value) {
+        .array => |a| a,
+        else => error.InvalidPayloadType,
+    };
+}
+
+fn parseJsonObject(value: std.json.Value) !std.json.ObjectMap {
+    return switch (value) {
+        .object => |o| o,
+        else => error.InvalidPayloadType,
+    };
+}
+
 fn parseUnsignedJsonInteger(comptime T: type, value: std.json.Value) !T {
     return switch (value) {
         .integer => |n| std.math.cast(T, n) orelse error.InvalidPayloadType,
@@ -291,15 +312,15 @@ fn parseOptionalUnsignedJsonInteger(comptime T: type, value: ?std.json.Value) !?
 
 fn deserializeArtifactReference(obj: std.json.ObjectMap, allocator: std.mem.Allocator) !tool_types.ArtifactReference {
     var artifact = tool_types.ArtifactReference{
-        .artifact_id = try allocator.dupe(u8, obj.get("artifact_id").?.string),
+        .artifact_id = try allocator.dupe(u8, try parseJsonString(obj.get("artifact_id").?)),
     };
     errdefer artifact.deinit(allocator);
 
-    if (obj.get("uri")) |v| artifact.uri = OwnedSlice(u8).initOwned(try allocator.dupe(u8, v.string));
-    if (obj.get("mime_type")) |v| artifact.mime_type = OwnedSlice(u8).initOwned(try allocator.dupe(u8, v.string));
-    if (obj.get("byte_size")) |v| artifact.byte_size = @as(u64, @intCast(v.integer));
-    if (obj.get("sha256")) |v| artifact.sha256 = OwnedSlice(u8).initOwned(try allocator.dupe(u8, v.string));
-    if (obj.get("description")) |v| artifact.description = OwnedSlice(u8).initOwned(try allocator.dupe(u8, v.string));
+    if (obj.get("uri")) |v| artifact.uri = OwnedSlice(u8).initOwned(try allocator.dupe(u8, try parseJsonString(v)));
+    if (obj.get("mime_type")) |v| artifact.mime_type = OwnedSlice(u8).initOwned(try allocator.dupe(u8, try parseJsonString(v)));
+    if (obj.get("byte_size")) |v| artifact.byte_size = try parseUnsignedJsonInteger(u64, v);
+    if (obj.get("sha256")) |v| artifact.sha256 = OwnedSlice(u8).initOwned(try allocator.dupe(u8, try parseJsonString(v)));
+    if (obj.get("description")) |v| artifact.description = OwnedSlice(u8).initOwned(try allocator.dupe(u8, try parseJsonString(v)));
 
     return artifact;
 }
@@ -313,7 +334,7 @@ fn deserializeArtifactReferences(array: std.json.Array, allocator: std.mem.Alloc
     }
 
     for (array.items, 0..) |item, i| {
-        artifacts[i] = try deserializeArtifactReference(item.object, allocator);
+        artifacts[i] = try deserializeArtifactReference(try parseJsonObject(item), allocator);
         initialized += 1;
     }
 
@@ -390,9 +411,16 @@ fn deserializePayload(type_str: []const u8, payload: std.json.ObjectMap, allocat
             .is_error = if (payload.get("is_error")) |v| v.bool else false,
             .duration_ms = @as(u32, @intCast(payload.get("duration_ms").?.integer)),
         };
+        errdefer {
+            allocator.free(result.tool_call_id);
+            allocator.free(result.result_json);
+            result.error_message.deinit(allocator);
+            result.details_json.deinit(allocator);
+            result.artifacts.deinit(allocator);
+        }
         if (payload.get("error_message")) |v| result.error_message = OwnedSlice(u8).initOwned(try allocator.dupe(u8, v.string));
         if (payload.get("details_json")) |v| result.details_json = OwnedSlice(u8).initOwned(try allocator.dupe(u8, v.string));
-        if (payload.get("artifacts")) |v| result.artifacts = OwnedSlice(tool_types.ArtifactReference).initOwned(try deserializeArtifactReferences(v.array, allocator));
+        if (payload.get("artifacts")) |v| result.artifacts = OwnedSlice(tool_types.ArtifactReference).initOwned(try deserializeArtifactReferences(try parseJsonArray(v), allocator));
         return .{ .tool_result = result };
     }
     if (std.mem.eql(u8, type_str, "tool_cancel")) {
@@ -447,10 +475,13 @@ fn deserializePayload(type_str: []const u8, payload: std.json.ObjectMap, allocat
         return .{ .artifact_retrieved = res };
     }
     if (std.mem.eql(u8, type_str, "artifact_search")) {
-        return .{ .artifact_search = .{
+        var req = tool_types.ArtifactSearchRequest{
             .query = try allocator.dupe(u8, payload.get("query").?.string),
-            .limit = if (payload.get("limit")) |v| @as(u32, @intCast(v.integer)) else null,
-        } };
+        };
+        errdefer allocator.free(req.query);
+
+        req.limit = try parseOptionalUnsignedJsonInteger(u32, payload.get("limit"));
+        return .{ .artifact_search = req };
     }
     if (std.mem.eql(u8, type_str, "artifact_search_result")) {
         const values = payload.get("results").?.array;
@@ -480,11 +511,14 @@ fn deserializePayload(type_str: []const u8, payload: std.json.ObjectMap, allocat
         return .{ .artifact_search_result = .{ .results = results } };
     }
     if (std.mem.eql(u8, type_str, "hashline_read")) {
-        return .{ .hashline_read = .{
+        var req = tool_types.HashlineReadRequest{
             .path = try allocator.dupe(u8, payload.get("path").?.string),
             .feature_enabled = if (payload.get("feature_enabled")) |v| v.bool else false,
-            .byte_limit = if (payload.get("byte_limit")) |v| @as(u64, @intCast(v.integer)) else null,
-        } };
+        };
+        errdefer allocator.free(req.path);
+
+        req.byte_limit = try parseOptionalUnsignedJsonInteger(u64, payload.get("byte_limit"));
+        return .{ .hashline_read = req };
     }
     if (std.mem.eql(u8, type_str, "hashline_read_result")) {
         const values = payload.get("lines").?.array;
@@ -497,12 +531,13 @@ fn deserializePayload(type_str: []const u8, payload: std.json.ObjectMap, allocat
         for (values.items, 0..) |item, i| {
             const obj = item.object;
             lines[i] = blk: {
+                const line = try parseUnsignedJsonInteger(u32, obj.get("line").?);
                 const hash = try allocator.dupe(u8, obj.get("hash").?.string);
                 errdefer allocator.free(hash);
                 const text = try allocator.dupe(u8, obj.get("text").?.string);
                 errdefer allocator.free(text);
                 break :blk .{
-                    .line = @as(u32, @intCast(obj.get("line").?.integer)),
+                    .line = line,
                     .hash = hash,
                     .text = text,
                 };
@@ -522,15 +557,17 @@ fn deserializePayload(type_str: []const u8, payload: std.json.ObjectMap, allocat
             .start_hash = "",
             .feature_enabled = if (payload.get("feature_enabled")) |v| v.bool else false,
         };
+        var owns_start_hash = false;
         errdefer {
             allocator.free(req.path);
-            allocator.free(req.start_hash);
+            if (owns_start_hash) allocator.free(req.start_hash);
             req.end_hash.deinit(allocator);
             req.replacement.deinit(allocator);
         }
         req.operation = std.meta.stringToEnum(tool_types.HashlineEditOperation, payload.get("operation").?.string) orelse return error.InvalidPayloadType;
         req.start_line = try parseUnsignedJsonInteger(u32, payload.get("start_line").?);
         req.start_hash = try allocator.dupe(u8, payload.get("start_hash").?.string);
+        owns_start_hash = true;
         if (payload.get("end_line")) |v| req.end_line = try parseUnsignedJsonInteger(u32, v);
         if (payload.get("end_hash")) |v| req.end_hash = OwnedSlice(u8).initOwned(try allocator.dupe(u8, v.string));
         if (payload.get("replacement")) |v| req.replacement = OwnedSlice(u8).initOwned(try allocator.dupe(u8, v.string));
@@ -816,4 +853,37 @@ test "tool envelope rejects malformed hashline edit without leaks" {
 
     try std.testing.expectError(error.InvalidPayloadType, deserializeEnvelope(invalid_operation, allocator));
     try std.testing.expectError(error.InvalidPayloadType, deserializeEnvelope(negative_start_line, allocator));
+}
+
+test "tool envelope rejects malformed artifact references without leaks" {
+    const allocator = std.testing.allocator;
+    const negative_byte_size =
+        "{\"type\":\"artifact_retrieved\",\"server_id\":\"00000000000000000000000001\",\"message_id\":\"00000000000000000000000002\",\"sequence\":1,\"timestamp\":1,\"version\":1,\"payload\":{\"artifact\":{\"artifact_id\":\"artifact-1\",\"byte_size\":-1}}}";
+    const non_string_uri =
+        "{\"type\":\"artifact_retrieved\",\"server_id\":\"00000000000000000000000001\",\"message_id\":\"00000000000000000000000002\",\"sequence\":1,\"timestamp\":1,\"version\":1,\"payload\":{\"artifact\":{\"artifact_id\":\"artifact-1\",\"uri\":42}}}";
+
+    try std.testing.expectError(error.InvalidPayloadType, deserializeEnvelope(negative_byte_size, allocator));
+    try std.testing.expectError(error.InvalidPayloadType, deserializeEnvelope(non_string_uri, allocator));
+}
+
+test "tool envelope rejects non-array tool result artifacts without leaks" {
+    const allocator = std.testing.allocator;
+    const json =
+        "{\"type\":\"tool_result\",\"server_id\":\"00000000000000000000000001\",\"message_id\":\"00000000000000000000000002\",\"sequence\":1,\"timestamp\":1,\"version\":1,\"payload\":{\"execution_id\":\"00000000000000000000000003\",\"tool_call_id\":\"call_1\",\"result_json\":\"{}\",\"duration_ms\":1,\"artifacts\":\"not-array\"}}";
+
+    try std.testing.expectError(error.InvalidPayloadType, deserializeEnvelope(json, allocator));
+}
+
+test "tool envelope rejects remaining negative unsigned fields without leaks" {
+    const allocator = std.testing.allocator;
+    const negative_search_limit =
+        "{\"type\":\"artifact_search\",\"server_id\":\"00000000000000000000000001\",\"message_id\":\"00000000000000000000000002\",\"sequence\":1,\"timestamp\":1,\"version\":1,\"payload\":{\"query\":\"needle\",\"limit\":-1}}";
+    const negative_read_limit =
+        "{\"type\":\"hashline_read\",\"server_id\":\"00000000000000000000000001\",\"message_id\":\"00000000000000000000000002\",\"sequence\":1,\"timestamp\":1,\"version\":1,\"payload\":{\"path\":\"src/main.zig\",\"byte_limit\":-1}}";
+    const negative_result_line =
+        "{\"type\":\"hashline_read_result\",\"server_id\":\"00000000000000000000000001\",\"message_id\":\"00000000000000000000000002\",\"sequence\":1,\"timestamp\":1,\"version\":1,\"payload\":{\"path\":\"src/main.zig\",\"lines\":[{\"line\":-1,\"hash\":\"abc\",\"text\":\"bad\"}]}}";
+
+    try std.testing.expectError(error.InvalidPayloadType, deserializeEnvelope(negative_search_limit, allocator));
+    try std.testing.expectError(error.InvalidPayloadType, deserializeEnvelope(negative_read_limit, allocator));
+    try std.testing.expectError(error.InvalidPayloadType, deserializeEnvelope(negative_result_line, allocator));
 }

--- a/zig/src/protocol/tool/envelope.zig
+++ b/zig/src/protocol/tool/envelope.zig
@@ -278,6 +278,17 @@ fn parseUlidRequired(str: []const u8) !tool_types.Ulid {
     return tool_types.parseUlid(str) orelse error.InvalidUlid;
 }
 
+fn parseUnsignedJsonInteger(comptime T: type, value: std.json.Value) !T {
+    return switch (value) {
+        .integer => |n| std.math.cast(T, n) orelse error.InvalidPayloadType,
+        else => error.InvalidPayloadType,
+    };
+}
+
+fn parseOptionalUnsignedJsonInteger(comptime T: type, value: ?std.json.Value) !?T {
+    return if (value) |v| try parseUnsignedJsonInteger(T, v) else null;
+}
+
 fn deserializeArtifactReference(obj: std.json.ObjectMap, allocator: std.mem.Allocator) !tool_types.ArtifactReference {
     var artifact = tool_types.ArtifactReference{
         .artifact_id = try allocator.dupe(u8, obj.get("artifact_id").?.string),
@@ -418,11 +429,14 @@ fn deserializePayload(type_str: []const u8, payload: std.json.ObjectMap, allocat
         } };
     }
     if (std.mem.eql(u8, type_str, "artifact_retrieve")) {
-        return .{ .artifact_retrieve = .{
+        var req = tool_types.ArtifactRetrieveRequest{
             .artifact_id = try allocator.dupe(u8, payload.get("artifact_id").?.string),
-            .byte_offset = if (payload.get("byte_offset")) |v| @as(u64, @intCast(v.integer)) else null,
-            .byte_limit = if (payload.get("byte_limit")) |v| @as(u64, @intCast(v.integer)) else null,
-        } };
+        };
+        errdefer allocator.free(req.artifact_id);
+
+        req.byte_offset = try parseOptionalUnsignedJsonInteger(u64, payload.get("byte_offset"));
+        req.byte_limit = try parseOptionalUnsignedJsonInteger(u64, payload.get("byte_limit"));
+        return .{ .artifact_retrieve = req };
     }
     if (std.mem.eql(u8, type_str, "artifact_retrieved")) {
         var res = tool_types.ArtifactRetrieveResponse{
@@ -503,9 +517,9 @@ fn deserializePayload(type_str: []const u8, payload: std.json.ObjectMap, allocat
     if (std.mem.eql(u8, type_str, "hashline_edit")) {
         var req = tool_types.HashlineEditRequest{
             .path = try allocator.dupe(u8, payload.get("path").?.string),
-            .operation = std.meta.stringToEnum(tool_types.HashlineEditOperation, payload.get("operation").?.string) orelse return error.InvalidPayloadType,
-            .start_line = @as(u32, @intCast(payload.get("start_line").?.integer)),
-            .start_hash = try allocator.dupe(u8, payload.get("start_hash").?.string),
+            .operation = undefined,
+            .start_line = undefined,
+            .start_hash = "",
             .feature_enabled = if (payload.get("feature_enabled")) |v| v.bool else false,
         };
         errdefer {
@@ -514,7 +528,10 @@ fn deserializePayload(type_str: []const u8, payload: std.json.ObjectMap, allocat
             req.end_hash.deinit(allocator);
             req.replacement.deinit(allocator);
         }
-        if (payload.get("end_line")) |v| req.end_line = @as(u32, @intCast(v.integer));
+        req.operation = std.meta.stringToEnum(tool_types.HashlineEditOperation, payload.get("operation").?.string) orelse return error.InvalidPayloadType;
+        req.start_line = try parseUnsignedJsonInteger(u32, payload.get("start_line").?);
+        req.start_hash = try allocator.dupe(u8, payload.get("start_hash").?.string);
+        if (payload.get("end_line")) |v| req.end_line = try parseUnsignedJsonInteger(u32, v);
         if (payload.get("end_hash")) |v| req.end_hash = OwnedSlice(u8).initOwned(try allocator.dupe(u8, v.string));
         if (payload.get("replacement")) |v| req.replacement = OwnedSlice(u8).initOwned(try allocator.dupe(u8, v.string));
         return .{ .hashline_edit = req };
@@ -777,4 +794,26 @@ test "tool envelope roundtrip hashline edit" {
     try std.testing.expectEqual(tool_types.HashlineEditOperation.replace_range, parsed.payload.hashline_edit.operation);
     try std.testing.expectEqualStrings("a1b2", parsed.payload.hashline_edit.start_hash);
     try std.testing.expectEqualStrings("const x = 1;", parsed.payload.hashline_edit.replacement.slice());
+}
+
+test "tool envelope rejects negative artifact retrieve byte ranges" {
+    const allocator = std.testing.allocator;
+    const negative_offset =
+        "{\"type\":\"artifact_retrieve\",\"server_id\":\"00000000000000000000000001\",\"message_id\":\"00000000000000000000000002\",\"sequence\":1,\"timestamp\":1,\"version\":1,\"payload\":{\"artifact_id\":\"artifact-1\",\"byte_offset\":-1}}";
+    const negative_limit =
+        "{\"type\":\"artifact_retrieve\",\"server_id\":\"00000000000000000000000001\",\"message_id\":\"00000000000000000000000002\",\"sequence\":1,\"timestamp\":1,\"version\":1,\"payload\":{\"artifact_id\":\"artifact-1\",\"byte_limit\":-1}}";
+
+    try std.testing.expectError(error.InvalidPayloadType, deserializeEnvelope(negative_offset, allocator));
+    try std.testing.expectError(error.InvalidPayloadType, deserializeEnvelope(negative_limit, allocator));
+}
+
+test "tool envelope rejects malformed hashline edit without leaks" {
+    const allocator = std.testing.allocator;
+    const invalid_operation =
+        "{\"type\":\"hashline_edit\",\"server_id\":\"00000000000000000000000001\",\"message_id\":\"00000000000000000000000002\",\"sequence\":1,\"timestamp\":1,\"version\":1,\"payload\":{\"path\":\"src/main.zig\",\"operation\":\"invalid\",\"start_line\":1,\"start_hash\":\"a1b2\"}}";
+    const negative_start_line =
+        "{\"type\":\"hashline_edit\",\"server_id\":\"00000000000000000000000001\",\"message_id\":\"00000000000000000000000002\",\"sequence\":1,\"timestamp\":1,\"version\":1,\"payload\":{\"path\":\"src/main.zig\",\"operation\":\"replace_range\",\"start_line\":-1,\"start_hash\":\"a1b2\"}}";
+
+    try std.testing.expectError(error.InvalidPayloadType, deserializeEnvelope(invalid_operation, allocator));
+    try std.testing.expectError(error.InvalidPayloadType, deserializeEnvelope(negative_start_line, allocator));
 }

--- a/zig/src/protocol/tool/types.zig
+++ b/zig/src/protocol/tool/types.zig
@@ -35,6 +35,9 @@ pub const ToolErrorCode = enum {
     internal_error,
     tool_unavailable,
     invalid_arguments,
+    artifact_not_found,
+    hashline_disabled,
+    stale_anchor,
 };
 
 /// Tool metadata for registration
@@ -151,6 +154,8 @@ pub const ToolExecuteResult = struct {
     error_message: OwnedSlice(u8) = OwnedSlice(u8).initBorrowed(""),
     /// Additional details JSON
     details_json: OwnedSlice(u8) = OwnedSlice(u8).initBorrowed(""),
+    /// Raw output artifacts retained outside context for retrieval.
+    artifacts: OwnedSlice(ArtifactReference) = OwnedSlice(ArtifactReference).initBorrowed(&.{}),
     /// Execution duration in milliseconds
     duration_ms: u32,
 
@@ -196,6 +201,164 @@ pub const ToolExecutionInfo = struct {
     completed_at: ?i64 = null,
 };
 
+/// Reference to raw tool output or analysis data kept outside model context.
+pub const ArtifactReference = struct {
+    artifact_id: []const u8,
+    uri: OwnedSlice(u8) = OwnedSlice(u8).initBorrowed(""),
+    mime_type: OwnedSlice(u8) = OwnedSlice(u8).initBorrowed(""),
+    byte_size: ?u64 = null,
+    sha256: OwnedSlice(u8) = OwnedSlice(u8).initBorrowed(""),
+    description: OwnedSlice(u8) = OwnedSlice(u8).initBorrowed(""),
+
+    pub fn getUri(self: *const ArtifactReference) ?[]const u8 {
+        const value = self.uri.slice();
+        return if (value.len > 0) value else null;
+    }
+
+    pub fn getMimeType(self: *const ArtifactReference) ?[]const u8 {
+        const value = self.mime_type.slice();
+        return if (value.len > 0) value else null;
+    }
+
+    pub fn getSha256(self: *const ArtifactReference) ?[]const u8 {
+        const value = self.sha256.slice();
+        return if (value.len > 0) value else null;
+    }
+
+    pub fn getDescription(self: *const ArtifactReference) ?[]const u8 {
+        const value = self.description.slice();
+        return if (value.len > 0) value else null;
+    }
+
+    pub fn deinit(self: *ArtifactReference, allocator: std.mem.Allocator) void {
+        allocator.free(self.artifact_id);
+        self.uri.deinit(allocator);
+        self.mime_type.deinit(allocator);
+        self.sha256.deinit(allocator);
+        self.description.deinit(allocator);
+    }
+};
+
+pub const ArtifactRetrieveRequest = struct {
+    artifact_id: []const u8,
+    byte_offset: ?u64 = null,
+    byte_limit: ?u64 = null,
+};
+
+pub const ArtifactRetrieveResponse = struct {
+    artifact: ArtifactReference,
+    content_json: OwnedSlice(u8) = OwnedSlice(u8).initBorrowed(""),
+
+    pub fn getContentJson(self: *const ArtifactRetrieveResponse) ?[]const u8 {
+        const value = self.content_json.slice();
+        return if (value.len > 0) value else null;
+    }
+
+    pub fn deinit(self: *ArtifactRetrieveResponse, allocator: std.mem.Allocator) void {
+        self.artifact.deinit(allocator);
+        self.content_json.deinit(allocator);
+    }
+};
+
+pub const ArtifactSearchRequest = struct {
+    query: []const u8,
+    limit: ?u32 = null,
+};
+
+pub const ArtifactSearchResult = struct {
+    artifact: ArtifactReference,
+    snippet: OwnedSlice(u8) = OwnedSlice(u8).initBorrowed(""),
+    score: ?f32 = null,
+
+    pub fn getSnippet(self: *const ArtifactSearchResult) ?[]const u8 {
+        const value = self.snippet.slice();
+        return if (value.len > 0) value else null;
+    }
+
+    pub fn deinit(self: *ArtifactSearchResult, allocator: std.mem.Allocator) void {
+        self.artifact.deinit(allocator);
+        self.snippet.deinit(allocator);
+    }
+};
+
+pub const ArtifactSearchResponse = struct {
+    results: []const ArtifactSearchResult,
+
+    pub fn deinit(self: *ArtifactSearchResponse, allocator: std.mem.Allocator) void {
+        const mut_results: []ArtifactSearchResult = @constCast(self.results);
+        for (mut_results) |*result| result.deinit(allocator);
+        allocator.free(self.results);
+    }
+};
+
+pub const HashlineEditOperation = enum {
+    replace_range,
+    insert_before,
+    insert_after,
+    delete_range,
+};
+
+pub const HashlineReadRequest = struct {
+    path: []const u8,
+    feature_enabled: bool = false,
+    byte_limit: ?u64 = null,
+};
+
+pub const HashlineLine = struct {
+    line: u32,
+    hash: []const u8,
+    text: []const u8,
+
+    pub fn deinit(self: *HashlineLine, allocator: std.mem.Allocator) void {
+        allocator.free(self.hash);
+        allocator.free(self.text);
+    }
+};
+
+pub const HashlineReadResponse = struct {
+    path: []const u8,
+    lines: []const HashlineLine,
+
+    pub fn deinit(self: *HashlineReadResponse, allocator: std.mem.Allocator) void {
+        allocator.free(self.path);
+        const mut_lines: []HashlineLine = @constCast(self.lines);
+        for (mut_lines) |*line| line.deinit(allocator);
+        allocator.free(self.lines);
+    }
+};
+
+pub const HashlineEditRequest = struct {
+    path: []const u8,
+    operation: HashlineEditOperation,
+    start_line: u32,
+    start_hash: []const u8,
+    end_line: ?u32 = null,
+    end_hash: OwnedSlice(u8) = OwnedSlice(u8).initBorrowed(""),
+    replacement: OwnedSlice(u8) = OwnedSlice(u8).initBorrowed(""),
+    feature_enabled: bool = false,
+
+    pub fn getEndHash(self: *const HashlineEditRequest) ?[]const u8 {
+        const value = self.end_hash.slice();
+        return if (value.len > 0) value else null;
+    }
+
+    pub fn getReplacement(self: *const HashlineEditRequest) ?[]const u8 {
+        const value = self.replacement.slice();
+        return if (value.len > 0) value else null;
+    }
+};
+
+pub const HashlineEditResponse = struct {
+    path: []const u8,
+    applied: bool,
+    new_artifact: ?ArtifactReference = null,
+
+    pub fn deinit(self: *HashlineEditResponse, allocator: std.mem.Allocator) void {
+        allocator.free(self.path);
+        if (self.new_artifact) |*artifact| artifact.deinit(allocator);
+    }
+};
+
 pub const Goodbye = struct {
     reason: OwnedSlice(u8) = OwnedSlice(u8).initBorrowed(""),
 
@@ -230,6 +393,19 @@ pub const Payload = union(enum) {
     tool_error: struct { execution_id: Ulid, code: ToolErrorCode, message: []const u8 },
     tool_status: struct { execution_id: Ulid },
     tool_status_response: ToolExecutionInfo,
+
+    // Artifact retrieval/search for reversible compression.
+    artifact_retrieve: ArtifactRetrieveRequest,
+    artifact_retrieved: ArtifactRetrieveResponse,
+    artifact_search: ArtifactSearchRequest,
+    artifact_search_result: ArtifactSearchResponse,
+
+    // Experimental hashline edit harness messages. Servers must require the
+    // feature flag before applying edits.
+    hashline_read: HashlineReadRequest,
+    hashline_read_result: HashlineReadResponse,
+    hashline_edit: HashlineEditRequest,
+    hashline_edit_result: HashlineEditResponse,
 
     // Keepalive
     ping: void,
@@ -285,10 +461,24 @@ pub const Payload = union(enum) {
                 allocator.free(res.result_json);
                 res.error_message.deinit(allocator);
                 res.details_json.deinit(allocator);
+                res.artifacts.deinit(allocator);
             },
             .tool_cancel => |*req| req.reason.deinit(allocator),
             .tool_error => |*err| allocator.free(err.message),
             .tool_status_response => |*info| allocator.free(info.tool_name),
+            .artifact_retrieve => |*req| allocator.free(req.artifact_id),
+            .artifact_retrieved => |*res| res.deinit(allocator),
+            .artifact_search => |*req| allocator.free(req.query),
+            .artifact_search_result => |*res| res.deinit(allocator),
+            .hashline_read => |*req| allocator.free(req.path),
+            .hashline_read_result => |*res| res.deinit(allocator),
+            .hashline_edit => |*req| {
+                allocator.free(req.path);
+                allocator.free(req.start_hash);
+                req.end_hash.deinit(allocator);
+                req.replacement.deinit(allocator);
+            },
+            .hashline_edit_result => |*res| res.deinit(allocator),
             .pong => |*p| p.ping_id.deinit(allocator),
             .goodbye => |*g| g.deinit(allocator),
             .ping, .tool_cancelled, .tool_status => {},

--- a/zig/src/providers/ollama_api.zig
+++ b/zig/src/providers/ollama_api.zig
@@ -581,8 +581,8 @@ fn runThread(ctx: *ThreadCtx) void {
     if (cancel_token) |ct| {
         if (ct.isCancelled()) {
             ctx.deinit();
-            stream.markThreadDone();
             stream.completeWithError("request cancelled");
+            stream.markThreadDone();
             return;
         }
     }
@@ -592,16 +592,16 @@ fn runThread(ctx: *ThreadCtx) void {
 
     const url = buildUrlWithSuffix(allocator, base_url, "/api/chat") catch {
         ctx.deinit();
-        stream.markThreadDone();
         stream.completeWithError("oom url");
+        stream.markThreadDone();
         return;
     };
     defer allocator.free(url);
 
     const uri = std.Uri.parse(url) catch {
         ctx.deinit();
-        stream.markThreadDone();
         stream.completeWithError("invalid URL");
+        stream.markThreadDone();
         return;
     };
 
@@ -609,8 +609,8 @@ fn runThread(ctx: *ThreadCtx) void {
     defer headers.deinit(allocator);
     headers.append(allocator, .{ .name = "content-type", .value = "application/json" }) catch {
         ctx.deinit();
-        stream.markThreadDone();
         stream.completeWithError("oom headers");
+        stream.markThreadDone();
         return;
     };
 
@@ -620,14 +620,14 @@ fn runThread(ctx: *ThreadCtx) void {
     if (api_key) |k| {
         auth_value = buildBearerAuthValue(allocator, k) catch {
             ctx.deinit();
-            stream.markThreadDone();
             stream.completeWithError("oom auth header");
+            stream.markThreadDone();
             return;
         };
         headers.append(allocator, .{ .name = "authorization", .value = auth_value.? }) catch {
             ctx.deinit();
-            stream.markThreadDone();
             stream.completeWithError("oom headers");
+            stream.markThreadDone();
             return;
         };
     }
@@ -649,8 +649,8 @@ fn runThread(ctx: *ThreadCtx) void {
         if (cancel_token) |ct| {
             if (ct.isCancelled()) {
                 ctx.deinit();
-                stream.markThreadDone();
                 stream.completeWithError("request cancelled");
+                stream.markThreadDone();
                 return;
             }
         }
@@ -671,13 +671,13 @@ fn runThread(ctx: *ThreadCtx) void {
                 }
                 // Sleep was cancelled
                 ctx.deinit();
-                stream.markThreadDone();
                 stream.completeWithError("request cancelled");
+                stream.markThreadDone();
                 return;
             }
             ctx.deinit();
-            stream.markThreadDone();
             stream.completeWithError("request failed");
+            stream.markThreadDone();
             return;
         };
         req_initialized = true;
@@ -692,13 +692,13 @@ fn runThread(ctx: *ThreadCtx) void {
                 }
                 // Sleep was cancelled
                 ctx.deinit();
-                stream.markThreadDone();
                 stream.completeWithError("request cancelled");
+                stream.markThreadDone();
                 return;
             }
             ctx.deinit();
-            stream.markThreadDone();
             stream.completeWithError("send failed");
+            stream.markThreadDone();
             return;
         };
 
@@ -712,13 +712,13 @@ fn runThread(ctx: *ThreadCtx) void {
                 }
                 // Sleep was cancelled
                 ctx.deinit();
-                stream.markThreadDone();
                 stream.completeWithError("request cancelled");
+                stream.markThreadDone();
                 return;
             }
             ctx.deinit();
-            stream.markThreadDone();
             stream.completeWithError("receive failed");
+            stream.markThreadDone();
             return;
         };
 
@@ -775,8 +775,8 @@ fn runThread(ctx: *ThreadCtx) void {
             if (!retry_util.sleepMs(delay, if (cancel_token) |ct| ct.cancelled else null)) {
                 // Sleep was cancelled
                 ctx.deinit();
-                stream.markThreadDone();
                 stream.completeWithError("request cancelled");
+                stream.markThreadDone();
                 return;
             }
 
@@ -791,8 +791,8 @@ fn runThread(ctx: *ThreadCtx) void {
     // After retry loop, check final status
     if (response.head.status != .ok) {
         ctx.deinit();
-        stream.markThreadDone();
         stream.completeWithError("ollama request failed");
+        stream.markThreadDone();
         return;
     }
 
@@ -836,16 +836,16 @@ fn runThread(ctx: *ThreadCtx) void {
         if (cancel_token) |ct| {
             if (ct.isCancelled()) {
                 ctx.deinit();
-                stream.markThreadDone();
                 stream.completeWithError("request cancelled");
+                stream.markThreadDone();
                 return;
             }
         }
 
         const n = compat.http.readResponse(reader, &read_buf) catch {
             ctx.deinit();
-            stream.markThreadDone();
             stream.completeWithError("read failed");
+            stream.markThreadDone();
             return;
         };
         if (n == 0) break;
@@ -987,8 +987,8 @@ fn runThread(ctx: *ThreadCtx) void {
             } else {
                 line.append(allocator, ch) catch {
                     ctx.deinit();
-                    stream.markThreadDone();
                     stream.completeWithError("oom line");
+                    stream.markThreadDone();
                     return;
                 };
             }
@@ -1159,8 +1159,8 @@ fn runThread(ctx: *ThreadCtx) void {
 
     const content_slice = content_blocks.toOwnedSlice(allocator) catch {
         ctx.deinit();
-        stream.markThreadDone();
         stream.completeWithError("oom content");
+        stream.markThreadDone();
         return;
     };
 
@@ -1169,16 +1169,16 @@ fn runThread(ctx: *ThreadCtx) void {
     const api_dup = allocator.dupe(u8, model.api) catch {
         ai_types.deinitAssistantContent(allocator, content_slice);
         ctx.deinit();
-        stream.markThreadDone();
         stream.completeWithError("oom");
+        stream.markThreadDone();
         return;
     };
     const provider_dup = allocator.dupe(u8, model.provider) catch {
         allocator.free(api_dup);
         ai_types.deinitAssistantContent(allocator, content_slice);
         ctx.deinit();
-        stream.markThreadDone();
         stream.completeWithError("oom");
+        stream.markThreadDone();
         return;
     };
     const model_dup = allocator.dupe(u8, model.id) catch {
@@ -1186,8 +1186,8 @@ fn runThread(ctx: *ThreadCtx) void {
         allocator.free(api_dup);
         ai_types.deinitAssistantContent(allocator, content_slice);
         ctx.deinit();
-        stream.markThreadDone();
         stream.completeWithError("oom");
+        stream.markThreadDone();
         return;
     };
 
@@ -1209,8 +1209,8 @@ fn runThread(ctx: *ThreadCtx) void {
     // Free ctx allocations before completing (out owns its strings, no UAF)
     ctx.deinit();
 
-    stream.markThreadDone();
     stream.complete(out);
+    stream.markThreadDone();
 }
 
 pub fn streamOllama(
@@ -1576,7 +1576,6 @@ test "parseLineExtended - tool call with array arguments" {
     try std.testing.expect(std.mem.find(u8, tc.arguments_json, "[\"ls\",\"pwd\",\"whoami\"]") != null);
 }
 
-
 fn regressionModel(api_name: []const u8, provider_name: []const u8, base_url: []const u8) ai_types.Model {
     return .{
         .id = "regression-model",
@@ -1615,7 +1614,6 @@ fn expectCancelledStream(stream: *event_stream.AssistantMessageEventStream, allo
     try std.testing.expect(stream.getError() != null);
     try std.testing.expectEqualStrings("request cancelled", stream.getError().?);
 }
-
 
 test "provider_cancellation_ollama_cancel_before_request" {
     var cancelled = std.atomic.Value(bool).init(true);

--- a/zig/src/providers/ollama_api.zig
+++ b/zig/src/providers/ollama_api.zig
@@ -563,6 +563,8 @@ fn runThread(ctx: *ThreadCtx) void {
     // Save values from ctx that we need after freeing ctx
     const allocator = ctx.allocator;
     const stream = ctx.stream;
+    defer stream.markThreadDone();
+
     const model = ctx.model;
     const base_url = ctx.base_url;
     const api_key = ctx.api_key;
@@ -582,7 +584,6 @@ fn runThread(ctx: *ThreadCtx) void {
         if (ct.isCancelled()) {
             ctx.deinit();
             stream.completeWithError("request cancelled");
-            stream.markThreadDone();
             return;
         }
     }
@@ -593,7 +594,6 @@ fn runThread(ctx: *ThreadCtx) void {
     const url = buildUrlWithSuffix(allocator, base_url, "/api/chat") catch {
         ctx.deinit();
         stream.completeWithError("oom url");
-        stream.markThreadDone();
         return;
     };
     defer allocator.free(url);
@@ -601,7 +601,6 @@ fn runThread(ctx: *ThreadCtx) void {
     const uri = std.Uri.parse(url) catch {
         ctx.deinit();
         stream.completeWithError("invalid URL");
-        stream.markThreadDone();
         return;
     };
 
@@ -610,7 +609,6 @@ fn runThread(ctx: *ThreadCtx) void {
     headers.append(allocator, .{ .name = "content-type", .value = "application/json" }) catch {
         ctx.deinit();
         stream.completeWithError("oom headers");
-        stream.markThreadDone();
         return;
     };
 
@@ -621,13 +619,11 @@ fn runThread(ctx: *ThreadCtx) void {
         auth_value = buildBearerAuthValue(allocator, k) catch {
             ctx.deinit();
             stream.completeWithError("oom auth header");
-            stream.markThreadDone();
             return;
         };
         headers.append(allocator, .{ .name = "authorization", .value = auth_value.? }) catch {
             ctx.deinit();
             stream.completeWithError("oom headers");
-            stream.markThreadDone();
             return;
         };
     }
@@ -650,7 +646,6 @@ fn runThread(ctx: *ThreadCtx) void {
             if (ct.isCancelled()) {
                 ctx.deinit();
                 stream.completeWithError("request cancelled");
-                stream.markThreadDone();
                 return;
             }
         }
@@ -672,12 +667,10 @@ fn runThread(ctx: *ThreadCtx) void {
                 // Sleep was cancelled
                 ctx.deinit();
                 stream.completeWithError("request cancelled");
-                stream.markThreadDone();
                 return;
             }
             ctx.deinit();
             stream.completeWithError("request failed");
-            stream.markThreadDone();
             return;
         };
         req_initialized = true;
@@ -693,12 +686,10 @@ fn runThread(ctx: *ThreadCtx) void {
                 // Sleep was cancelled
                 ctx.deinit();
                 stream.completeWithError("request cancelled");
-                stream.markThreadDone();
                 return;
             }
             ctx.deinit();
             stream.completeWithError("send failed");
-            stream.markThreadDone();
             return;
         };
 
@@ -713,12 +704,10 @@ fn runThread(ctx: *ThreadCtx) void {
                 // Sleep was cancelled
                 ctx.deinit();
                 stream.completeWithError("request cancelled");
-                stream.markThreadDone();
                 return;
             }
             ctx.deinit();
             stream.completeWithError("receive failed");
-            stream.markThreadDone();
             return;
         };
 
@@ -776,7 +765,6 @@ fn runThread(ctx: *ThreadCtx) void {
                 // Sleep was cancelled
                 ctx.deinit();
                 stream.completeWithError("request cancelled");
-                stream.markThreadDone();
                 return;
             }
 
@@ -792,7 +780,6 @@ fn runThread(ctx: *ThreadCtx) void {
     if (response.head.status != .ok) {
         ctx.deinit();
         stream.completeWithError("ollama request failed");
-        stream.markThreadDone();
         return;
     }
 
@@ -837,7 +824,6 @@ fn runThread(ctx: *ThreadCtx) void {
             if (ct.isCancelled()) {
                 ctx.deinit();
                 stream.completeWithError("request cancelled");
-                stream.markThreadDone();
                 return;
             }
         }
@@ -845,7 +831,6 @@ fn runThread(ctx: *ThreadCtx) void {
         const n = compat.http.readResponse(reader, &read_buf) catch {
             ctx.deinit();
             stream.completeWithError("read failed");
-            stream.markThreadDone();
             return;
         };
         if (n == 0) break;
@@ -988,7 +973,6 @@ fn runThread(ctx: *ThreadCtx) void {
                 line.append(allocator, ch) catch {
                     ctx.deinit();
                     stream.completeWithError("oom line");
-                    stream.markThreadDone();
                     return;
                 };
             }
@@ -1160,7 +1144,6 @@ fn runThread(ctx: *ThreadCtx) void {
     const content_slice = content_blocks.toOwnedSlice(allocator) catch {
         ctx.deinit();
         stream.completeWithError("oom content");
-        stream.markThreadDone();
         return;
     };
 
@@ -1170,7 +1153,6 @@ fn runThread(ctx: *ThreadCtx) void {
         ai_types.deinitAssistantContent(allocator, content_slice);
         ctx.deinit();
         stream.completeWithError("oom");
-        stream.markThreadDone();
         return;
     };
     const provider_dup = allocator.dupe(u8, model.provider) catch {
@@ -1178,7 +1160,6 @@ fn runThread(ctx: *ThreadCtx) void {
         ai_types.deinitAssistantContent(allocator, content_slice);
         ctx.deinit();
         stream.completeWithError("oom");
-        stream.markThreadDone();
         return;
     };
     const model_dup = allocator.dupe(u8, model.id) catch {
@@ -1187,7 +1168,6 @@ fn runThread(ctx: *ThreadCtx) void {
         ai_types.deinitAssistantContent(allocator, content_slice);
         ctx.deinit();
         stream.completeWithError("oom");
-        stream.markThreadDone();
         return;
     };
 
@@ -1210,7 +1190,6 @@ fn runThread(ctx: *ThreadCtx) void {
     ctx.deinit();
 
     stream.complete(out);
-    stream.markThreadDone();
 }
 
 pub fn streamOllama(

--- a/zig/src/tools/makai.zig
+++ b/zig/src/tools/makai.zig
@@ -1437,6 +1437,24 @@ fn serializeAgentLoopEvent(
                 try writeUsageField(&w, payload.message.assistant.usage);
             }
         },
+        .context_usage => |payload| {
+            try w.writeStringField("type", "context_usage");
+            try w.writeIntField("system_prompt_bytes", payload.system_prompt_bytes);
+            try w.writeIntField("message_bytes", payload.message_bytes);
+            try w.writeIntField("tool_definition_bytes", payload.tool_definition_bytes);
+            try w.writeIntField("total_bytes", payload.total_bytes);
+            try w.writeIntField("estimated_tokens", payload.estimated_tokens);
+            try w.writeIntField("message_count", payload.message_count);
+            try w.writeIntField("tool_count", payload.tool_count);
+        },
+        .prompt_segment_usage => |payload| {
+            try w.writeStringField("type", "prompt_segment_usage");
+            try w.writeStringField("segment", @tagName(payload.segment));
+            try w.writeStringField("cache_role", @tagName(payload.cache_role));
+            try w.writeIntField("bytes", payload.bytes);
+            try w.writeIntField("estimated_tokens", payload.estimated_tokens);
+            try w.writeIntField("item_count", payload.item_count);
+        },
         .tool_execution_start => |payload| {
             try w.writeStringField("type", "tool_execution_start");
             try w.writeStringField("tool_call_id", payload.tool_call_id);
@@ -1455,6 +1473,16 @@ fn serializeAgentLoopEvent(
             try w.writeStringField("tool_name", payload.tool_name);
             try w.writeStringField("result_json", payload.result_json);
             try w.writeBoolField("is_error", payload.is_error);
+            try w.writeIntField("args_bytes", payload.args_bytes);
+            try w.writeIntField("raw_result_bytes", payload.raw_result_bytes);
+            try w.writeIntField("returned_result_bytes", payload.returned_result_bytes);
+            try w.writeIntField("raw_details_bytes", payload.raw_details_bytes);
+            try w.writeIntField("returned_details_bytes", payload.returned_details_bytes);
+            try w.writeIntField("raw_total_bytes", payload.raw_total_bytes);
+            try w.writeIntField("returned_total_bytes", payload.returned_total_bytes);
+            try w.writeIntField("estimated_returned_tokens", payload.estimated_returned_tokens);
+            try w.writeIntField("artifact_count", payload.artifact_count);
+            try writeArtifactReferences(&w, payload.artifacts);
         },
     }
     try w.endObject();
@@ -1462,6 +1490,23 @@ fn serializeAgentLoopEvent(
     const out = try allocator.dupe(u8, buffer.items);
     buffer.deinit(allocator);
     return out;
+}
+
+fn writeArtifactReferences(w: *json_writer.JsonWriter, artifacts: []const ai_types.ArtifactReference) !void {
+    if (artifacts.len == 0) return;
+    try w.writeKey("artifacts");
+    try w.beginArray();
+    for (artifacts) |artifact| {
+        try w.beginObject();
+        try w.writeStringField("artifact_id", artifact.artifact_id);
+        if (artifact.getUri()) |uri| try w.writeStringField("uri", uri);
+        if (artifact.getMimeType()) |mime_type| try w.writeStringField("mime_type", mime_type);
+        if (artifact.byte_size) |byte_size| try w.writeIntField("byte_size", byte_size);
+        if (artifact.getSha256()) |sha256| try w.writeStringField("sha256", sha256);
+        if (artifact.getDescription()) |description| try w.writeStringField("description", description);
+        try w.endObject();
+    }
+    try w.endArray();
 }
 
 fn serializeAgentErrorEvent(allocator: std.mem.Allocator, message: []const u8, code: []const u8) ![]u8 {


### PR DESCRIPTION
## Summary

Adds the runtime/protocol primitives needed for later TUI token-efficiency features, now targeting `main` after PR #91 merged.

- emit agent context usage and prompt segment telemetry before provider calls
- add tool-output middleware hook points with raw vs returned byte/token accounting
- carry artifact references through tool results and agent event serialization
- add tool protocol artifact retrieve/search message shapes
- add cache-role prompt segment metadata for stable vs dynamic context
- add experimental hashline read/edit protocol shapes behind `feature_enabled`

## Validation

- `zig build test`
- `zig build test-unit-core test-unit-agent test-unit-protocol test-unit-makai-cli`
- `zig build test-unit-agent-loop test-unit-agent-types test-unit-protocol`
- `./scripts/check-zig-patterns.sh`
- `git diff --check`
- GitHub CI