### PR TITLE
Add libvaxis TUI spike

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ yarn-error.log*
 zig-cache/
 zig-out/
 .zig-cache/
+zig/zig-pkg/
 *.o
 *.a
 *.so

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -3,6 +3,11 @@ const std = @import("std");
 pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
+    const vaxis_dep = b.dependency("vaxis", .{
+        .target = target,
+        .optimize = optimize,
+    });
+    const vaxis_mod = vaxis_dep.module("vaxis");
 
     const ai_types_mod = b.createModule(.{
         .root_source_file = b.path("src/ai_types.zig"),
@@ -1221,6 +1226,23 @@ pub fn build(b: *std.Build) void {
         .name = "makai",
         .root_module = makai_cli_module,
     });
+
+    const tui_module = b.createModule(.{
+        .root_source_file = b.path("src/tui/main.zig"),
+        .target = target,
+        .optimize = optimize,
+        .imports = &.{
+            .{ .name = "vaxis", .module = vaxis_mod },
+        },
+    });
+    const tui_exe = b.addExecutable(.{
+        .name = "makai-tui",
+        .root_module = tui_module,
+    });
+    b.installArtifact(tui_exe);
+    const tui_build_step = b.step("tui", "Build the libvaxis TUI spike");
+    tui_build_step.dependOn(&tui_exe.step);
+
     const makai_cli_test = b.addTest(.{ .root_module = makai_cli_module });
     const makai_cli_test_run = b.addRunArtifact(makai_cli_test);
     const auth_cli_test = b.addTest(.{ .root_module = auth_cli_mod });
@@ -1233,6 +1255,13 @@ pub fn build(b: *std.Build) void {
     }
     const run_step = b.step("run", "Run the Makai CLI");
     run_step.dependOn(&run_cmd.step);
+
+    const run_tui_cmd = b.addRunArtifact(tui_exe);
+    if (b.args) |args| {
+        run_tui_cmd.addArgs(args);
+    }
+    const run_tui_step = b.step("run-tui", "Run the libvaxis TUI spike");
+    run_tui_step.dependOn(&run_tui_cmd.step);
 
     const test_step = b.step("test", "Run tests");
     test_step.dependOn(&b.addRunArtifact(owned_slice_test).step);

--- a/zig/build.zig.zon
+++ b/zig/build.zig.zon
@@ -1,7 +1,12 @@
 .{
     .name = .zig,
     .version = "0.16.0",
-    .dependencies = .{},
+    .dependencies = .{
+        .vaxis = .{
+            .url = "git+https://github.com/rockorager/libvaxis#60a507c25b5335e222eb12320aa7514db684d4a4",
+            .hash = "vaxis-0.6.0-BWNV_HHwCQCy33z_jb0RHLjoinqQ8tgQVZI9z2e5Yqdd",
+        },
+    },
     .paths = .{""},
     .fingerprint = 0xc1ce1081631dd09f,
 }

--- a/zig/src/tui/app.zig
+++ b/zig/src/tui/app.zig
@@ -42,6 +42,7 @@ pub const AppState = struct {
 
 pub const App = struct {
     allocator: std.mem.Allocator,
+    tty_buffer: []u8,
     tty: vaxis.Tty,
     vx: vaxis.Vaxis,
     state: AppState,
@@ -49,8 +50,10 @@ pub const App = struct {
     mock_thread: ?std.Thread = null,
 
     pub fn init(init_args: std.process.Init) !App {
-        var buffer: [1024]u8 = undefined;
-        var tty = try vaxis.Tty.init(init_args.io, &buffer);
+        const tty_buffer = try init_args.gpa.alloc(u8, 1024);
+        errdefer init_args.gpa.free(tty_buffer);
+
+        var tty = try vaxis.Tty.init(init_args.io, tty_buffer);
         errdefer tty.deinit();
 
         var vx = try vaxis.init(init_args.io, init_args.gpa, init_args.environ_map, .{
@@ -66,6 +69,7 @@ pub const App = struct {
 
         return .{
             .allocator = init_args.gpa,
+            .tty_buffer = tty_buffer,
             .tty = tty,
             .vx = vx,
             .state = state,
@@ -77,6 +81,7 @@ pub const App = struct {
         self.state.deinit();
         self.vx.deinit(self.allocator, self.tty.writer());
         self.tty.deinit();
+        self.allocator.free(self.tty_buffer);
         self.* = undefined;
     }
 

--- a/zig/src/tui/app.zig
+++ b/zig/src/tui/app.zig
@@ -1,0 +1,207 @@
+const std = @import("std");
+const vaxis = @import("vaxis");
+
+const composer_view = @import("views/composer.zig");
+const status_bar_view = @import("views/status_bar.zig");
+const transcript_view = @import("views/transcript.zig");
+
+pub const UiEvent = union(enum) {
+    key_press: vaxis.Key,
+    mouse: vaxis.Mouse,
+    winsize: vaxis.Winsize,
+    focus_in,
+    focus_out,
+    mock_delta: []const u8,
+};
+
+pub const AppState = struct {
+    transcript: transcript_view.Transcript,
+    composer: composer_view.Composer,
+    status: status_bar_view.Status = .{},
+    running: bool = true,
+
+    pub fn init(allocator: std.mem.Allocator) !AppState {
+        var state: AppState = .{
+            .transcript = transcript_view.Transcript.init(allocator),
+            .composer = composer_view.Composer.init(allocator),
+        };
+        errdefer state.deinit();
+
+        try state.transcript.add(.system, "libvaxis spike booted");
+        try state.transcript.add(.assistant, "background queue will push mock streaming rows");
+        try state.transcript.add(.tool, "resize terminal; vaxis winsize event redraws frame");
+        return state;
+    }
+
+    pub fn deinit(self: *AppState) void {
+        self.composer.deinit();
+        self.transcript.deinit();
+        self.* = undefined;
+    }
+};
+
+pub const App = struct {
+    allocator: std.mem.Allocator,
+    tty: vaxis.Tty,
+    vx: vaxis.Vaxis,
+    state: AppState,
+    mock_done: std.atomic.Value(bool) = .init(false),
+    mock_thread: ?std.Thread = null,
+
+    pub fn init(init_args: std.process.Init) !App {
+        var buffer: [1024]u8 = undefined;
+        var tty = try vaxis.Tty.init(init_args.io, &buffer);
+        errdefer tty.deinit();
+
+        var vx = try vaxis.init(init_args.io, init_args.gpa, init_args.environ_map, .{
+            .kitty_keyboard_flags = .{ .report_events = true },
+        });
+        errdefer vx.deinit(init_args.gpa, tty.writer());
+
+        const state = try AppState.init(init_args.gpa);
+        errdefer {
+            var mutable_state = state;
+            mutable_state.deinit();
+        }
+
+        return .{
+            .allocator = init_args.gpa,
+            .tty = tty,
+            .vx = vx,
+            .state = state,
+        };
+    }
+
+    pub fn deinit(self: *App) void {
+        self.stopMockProducer();
+        self.state.deinit();
+        self.vx.deinit(self.allocator, self.tty.writer());
+        self.tty.deinit();
+        self.* = undefined;
+    }
+
+    pub fn run(self: *App) !void {
+        var loop: vaxis.Loop(UiEvent) = .init(self.tty.io, &self.tty, &self.vx);
+        try loop.start();
+        defer loop.stop();
+
+        const writer = self.tty.writer();
+        try self.vx.enterAltScreen(writer);
+        try writer.flush();
+        try self.vx.queryTerminal(writer, .fromSeconds(1));
+
+        self.mock_thread = try std.Thread.spawn(.{}, mockProducer, .{ self, &loop });
+        defer self.stopMockProducer();
+
+        while (self.state.running) {
+            const event = try loop.nextEvent();
+            try self.handleEvent(event);
+            try self.render();
+        }
+    }
+
+    fn stopMockProducer(self: *App) void {
+        self.mock_done.store(true, .release);
+        if (self.mock_thread) |thread| {
+            thread.join();
+            self.mock_thread = null;
+        }
+    }
+
+    fn handleEvent(self: *App, event: UiEvent) !void {
+        switch (event) {
+            .key_press => |key| {
+                if (key.matches('c', .{ .ctrl = true })) {
+                    self.state.running = false;
+                    return;
+                }
+
+                if (key.matches('l', .{ .ctrl = true })) {
+                    self.vx.queueRefresh();
+                    return;
+                }
+
+                const maybe_submitted = try self.state.composer.handleKey(key);
+                if (maybe_submitted) |submitted| {
+                    defer self.allocator.free(submitted);
+                    if (std.mem.eql(u8, std.mem.trim(u8, submitted, " \t\r\n"), "/quit")) {
+                        self.state.running = false;
+                        return;
+                    }
+                    if (submitted.len > 0) {
+                        try self.state.transcript.add(.user, submitted);
+                    }
+                } else if (self.state.composer.isQuitCommand()) {
+                    self.state.status.state = "press Enter to quit";
+                } else {
+                    self.state.status.state = "typing";
+                }
+            },
+            .winsize => |ws| try self.vx.resize(self.allocator, self.tty.writer(), ws),
+            .mock_delta => |text| {
+                defer self.allocator.free(text);
+                self.state.status.state = "streaming mock events";
+                try self.state.transcript.add(.assistant, text);
+            },
+            .mouse, .focus_in, .focus_out => {},
+        }
+    }
+
+    fn render(self: *App) !void {
+        const writer = self.tty.writer();
+        const win = self.vx.window();
+        win.clear();
+
+        if (win.height == 0 or win.width == 0) return;
+
+        const status_height: u16 = 1;
+        const composer_height: u16 = if (win.height >= 5) 3 else 1;
+        const transcript_height: u16 = if (win.height > status_height + composer_height)
+            win.height - status_height - composer_height
+        else
+            0;
+
+        status_bar_view.draw(win.child(.{ .height = status_height }), self.state.status);
+
+        if (transcript_height > 0) {
+            transcript_view.Transcript.draw(self.state.transcript, win.child(.{
+                .y_off = status_height,
+                .height = transcript_height,
+            }));
+        }
+
+        self.state.composer.draw(win.child(.{
+            .y_off = @intCast(status_height + transcript_height),
+            .height = composer_height,
+        }));
+
+        try self.vx.render(writer);
+        try writer.flush();
+    }
+};
+
+pub fn run(init_args: std.process.Init) !void {
+    var app = try App.init(init_args);
+    defer app.deinit();
+    try app.run();
+}
+
+fn mockProducer(app: *App, loop: *vaxis.Loop(UiEvent)) void {
+    var counter: usize = 1;
+    while (!app.mock_done.load(.acquire)) : (counter += 1) {
+        loop.io.sleep(.fromMilliseconds(900), .real) catch break;
+        if (app.mock_done.load(.acquire)) break;
+
+        var buf: [128]u8 = undefined;
+        const text = std.fmt.bufPrint(&buf, "mock streamed delta #{d}", .{counter}) catch continue;
+        const owned = app.allocator.dupe(u8, text) catch continue;
+        loop.postEvent(.{ .mock_delta = owned }) catch {
+            app.allocator.free(owned);
+            break;
+        };
+    }
+}
+
+test {
+    std.testing.refAllDecls(@This());
+}

--- a/zig/src/tui/main.zig
+++ b/zig/src/tui/main.zig
@@ -1,0 +1,10 @@
+const std = @import("std");
+const app = @import("app.zig");
+
+pub fn main(init: std.process.Init) !void {
+    try app.run(init);
+}
+
+test {
+    std.testing.refAllDecls(@This());
+}

--- a/zig/src/tui/views/composer.zig
+++ b/zig/src/tui/views/composer.zig
@@ -1,0 +1,72 @@
+const std = @import("std");
+const vaxis = @import("vaxis");
+
+const Segment = vaxis.Cell.Segment;
+
+pub const Composer = struct {
+    allocator: std.mem.Allocator,
+    input: std.ArrayList(u8),
+
+    pub fn init(allocator: std.mem.Allocator) Composer {
+        return .{
+            .allocator = allocator,
+            .input = .empty,
+        };
+    }
+
+    pub fn deinit(self: *Composer) void {
+        self.input.deinit(self.allocator);
+        self.* = undefined;
+    }
+
+    pub fn handleKey(self: *Composer, key: vaxis.Key) !?[]const u8 {
+        if (key.matches(vaxis.Key.enter, .{})) {
+            const submitted = try self.allocator.dupe(u8, self.input.items);
+            self.input.clearRetainingCapacity();
+            return submitted;
+        }
+
+        if (key.matches(vaxis.Key.backspace, .{})) {
+            _ = self.input.pop();
+            return null;
+        }
+
+        if (key.mods.ctrl or key.mods.alt or key.mods.super) return null;
+        if (key.text) |text| {
+            try self.input.appendSlice(self.allocator, text);
+        }
+        return null;
+    }
+
+    pub fn isQuitCommand(self: Composer) bool {
+        return std.mem.eql(u8, std.mem.trim(u8, self.input.items, " \t\r\n"), "/quit");
+    }
+
+    pub fn draw(self: Composer, win: vaxis.Window) void {
+        const border_style: vaxis.Style = .{ .fg = .{ .index = 67 } };
+        const input_style: vaxis.Style = .{ .fg = .{ .index = 15 } };
+        const hint_style: vaxis.Style = .{ .fg = .{ .index = 245 } };
+
+        const inner = win.child(.{
+            .border = .{ .where = .all, .style = border_style },
+        });
+        inner.clear();
+
+        const prompt = Segment{ .text = "> ", .style = border_style };
+        const text = Segment{ .text = self.input.items, .style = input_style };
+        _ = inner.print(&.{ prompt, text }, .{ .row_offset = 0, .col_offset = 0, .wrap = .none });
+
+        if (self.input.items.len == 0 and inner.width > 2) {
+            _ = inner.printSegment(.{ .text = "type message, Enter submits", .style = hint_style }, .{
+                .row_offset = 0,
+                .col_offset = 2,
+                .wrap = .none,
+            });
+        }
+
+        const max_col = inner.width -| 1;
+        const wanted_col: u16 = @intCast(@min(self.input.items.len + 2, std.math.maxInt(u16)));
+        inner.showCursor(@min(max_col, wanted_col), 0);
+        inner.setCursorShape(.beam);
+    }
+};

--- a/zig/src/tui/views/status_bar.zig
+++ b/zig/src/tui/views/status_bar.zig
@@ -1,0 +1,28 @@
+const std = @import("std");
+const vaxis = @import("vaxis");
+
+const Segment = vaxis.Cell.Segment;
+
+pub const Status = struct {
+    provider: []const u8 = "anthropic",
+    model: []const u8 = "claude-sonnet-4-5",
+    state: []const u8 = "streaming mock events",
+};
+
+pub fn draw(win: vaxis.Window, status: Status) void {
+    const bg: vaxis.Style = .{
+        .fg = .{ .index = 15 },
+        .bg = .{ .index = 24 },
+        .bold = true,
+    };
+    win.fill(.{ .char = .{ .grapheme = " ", .width = 1 }, .style = bg });
+
+    var buf: [256]u8 = undefined;
+    const line = std.fmt.bufPrint(&buf, " {s}/{s} | {s} | Ctrl+C or /quit exits ", .{
+        status.provider,
+        status.model,
+        status.state,
+    }) catch " Makai TUI | status overflow ";
+
+    _ = win.printSegment(.{ .text = line, .style = bg }, .{ .wrap = .none });
+}

--- a/zig/src/tui/views/transcript.zig
+++ b/zig/src/tui/views/transcript.zig
@@ -1,0 +1,90 @@
+const std = @import("std");
+const vaxis = @import("vaxis");
+
+pub const Role = enum {
+    system,
+    user,
+    assistant,
+    tool,
+};
+
+pub const Message = struct {
+    role: Role,
+    text: []const u8,
+};
+
+pub const Transcript = struct {
+    allocator: std.mem.Allocator,
+    messages: std.ArrayList(Message),
+    scroll_bottom: bool = true,
+
+    pub fn init(allocator: std.mem.Allocator) Transcript {
+        return .{
+            .allocator = allocator,
+            .messages = .empty,
+        };
+    }
+
+    pub fn deinit(self: *Transcript) void {
+        for (self.messages.items) |message| {
+            self.allocator.free(message.text);
+        }
+        self.messages.deinit(self.allocator);
+        self.* = undefined;
+    }
+
+    pub fn add(self: *Transcript, role: Role, text: []const u8) !void {
+        try self.messages.append(self.allocator, .{
+            .role = role,
+            .text = try self.allocator.dupe(u8, text),
+        });
+        self.scroll_bottom = true;
+    }
+
+    pub fn draw(self: Transcript, win: vaxis.Window) void {
+        win.clear();
+
+        const title_style: vaxis.Style = .{ .fg = .{ .index = 81 }, .bold = true };
+        _ = win.printSegment(.{ .text = "Transcript", .style = title_style }, .{ .row_offset = 0, .wrap = .none });
+
+        if (win.height <= 1) return;
+
+        const body = win.child(.{ .y_off = 1, .height = win.height - 1 });
+        const visible_rows = body.height;
+        const start_index = if (self.messages.items.len > visible_rows)
+            self.messages.items.len - visible_rows
+        else
+            0;
+
+        var row: u16 = 0;
+        for (self.messages.items[start_index..]) |message| {
+            if (row >= body.height) break;
+            const role_text = roleLabel(message.role);
+            const role_style = roleStyle(message.role);
+            const text_style: vaxis.Style = .{ .fg = .{ .index = 252 } };
+            _ = body.print(&.{
+                .{ .text = role_text, .style = role_style },
+                .{ .text = message.text, .style = text_style },
+            }, .{ .row_offset = row, .wrap = .none });
+            row += 1;
+        }
+    }
+};
+
+fn roleLabel(role: Role) []const u8 {
+    return switch (role) {
+        .system => "system    ",
+        .user => "user      ",
+        .assistant => "assistant ",
+        .tool => "tool      ",
+    };
+}
+
+fn roleStyle(role: Role) vaxis.Style {
+    return switch (role) {
+        .system => .{ .fg = .{ .index = 245 }, .bold = true },
+        .user => .{ .fg = .{ .index = 214 }, .bold = true },
+        .assistant => .{ .fg = .{ .index = 83 }, .bold = true },
+        .tool => .{ .fg = .{ .index = 141 }, .bold = true },
+    };
+}


### PR DESCRIPTION
## Summary
- Add libvaxis dependency and a `zig build run-tui` spike target.
- Add retained-state TUI skeleton with transcript, composer, and status bar views.
- Push mock streaming events from a background thread through the libvaxis event queue and redraw on resize/input.

## Test plan
- [x] `cd zig && zig build tui`
- [x] `cd zig && zig build test`
- [x] `cd zig && script -q /tmp/makai-tui-smoke.log zig build run-tui` (pseudo-terminal smoke; confirmed render start before terminating test process)

## Manual smoke notes
- `zig build run-tui` needs a real terminal because libvaxis opens `/dev/tty`.
- In non-interactive runner, direct `zig build run-tui` fails with `error: NoDevice`; pseudo-terminal run starts and emits alternate-screen/control sequences.