### PR TITLE
Add local tool runtime surface

### DIFF
--- a/zig/build.zig
+++ b/zig/build.zig
@@ -752,104 +752,6 @@ pub fn build(b: *std.Build) void {
         },
     });
 
-    const tools_common_mod = b.createModule(.{
-        .root_source_file = b.path("src/tools/common.zig"),
-        .target = target,
-        .optimize = optimize,
-        .imports = &.{
-            .{ .name = "compat", .module = compat_mod },
-            .{ .name = "ai_types", .module = ai_types_mod },
-            .{ .name = "agent_types", .module = agent_types_mod },
-            .{ .name = "owned_slice", .module = owned_slice_mod },
-        },
-    });
-
-    const tools_artifact_mod = b.createModule(.{
-        .root_source_file = b.path("src/tools/artifact.zig"),
-        .target = target,
-        .optimize = optimize,
-        .imports = &.{
-            .{ .name = "ai_types", .module = ai_types_mod },
-            .{ .name = "agent_types", .module = agent_types_mod },
-            .{ .name = "tools/common", .module = tools_common_mod },
-            .{ .name = "owned_slice", .module = owned_slice_mod },
-        },
-    });
-
-    const tools_file_mod = b.createModule(.{
-        .root_source_file = b.path("src/tools/file.zig"),
-        .target = target,
-        .optimize = optimize,
-        .imports = &.{
-            .{ .name = "compat", .module = compat_mod },
-            .{ .name = "ai_types", .module = ai_types_mod },
-            .{ .name = "agent_types", .module = agent_types_mod },
-            .{ .name = "tools/common", .module = tools_common_mod },
-        },
-    });
-
-    const tools_edit_mod = b.createModule(.{
-        .root_source_file = b.path("src/tools/edit.zig"),
-        .target = target,
-        .optimize = optimize,
-        .imports = &.{
-            .{ .name = "compat", .module = compat_mod },
-            .{ .name = "ai_types", .module = ai_types_mod },
-            .{ .name = "agent_types", .module = agent_types_mod },
-            .{ .name = "tools/common", .module = tools_common_mod },
-        },
-    });
-
-    const tools_shell_mod = b.createModule(.{
-        .root_source_file = b.path("src/tools/shell.zig"),
-        .target = target,
-        .optimize = optimize,
-        .imports = &.{
-            .{ .name = "ai_types", .module = ai_types_mod },
-            .{ .name = "agent_types", .module = agent_types_mod },
-            .{ .name = "tools/common", .module = tools_common_mod },
-        },
-    });
-
-    const tools_search_mod = b.createModule(.{
-        .root_source_file = b.path("src/tools/search.zig"),
-        .target = target,
-        .optimize = optimize,
-        .imports = &.{
-            .{ .name = "compat", .module = compat_mod },
-            .{ .name = "ai_types", .module = ai_types_mod },
-            .{ .name = "agent_types", .module = agent_types_mod },
-            .{ .name = "tools/common", .module = tools_common_mod },
-        },
-    });
-
-    const tools_workspace_mod = b.createModule(.{
-        .root_source_file = b.path("src/tools/workspace.zig"),
-        .target = target,
-        .optimize = optimize,
-        .imports = &.{
-            .{ .name = "compat", .module = compat_mod },
-            .{ .name = "ai_types", .module = ai_types_mod },
-            .{ .name = "agent_types", .module = agent_types_mod },
-            .{ .name = "tools/common", .module = tools_common_mod },
-        },
-    });
-
-    const tools_registry_mod = b.createModule(.{
-        .root_source_file = b.path("src/tools/registry.zig"),
-        .target = target,
-        .optimize = optimize,
-        .imports = &.{
-            .{ .name = "agent_types", .module = agent_types_mod },
-            .{ .name = "tools/artifact", .module = tools_artifact_mod },
-            .{ .name = "tools/file", .module = tools_file_mod },
-            .{ .name = "tools/edit", .module = tools_edit_mod },
-            .{ .name = "tools/shell", .module = tools_shell_mod },
-            .{ .name = "tools/search", .module = tools_search_mod },
-            .{ .name = "tools/workspace", .module = tools_workspace_mod },
-        },
-    });
-
     const agent_loop_mod = b.createModule(.{
         .root_source_file = b.path("src/agent/agent_loop.zig"),
         .target = target,
@@ -911,12 +813,13 @@ pub fn build(b: *std.Build) void {
 
     const tools_common_mod = b.createModule(.{ .root_source_file = b.path("src/tools/common.zig"), .target = target, .optimize = optimize, .imports = &.{ .{ .name = "ai_types", .module = ai_types_mod }, .{ .name = "agent", .module = agent_mod }, .{ .name = "compat", .module = compat_mod } } });
     const tools_process_runner_mod = b.createModule(.{ .root_source_file = b.path("src/tools/process_runner.zig"), .target = target, .optimize = optimize, .imports = &.{ .{ .name = "ai_types", .module = ai_types_mod }, .{ .name = "tools/common", .module = tools_common_mod } } });
+    const tools_artifact_mod = b.createModule(.{ .root_source_file = b.path("src/tools/artifact.zig"), .target = target, .optimize = optimize, .imports = &.{ .{ .name = "ai_types", .module = ai_types_mod }, .{ .name = "agent", .module = agent_mod }, .{ .name = "tools/common", .module = tools_common_mod } } });
     const tools_shell_mod = b.createModule(.{ .root_source_file = b.path("src/tools/shell.zig"), .target = target, .optimize = optimize, .imports = &.{ .{ .name = "ai_types", .module = ai_types_mod }, .{ .name = "agent", .module = agent_mod }, .{ .name = "tools/common", .module = tools_common_mod }, .{ .name = "tools/process_runner", .module = tools_process_runner_mod } } });
     const tools_file_mod = b.createModule(.{ .root_source_file = b.path("src/tools/file.zig"), .target = target, .optimize = optimize, .imports = &.{ .{ .name = "ai_types", .module = ai_types_mod }, .{ .name = "agent", .module = agent_mod }, .{ .name = "tools/common", .module = tools_common_mod } } });
     const tools_edit_mod = b.createModule(.{ .root_source_file = b.path("src/tools/edit.zig"), .target = target, .optimize = optimize, .imports = &.{ .{ .name = "ai_types", .module = ai_types_mod }, .{ .name = "agent", .module = agent_mod }, .{ .name = "tools/common", .module = tools_common_mod } } });
     const tools_search_mod = b.createModule(.{ .root_source_file = b.path("src/tools/search.zig"), .target = target, .optimize = optimize, .imports = &.{ .{ .name = "ai_types", .module = ai_types_mod }, .{ .name = "agent", .module = agent_mod }, .{ .name = "tools/common", .module = tools_common_mod } } });
     const tools_workspace_mod = b.createModule(.{ .root_source_file = b.path("src/tools/workspace.zig"), .target = target, .optimize = optimize, .imports = &.{ .{ .name = "ai_types", .module = ai_types_mod }, .{ .name = "agent", .module = agent_mod }, .{ .name = "tools/common", .module = tools_common_mod }, .{ .name = "tools/process_runner", .module = tools_process_runner_mod } } });
-    const tools_registry_mod = b.createModule(.{ .root_source_file = b.path("src/tools/registry.zig"), .target = target, .optimize = optimize, .imports = &.{ .{ .name = "agent", .module = agent_mod }, .{ .name = "tools/shell", .module = tools_shell_mod }, .{ .name = "tools/file", .module = tools_file_mod }, .{ .name = "tools/edit", .module = tools_edit_mod }, .{ .name = "tools/search", .module = tools_search_mod }, .{ .name = "tools/workspace", .module = tools_workspace_mod } } });
+    const tools_registry_mod = b.createModule(.{ .root_source_file = b.path("src/tools/registry.zig"), .target = target, .optimize = optimize, .imports = &.{ .{ .name = "agent", .module = agent_mod }, .{ .name = "tools/shell", .module = tools_shell_mod }, .{ .name = "tools/file", .module = tools_file_mod }, .{ .name = "tools/edit", .module = tools_edit_mod }, .{ .name = "tools/search", .module = tools_search_mod }, .{ .name = "tools/workspace", .module = tools_workspace_mod }, .{ .name = "tools/artifact", .module = tools_artifact_mod } } });
 
     const tui_runtime_mod = b.createModule(.{
         .root_source_file = b.path("src/tui/runtime.zig"),
@@ -1303,15 +1206,6 @@ pub fn build(b: *std.Build) void {
 
     // Agent tests
     const agent_types_test = b.addTest(.{ .root_module = agent_types_mod });
-    const tools_common_test = b.addTest(.{ .root_module = tools_common_mod });
-    const tools_artifact_test = b.addTest(.{ .root_module = tools_artifact_mod });
-    const tools_file_test = b.addTest(.{ .root_module = tools_file_mod });
-    const tools_edit_test = b.addTest(.{ .root_module = tools_edit_mod });
-    const tools_shell_test = b.addTest(.{ .root_module = tools_shell_mod });
-    const tools_search_test = b.addTest(.{ .root_module = tools_search_mod });
-    const tools_workspace_test = b.addTest(.{ .root_module = tools_workspace_mod });
-    const tools_registry_test = b.addTest(.{ .root_module = tools_registry_mod });
-
     const agent_loop_test = b.addTest(.{ .root_module = agent_loop_mod });
 
     const agent_mod_test = b.addTest(.{ .root_module = agent_mod });
@@ -1323,6 +1217,7 @@ pub fn build(b: *std.Build) void {
     const tui_tests_mock_transport_test = b.addTest(.{ .root_module = tui_tests_mock_transport_mod });
     const tools_common_test = b.addTest(.{ .root_module = tools_common_mod });
     const tools_process_runner_test = b.addTest(.{ .root_module = tools_process_runner_mod });
+    const tools_artifact_test = b.addTest(.{ .root_module = tools_artifact_mod });
     const tools_shell_test = b.addTest(.{ .root_module = tools_shell_mod });
     const tools_file_test = b.addTest(.{ .root_module = tools_file_mod });
     const tools_edit_test = b.addTest(.{ .root_module = tools_edit_mod });

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -812,11 +812,12 @@ pub fn build(b: *std.Build) void {
     });
 
     const tools_common_mod = b.createModule(.{ .root_source_file = b.path("src/tools/common.zig"), .target = target, .optimize = optimize, .imports = &.{ .{ .name = "ai_types", .module = ai_types_mod }, .{ .name = "agent", .module = agent_mod }, .{ .name = "compat", .module = compat_mod } } });
-    const tools_shell_mod = b.createModule(.{ .root_source_file = b.path("src/tools/shell.zig"), .target = target, .optimize = optimize, .imports = &.{ .{ .name = "ai_types", .module = ai_types_mod }, .{ .name = "agent", .module = agent_mod }, .{ .name = "tools/common", .module = tools_common_mod } } });
+    const tools_process_runner_mod = b.createModule(.{ .root_source_file = b.path("src/tools/process_runner.zig"), .target = target, .optimize = optimize, .imports = &.{ .{ .name = "ai_types", .module = ai_types_mod }, .{ .name = "tools/common", .module = tools_common_mod } } });
+    const tools_shell_mod = b.createModule(.{ .root_source_file = b.path("src/tools/shell.zig"), .target = target, .optimize = optimize, .imports = &.{ .{ .name = "ai_types", .module = ai_types_mod }, .{ .name = "agent", .module = agent_mod }, .{ .name = "tools/common", .module = tools_common_mod }, .{ .name = "tools/process_runner", .module = tools_process_runner_mod } } });
     const tools_file_mod = b.createModule(.{ .root_source_file = b.path("src/tools/file.zig"), .target = target, .optimize = optimize, .imports = &.{ .{ .name = "ai_types", .module = ai_types_mod }, .{ .name = "agent", .module = agent_mod }, .{ .name = "tools/common", .module = tools_common_mod } } });
     const tools_edit_mod = b.createModule(.{ .root_source_file = b.path("src/tools/edit.zig"), .target = target, .optimize = optimize, .imports = &.{ .{ .name = "ai_types", .module = ai_types_mod }, .{ .name = "agent", .module = agent_mod }, .{ .name = "tools/common", .module = tools_common_mod } } });
     const tools_search_mod = b.createModule(.{ .root_source_file = b.path("src/tools/search.zig"), .target = target, .optimize = optimize, .imports = &.{ .{ .name = "ai_types", .module = ai_types_mod }, .{ .name = "agent", .module = agent_mod }, .{ .name = "tools/common", .module = tools_common_mod } } });
-    const tools_workspace_mod = b.createModule(.{ .root_source_file = b.path("src/tools/workspace.zig"), .target = target, .optimize = optimize, .imports = &.{ .{ .name = "ai_types", .module = ai_types_mod }, .{ .name = "agent", .module = agent_mod }, .{ .name = "tools/common", .module = tools_common_mod } } });
+    const tools_workspace_mod = b.createModule(.{ .root_source_file = b.path("src/tools/workspace.zig"), .target = target, .optimize = optimize, .imports = &.{ .{ .name = "ai_types", .module = ai_types_mod }, .{ .name = "agent", .module = agent_mod }, .{ .name = "tools/common", .module = tools_common_mod }, .{ .name = "tools/process_runner", .module = tools_process_runner_mod } } });
     const tools_registry_mod = b.createModule(.{ .root_source_file = b.path("src/tools/registry.zig"), .target = target, .optimize = optimize, .imports = &.{ .{ .name = "agent", .module = agent_mod }, .{ .name = "tools/shell", .module = tools_shell_mod }, .{ .name = "tools/file", .module = tools_file_mod }, .{ .name = "tools/edit", .module = tools_edit_mod }, .{ .name = "tools/search", .module = tools_search_mod }, .{ .name = "tools/workspace", .module = tools_workspace_mod } } });
 
     const tui_runtime_mod = b.createModule(.{
@@ -1215,6 +1216,7 @@ pub fn build(b: *std.Build) void {
     const tui_tests_scenarios_test = b.addTest(.{ .root_module = tui_tests_scenarios_mod });
     const tui_tests_mock_transport_test = b.addTest(.{ .root_module = tui_tests_mock_transport_mod });
     const tools_common_test = b.addTest(.{ .root_module = tools_common_mod });
+    const tools_process_runner_test = b.addTest(.{ .root_module = tools_process_runner_mod });
     const tools_shell_test = b.addTest(.{ .root_module = tools_shell_mod });
     const tools_file_test = b.addTest(.{ .root_module = tools_file_mod });
     const tools_edit_test = b.addTest(.{ .root_module = tools_edit_mod });
@@ -1388,6 +1390,7 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(&b.addRunArtifact(tui_tests_scenarios_test).step);
     test_step.dependOn(&b.addRunArtifact(tui_tests_mock_transport_test).step);
     test_step.dependOn(&b.addRunArtifact(tools_common_test).step);
+    test_step.dependOn(&b.addRunArtifact(tools_process_runner_test).step);
     test_step.dependOn(&b.addRunArtifact(tools_shell_test).step);
     test_step.dependOn(&b.addRunArtifact(tools_file_test).step);
     test_step.dependOn(&b.addRunArtifact(tools_edit_test).step);
@@ -1492,6 +1495,7 @@ pub fn build(b: *std.Build) void {
     test_unit_agent_step.dependOn(&b.addRunArtifact(tui_session_test).step);
     test_unit_agent_step.dependOn(&b.addRunArtifact(tui_runtime_test).step);
     test_unit_agent_step.dependOn(&b.addRunArtifact(tools_common_test).step);
+    test_unit_agent_step.dependOn(&b.addRunArtifact(tools_process_runner_test).step);
     test_unit_agent_step.dependOn(&b.addRunArtifact(tools_shell_test).step);
     test_unit_agent_step.dependOn(&b.addRunArtifact(tools_file_test).step);
     test_unit_agent_step.dependOn(&b.addRunArtifact(tools_edit_test).step);
@@ -1525,6 +1529,7 @@ pub fn build(b: *std.Build) void {
     test_unit_tui_step.dependOn(&b.addRunArtifact(tui_tests_scenarios_test).step);
     test_unit_tui_step.dependOn(&b.addRunArtifact(tui_tests_mock_transport_test).step);
     test_unit_tui_step.dependOn(&b.addRunArtifact(tools_common_test).step);
+    test_unit_tui_step.dependOn(&b.addRunArtifact(tools_process_runner_test).step);
     test_unit_tui_step.dependOn(&b.addRunArtifact(tools_shell_test).step);
     test_unit_tui_step.dependOn(&b.addRunArtifact(tools_file_test).step);
     test_unit_tui_step.dependOn(&b.addRunArtifact(tools_edit_test).step);

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -752,6 +752,104 @@ pub fn build(b: *std.Build) void {
         },
     });
 
+    const tools_common_mod = b.createModule(.{
+        .root_source_file = b.path("src/tools/common.zig"),
+        .target = target,
+        .optimize = optimize,
+        .imports = &.{
+            .{ .name = "compat", .module = compat_mod },
+            .{ .name = "ai_types", .module = ai_types_mod },
+            .{ .name = "agent_types", .module = agent_types_mod },
+            .{ .name = "owned_slice", .module = owned_slice_mod },
+        },
+    });
+
+    const tools_artifact_mod = b.createModule(.{
+        .root_source_file = b.path("src/tools/artifact.zig"),
+        .target = target,
+        .optimize = optimize,
+        .imports = &.{
+            .{ .name = "ai_types", .module = ai_types_mod },
+            .{ .name = "agent_types", .module = agent_types_mod },
+            .{ .name = "tools/common", .module = tools_common_mod },
+            .{ .name = "owned_slice", .module = owned_slice_mod },
+        },
+    });
+
+    const tools_file_mod = b.createModule(.{
+        .root_source_file = b.path("src/tools/file.zig"),
+        .target = target,
+        .optimize = optimize,
+        .imports = &.{
+            .{ .name = "compat", .module = compat_mod },
+            .{ .name = "ai_types", .module = ai_types_mod },
+            .{ .name = "agent_types", .module = agent_types_mod },
+            .{ .name = "tools/common", .module = tools_common_mod },
+        },
+    });
+
+    const tools_edit_mod = b.createModule(.{
+        .root_source_file = b.path("src/tools/edit.zig"),
+        .target = target,
+        .optimize = optimize,
+        .imports = &.{
+            .{ .name = "compat", .module = compat_mod },
+            .{ .name = "ai_types", .module = ai_types_mod },
+            .{ .name = "agent_types", .module = agent_types_mod },
+            .{ .name = "tools/common", .module = tools_common_mod },
+        },
+    });
+
+    const tools_shell_mod = b.createModule(.{
+        .root_source_file = b.path("src/tools/shell.zig"),
+        .target = target,
+        .optimize = optimize,
+        .imports = &.{
+            .{ .name = "ai_types", .module = ai_types_mod },
+            .{ .name = "agent_types", .module = agent_types_mod },
+            .{ .name = "tools/common", .module = tools_common_mod },
+        },
+    });
+
+    const tools_search_mod = b.createModule(.{
+        .root_source_file = b.path("src/tools/search.zig"),
+        .target = target,
+        .optimize = optimize,
+        .imports = &.{
+            .{ .name = "compat", .module = compat_mod },
+            .{ .name = "ai_types", .module = ai_types_mod },
+            .{ .name = "agent_types", .module = agent_types_mod },
+            .{ .name = "tools/common", .module = tools_common_mod },
+        },
+    });
+
+    const tools_workspace_mod = b.createModule(.{
+        .root_source_file = b.path("src/tools/workspace.zig"),
+        .target = target,
+        .optimize = optimize,
+        .imports = &.{
+            .{ .name = "compat", .module = compat_mod },
+            .{ .name = "ai_types", .module = ai_types_mod },
+            .{ .name = "agent_types", .module = agent_types_mod },
+            .{ .name = "tools/common", .module = tools_common_mod },
+        },
+    });
+
+    const tools_registry_mod = b.createModule(.{
+        .root_source_file = b.path("src/tools/registry.zig"),
+        .target = target,
+        .optimize = optimize,
+        .imports = &.{
+            .{ .name = "agent_types", .module = agent_types_mod },
+            .{ .name = "tools/artifact", .module = tools_artifact_mod },
+            .{ .name = "tools/file", .module = tools_file_mod },
+            .{ .name = "tools/edit", .module = tools_edit_mod },
+            .{ .name = "tools/shell", .module = tools_shell_mod },
+            .{ .name = "tools/search", .module = tools_search_mod },
+            .{ .name = "tools/workspace", .module = tools_workspace_mod },
+        },
+    });
+
     const agent_loop_mod = b.createModule(.{
         .root_source_file = b.path("src/agent/agent_loop.zig"),
         .target = target,
@@ -1205,6 +1303,14 @@ pub fn build(b: *std.Build) void {
 
     // Agent tests
     const agent_types_test = b.addTest(.{ .root_module = agent_types_mod });
+    const tools_common_test = b.addTest(.{ .root_module = tools_common_mod });
+    const tools_artifact_test = b.addTest(.{ .root_module = tools_artifact_mod });
+    const tools_file_test = b.addTest(.{ .root_module = tools_file_mod });
+    const tools_edit_test = b.addTest(.{ .root_module = tools_edit_mod });
+    const tools_shell_test = b.addTest(.{ .root_module = tools_shell_mod });
+    const tools_search_test = b.addTest(.{ .root_module = tools_search_mod });
+    const tools_workspace_test = b.addTest(.{ .root_module = tools_workspace_mod });
+    const tools_registry_test = b.addTest(.{ .root_module = tools_registry_mod });
 
     const agent_loop_test = b.addTest(.{ .root_module = agent_loop_mod });
 
@@ -1382,6 +1488,14 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(&b.addRunArtifact(refresh_lock_test).step);
     test_step.dependOn(&b.addRunArtifact(oauth_test).step);
     test_step.dependOn(&b.addRunArtifact(agent_types_test).step);
+    test_step.dependOn(&b.addRunArtifact(tools_common_test).step);
+    test_step.dependOn(&b.addRunArtifact(tools_artifact_test).step);
+    test_step.dependOn(&b.addRunArtifact(tools_file_test).step);
+    test_step.dependOn(&b.addRunArtifact(tools_edit_test).step);
+    test_step.dependOn(&b.addRunArtifact(tools_shell_test).step);
+    test_step.dependOn(&b.addRunArtifact(tools_search_test).step);
+    test_step.dependOn(&b.addRunArtifact(tools_workspace_test).step);
+    test_step.dependOn(&b.addRunArtifact(tools_registry_test).step);
     test_step.dependOn(&b.addRunArtifact(agent_loop_test).step);
     test_step.dependOn(&b.addRunArtifact(agent_mod_test).step);
     test_step.dependOn(&b.addRunArtifact(agent_provider_protocol_bridge_test).step);
@@ -1489,6 +1603,14 @@ pub fn build(b: *std.Build) void {
 
     const test_unit_agent_step = b.step("test-unit-agent", "Run agent unit tests");
     test_unit_agent_step.dependOn(&b.addRunArtifact(agent_types_test).step);
+    test_unit_agent_step.dependOn(&b.addRunArtifact(tools_common_test).step);
+    test_unit_agent_step.dependOn(&b.addRunArtifact(tools_artifact_test).step);
+    test_unit_agent_step.dependOn(&b.addRunArtifact(tools_file_test).step);
+    test_unit_agent_step.dependOn(&b.addRunArtifact(tools_edit_test).step);
+    test_unit_agent_step.dependOn(&b.addRunArtifact(tools_shell_test).step);
+    test_unit_agent_step.dependOn(&b.addRunArtifact(tools_search_test).step);
+    test_unit_agent_step.dependOn(&b.addRunArtifact(tools_workspace_test).step);
+    test_unit_agent_step.dependOn(&b.addRunArtifact(tools_registry_test).step);
     test_unit_agent_step.dependOn(&b.addRunArtifact(agent_loop_test).step);
     test_unit_agent_step.dependOn(&b.addRunArtifact(agent_mod_test).step);
     test_unit_agent_step.dependOn(&b.addRunArtifact(agent_provider_protocol_bridge_test).step);

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -811,6 +811,14 @@ pub fn build(b: *std.Build) void {
         },
     });
 
+    const tools_common_mod = b.createModule(.{ .root_source_file = b.path("src/tools/common.zig"), .target = target, .optimize = optimize, .imports = &.{ .{ .name = "ai_types", .module = ai_types_mod }, .{ .name = "agent", .module = agent_mod }, .{ .name = "compat", .module = compat_mod } } });
+    const tools_shell_mod = b.createModule(.{ .root_source_file = b.path("src/tools/shell.zig"), .target = target, .optimize = optimize, .imports = &.{ .{ .name = "ai_types", .module = ai_types_mod }, .{ .name = "agent", .module = agent_mod }, .{ .name = "tools/common", .module = tools_common_mod } } });
+    const tools_file_mod = b.createModule(.{ .root_source_file = b.path("src/tools/file.zig"), .target = target, .optimize = optimize, .imports = &.{ .{ .name = "ai_types", .module = ai_types_mod }, .{ .name = "agent", .module = agent_mod }, .{ .name = "tools/common", .module = tools_common_mod } } });
+    const tools_edit_mod = b.createModule(.{ .root_source_file = b.path("src/tools/edit.zig"), .target = target, .optimize = optimize, .imports = &.{ .{ .name = "ai_types", .module = ai_types_mod }, .{ .name = "agent", .module = agent_mod }, .{ .name = "tools/common", .module = tools_common_mod } } });
+    const tools_search_mod = b.createModule(.{ .root_source_file = b.path("src/tools/search.zig"), .target = target, .optimize = optimize, .imports = &.{ .{ .name = "ai_types", .module = ai_types_mod }, .{ .name = "agent", .module = agent_mod }, .{ .name = "tools/common", .module = tools_common_mod } } });
+    const tools_workspace_mod = b.createModule(.{ .root_source_file = b.path("src/tools/workspace.zig"), .target = target, .optimize = optimize, .imports = &.{ .{ .name = "ai_types", .module = ai_types_mod }, .{ .name = "agent", .module = agent_mod }, .{ .name = "tools/common", .module = tools_common_mod } } });
+    const tools_registry_mod = b.createModule(.{ .root_source_file = b.path("src/tools/registry.zig"), .target = target, .optimize = optimize, .imports = &.{ .{ .name = "agent", .module = agent_mod }, .{ .name = "tools/shell", .module = tools_shell_mod }, .{ .name = "tools/file", .module = tools_file_mod }, .{ .name = "tools/edit", .module = tools_edit_mod }, .{ .name = "tools/search", .module = tools_search_mod }, .{ .name = "tools/workspace", .module = tools_workspace_mod } } });
+
     const tui_runtime_mod = b.createModule(.{
         .root_source_file = b.path("src/tui/runtime.zig"),
         .target = target,
@@ -822,6 +830,7 @@ pub fn build(b: *std.Build) void {
             .{ .name = "agent", .module = agent_mod },
             .{ .name = "agent_protocol_client", .module = protocol_agent_client_mod },
             .{ .name = "tui_session", .module = tui_session_mod },
+            .{ .name = "tools/registry", .module = tools_registry_mod },
             .{ .name = "owned_slice", .module = owned_slice_mod },
         },
     });
@@ -1205,6 +1214,13 @@ pub fn build(b: *std.Build) void {
     const tui_runtime_test = b.addTest(.{ .root_module = tui_runtime_mod });
     const tui_tests_scenarios_test = b.addTest(.{ .root_module = tui_tests_scenarios_mod });
     const tui_tests_mock_transport_test = b.addTest(.{ .root_module = tui_tests_mock_transport_mod });
+    const tools_common_test = b.addTest(.{ .root_module = tools_common_mod });
+    const tools_shell_test = b.addTest(.{ .root_module = tools_shell_mod });
+    const tools_file_test = b.addTest(.{ .root_module = tools_file_mod });
+    const tools_edit_test = b.addTest(.{ .root_module = tools_edit_mod });
+    const tools_search_test = b.addTest(.{ .root_module = tools_search_mod });
+    const tools_workspace_test = b.addTest(.{ .root_module = tools_workspace_mod });
+    const tools_registry_test = b.addTest(.{ .root_module = tools_registry_mod });
     // TODO: Remove once Zig 0.16 self-hosted backend handles this test correctly.
     // The bridge test uses in-process threading + condition variables that trigger
     // a known backend bug; LLVM handles it fine.
@@ -1371,6 +1387,13 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(&b.addRunArtifact(tui_runtime_test).step);
     test_step.dependOn(&b.addRunArtifact(tui_tests_scenarios_test).step);
     test_step.dependOn(&b.addRunArtifact(tui_tests_mock_transport_test).step);
+    test_step.dependOn(&b.addRunArtifact(tools_common_test).step);
+    test_step.dependOn(&b.addRunArtifact(tools_shell_test).step);
+    test_step.dependOn(&b.addRunArtifact(tools_file_test).step);
+    test_step.dependOn(&b.addRunArtifact(tools_edit_test).step);
+    test_step.dependOn(&b.addRunArtifact(tools_search_test).step);
+    test_step.dependOn(&b.addRunArtifact(tools_workspace_test).step);
+    test_step.dependOn(&b.addRunArtifact(tools_registry_test).step);
     test_step.dependOn(&b.addRunArtifact(agent_test).step);
     test_step.dependOn(&b.addRunArtifact(agent_protocol_chain_test).step);
     test_step.dependOn(&b.addRunArtifact(protocol_agent_types_test).step);
@@ -1468,6 +1491,13 @@ pub fn build(b: *std.Build) void {
     test_unit_agent_step.dependOn(&b.addRunArtifact(agent_provider_protocol_bridge_test).step);
     test_unit_agent_step.dependOn(&b.addRunArtifact(tui_session_test).step);
     test_unit_agent_step.dependOn(&b.addRunArtifact(tui_runtime_test).step);
+    test_unit_agent_step.dependOn(&b.addRunArtifact(tools_common_test).step);
+    test_unit_agent_step.dependOn(&b.addRunArtifact(tools_shell_test).step);
+    test_unit_agent_step.dependOn(&b.addRunArtifact(tools_file_test).step);
+    test_unit_agent_step.dependOn(&b.addRunArtifact(tools_edit_test).step);
+    test_unit_agent_step.dependOn(&b.addRunArtifact(tools_search_test).step);
+    test_unit_agent_step.dependOn(&b.addRunArtifact(tools_workspace_test).step);
+    test_unit_agent_step.dependOn(&b.addRunArtifact(tools_registry_test).step);
     test_unit_agent_step.dependOn(&b.addRunArtifact(agent_test).step);
     test_unit_agent_step.dependOn(&b.addRunArtifact(agent_protocol_chain_test).step);
 
@@ -1494,6 +1524,13 @@ pub fn build(b: *std.Build) void {
     test_unit_tui_step.dependOn(&b.addRunArtifact(tui_runtime_test).step);
     test_unit_tui_step.dependOn(&b.addRunArtifact(tui_tests_scenarios_test).step);
     test_unit_tui_step.dependOn(&b.addRunArtifact(tui_tests_mock_transport_test).step);
+    test_unit_tui_step.dependOn(&b.addRunArtifact(tools_common_test).step);
+    test_unit_tui_step.dependOn(&b.addRunArtifact(tools_shell_test).step);
+    test_unit_tui_step.dependOn(&b.addRunArtifact(tools_file_test).step);
+    test_unit_tui_step.dependOn(&b.addRunArtifact(tools_edit_test).step);
+    test_unit_tui_step.dependOn(&b.addRunArtifact(tools_search_test).step);
+    test_unit_tui_step.dependOn(&b.addRunArtifact(tools_workspace_test).step);
+    test_unit_tui_step.dependOn(&b.addRunArtifact(tools_registry_test).step);
 
     const test_e2e_anthropic_step = b.step("test-e2e-anthropic", "Run Anthropic E2E tests");
     test_e2e_anthropic_step.dependOn(&b.addRunArtifact(e2e_anthropic_test).step);

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -1398,14 +1398,7 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(&b.addRunArtifact(tui_runtime_test).step);
     test_step.dependOn(&b.addRunArtifact(tui_tests_scenarios_test).step);
     test_step.dependOn(&b.addRunArtifact(tui_tests_mock_transport_test).step);
-    test_step.dependOn(&b.addRunArtifact(tools_common_test).step);
     test_step.dependOn(&b.addRunArtifact(tools_process_runner_test).step);
-    test_step.dependOn(&b.addRunArtifact(tools_shell_test).step);
-    test_step.dependOn(&b.addRunArtifact(tools_file_test).step);
-    test_step.dependOn(&b.addRunArtifact(tools_edit_test).step);
-    test_step.dependOn(&b.addRunArtifact(tools_search_test).step);
-    test_step.dependOn(&b.addRunArtifact(tools_workspace_test).step);
-    test_step.dependOn(&b.addRunArtifact(tools_registry_test).step);
     test_step.dependOn(&b.addRunArtifact(agent_test).step);
     test_step.dependOn(&b.addRunArtifact(agent_protocol_chain_test).step);
     test_step.dependOn(&b.addRunArtifact(protocol_agent_types_test).step);

--- a/zig/src/agent/agent.zig
+++ b/zig/src/agent/agent.zig
@@ -56,6 +56,7 @@ pub const AgentOptions = struct {
     get_api_key_ctx: ?*anyopaque = null,
     thinking_budgets: ?ai_types.ThinkingBudgets = null,
     max_retry_delay_ms: ?u32 = 60_000,
+    compact_tool_output: bool = false,
 };
 
 /// High-level Agent class that manages state, subscriptions, and message queues.
@@ -100,6 +101,7 @@ pub const Agent = struct {
     _get_api_key_ctx: ?*anyopaque,
     _thinking_budgets: ?ai_types.ThinkingBudgets,
     _max_retry_delay_ms: ?u32,
+    _compact_tool_output: bool,
 
     // Async support
     _thread: ?std.Thread,
@@ -137,6 +139,7 @@ pub const Agent = struct {
             ._get_api_key_ctx = options.get_api_key_ctx,
             ._thinking_budgets = options.thinking_budgets,
             ._max_retry_delay_ms = options.max_retry_delay_ms,
+            ._compact_tool_output = options.compact_tool_output,
             ._thread = null,
             ._done_event = .is_set,
             ._mutex = .init,
@@ -181,7 +184,7 @@ pub const Agent = struct {
     /// Subscribe to agent events.
     /// Returns a token that can be used to unsubscribe.
     pub fn subscribe(self: *Agent, callback: *const fn (event: AgentEvent) void) void {
-        self.subscribeWithContext(@constCast(@ptrCast(callback)), legacyListenerShim);
+        self.subscribeWithContext(@ptrCast(@constCast(callback)), legacyListenerShim);
     }
 
     /// Subscribe to agent events with caller context.
@@ -196,7 +199,7 @@ pub const Agent = struct {
     /// Unsubscribe from agent events.
     pub fn unsubscribe(self: *Agent, callback: *const fn (event: AgentEvent) void) void {
         for (self._listeners.items, 0..) |listener, i| {
-            if (listener.callback == legacyListenerShim and listener.ctx == @as(?*anyopaque, @constCast(@ptrCast(callback)))) {
+            if (listener.callback == legacyListenerShim and listener.ctx == @as(?*anyopaque, @ptrCast(@constCast(callback)))) {
                 _ = self._listeners.orderedRemove(i);
                 return;
             }
@@ -272,6 +275,10 @@ pub const Agent = struct {
     /// Set the tools.
     pub fn setTools(self: *Agent, tools: []const AgentTool) void {
         self._state.tools = tools;
+    }
+
+    pub fn setCompactToolOutput(self: *Agent, enabled: bool) void {
+        self._compact_tool_output = enabled;
     }
 
     /// Set the steering mode.
@@ -894,6 +901,7 @@ pub const Agent = struct {
             .session_id = self._session_id,
             .thinking_budgets = self._thinking_budgets,
             .max_retry_delay_ms = self._max_retry_delay_ms,
+            .compact_tool_output = self._compact_tool_output,
             .transform_context_fn = self._transform_context_fn,
             .transform_context_ctx = self._transform_context_ctx,
             .get_steering_messages_fn = getSteeringMessages,

--- a/zig/src/agent/agent_loop.zig
+++ b/zig/src/agent/agent_loop.zig
@@ -423,6 +423,7 @@ fn finalizeToolExecution(
 /// Result from tool execution phase
 const ToolExecutionResult = struct {
     tool_results: []ai_types.ToolResultMessage,
+    compact_args: [][]u8 = &.{},
     has_steering: bool,
     steering_messages: ?[]const ai_types.Message,
 
@@ -431,6 +432,8 @@ const ToolExecutionResult = struct {
             result.deinit(allocator);
         }
         allocator.free(self.tool_results);
+        for (self.compact_args) |args| allocator.free(args);
+        allocator.free(self.compact_args);
         if (self.steering_messages) |msgs| {
             const mut_msgs: []ai_types.Message = @constCast(msgs);
             for (mut_msgs) |*msg| msg.deinit(allocator);
@@ -469,6 +472,11 @@ fn executeToolCalls(
     }
 
     var results: std.ArrayList(ai_types.ToolResultMessage) = .empty;
+    var compact_args: std.ArrayList([]u8) = .empty;
+    errdefer {
+        for (compact_args.items) |args| allocator.free(args);
+        compact_args.deinit(allocator);
+    }
     var has_steering = false;
     var steering_messages: ?[]const ai_types.Message = null;
 
@@ -497,12 +505,15 @@ fn executeToolCalls(
             };
             const should_compact = config.compact_tool_output and supportsCompactToolOutput(t);
             if (should_compact) {
-                execution_args = withCompactToolOutput(allocator, validated_args) catch |err| {
+                const owned_args = withCompactToolOutput(allocator, validated_args) catch |err| {
                     result = try createErrorResult(allocator, err);
                     is_error = true;
                     try finalizeToolExecution(allocator, config, event_stream, &results, tool_call, execution_args, &result, is_error);
                     continue;
                 };
+                errdefer allocator.free(owned_args);
+                try compact_args.append(allocator, owned_args);
+                execution_args = owned_args;
             }
 
             const approval_request = types.ToolApprovalRequest{
@@ -592,6 +603,7 @@ fn executeToolCalls(
 
     return .{
         .tool_results = try results.toOwnedSlice(allocator),
+        .compact_args = try compact_args.toOwnedSlice(allocator),
         .has_steering = has_steering,
         .steering_messages = steering_messages,
     };

--- a/zig/src/agent/agent_loop.zig
+++ b/zig/src/agent/agent_loop.zig
@@ -440,6 +440,10 @@ const ToolExecutionResult = struct {
 };
 
 /// Execute tool calls from assistant message
+fn supportsCompactToolOutput(tool: AgentTool) bool {
+    return std.mem.indexOf(u8, tool.parameters_schema_json, "\"compact_output\"") != null;
+}
+
 fn withCompactToolOutput(allocator: std.mem.Allocator, args_json: []const u8) ![]u8 {
     var parsed = try std.json.parseFromSlice(std.json.Value, allocator, args_json, .{});
     defer parsed.deinit();
@@ -491,11 +495,15 @@ fn executeToolCalls(
                 try finalizeToolExecution(allocator, config, event_stream, &results, tool_call, execution_args, &result, is_error);
                 continue;
             };
-            execution_args = if (config.compact_tool_output)
-                try withCompactToolOutput(allocator, validated_args)
-            else
-                validated_args;
-            defer if (config.compact_tool_output) allocator.free(execution_args);
+            const should_compact = config.compact_tool_output and supportsCompactToolOutput(t);
+            if (should_compact) {
+                execution_args = withCompactToolOutput(allocator, validated_args) catch |err| {
+                    result = try createErrorResult(allocator, err);
+                    is_error = true;
+                    try finalizeToolExecution(allocator, config, event_stream, &results, tool_call, execution_args, &result, is_error);
+                    continue;
+                };
+            }
 
             const approval_request = types.ToolApprovalRequest{
                 .tool_call_id = tool_call.id,

--- a/zig/src/agent/agent_loop.zig
+++ b/zig/src/agent/agent_loop.zig
@@ -440,6 +440,14 @@ const ToolExecutionResult = struct {
 };
 
 /// Execute tool calls from assistant message
+fn withCompactToolOutput(allocator: std.mem.Allocator, args_json: []const u8) ![]u8 {
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, args_json, .{});
+    defer parsed.deinit();
+    if (parsed.value != .object) return try allocator.dupe(u8, args_json);
+    try parsed.value.object.put(allocator, "compact_output", .{ .bool = true });
+    return std.json.Stringify.valueAlloc(allocator, parsed.value, .{});
+}
+
 fn executeToolCalls(
     allocator: std.mem.Allocator,
     assistant_message: ai_types.AssistantMessage,
@@ -483,12 +491,16 @@ fn executeToolCalls(
                 try finalizeToolExecution(allocator, config, event_stream, &results, tool_call, execution_args, &result, is_error);
                 continue;
             };
-            execution_args = validated_args;
+            execution_args = if (config.compact_tool_output)
+                try withCompactToolOutput(allocator, validated_args)
+            else
+                validated_args;
+            defer if (config.compact_tool_output) allocator.free(execution_args);
 
             const approval_request = types.ToolApprovalRequest{
                 .tool_call_id = tool_call.id,
                 .tool_name = tool_call.name,
-                .args_json = validated_args,
+                .args_json = execution_args,
             };
             if (t.approval_ui_fn) |notify| {
                 notify(t.approval_ui_ctx, approval_request, allocator);
@@ -508,7 +520,7 @@ fn executeToolCalls(
                 .event_stream = event_stream,
                 .tool_call_id = tool_call.id,
                 .tool_name = tool_call.name,
-                .args_json = validated_args,
+                .args_json = execution_args,
             };
 
             result = blk: {
@@ -517,7 +529,7 @@ fn executeToolCalls(
                         config.execute_tool_via_protocol_ctx,
                         tool_call.id,
                         tool_call.name,
-                        validated_args,
+                        execution_args,
                         config.cancel_token,
                         &update_ctx,
                         onToolUpdate,
@@ -531,7 +543,7 @@ fn executeToolCalls(
 
                 break :blk t.execute(
                     tool_call.id,
-                    validated_args,
+                    execution_args,
                     config.cancel_token,
                     &update_ctx,
                     onToolUpdate,

--- a/zig/src/agent/agent_loop.zig
+++ b/zig/src/agent/agent_loop.zig
@@ -443,8 +443,32 @@ const ToolExecutionResult = struct {
 };
 
 /// Execute tool calls from assistant message
-fn supportsCompactToolOutput(tool: AgentTool) bool {
-    return std.mem.indexOf(u8, tool.parameters_schema_json, "\"compact_output\"") != null;
+fn supportsCompactToolOutput(allocator: std.mem.Allocator, tool: AgentTool) !bool {
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, tool.parameters_schema_json, .{});
+    defer parsed.deinit();
+    if (parsed.value != .object) return false;
+    const properties = parsed.value.object.get("properties") orelse return false;
+    if (properties != .object) return false;
+    return properties.object.contains("compact_output");
+}
+
+test "compact output support requires root schema property" {
+    const nested = AgentTool{
+        .label = "Nested",
+        .name = "nested",
+        .description = "Nested compact_output mention only.",
+        .parameters_schema_json = "{\"type\":\"object\",\"properties\":{\"options\":{\"type\":\"object\",\"properties\":{\"compact_output\":{\"type\":\"boolean\"}}}},\"additionalProperties\":false}",
+        .execute = undefined,
+    };
+    try std.testing.expect(!try supportsCompactToolOutput(std.testing.allocator, nested));
+    const root = AgentTool{
+        .label = "Root",
+        .name = "root",
+        .description = "Root compact_output property.",
+        .parameters_schema_json = "{\"type\":\"object\",\"properties\":{\"compact_output\":{\"type\":\"boolean\"}},\"additionalProperties\":false}",
+        .execute = undefined,
+    };
+    try std.testing.expect(try supportsCompactToolOutput(std.testing.allocator, root));
 }
 
 fn withCompactToolOutput(allocator: std.mem.Allocator, args_json: []const u8) ![]u8 {
@@ -503,7 +527,12 @@ fn executeToolCalls(
                 try finalizeToolExecution(allocator, config, event_stream, &results, tool_call, execution_args, &result, is_error);
                 continue;
             };
-            const should_compact = config.compact_tool_output and supportsCompactToolOutput(t);
+            const should_compact = if (config.compact_tool_output) supportsCompactToolOutput(allocator, t) catch |err| {
+                result = try createErrorResult(allocator, err);
+                is_error = true;
+                try finalizeToolExecution(allocator, config, event_stream, &results, tool_call, execution_args, &result, is_error);
+                continue;
+            } else false;
             if (should_compact) {
                 const owned_args = withCompactToolOutput(allocator, validated_args) catch |err| {
                     result = try createErrorResult(allocator, err);

--- a/zig/src/agent/types.zig
+++ b/zig/src/agent/types.zig
@@ -240,6 +240,7 @@ pub const AgentTool = struct {
     label: []const u8, // Human-readable label for UI
     name: []const u8,
     description: []const u8,
+    short_description: ?[]const u8 = null,
     parameters_schema_json: []const u8,
     execute: ToolExecuteFn,
     approval_ctx: ?*anyopaque = null,
@@ -252,7 +253,7 @@ pub const AgentTool = struct {
         _ = allocator;
         return .{
             .name = self.name,
-            .description = self.description,
+            .description = self.short_description orelse self.description,
             .parameters_schema_json = self.parameters_schema_json,
         };
     }
@@ -660,13 +661,14 @@ test "AgentTool.toTool conversion" {
         .label = "Test Tool",
         .name = "test_tool",
         .description = "A test tool",
+        .short_description = "Test compact",
         .parameters_schema_json = "{}",
         .execute = undefined, // Would be a real function in practice
     };
 
     const converted = try tool.toTool(std.testing.allocator);
     try std.testing.expectEqualStrings("test_tool", converted.name);
-    try std.testing.expectEqualStrings("A test tool", converted.description);
+    try std.testing.expectEqualStrings("Test compact", converted.description);
 }
 
 test "QueueMode enum values" {

--- a/zig/src/agent/types.zig
+++ b/zig/src/agent/types.zig
@@ -373,6 +373,7 @@ pub const AgentLoopConfig = struct {
     execute_tool_via_protocol_ctx: ?*anyopaque = null,
     tool_output_middleware_fn: ?ToolOutputMiddlewareFn = null,
     tool_output_middleware_ctx: ?*anyopaque = null,
+    compact_tool_output: bool = false,
 
     // Streaming options (passed through to protocol)
     temperature: ?f32 = null,

--- a/zig/src/tools/artifact.zig
+++ b/zig/src/tools/artifact.zig
@@ -21,18 +21,20 @@ pub fn executeRetrieve(
     allocator: std.mem.Allocator,
 ) anyerror!agent.AgentToolResult {
     _ = tool_call_id;
-    _ = cancel_token;
     _ = on_update_ctx;
     _ = on_update;
+    if (common.isCancelled(cancel_token)) return error.Cancelled;
 
     const parsed = try std.json.parseFromSlice(std.json.Value, allocator, args_json, .{});
     defer parsed.deinit();
     if (parsed.value != .object) return error.InvalidArguments;
     const reference_value = parsed.value.object.get("reference") orelse return error.InvalidArguments;
     if (reference_value != .string) return error.InvalidArguments;
+    if (common.isCancelled(cancel_token)) return error.Cancelled;
 
     const data = try common.retrieveArtifact(allocator, reference_value.string, 64 * 1024 * 1024);
     defer allocator.free(data);
+    if (common.isCancelled(cancel_token)) return error.Cancelled;
     const details = try common.telemetryDetails(allocator, data.len, data.len, false);
     defer allocator.free(details);
     return common.makeTextResult(allocator, data, details);

--- a/zig/src/tools/artifact.zig
+++ b/zig/src/tools/artifact.zig
@@ -1,28 +1,25 @@
 const std = @import("std");
 const ai_types = @import("ai_types");
-const agent_types = @import("agent_types");
+const agent = @import("agent");
 const common = @import("tools/common");
-const OwnedSlice = @import("owned_slice").OwnedSlice;
 
-pub fn retrieveTool() agent_types.AgentTool {
-    return .{
-        .label = "Artifact Retrieve",
-        .name = "artifact_retrieve",
-        .description = "Retrieve full tool output previously stored as a local artifact. Use when a tool result summary references an artifact path and complete output is needed.",
-        .short_description = "Retrieve stored full tool output by artifact path.",
-        .parameters_schema_json = "{\"type\":\"object\",\"properties\":{\"reference\":{\"type\":\"string\"}},\"required\":[\"reference\"]}",
-        .execute = executeRetrieve,
-    };
-}
+pub const retrieve_tool = agent.AgentTool{
+    .label = "Artifact Retrieve",
+    .name = "artifact_retrieve",
+    .description = "Retrieve full tool output previously stored as a local artifact. Use when a tool result summary references an artifact path and complete output is needed.",
+    .short_description = "Retrieve stored full tool output by artifact path.",
+    .parameters_schema_json = "{\"type\":\"object\",\"properties\":{\"reference\":{\"type\":\"string\"}},\"required\":[\"reference\"],\"additionalProperties\":false}",
+    .execute = executeRetrieve,
+};
 
 pub fn executeRetrieve(
     tool_call_id: []const u8,
     args_json: []const u8,
     cancel_token: ?ai_types.CancelToken,
     on_update_ctx: ?*anyopaque,
-    on_update: ?agent_types.ToolUpdateCallback,
+    on_update: ?agent.ToolUpdateCallback,
     allocator: std.mem.Allocator,
-) anyerror!agent_types.AgentToolResult {
+) anyerror!agent.AgentToolResult {
     _ = tool_call_id;
     _ = cancel_token;
     _ = on_update_ctx;
@@ -50,4 +47,6 @@ test "artifact_retrieve loads stored output" {
     var result = try executeRetrieve("call", args, null, null, null, allocator);
     defer result.deinit(allocator);
     try std.testing.expectEqualStrings("full output", result.content.slice()[0].text.text);
+    try std.testing.expectError(error.InvalidArtifactReference, common.retrieveArtifact(allocator, "../build.zig", 1024));
+    try std.testing.expectError(error.InvalidArtifactReference, common.retrieveArtifact(allocator, "/tmp/not-an-artifact", 1024));
 }

--- a/zig/src/tools/artifact.zig
+++ b/zig/src/tools/artifact.zig
@@ -1,0 +1,53 @@
+const std = @import("std");
+const ai_types = @import("ai_types");
+const agent_types = @import("agent_types");
+const common = @import("tools/common");
+const OwnedSlice = @import("owned_slice").OwnedSlice;
+
+pub fn retrieveTool() agent_types.AgentTool {
+    return .{
+        .label = "Artifact Retrieve",
+        .name = "artifact_retrieve",
+        .description = "Retrieve full tool output previously stored as a local artifact. Use when a tool result summary references an artifact path and complete output is needed.",
+        .short_description = "Retrieve stored full tool output by artifact path.",
+        .parameters_schema_json = "{\"type\":\"object\",\"properties\":{\"reference\":{\"type\":\"string\"}},\"required\":[\"reference\"]}",
+        .execute = executeRetrieve,
+    };
+}
+
+pub fn executeRetrieve(
+    tool_call_id: []const u8,
+    args_json: []const u8,
+    cancel_token: ?ai_types.CancelToken,
+    on_update_ctx: ?*anyopaque,
+    on_update: ?agent_types.ToolUpdateCallback,
+    allocator: std.mem.Allocator,
+) anyerror!agent_types.AgentToolResult {
+    _ = tool_call_id;
+    _ = cancel_token;
+    _ = on_update_ctx;
+    _ = on_update;
+
+    const parsed = try std.json.parseFromSlice(std.json.Value, allocator, args_json, .{});
+    defer parsed.deinit();
+    if (parsed.value != .object) return error.InvalidArguments;
+    const reference_value = parsed.value.object.get("reference") orelse return error.InvalidArguments;
+    if (reference_value != .string) return error.InvalidArguments;
+
+    const data = try common.retrieveArtifact(allocator, reference_value.string, 64 * 1024 * 1024);
+    defer allocator.free(data);
+    const details = try common.telemetryDetails(allocator, data.len, data.len, false);
+    defer allocator.free(details);
+    return common.makeTextResult(allocator, data, details);
+}
+
+test "artifact_retrieve loads stored output" {
+    const allocator = std.testing.allocator;
+    const path = try common.storeArtifact(allocator, "artifact-test", "full output");
+    defer allocator.free(path);
+    const args = try std.fmt.allocPrint(allocator, "{{\"reference\":\"{s}\"}}", .{path});
+    defer allocator.free(args);
+    var result = try executeRetrieve("call", args, null, null, null, allocator);
+    defer result.deinit(allocator);
+    try std.testing.expectEqualStrings("full output", result.content.slice()[0].text.text);
+}

--- a/zig/src/tools/common.zig
+++ b/zig/src/tools/common.zig
@@ -1,0 +1,154 @@
+const std = @import("std");
+const ai_types = @import("ai_types");
+const agent = @import("agent");
+const compat = @import("compat");
+
+pub const max_file_bytes: usize = 16 * 1024 * 1024;
+pub const max_results: usize = 200;
+
+pub fn defaultIo() std.Io {
+    return if (@import("builtin").is_test)
+        std.testing.io
+    else
+        std.Io.Threaded.global_single_threaded.io();
+}
+
+pub fn nowMs() i64 {
+    return compat.time.nowMillis();
+}
+
+pub fn durationMs(start_ms: i64) u64 {
+    const elapsed = nowMs() - start_ms;
+    return if (elapsed <= 0) 0 else @intCast(elapsed);
+}
+
+pub fn isCancelled(cancel_token: ?ai_types.CancelToken) bool {
+    if (cancel_token) |token| return token.isCancelled();
+    return false;
+}
+
+pub fn parseArgs(allocator: std.mem.Allocator, args_json: []const u8) !std.json.Parsed(std.json.Value) {
+    const parsed = std.json.parseFromSlice(std.json.Value, allocator, args_json, .{}) catch return error.InvalidArgumentsJson;
+    if (parsed.value != .object) {
+        var mutable = parsed;
+        mutable.deinit();
+        return error.InvalidArgumentsJson;
+    }
+    return parsed;
+}
+
+pub fn requiredString(obj: std.json.ObjectMap, key: []const u8) ![]const u8 {
+    const value = obj.get(key) orelse return error.MissingRequiredArgument;
+    if (value != .string) return error.InvalidArgumentType;
+    return value.string;
+}
+
+pub fn optionalString(obj: std.json.ObjectMap, key: []const u8) ?[]const u8 {
+    const value = obj.get(key) orelse return null;
+    if (value != .string) return null;
+    return value.string;
+}
+
+pub fn optionalBool(obj: std.json.ObjectMap, key: []const u8, default: bool) bool {
+    const value = obj.get(key) orelse return default;
+    if (value != .bool) return default;
+    return value.bool;
+}
+
+pub fn optionalU64(obj: std.json.ObjectMap, key: []const u8, default: u64) u64 {
+    const value = obj.get(key) orelse return default;
+    return switch (value) {
+        .integer => |i| if (i < 0) default else @intCast(i),
+        .float => |f| if (f < 0) default else @intFromFloat(f),
+        .number_string => |s| std.fmt.parseUnsigned(u64, s, 10) catch default,
+        else => default,
+    };
+}
+
+pub fn optionalUsize(obj: std.json.ObjectMap, key: []const u8, default: usize) usize {
+    return @intCast(optionalU64(obj, key, default));
+}
+
+pub fn hasParentTraversal(path: []const u8) bool {
+    var it = std.mem.tokenizeAny(u8, path, "/\\");
+    while (it.next()) |part| {
+        if (std.mem.eql(u8, part, "..")) return true;
+    }
+    return false;
+}
+
+pub fn openWorkspace(workspace_root: []const u8, iterate: bool) !std.Io.Dir {
+    if (!std.Io.Dir.path.isAbsolute(workspace_root)) return error.WorkspaceRootMustBeAbsolute;
+    return std.Io.Dir.openDirAbsolute(defaultIo(), workspace_root, .{ .iterate = iterate });
+}
+
+pub fn resolveRelativePath(allocator: std.mem.Allocator, path_value: []const u8) ![]u8 {
+    if (std.Io.Dir.path.isAbsolute(path_value)) return try allocator.dupe(u8, path_value);
+    if (hasParentTraversal(path_value)) return error.PathEscapesWorkspace;
+    return try allocator.dupe(u8, path_value);
+}
+
+pub fn readWorkspaceFile(allocator: std.mem.Allocator, workspace_root: []const u8, path_value: []const u8, max_bytes: usize) ![]u8 {
+    if (std.Io.Dir.path.isAbsolute(path_value)) {
+        return std.Io.Dir.cwd().readFileAlloc(defaultIo(), path_value, allocator, .limited(max_bytes));
+    }
+    if (hasParentTraversal(path_value)) return error.PathEscapesWorkspace;
+    var dir = try openWorkspace(workspace_root, false);
+    defer dir.close(defaultIo());
+    return dir.readFileAlloc(defaultIo(), path_value, allocator, .limited(max_bytes));
+}
+
+pub fn writeWorkspaceFile(workspace_root: []const u8, path_value: []const u8, data: []const u8) !void {
+    if (std.Io.Dir.path.isAbsolute(path_value)) {
+        var file = try std.Io.Dir.cwd().createFile(defaultIo(), path_value, .{ .truncate = true, .permissions = compat.fs.default_file_mode });
+        defer file.close(defaultIo());
+        try file.writeStreamingAll(defaultIo(), data);
+        return;
+    }
+    if (hasParentTraversal(path_value)) return error.PathEscapesWorkspace;
+    var dir = try openWorkspace(workspace_root, false);
+    defer dir.close(defaultIo());
+    var file = try dir.createFile(defaultIo(), path_value, .{ .truncate = true, .permissions = compat.fs.default_file_mode });
+    defer file.close(defaultIo());
+    try file.writeStreamingAll(defaultIo(), data);
+}
+
+pub fn statWorkspaceFile(workspace_root: []const u8, path_value: []const u8) !std.Io.File.Stat {
+    if (std.Io.Dir.path.isAbsolute(path_value)) {
+        return std.Io.Dir.cwd().statFile(defaultIo(), path_value, .{});
+    }
+    if (hasParentTraversal(path_value)) return error.PathEscapesWorkspace;
+    var dir = try openWorkspace(workspace_root, false);
+    defer dir.close(defaultIo());
+    return dir.statFile(defaultIo(), path_value, .{});
+}
+
+pub fn isBinary(data: []const u8) bool {
+    const limit = @min(data.len, 4096);
+    return std.mem.indexOfScalar(u8, data[0..limit], 0) != null;
+}
+
+pub fn makeTextResult(allocator: std.mem.Allocator, text: []const u8, details_json: []const u8) !agent.AgentToolResult {
+    const parts = try allocator.alloc(ai_types.UserContentPart, 1);
+    errdefer allocator.free(parts);
+    parts[0] = .{ .text = .{ .text = try allocator.dupe(u8, text) } };
+    errdefer parts[0].deinit(allocator);
+    return .{
+        .content = ai_types.OwnedSlice(ai_types.UserContentPart).initOwned(parts),
+        .details_json = ai_types.OwnedSlice(u8).initOwned(try allocator.dupe(u8, details_json)),
+    };
+}
+
+pub fn makeTextResultOwned(allocator: std.mem.Allocator, text: []u8, details_json: []u8) !agent.AgentToolResult {
+    const parts = try allocator.alloc(ai_types.UserContentPart, 1);
+    errdefer allocator.free(parts);
+    parts[0] = .{ .text = .{ .text = text } };
+    return .{
+        .content = ai_types.OwnedSlice(ai_types.UserContentPart).initOwned(parts),
+        .details_json = ai_types.OwnedSlice(u8).initOwned(details_json),
+    };
+}
+
+pub fn jsonString(allocator: std.mem.Allocator, value: anytype) ![]u8 {
+    return std.json.Stringify.valueAlloc(allocator, value, .{});
+}

--- a/zig/src/tools/common.zig
+++ b/zig/src/tools/common.zig
@@ -317,9 +317,13 @@ pub fn makeTextResultWithArtifact(allocator: std.mem.Allocator, options: TextRes
     errdefer result.deinit(allocator);
     const artifact_refs = try allocator.alloc(ai_types.ArtifactReference, 1);
     errdefer allocator.free(artifact_refs);
+    const artifact_id = try allocator.dupe(u8, key);
+    errdefer allocator.free(artifact_id);
+    const uri = try allocator.dupe(u8, artifact_path);
+    errdefer allocator.free(uri);
     artifact_refs[0] = .{
-        .artifact_id = try allocator.dupe(u8, key),
-        .uri = ai_types.OwnedSlice(u8).initOwned(try allocator.dupe(u8, artifact_path)),
+        .artifact_id = artifact_id,
+        .uri = ai_types.OwnedSlice(u8).initOwned(uri),
         .byte_size = raw_bytes,
     };
     errdefer artifact_refs[0].deinit(allocator);

--- a/zig/src/tools/common.zig
+++ b/zig/src/tools/common.zig
@@ -119,7 +119,14 @@ pub fn readWorkspaceFile(allocator: std.mem.Allocator, workspace_root: []const u
     defer allocator.free(relative_path);
     var dir = try openWorkspace(workspace_root, false);
     defer dir.close(defaultIo());
-    return dir.readFileAlloc(defaultIo(), relative_path, allocator, .limited(max_bytes));
+    try ensureNoSymlinkComponents(allocator, dir, relative_path);
+    var file = try dir.openFile(defaultIo(), relative_path, .{ .allow_directory = false, .follow_symlinks = false, .resolve_beneath = true });
+    defer file.close(defaultIo());
+    var file_reader = file.reader(defaultIo(), &.{});
+    return file_reader.interface.allocRemaining(allocator, .limited(max_bytes)) catch |err| switch (err) {
+        error.ReadFailed => return file_reader.err.?,
+        error.OutOfMemory, error.StreamTooLong => |e| return e,
+    };
 }
 
 pub fn writeWorkspaceFile(allocator: std.mem.Allocator, workspace_root: []const u8, path_value: []const u8, data: []const u8) !void {
@@ -127,7 +134,8 @@ pub fn writeWorkspaceFile(allocator: std.mem.Allocator, workspace_root: []const 
     defer allocator.free(relative_path);
     var dir = try openWorkspace(workspace_root, false);
     defer dir.close(defaultIo());
-    var file = try dir.createFile(defaultIo(), relative_path, .{ .truncate = true, .permissions = compat.fs.default_file_mode });
+    try ensureNoSymlinkComponents(allocator, dir, relative_path);
+    var file = try dir.createFile(defaultIo(), relative_path, .{ .truncate = true, .permissions = compat.fs.default_file_mode, .resolve_beneath = true });
     defer file.close(defaultIo());
     try file.writeStreamingAll(defaultIo(), data);
 }
@@ -137,7 +145,25 @@ pub fn statWorkspaceFile(allocator: std.mem.Allocator, workspace_root: []const u
     defer allocator.free(relative_path);
     var dir = try openWorkspace(workspace_root, false);
     defer dir.close(defaultIo());
-    return dir.statFile(defaultIo(), relative_path, .{});
+    try ensureNoSymlinkComponents(allocator, dir, relative_path);
+    return dir.statFile(defaultIo(), relative_path, .{ .follow_symlinks = false });
+}
+
+fn ensureNoSymlinkComponents(allocator: std.mem.Allocator, dir: std.Io.Dir, relative_path: []const u8) !void {
+    if (relative_path.len == 0) return error.InvalidFilePath;
+    var prefix = std.ArrayList(u8).empty;
+    defer prefix.deinit(allocator);
+    var it = std.mem.tokenizeAny(u8, relative_path, "/\\");
+    while (it.next()) |part| {
+        if (prefix.items.len != 0) try prefix.append(allocator, std.Io.Dir.path.sep);
+        try prefix.appendSlice(allocator, part);
+        dir.access(defaultIo(), prefix.items, .{ .follow_symlinks = false }) catch |err| switch (err) {
+            error.FileNotFound => continue,
+            else => return err,
+        };
+        const st = try dir.statFile(defaultIo(), prefix.items, .{ .follow_symlinks = false });
+        if (st.kind == .sym_link) return error.PathEscapesWorkspace;
+    }
 }
 
 pub fn isBinary(data: []const u8) bool {
@@ -189,6 +215,12 @@ test "common path and binary helpers" {
     const traversal = try std.Io.Dir.path.join(std.testing.allocator, &.{ root, "..", "outside.txt" });
     defer std.testing.allocator.free(traversal);
     try std.testing.expectError(error.PathEscapesWorkspace, resolveWorkspacePath(std.testing.allocator, root, traversal));
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const tmp_root = try std.Io.Dir.path.join(std.testing.allocator, &.{ cwd, ".zig-cache", "tmp", tmp.sub_path[0..] });
+    defer std.testing.allocator.free(tmp_root);
+    try tmp.dir.symLink(defaultIo(), "/", "link", .{ .is_directory = true });
+    try std.testing.expectError(error.PathEscapesWorkspace, readWorkspaceFile(std.testing.allocator, tmp_root, "link/passwd", 1024));
     try std.testing.expect(hasParentTraversal("a/../b"));
     try std.testing.expect(hasParentTraversal("a\\..\\b"));
     try std.testing.expect(!hasParentTraversal("a/..b/c"));

--- a/zig/src/tools/common.zig
+++ b/zig/src/tools/common.zig
@@ -4,6 +4,8 @@ const agent = @import("agent");
 const compat = @import("compat");
 
 pub const max_file_bytes: usize = 16 * 1024 * 1024;
+pub const process_output_bytes: usize = 16 * 1024 * 1024;
+pub const process_poll_ms: u64 = 100;
 pub const max_results: usize = 200;
 
 pub fn defaultIo() std.Io {
@@ -115,12 +117,7 @@ pub fn resolveWorkspacePath(allocator: std.mem.Allocator, workspace_root: []cons
 }
 
 pub fn readWorkspaceFile(allocator: std.mem.Allocator, workspace_root: []const u8, path_value: []const u8, max_bytes: usize) ![]u8 {
-    const relative_path = try resolveWorkspacePath(allocator, workspace_root, path_value);
-    defer allocator.free(relative_path);
-    var dir = try openWorkspace(workspace_root, false);
-    defer dir.close(defaultIo());
-    try ensureNoSymlinkComponents(allocator, dir, relative_path);
-    var file = try dir.openFile(defaultIo(), relative_path, .{ .allow_directory = false, .follow_symlinks = false, .resolve_beneath = true });
+    var file = try openWorkspaceFile(allocator, workspace_root, path_value);
     defer file.close(defaultIo());
     var file_reader = file.reader(defaultIo(), &.{});
     return file_reader.interface.allocRemaining(allocator, .limited(max_bytes)) catch |err| switch (err) {
@@ -147,6 +144,15 @@ pub fn statWorkspaceFile(allocator: std.mem.Allocator, workspace_root: []const u
     defer dir.close(defaultIo());
     try ensureNoSymlinkComponents(allocator, dir, relative_path);
     return dir.statFile(defaultIo(), relative_path, .{ .follow_symlinks = false });
+}
+
+pub fn openWorkspaceFile(allocator: std.mem.Allocator, workspace_root: []const u8, path_value: []const u8) !std.Io.File {
+    const relative_path = try resolveWorkspacePath(allocator, workspace_root, path_value);
+    defer allocator.free(relative_path);
+    var dir = try openWorkspace(workspace_root, false);
+    defer dir.close(defaultIo());
+    try ensureNoSymlinkComponents(allocator, dir, relative_path);
+    return dir.openFile(defaultIo(), relative_path, .{ .allow_directory = false, .follow_symlinks = false, .resolve_beneath = true });
 }
 
 fn ensureNoSymlinkComponents(allocator: std.mem.Allocator, dir: std.Io.Dir, relative_path: []const u8) !void {

--- a/zig/src/tools/common.zig
+++ b/zig/src/tools/common.zig
@@ -82,45 +82,42 @@ pub fn openWorkspace(workspace_root: []const u8, iterate: bool) !std.Io.Dir {
     return std.Io.Dir.openDirAbsolute(defaultIo(), workspace_root, .{ .iterate = iterate });
 }
 
-pub fn resolveRelativePath(allocator: std.mem.Allocator, path_value: []const u8) ![]u8 {
-    if (std.Io.Dir.path.isAbsolute(path_value)) return try allocator.dupe(u8, path_value);
+pub fn resolveWorkspacePath(allocator: std.mem.Allocator, workspace_root: []const u8, path_value: []const u8) ![]u8 {
+    if (std.Io.Dir.path.isAbsolute(path_value)) {
+        if (!std.mem.startsWith(u8, path_value, workspace_root)) return error.PathEscapesWorkspace;
+        if (path_value.len == workspace_root.len) return try allocator.dupe(u8, "");
+        const sep = path_value[workspace_root.len];
+        if (sep != std.Io.Dir.path.sep) return error.PathEscapesWorkspace;
+        return try allocator.dupe(u8, path_value[workspace_root.len + 1 ..]);
+    }
     if (hasParentTraversal(path_value)) return error.PathEscapesWorkspace;
     return try allocator.dupe(u8, path_value);
 }
 
 pub fn readWorkspaceFile(allocator: std.mem.Allocator, workspace_root: []const u8, path_value: []const u8, max_bytes: usize) ![]u8 {
-    if (std.Io.Dir.path.isAbsolute(path_value)) {
-        return std.Io.Dir.cwd().readFileAlloc(defaultIo(), path_value, allocator, .limited(max_bytes));
-    }
-    if (hasParentTraversal(path_value)) return error.PathEscapesWorkspace;
+    const relative_path = try resolveWorkspacePath(allocator, workspace_root, path_value);
+    defer allocator.free(relative_path);
     var dir = try openWorkspace(workspace_root, false);
     defer dir.close(defaultIo());
-    return dir.readFileAlloc(defaultIo(), path_value, allocator, .limited(max_bytes));
+    return dir.readFileAlloc(defaultIo(), relative_path, allocator, .limited(max_bytes));
 }
 
-pub fn writeWorkspaceFile(workspace_root: []const u8, path_value: []const u8, data: []const u8) !void {
-    if (std.Io.Dir.path.isAbsolute(path_value)) {
-        var file = try std.Io.Dir.cwd().createFile(defaultIo(), path_value, .{ .truncate = true, .permissions = compat.fs.default_file_mode });
-        defer file.close(defaultIo());
-        try file.writeStreamingAll(defaultIo(), data);
-        return;
-    }
-    if (hasParentTraversal(path_value)) return error.PathEscapesWorkspace;
+pub fn writeWorkspaceFile(allocator: std.mem.Allocator, workspace_root: []const u8, path_value: []const u8, data: []const u8) !void {
+    const relative_path = try resolveWorkspacePath(allocator, workspace_root, path_value);
+    defer allocator.free(relative_path);
     var dir = try openWorkspace(workspace_root, false);
     defer dir.close(defaultIo());
-    var file = try dir.createFile(defaultIo(), path_value, .{ .truncate = true, .permissions = compat.fs.default_file_mode });
+    var file = try dir.createFile(defaultIo(), relative_path, .{ .truncate = true, .permissions = compat.fs.default_file_mode });
     defer file.close(defaultIo());
     try file.writeStreamingAll(defaultIo(), data);
 }
 
-pub fn statWorkspaceFile(workspace_root: []const u8, path_value: []const u8) !std.Io.File.Stat {
-    if (std.Io.Dir.path.isAbsolute(path_value)) {
-        return std.Io.Dir.cwd().statFile(defaultIo(), path_value, .{});
-    }
-    if (hasParentTraversal(path_value)) return error.PathEscapesWorkspace;
+pub fn statWorkspaceFile(allocator: std.mem.Allocator, workspace_root: []const u8, path_value: []const u8) !std.Io.File.Stat {
+    const relative_path = try resolveWorkspacePath(allocator, workspace_root, path_value);
+    defer allocator.free(relative_path);
     var dir = try openWorkspace(workspace_root, false);
     defer dir.close(defaultIo());
-    return dir.statFile(defaultIo(), path_value, .{});
+    return dir.statFile(defaultIo(), relative_path, .{});
 }
 
 pub fn isBinary(data: []const u8) bool {

--- a/zig/src/tools/common.zig
+++ b/zig/src/tools/common.zig
@@ -256,7 +256,15 @@ pub fn retrieveArtifact(allocator: std.mem.Allocator, reference: []const u8, max
     if (!std.mem.startsWith(u8, reference, ".makai/tool-artifacts/")) return error.InvalidArtifactReference;
     if (hasParentTraversal(reference) or std.Io.Dir.path.isAbsolute(reference)) return error.InvalidArtifactReference;
     var cwd = std.Io.Dir.cwd();
-    return cwd.readFileAlloc(defaultIo(), reference, allocator, .limited(max_bytes));
+    const st = try cwd.statFile(defaultIo(), reference, .{ .follow_symlinks = false });
+    if (st.kind == .sym_link) return error.InvalidArtifactReference;
+    var file = try cwd.openFile(defaultIo(), reference, .{ .allow_directory = false, .follow_symlinks = false, .resolve_beneath = true });
+    defer file.close(defaultIo());
+    var reader = file.reader(defaultIo(), &.{});
+    return reader.interface.allocRemaining(allocator, .limited(max_bytes)) catch |err| switch (err) {
+        error.ReadFailed => return reader.err.?,
+        error.OutOfMemory, error.StreamTooLong => |e| return e,
+    };
 }
 
 pub fn telemetryDetails(allocator: std.mem.Allocator, raw_bytes: usize, returned_bytes: usize, compressed: bool) ![]u8 {
@@ -431,4 +439,18 @@ test "line hash and artifact helpers" {
     try std.testing.expectEqualStrings(buf, full);
     try cleanupArtifacts();
     try std.testing.expectError(error.FileNotFound, retrieveArtifact(std.testing.allocator, made.artifact_path.?, buf.len + 1));
+}
+
+test "artifact retrieval rejects symlink targets" {
+    if (@import("builtin").os.tag == .windows) return error.SkipZigTest;
+    var cwd = std.Io.Dir.cwd();
+    cwd.createDirPath(defaultIo(), ".makai/tool-artifacts") catch |err| switch (err) {
+        error.PathAlreadyExists => {},
+        else => return err,
+    };
+    defer cleanupArtifacts() catch {};
+    try cwd.writeFile(defaultIo(), .{ .sub_path = ".makai/artifact-outside.txt", .data = "secret" });
+    defer cwd.deleteFile(defaultIo(), ".makai/artifact-outside.txt") catch {};
+    try cwd.symLink(defaultIo(), "../artifact-outside.txt", ".makai/tool-artifacts/link.txt", .{ .is_directory = false });
+    try std.testing.expectError(error.InvalidArtifactReference, retrieveArtifact(std.testing.allocator, ".makai/tool-artifacts/link.txt", 1024));
 }

--- a/zig/src/tools/common.zig
+++ b/zig/src/tools/common.zig
@@ -106,6 +106,10 @@ pub fn resolveWorkspacePath(allocator: std.mem.Allocator, workspace_root: []cons
         const normalized_path = try std.Io.Dir.path.resolve(allocator, &.{path_value});
         defer allocator.free(normalized_path);
         if (std.mem.eql(u8, normalized_path, normalized_root)) return try allocator.dupe(u8, "");
+        if (std.mem.eql(u8, normalized_root, &.{std.Io.Dir.path.sep})) {
+            if (!std.mem.startsWith(u8, normalized_path, normalized_root)) return error.PathEscapesWorkspace;
+            return try allocator.dupe(u8, normalized_path[1..]);
+        }
         if (!std.mem.startsWith(u8, normalized_path, normalized_root)) return error.PathEscapesWorkspace;
         if (normalized_path.len <= normalized_root.len) return error.PathEscapesWorkspace;
         const sep = normalized_path[normalized_root.len];
@@ -215,6 +219,11 @@ test "common path and binary helpers" {
     const root_rel = try resolveWorkspacePath(std.testing.allocator, root, root);
     defer std.testing.allocator.free(root_rel);
     try std.testing.expectEqualStrings("", root_rel);
+    if (@import("builtin").os.tag != .windows) {
+        const root_child = try resolveWorkspacePath(std.testing.allocator, "/", "/tmp/root-child.txt");
+        defer std.testing.allocator.free(root_child);
+        try std.testing.expectEqualStrings("tmp/root-child.txt", root_child);
+    }
     const outside = try std.Io.Dir.path.join(std.testing.allocator, &.{ cwd, ".zig-cache", "outside.txt" });
     defer std.testing.allocator.free(outside);
     try std.testing.expectError(error.PathEscapesWorkspace, resolveWorkspacePath(std.testing.allocator, root, outside));

--- a/zig/src/tools/common.zig
+++ b/zig/src/tools/common.zig
@@ -106,9 +106,11 @@ pub fn resolveWorkspacePath(allocator: std.mem.Allocator, workspace_root: []cons
         const normalized_path = try std.Io.Dir.path.resolve(allocator, &.{path_value});
         defer allocator.free(normalized_path);
         if (std.mem.eql(u8, normalized_path, normalized_root)) return try allocator.dupe(u8, "");
-        if (std.mem.eql(u8, normalized_root, &.{std.Io.Dir.path.sep})) {
+        if (isFilesystemRoot(normalized_root)) {
             if (!std.mem.startsWith(u8, normalized_path, normalized_root)) return error.PathEscapesWorkspace;
-            return try allocator.dupe(u8, normalized_path[1..]);
+            const offset: usize = if (std.mem.endsWith(u8, normalized_root, &.{std.Io.Dir.path.sep})) normalized_root.len else normalized_root.len + 1;
+            if (normalized_path.len < offset) return try allocator.dupe(u8, "");
+            return try allocator.dupe(u8, normalized_path[offset..]);
         }
         if (!std.mem.startsWith(u8, normalized_path, normalized_root)) return error.PathEscapesWorkspace;
         if (normalized_path.len <= normalized_root.len) return error.PathEscapesWorkspace;
@@ -118,6 +120,14 @@ pub fn resolveWorkspacePath(allocator: std.mem.Allocator, workspace_root: []cons
     }
     if (hasParentTraversal(path_value)) return error.PathEscapesWorkspace;
     return try allocator.dupe(u8, path_value);
+}
+
+fn isFilesystemRoot(path: []const u8) bool {
+    if (std.mem.eql(u8, path, &.{std.Io.Dir.path.sep})) return true;
+    if (@import("builtin").os.tag == .windows) {
+        return path.len == 3 and std.ascii.isAlphabetic(path[0]) and path[1] == ':' and (path[2] == '/' or path[2] == '\\');
+    }
+    return false;
 }
 
 pub fn readWorkspaceFile(allocator: std.mem.Allocator, workspace_root: []const u8, path_value: []const u8, max_bytes: usize) ![]u8 {
@@ -223,6 +233,8 @@ test "common path and binary helpers" {
         const root_child = try resolveWorkspacePath(std.testing.allocator, "/", "/tmp/root-child.txt");
         defer std.testing.allocator.free(root_child);
         try std.testing.expectEqualStrings("tmp/root-child.txt", root_child);
+    } else {
+        try std.testing.expect(isFilesystemRoot("C:\\"));
     }
     const outside = try std.Io.Dir.path.join(std.testing.allocator, &.{ cwd, ".zig-cache", "outside.txt" });
     defer std.testing.allocator.free(outside);

--- a/zig/src/tools/common.zig
+++ b/zig/src/tools/common.zig
@@ -245,6 +245,13 @@ pub fn storeArtifact(allocator: std.mem.Allocator, key: []const u8, data: []cons
     return path;
 }
 
+pub fn cleanupArtifacts() !void {
+    var cwd = std.Io.Dir.cwd();
+    if (cwd.access(defaultIo(), ".makai/tool-artifacts", .{})) {
+        try cwd.deleteTree(defaultIo(), ".makai/tool-artifacts");
+    } else |_| {}
+}
+
 pub fn retrieveArtifact(allocator: std.mem.Allocator, reference: []const u8, max_bytes: usize) ![]u8 {
     if (!std.mem.startsWith(u8, reference, ".makai/tool-artifacts/")) return error.InvalidArtifactReference;
     if (hasParentTraversal(reference) or std.Io.Dir.path.isAbsolute(reference)) return error.InvalidArtifactReference;
@@ -306,7 +313,17 @@ pub fn makeTextResultWithArtifact(allocator: std.mem.Allocator, options: TextRes
     else
         try std.fmt.allocPrint(allocator, "{{\"raw_bytes\":{d},\"returned_bytes\":{d},\"saved_bytes\":{d},\"compressed\":true,\"artifact_path\":\"{s}\"}}", .{ raw_bytes, summary.len, raw_bytes -| summary.len, artifact_path });
     defer allocator.free(details);
-    const result = try makeTextResult(allocator, summary, details);
+    var result = try makeTextResult(allocator, summary, details);
+    errdefer result.deinit(allocator);
+    const artifact_refs = try allocator.alloc(ai_types.ArtifactReference, 1);
+    errdefer allocator.free(artifact_refs);
+    artifact_refs[0] = .{
+        .artifact_id = try allocator.dupe(u8, key),
+        .uri = ai_types.OwnedSlice(u8).initOwned(try allocator.dupe(u8, artifact_path)),
+        .byte_size = raw_bytes,
+    };
+    errdefer artifact_refs[0].deinit(allocator);
+    result.artifacts = ai_types.OwnedSlice(ai_types.ArtifactReference).initOwned(artifact_refs);
     return .{ .result = result, .raw_bytes = raw_bytes, .returned_bytes = summary.len + details.len, .compressed = true, .artifact_path = artifact_path };
 }
 
@@ -400,8 +417,14 @@ test "line hash and artifact helpers" {
     defer made.deinit(std.testing.allocator);
     try std.testing.expect(made.compressed);
     try std.testing.expect(made.artifact_path != null);
+    try std.testing.expectEqual(@as(usize, 1), made.result.artifacts.slice().len);
+    try std.testing.expectEqualStrings("test:call", made.result.artifacts.slice()[0].artifact_id);
+    try std.testing.expectEqualStrings(made.artifact_path.?, made.result.artifacts.slice()[0].getUri().?);
+    try std.testing.expectEqual(@as(?u64, buf.len), made.result.artifacts.slice()[0].byte_size);
     try std.testing.expect(std.mem.indexOf(u8, made.result.content.slice()[0].text.text, "output stored as artifact") != null);
     const full = try retrieveArtifact(std.testing.allocator, made.artifact_path.?, buf.len + 1);
     defer std.testing.allocator.free(full);
     try std.testing.expectEqualStrings(buf, full);
+    try cleanupArtifacts();
+    try std.testing.expectError(error.FileNotFound, retrieveArtifact(std.testing.allocator, made.artifact_path.?, buf.len + 1));
 }

--- a/zig/src/tools/common.zig
+++ b/zig/src/tools/common.zig
@@ -7,6 +7,30 @@ pub const max_file_bytes: usize = 16 * 1024 * 1024;
 pub const process_output_bytes: usize = 16 * 1024 * 1024;
 pub const process_poll_ms: u64 = 100;
 pub const max_results: usize = 200;
+pub const tool_output_threshold: usize = 4 * 1024;
+pub const snippet_bytes: usize = 512;
+
+pub const TextResultOptions = struct {
+    tool_name: []const u8,
+    call_id: []const u8,
+    text: []const u8,
+    stderr: []const u8 = "",
+    details_json: []const u8 = "",
+    force_artifact: bool = false,
+};
+
+pub const TextResult = struct {
+    result: agent.AgentToolResult,
+    raw_bytes: usize,
+    returned_bytes: usize,
+    compressed: bool,
+    artifact_path: ?[]const u8 = null,
+
+    pub fn deinit(self: *TextResult, allocator: std.mem.Allocator) void {
+        self.result.deinit(allocator);
+        if (self.artifact_path) |path| allocator.free(path);
+    }
+};
 
 pub fn defaultIo() std.Io {
     return if (@import("builtin").is_test)
@@ -191,6 +215,47 @@ pub fn isBinary(data: []const u8) bool {
     return std.mem.indexOfScalar(u8, data[0..limit], 0) != null;
 }
 
+pub fn lineHash(line: []const u8) [16]u8 {
+    var hasher = std.hash.Wyhash.init(0);
+    hasher.update(line);
+    return hexU64(hasher.final());
+}
+
+pub fn countLines(text: []const u8) usize {
+    if (text.len == 0) return 0;
+    var count: usize = 1;
+    for (text) |c| {
+        if (c == '\n') count += 1;
+    }
+    if (text[text.len - 1] == '\n') count -= 1;
+    return count;
+}
+
+pub fn storeArtifact(allocator: std.mem.Allocator, key: []const u8, data: []const u8) ![]u8 {
+    var cwd = std.Io.Dir.cwd();
+    cwd.createDirPath(defaultIo(), ".makai/tool-artifacts") catch |err| switch (err) {
+        error.PathAlreadyExists => {},
+        else => return err,
+    };
+    const safe = try sanitizeKey(allocator, key);
+    defer allocator.free(safe);
+    const path = try std.fmt.allocPrint(allocator, ".makai/tool-artifacts/{s}.txt", .{safe});
+    errdefer allocator.free(path);
+    try cwd.writeFile(defaultIo(), .{ .sub_path = path, .data = data });
+    return path;
+}
+
+pub fn retrieveArtifact(allocator: std.mem.Allocator, reference: []const u8, max_bytes: usize) ![]u8 {
+    if (!std.mem.startsWith(u8, reference, ".makai/tool-artifacts/")) return error.InvalidArtifactReference;
+    if (hasParentTraversal(reference) or std.Io.Dir.path.isAbsolute(reference)) return error.InvalidArtifactReference;
+    var cwd = std.Io.Dir.cwd();
+    return cwd.readFileAlloc(defaultIo(), reference, allocator, .limited(max_bytes));
+}
+
+pub fn telemetryDetails(allocator: std.mem.Allocator, raw_bytes: usize, returned_bytes: usize, compressed: bool) ![]u8 {
+    return std.fmt.allocPrint(allocator, "{{\"raw_bytes\":{d},\"returned_bytes\":{d},\"saved_bytes\":{d},\"compressed\":{s}}}", .{ raw_bytes, returned_bytes, raw_bytes -| returned_bytes, if (compressed) "true" else "false" });
+}
+
 pub fn makeTextResult(allocator: std.mem.Allocator, text: []const u8, details_json: []const u8) !agent.AgentToolResult {
     const parts = try allocator.alloc(ai_types.UserContentPart, 1);
     errdefer allocator.free(parts);
@@ -214,6 +279,69 @@ pub fn makeTextResultOwned(allocator: std.mem.Allocator, text: []u8, details_jso
 
 pub fn jsonString(allocator: std.mem.Allocator, value: anytype) ![]u8 {
     return std.json.Stringify.valueAlloc(allocator, value, .{});
+}
+
+pub fn makeTextResultWithArtifact(allocator: std.mem.Allocator, options: TextResultOptions) !TextResult {
+    const raw_bytes = options.text.len + options.stderr.len;
+    const should_store = options.force_artifact or options.text.len > tool_output_threshold;
+    if (!should_store) {
+        const body = if (options.stderr.len > 0)
+            try std.fmt.allocPrint(allocator, "{s}\nstderr:\n{s}", .{ options.text, options.stderr })
+        else
+            try allocator.dupe(u8, options.text);
+        defer allocator.free(body);
+        const result = try makeTextResult(allocator, body, options.details_json);
+        const returned_bytes = body.len + options.details_json.len;
+        return .{ .result = result, .raw_bytes = raw_bytes, .returned_bytes = returned_bytes, .compressed = false };
+    }
+
+    const key = try std.fmt.allocPrint(allocator, "{s}:{s}", .{ options.tool_name, options.call_id });
+    defer allocator.free(key);
+    const artifact_path = try storeArtifact(allocator, key, options.text);
+    errdefer allocator.free(artifact_path);
+    const summary = try summarizeArtifactBackedOutput(allocator, options.text, options.stderr, artifact_path);
+    defer allocator.free(summary);
+    const details = if (options.details_json.len > 0)
+        try std.fmt.allocPrint(allocator, "{{\"raw_bytes\":{d},\"returned_bytes\":{d},\"saved_bytes\":{d},\"compressed\":true,\"artifact_path\":\"{s}\",\"details\":{s}}}", .{ raw_bytes, summary.len, raw_bytes -| summary.len, artifact_path, options.details_json })
+    else
+        try std.fmt.allocPrint(allocator, "{{\"raw_bytes\":{d},\"returned_bytes\":{d},\"saved_bytes\":{d},\"compressed\":true,\"artifact_path\":\"{s}\"}}", .{ raw_bytes, summary.len, raw_bytes -| summary.len, artifact_path });
+    defer allocator.free(details);
+    const result = try makeTextResult(allocator, summary, details);
+    return .{ .result = result, .raw_bytes = raw_bytes, .returned_bytes = summary.len + details.len, .compressed = true, .artifact_path = artifact_path };
+}
+
+fn summarizeArtifactBackedOutput(allocator: std.mem.Allocator, text: []const u8, stderr: []const u8, artifact_path: []const u8) ![]u8 {
+    const head = text[0..@min(text.len, snippet_bytes)];
+    const tail_start = if (text.len > snippet_bytes) text.len - snippet_bytes else 0;
+    const tail = text[tail_start..];
+    if (stderr.len > 0) {
+        return std.fmt.allocPrint(
+            allocator,
+            "output stored as artifact\nbytes: {d}\nlines: {d}\nartifact: {s}\nhead:\n{s}\ntail:\n{s}\nstderr:\n{s}",
+            .{ text.len, countLines(text), artifact_path, head, tail, stderr },
+        );
+    }
+    return std.fmt.allocPrint(
+        allocator,
+        "output stored as artifact\nbytes: {d}\nlines: {d}\nartifact: {s}\nhead:\n{s}\ntail:\n{s}",
+        .{ text.len, countLines(text), artifact_path, head, tail },
+    );
+}
+
+fn sanitizeKey(allocator: std.mem.Allocator, key: []const u8) ![]u8 {
+    var out = try allocator.alloc(u8, key.len);
+    for (key, 0..) |c, i| out[i] = if (std.ascii.isAlphanumeric(c) or c == '-' or c == '_') c else '_';
+    return out;
+}
+
+fn hexU64(value: u64) [16]u8 {
+    const alphabet = "0123456789abcdef";
+    var out: [16]u8 = undefined;
+    for (&out, 0..) |*c, i| {
+        const shift: u6 = @intCast((15 - i) * 4);
+        c.* = alphabet[@as(u4, @truncate(value >> shift))];
+    }
+    return out;
 }
 
 test "common path and binary helpers" {
@@ -260,4 +388,20 @@ test "common path and binary helpers" {
     boundary[4095] = 'a';
     boundary[4096] = 0;
     try std.testing.expect(!isBinary(&boundary));
+}
+
+test "line hash and artifact helpers" {
+    try std.testing.expectEqual(@as(usize, 16), lineHash("one").len);
+    try std.testing.expect(!std.mem.eql(u8, &lineHash("one"), &lineHash("two")));
+    const buf = try std.testing.allocator.alloc(u8, tool_output_threshold + 10);
+    defer std.testing.allocator.free(buf);
+    @memset(buf, 'x');
+    var made = try makeTextResultWithArtifact(std.testing.allocator, .{ .tool_name = "test", .call_id = "call", .text = buf });
+    defer made.deinit(std.testing.allocator);
+    try std.testing.expect(made.compressed);
+    try std.testing.expect(made.artifact_path != null);
+    try std.testing.expect(std.mem.indexOf(u8, made.result.content.slice()[0].text.text, "output stored as artifact") != null);
+    const full = try retrieveArtifact(std.testing.allocator, made.artifact_path.?, buf.len + 1);
+    defer std.testing.allocator.free(full);
+    try std.testing.expectEqualStrings(buf, full);
 }

--- a/zig/src/tools/common.zig
+++ b/zig/src/tools/common.zig
@@ -169,3 +169,36 @@ pub fn makeTextResultOwned(allocator: std.mem.Allocator, text: []u8, details_jso
 pub fn jsonString(allocator: std.mem.Allocator, value: anytype) ![]u8 {
     return std.json.Stringify.valueAlloc(allocator, value, .{});
 }
+
+test "common path and binary helpers" {
+    const cwd = try std.process.currentPathAlloc(defaultIo(), std.testing.allocator);
+    defer std.testing.allocator.free(cwd);
+    const root = try std.Io.Dir.path.join(std.testing.allocator, &.{ cwd, ".zig-cache", "tmp", "common-test-root" });
+    defer std.testing.allocator.free(root);
+    const inside_abs = try std.Io.Dir.path.join(std.testing.allocator, &.{ root, "dir", "file.txt" });
+    defer std.testing.allocator.free(inside_abs);
+    const inside_rel = try resolveWorkspacePath(std.testing.allocator, root, inside_abs);
+    defer std.testing.allocator.free(inside_rel);
+    try std.testing.expectEqualStrings("dir/file.txt", inside_rel);
+    const root_rel = try resolveWorkspacePath(std.testing.allocator, root, root);
+    defer std.testing.allocator.free(root_rel);
+    try std.testing.expectEqualStrings("", root_rel);
+    const outside = try std.Io.Dir.path.join(std.testing.allocator, &.{ cwd, ".zig-cache", "outside.txt" });
+    defer std.testing.allocator.free(outside);
+    try std.testing.expectError(error.PathEscapesWorkspace, resolveWorkspacePath(std.testing.allocator, root, outside));
+    const traversal = try std.Io.Dir.path.join(std.testing.allocator, &.{ root, "..", "outside.txt" });
+    defer std.testing.allocator.free(traversal);
+    try std.testing.expectError(error.PathEscapesWorkspace, resolveWorkspacePath(std.testing.allocator, root, traversal));
+    try std.testing.expect(hasParentTraversal("a/../b"));
+    try std.testing.expect(hasParentTraversal("a\\..\\b"));
+    try std.testing.expect(!hasParentTraversal("a/..b/c"));
+    try std.testing.expect(!isBinary(""));
+    try std.testing.expect(!isBinary("abc"));
+    try std.testing.expect(isBinary("a\x00b"));
+    var boundary = [_]u8{'a'} ** 4097;
+    boundary[4095] = 0;
+    try std.testing.expect(isBinary(&boundary));
+    boundary[4095] = 'a';
+    boundary[4096] = 0;
+    try std.testing.expect(!isBinary(&boundary));
+}

--- a/zig/src/tools/common.zig
+++ b/zig/src/tools/common.zig
@@ -59,14 +59,29 @@ pub fn optionalU64(obj: std.json.ObjectMap, key: []const u8, default: u64) u64 {
     const value = obj.get(key) orelse return default;
     return switch (value) {
         .integer => |i| if (i < 0) default else @intCast(i),
-        .float => |f| if (f < 0) default else @intFromFloat(f),
+        .float => |f| floatToU64(f) orelse default,
         .number_string => |s| std.fmt.parseUnsigned(u64, s, 10) catch default,
         else => default,
     };
 }
 
 pub fn optionalUsize(obj: std.json.ObjectMap, key: []const u8, default: usize) usize {
-    return @intCast(optionalU64(obj, key, default));
+    const value = optionalU64(obj, key, default);
+    if (value > std.math.maxInt(usize)) return default;
+    return @intCast(value);
+}
+
+fn floatToU64(value: f64) ?u64 {
+    if (!std.math.isFinite(value) or value < 0 or value >= 18446744073709551616.0) return null;
+    return @intFromFloat(value);
+}
+
+test "optional numeric helpers reject overflow floats" {
+    var parsed = try parseArgs(std.testing.allocator, "{\"timeout_ms\":1e30,\"ok\":42}");
+    defer parsed.deinit();
+    const obj = parsed.value.object;
+    try std.testing.expectEqual(@as(u64, 30_000), optionalU64(obj, "timeout_ms", 30_000));
+    try std.testing.expectEqual(@as(usize, 42), optionalUsize(obj, "ok", 0));
 }
 
 pub fn hasParentTraversal(path: []const u8) bool {
@@ -84,11 +99,16 @@ pub fn openWorkspace(workspace_root: []const u8, iterate: bool) !std.Io.Dir {
 
 pub fn resolveWorkspacePath(allocator: std.mem.Allocator, workspace_root: []const u8, path_value: []const u8) ![]u8 {
     if (std.Io.Dir.path.isAbsolute(path_value)) {
-        if (!std.mem.startsWith(u8, path_value, workspace_root)) return error.PathEscapesWorkspace;
-        if (path_value.len == workspace_root.len) return try allocator.dupe(u8, "");
-        const sep = path_value[workspace_root.len];
+        const normalized_root = try std.Io.Dir.path.resolve(allocator, &.{workspace_root});
+        defer allocator.free(normalized_root);
+        const normalized_path = try std.Io.Dir.path.resolve(allocator, &.{path_value});
+        defer allocator.free(normalized_path);
+        if (std.mem.eql(u8, normalized_path, normalized_root)) return try allocator.dupe(u8, "");
+        if (!std.mem.startsWith(u8, normalized_path, normalized_root)) return error.PathEscapesWorkspace;
+        if (normalized_path.len <= normalized_root.len) return error.PathEscapesWorkspace;
+        const sep = normalized_path[normalized_root.len];
         if (sep != std.Io.Dir.path.sep) return error.PathEscapesWorkspace;
-        return try allocator.dupe(u8, path_value[workspace_root.len + 1 ..]);
+        return try allocator.dupe(u8, normalized_path[normalized_root.len + 1 ..]);
     }
     if (hasParentTraversal(path_value)) return error.PathEscapesWorkspace;
     return try allocator.dupe(u8, path_value);

--- a/zig/src/tools/edit.zig
+++ b/zig/src/tools/edit.zig
@@ -41,7 +41,7 @@ pub fn applyExecute(tool_call_id: []const u8, args_json: []const u8, cancel_toke
         break :blk try applyLineRange(allocator, original, start_line, start_line -| 1, content, &replacement_count);
     } else if (std.mem.eql(u8, operation, "delete")) blk: {
         const start_line = common.optionalUsize(obj, "start_line", 0);
-        const end_line = common.optionalUsize(obj, "end_line", 0);
+        const end_line = common.optionalUsize(obj, "end_line", start_line);
         break :blk try applyLineRange(allocator, original, start_line, end_line, "", &replacement_count);
     } else return error.InvalidEditOperation;
     defer allocator.free(edited);
@@ -139,4 +139,11 @@ test "edit line replace insert delete" {
     const default_end_data = try tmp.dir.readFileAlloc(common.defaultIo(), "a.txt", std.testing.allocator, .limited(1024));
     defer std.testing.allocator.free(default_end_data);
     try std.testing.expectEqualStrings("one\ntwo\nthree\n", default_end_data);
+    const delete_args = try std.fmt.allocPrint(std.testing.allocator, "{{\"workspace_root\":\"{s}\",\"path\":\"a.txt\",\"operation\":\"delete\",\"start_line\":2}}", .{root});
+    defer std.testing.allocator.free(delete_args);
+    var delete_result = try applyExecute("call", delete_args, null, null, null, std.testing.allocator);
+    defer delete_result.deinit(std.testing.allocator);
+    const delete_data = try tmp.dir.readFileAlloc(common.defaultIo(), "a.txt", std.testing.allocator, .limited(1024));
+    defer std.testing.allocator.free(delete_data);
+    try std.testing.expectEqualStrings("one\nthree\n", delete_data);
 }

--- a/zig/src/tools/edit.zig
+++ b/zig/src/tools/edit.zig
@@ -4,10 +4,10 @@ const agent = @import("agent");
 const common = @import("tools/common");
 
 pub const schema_apply =
-    \\{"type":"object","properties":{"workspace_root":{"type":"string"},"path":{"type":"string"},"operation":{"type":"string","enum":["find_replace","line_replace","insert","delete"]},"find":{"type":"string"},"replace":{"type":"string"},"start_line":{"type":"integer","minimum":1},"end_line":{"type":"integer","minimum":1},"content":{"type":"string"}},"required":["workspace_root","path","operation"],"additionalProperties":false}
+    \\{"type":"object","properties":{"workspace_root":{"type":"string"},"path":{"type":"string"},"operation":{"type":"string","enum":["find_replace","line_replace","insert","delete","hash_replace","hash_range_replace"]},"find":{"type":"string"},"replace":{"type":"string"},"start_line":{"type":"integer","minimum":1},"end_line":{"type":"integer","minimum":1},"line_hash":{"type":"string"},"start_hash":{"type":"string"},"end_hash":{"type":"string"},"content":{"type":"string"}},"required":["workspace_root","path","operation"],"additionalProperties":false}
 ;
 
-pub const apply_tool = agent.AgentTool{ .label = "Structured Edit", .name = "edit_apply", .description = "Apply structured edits: find/replace, line range replace, insert, or delete.", .parameters_schema_json = schema_apply, .execute = applyExecute };
+pub const apply_tool = agent.AgentTool{ .label = "Structured Edit", .name = "edit_apply", .description = "Apply structured edits: find/replace, line range replace, insert, delete, hash_replace, or hash_range_replace. Hash operations reject stale reads before mutation.", .short_description = "Edit file; supports hash-anchored replacements.", .parameters_schema_json = schema_apply, .execute = applyExecute };
 
 pub fn applyExecute(tool_call_id: []const u8, args_json: []const u8, cancel_token: ?ai_types.CancelToken, on_update_ctx: ?*anyopaque, on_update: ?agent.ToolUpdateCallback, allocator: std.mem.Allocator) anyerror!agent.AgentToolResult {
     _ = tool_call_id;
@@ -43,6 +43,18 @@ pub fn applyExecute(tool_call_id: []const u8, args_json: []const u8, cancel_toke
         const start_line = common.optionalUsize(obj, "start_line", 0);
         const end_line = common.optionalUsize(obj, "end_line", start_line);
         break :blk try applyLineRange(allocator, original, start_line, end_line, "", &replacement_count);
+    } else if (std.mem.eql(u8, operation, "hash_replace")) blk: {
+        const start_line = common.optionalUsize(obj, "start_line", 0);
+        const line_hash = try common.requiredString(obj, "line_hash");
+        const content = try common.requiredString(obj, "content");
+        break :blk try applyHashReplace(allocator, original, start_line, line_hash, content, &replacement_count);
+    } else if (std.mem.eql(u8, operation, "hash_range_replace")) blk: {
+        const start_line = common.optionalUsize(obj, "start_line", 0);
+        const end_line = common.optionalUsize(obj, "end_line", start_line);
+        const start_hash = try common.requiredString(obj, "start_hash");
+        const end_hash = try common.requiredString(obj, "end_hash");
+        const content = try common.requiredString(obj, "content");
+        break :blk try applyHashRangeReplace(allocator, original, start_line, end_line, start_hash, end_hash, content, &replacement_count);
     } else return error.InvalidEditOperation;
     defer allocator.free(edited);
 
@@ -74,6 +86,20 @@ fn lineStartOffset(input: []const u8, target_line: usize) !usize {
     return error.LineOutOfBounds;
 }
 
+fn getLine(input: []const u8, target_line: usize) ?[]const u8 {
+    if (target_line == 0) return null;
+    var line: usize = 1;
+    var start: usize = 0;
+    while (start <= input.len) {
+        const end = std.mem.indexOfScalarPos(u8, input, start, '\n') orelse input.len;
+        if (line == target_line) return input[start..end];
+        if (end == input.len) break;
+        start = end + 1;
+        line += 1;
+    }
+    return null;
+}
+
 fn lineEndOffset(input: []const u8, target_line: usize) !usize {
     if (target_line == 0) return error.InvalidLineRange;
     var line: usize = 1;
@@ -98,6 +124,23 @@ fn applyLineRange(allocator: std.mem.Allocator, input: []const u8, start_line: u
     if (content.len > 0 and (content[content.len - 1] != '\n') and end < input.len) try out.append(allocator, '\n');
     try out.appendSlice(allocator, input[end..]);
     return out.toOwnedSlice(allocator);
+}
+
+fn applyHashReplace(allocator: std.mem.Allocator, input: []const u8, line: usize, expected_hash: []const u8, content: []const u8, count: *usize) ![]u8 {
+    const current = getLine(input, line) orelse return error.LineOutOfBounds;
+    const actual = common.lineHash(current);
+    if (!std.mem.eql(u8, expected_hash, &actual)) return error.StaleHash;
+    return applyLineRange(allocator, input, line, line, content, count);
+}
+
+fn applyHashRangeReplace(allocator: std.mem.Allocator, input: []const u8, start_line: usize, end_line: usize, start_hash: []const u8, end_hash: []const u8, content: []const u8, count: *usize) ![]u8 {
+    if (end_line < start_line) return error.InvalidLineRange;
+    const first = getLine(input, start_line) orelse return error.LineOutOfBounds;
+    const last = getLine(input, end_line) orelse return error.LineOutOfBounds;
+    const actual_start = common.lineHash(first);
+    const actual_end = common.lineHash(last);
+    if (!std.mem.eql(u8, start_hash, &actual_start) or !std.mem.eql(u8, end_hash, &actual_end)) return error.StaleHash;
+    return applyLineRange(allocator, input, start_line, end_line, content, count);
 }
 
 test "edit find replace modifies file" {
@@ -153,6 +196,37 @@ test "edit line replace insert delete" {
     const delete_data = try tmp.dir.readFileAlloc(common.defaultIo(), "a.txt", std.testing.allocator, .limited(1024));
     defer std.testing.allocator.free(delete_data);
     try std.testing.expectEqualStrings("one\ntwo\nthree\n", delete_data);
+}
+
+test "edit hash anchored replacements reject stale hashes" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const cwd = try std.process.currentPathAlloc(common.defaultIo(), std.testing.allocator);
+    defer std.testing.allocator.free(cwd);
+    const root = try std.Io.Dir.path.join(std.testing.allocator, &.{ cwd, ".zig-cache", "tmp", tmp.sub_path[0..] });
+    defer std.testing.allocator.free(root);
+    try tmp.dir.writeFile(common.defaultIo(), .{ .sub_path = "a.txt", .data = "one\ntwo\nthree\n" });
+    const hash = common.lineHash("two");
+    const args = try std.fmt.allocPrint(std.testing.allocator, "{{\"workspace_root\":\"{s}\",\"path\":\"a.txt\",\"operation\":\"hash_replace\",\"start_line\":2,\"line_hash\":\"{s}\",\"content\":\"TWO\"}}", .{ root, &hash });
+    defer std.testing.allocator.free(args);
+    var result = try applyExecute("call", args, null, null, null, std.testing.allocator);
+    defer result.deinit(std.testing.allocator);
+    const data = try tmp.dir.readFileAlloc(common.defaultIo(), "a.txt", std.testing.allocator, .limited(1024));
+    defer std.testing.allocator.free(data);
+    try std.testing.expectEqualStrings("one\nTWO\nthree\n", data);
+    try tmp.dir.writeFile(common.defaultIo(), .{ .sub_path = "a.txt", .data = "one\ntwo\nthree\n" });
+    const stale_args = try std.fmt.allocPrint(std.testing.allocator, "{{\"workspace_root\":\"{s}\",\"path\":\"a.txt\",\"operation\":\"hash_replace\",\"start_line\":2,\"line_hash\":\"00\",\"content\":\"TWO\"}}", .{root});
+    defer std.testing.allocator.free(stale_args);
+    try std.testing.expectError(error.StaleHash, applyExecute("call", stale_args, null, null, null, std.testing.allocator));
+    const start_hash = common.lineHash("one");
+    const end_hash = common.lineHash("three");
+    const range_args = try std.fmt.allocPrint(std.testing.allocator, "{{\"workspace_root\":\"{s}\",\"path\":\"a.txt\",\"operation\":\"hash_range_replace\",\"start_line\":1,\"end_line\":3,\"start_hash\":\"{s}\",\"end_hash\":\"{s}\",\"content\":\"all\"}}", .{ root, &start_hash, &end_hash });
+    defer std.testing.allocator.free(range_args);
+    var range_result = try applyExecute("call", range_args, null, null, null, std.testing.allocator);
+    defer range_result.deinit(std.testing.allocator);
+    const range_data = try tmp.dir.readFileAlloc(common.defaultIo(), "a.txt", std.testing.allocator, .limited(1024));
+    defer std.testing.allocator.free(range_data);
+    try std.testing.expectEqualStrings("all", range_data);
 }
 
 test "edit rejects invalid inputs" {

--- a/zig/src/tools/edit.zig
+++ b/zig/src/tools/edit.zig
@@ -139,11 +139,47 @@ test "edit line replace insert delete" {
     const default_end_data = try tmp.dir.readFileAlloc(common.defaultIo(), "a.txt", std.testing.allocator, .limited(1024));
     defer std.testing.allocator.free(default_end_data);
     try std.testing.expectEqualStrings("one\ntwo\nthree\n", default_end_data);
+    const insert_args = try std.fmt.allocPrint(std.testing.allocator, "{{\"workspace_root\":\"{s}\",\"path\":\"a.txt\",\"operation\":\"insert\",\"start_line\":2,\"content\":\"INSERTED\"}}", .{root});
+    defer std.testing.allocator.free(insert_args);
+    var insert_result = try applyExecute("call", insert_args, null, null, null, std.testing.allocator);
+    defer insert_result.deinit(std.testing.allocator);
+    const insert_data = try tmp.dir.readFileAlloc(common.defaultIo(), "a.txt", std.testing.allocator, .limited(1024));
+    defer std.testing.allocator.free(insert_data);
+    try std.testing.expectEqualStrings("one\nINSERTED\ntwo\nthree\n", insert_data);
     const delete_args = try std.fmt.allocPrint(std.testing.allocator, "{{\"workspace_root\":\"{s}\",\"path\":\"a.txt\",\"operation\":\"delete\",\"start_line\":2}}", .{root});
     defer std.testing.allocator.free(delete_args);
     var delete_result = try applyExecute("call", delete_args, null, null, null, std.testing.allocator);
     defer delete_result.deinit(std.testing.allocator);
     const delete_data = try tmp.dir.readFileAlloc(common.defaultIo(), "a.txt", std.testing.allocator, .limited(1024));
     defer std.testing.allocator.free(delete_data);
-    try std.testing.expectEqualStrings("one\nthree\n", delete_data);
+    try std.testing.expectEqualStrings("one\ntwo\nthree\n", delete_data);
+}
+
+test "edit rejects invalid inputs" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const cwd = try std.process.currentPathAlloc(common.defaultIo(), std.testing.allocator);
+    defer std.testing.allocator.free(cwd);
+    const root = try std.Io.Dir.path.join(std.testing.allocator, &.{ cwd, ".zig-cache", "tmp", tmp.sub_path[0..] });
+    defer std.testing.allocator.free(root);
+    try tmp.dir.writeFile(common.defaultIo(), .{ .sub_path = "a.txt", .data = "one\ntwo\n" });
+    const empty_find_args = try std.fmt.allocPrint(std.testing.allocator, "{{\"workspace_root\":\"{s}\",\"path\":\"a.txt\",\"operation\":\"find_replace\",\"find\":\"\",\"replace\":\"x\"}}", .{root});
+    defer std.testing.allocator.free(empty_find_args);
+    try std.testing.expectError(error.EmptyFind, applyExecute("call", empty_find_args, null, null, null, std.testing.allocator));
+    const absent_find_args = try std.fmt.allocPrint(std.testing.allocator, "{{\"workspace_root\":\"{s}\",\"path\":\"a.txt\",\"operation\":\"find_replace\",\"find\":\"absent\",\"replace\":\"x\"}}", .{root});
+    defer std.testing.allocator.free(absent_find_args);
+    try std.testing.expectError(error.FindNotFound, applyExecute("call", absent_find_args, null, null, null, std.testing.allocator));
+    const line_oob_args = try std.fmt.allocPrint(std.testing.allocator, "{{\"workspace_root\":\"{s}\",\"path\":\"a.txt\",\"operation\":\"line_replace\",\"start_line\":9,\"content\":\"x\"}}", .{root});
+    defer std.testing.allocator.free(line_oob_args);
+    try std.testing.expectError(error.LineOutOfBounds, applyExecute("call", line_oob_args, null, null, null, std.testing.allocator));
+    const delete_oob_args = try std.fmt.allocPrint(std.testing.allocator, "{{\"workspace_root\":\"{s}\",\"path\":\"a.txt\",\"operation\":\"delete\",\"start_line\":9}}", .{root});
+    defer std.testing.allocator.free(delete_oob_args);
+    try std.testing.expectError(error.LineOutOfBounds, applyExecute("call", delete_oob_args, null, null, null, std.testing.allocator));
+    const insert_oob_args = try std.fmt.allocPrint(std.testing.allocator, "{{\"workspace_root\":\"{s}\",\"path\":\"a.txt\",\"operation\":\"insert\",\"start_line\":9,\"content\":\"x\"}}", .{root});
+    defer std.testing.allocator.free(insert_oob_args);
+    try std.testing.expectError(error.LineOutOfBounds, applyExecute("call", insert_oob_args, null, null, null, std.testing.allocator));
+    try tmp.dir.writeFile(common.defaultIo(), .{ .sub_path = "bin.dat", .data = "a\x00b" });
+    const binary_args = try std.fmt.allocPrint(std.testing.allocator, "{{\"workspace_root\":\"{s}\",\"path\":\"bin.dat\",\"operation\":\"find_replace\",\"find\":\"a\",\"replace\":\"b\"}}", .{root});
+    defer std.testing.allocator.free(binary_args);
+    try std.testing.expectError(error.BinaryFileRejected, applyExecute("call", binary_args, null, null, null, std.testing.allocator));
 }

--- a/zig/src/tools/edit.zig
+++ b/zig/src/tools/edit.zig
@@ -32,7 +32,7 @@ pub fn applyExecute(tool_call_id: []const u8, args_json: []const u8, cancel_toke
         break :blk try applyFindReplace(allocator, original, find, replace, &replacement_count);
     } else if (std.mem.eql(u8, operation, "line_replace")) blk: {
         const start_line = common.optionalUsize(obj, "start_line", 0);
-        const end_line = common.optionalUsize(obj, "end_line", 0);
+        const end_line = common.optionalUsize(obj, "end_line", start_line);
         const content = try common.requiredString(obj, "content");
         break :blk try applyLineRange(allocator, original, start_line, end_line, content, &replacement_count);
     } else if (std.mem.eql(u8, operation, "insert")) blk: {
@@ -46,7 +46,7 @@ pub fn applyExecute(tool_call_id: []const u8, args_json: []const u8, cancel_toke
     } else return error.InvalidEditOperation;
     defer allocator.free(edited);
 
-    try common.writeWorkspaceFile(workspace_root, path, edited);
+    try common.writeWorkspaceFile(allocator, workspace_root, path, edited);
     const details = try common.jsonString(allocator, .{ .ok = true, .path = path, .operation = operation, .duration_ms = common.durationMs(start_ms), .raw_bytes = original.len, .returned_bytes = edited.len, .replacement_count = replacement_count });
     errdefer allocator.free(details);
     const text = try std.fmt.allocPrint(allocator, "edited {s}: {d} replacement(s)", .{ path, replacement_count });
@@ -132,4 +132,11 @@ test "edit line replace insert delete" {
     const data = try tmp.dir.readFileAlloc(common.defaultIo(), "a.txt", std.testing.allocator, .limited(1024));
     defer std.testing.allocator.free(data);
     try std.testing.expectEqualStrings("one\nTWO\nthree\n", data);
+    const default_end_args = try std.fmt.allocPrint(std.testing.allocator, "{{\"workspace_root\":\"{s}\",\"path\":\"a.txt\",\"operation\":\"line_replace\",\"start_line\":2,\"content\":\"two\"}}", .{root});
+    defer std.testing.allocator.free(default_end_args);
+    var default_end_result = try applyExecute("call", default_end_args, null, null, null, std.testing.allocator);
+    defer default_end_result.deinit(std.testing.allocator);
+    const default_end_data = try tmp.dir.readFileAlloc(common.defaultIo(), "a.txt", std.testing.allocator, .limited(1024));
+    defer std.testing.allocator.free(default_end_data);
+    try std.testing.expectEqualStrings("one\ntwo\nthree\n", default_end_data);
 }

--- a/zig/src/tools/edit.zig
+++ b/zig/src/tools/edit.zig
@@ -1,0 +1,135 @@
+const std = @import("std");
+const ai_types = @import("ai_types");
+const agent = @import("agent");
+const common = @import("tools/common");
+
+pub const schema_apply =
+    \\{"type":"object","properties":{"workspace_root":{"type":"string"},"path":{"type":"string"},"operation":{"type":"string","enum":["find_replace","line_replace","insert","delete"]},"find":{"type":"string"},"replace":{"type":"string"},"start_line":{"type":"integer","minimum":1},"end_line":{"type":"integer","minimum":1},"content":{"type":"string"}},"required":["workspace_root","path","operation"],"additionalProperties":false}
+;
+
+pub const apply_tool = agent.AgentTool{ .label = "Structured Edit", .name = "edit_apply", .description = "Apply structured edits: find/replace, line range replace, insert, or delete.", .parameters_schema_json = schema_apply, .execute = applyExecute };
+
+pub fn applyExecute(tool_call_id: []const u8, args_json: []const u8, cancel_token: ?ai_types.CancelToken, on_update_ctx: ?*anyopaque, on_update: ?agent.ToolUpdateCallback, allocator: std.mem.Allocator) anyerror!agent.AgentToolResult {
+    _ = tool_call_id;
+    _ = on_update_ctx;
+    _ = on_update;
+    if (common.isCancelled(cancel_token)) return error.Cancelled;
+    const start_ms = common.nowMs();
+    var parsed = try common.parseArgs(allocator, args_json);
+    defer parsed.deinit();
+    const obj = parsed.value.object;
+    const workspace_root = try common.requiredString(obj, "workspace_root");
+    const path = try common.requiredString(obj, "path");
+    const operation = try common.requiredString(obj, "operation");
+    const original = try common.readWorkspaceFile(allocator, workspace_root, path, common.max_file_bytes);
+    defer allocator.free(original);
+    if (common.isBinary(original)) return error.BinaryFileRejected;
+
+    var replacement_count: usize = 0;
+    const edited = if (std.mem.eql(u8, operation, "find_replace")) blk: {
+        const find = try common.requiredString(obj, "find");
+        const replace = try common.requiredString(obj, "replace");
+        break :blk try applyFindReplace(allocator, original, find, replace, &replacement_count);
+    } else if (std.mem.eql(u8, operation, "line_replace")) blk: {
+        const start_line = common.optionalUsize(obj, "start_line", 0);
+        const end_line = common.optionalUsize(obj, "end_line", 0);
+        const content = try common.requiredString(obj, "content");
+        break :blk try applyLineRange(allocator, original, start_line, end_line, content, &replacement_count);
+    } else if (std.mem.eql(u8, operation, "insert")) blk: {
+        const start_line = common.optionalUsize(obj, "start_line", 0);
+        const content = try common.requiredString(obj, "content");
+        break :blk try applyLineRange(allocator, original, start_line, start_line -| 1, content, &replacement_count);
+    } else if (std.mem.eql(u8, operation, "delete")) blk: {
+        const start_line = common.optionalUsize(obj, "start_line", 0);
+        const end_line = common.optionalUsize(obj, "end_line", 0);
+        break :blk try applyLineRange(allocator, original, start_line, end_line, "", &replacement_count);
+    } else return error.InvalidEditOperation;
+    defer allocator.free(edited);
+
+    try common.writeWorkspaceFile(workspace_root, path, edited);
+    const details = try common.jsonString(allocator, .{ .ok = true, .path = path, .operation = operation, .duration_ms = common.durationMs(start_ms), .raw_bytes = original.len, .returned_bytes = edited.len, .replacement_count = replacement_count });
+    errdefer allocator.free(details);
+    const text = try std.fmt.allocPrint(allocator, "edited {s}: {d} replacement(s)", .{ path, replacement_count });
+    return common.makeTextResultOwned(allocator, text, details);
+}
+
+fn applyFindReplace(allocator: std.mem.Allocator, input: []const u8, find: []const u8, replace: []const u8, count: *usize) ![]u8 {
+    if (find.len == 0) return error.EmptyFind;
+    count.* = std.mem.count(u8, input, find);
+    if (count.* == 0) return error.FindNotFound;
+    return std.mem.replaceOwned(u8, allocator, input, find, replace);
+}
+
+fn lineStartOffset(input: []const u8, target_line: usize) !usize {
+    if (target_line == 0) return error.InvalidLineRange;
+    if (target_line == 1) return 0;
+    var line: usize = 1;
+    for (input, 0..) |c, i| {
+        if (c == '\n') {
+            line += 1;
+            if (line == target_line) return i + 1;
+        }
+    }
+    if (line + 1 == target_line) return input.len;
+    return error.LineOutOfBounds;
+}
+
+fn lineEndOffset(input: []const u8, target_line: usize) !usize {
+    if (target_line == 0) return error.InvalidLineRange;
+    var line: usize = 1;
+    for (input, 0..) |c, i| {
+        if (line == target_line and c == '\n') return i + 1;
+        if (c == '\n') line += 1;
+    }
+    if (line == target_line) return input.len;
+    return error.LineOutOfBounds;
+}
+
+fn applyLineRange(allocator: std.mem.Allocator, input: []const u8, start_line: usize, end_line: usize, content: []const u8, count: *usize) ![]u8 {
+    if (start_line == 0) return error.InvalidLineRange;
+    if (end_line != 0 and end_line < start_line - 1) return error.InvalidLineRange;
+    const start = try lineStartOffset(input, start_line);
+    const end = if (end_line < start_line) start else try lineEndOffset(input, end_line);
+    count.* = if (end > start) 1 else 0;
+    var out = std.ArrayList(u8).empty;
+    errdefer out.deinit(allocator);
+    try out.appendSlice(allocator, input[0..start]);
+    try out.appendSlice(allocator, content);
+    if (content.len > 0 and (content[content.len - 1] != '\n') and end < input.len) try out.append(allocator, '\n');
+    try out.appendSlice(allocator, input[end..]);
+    return out.toOwnedSlice(allocator);
+}
+
+test "edit find replace modifies file" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const cwd = try std.process.currentPathAlloc(common.defaultIo(), std.testing.allocator);
+    defer std.testing.allocator.free(cwd);
+    const root = try std.Io.Dir.path.join(std.testing.allocator, &.{ cwd, ".zig-cache", "tmp", tmp.sub_path[0..] });
+    defer std.testing.allocator.free(root);
+    try tmp.dir.writeFile(common.defaultIo(), .{ .sub_path = "a.txt", .data = "hello world\n" });
+    const args = try std.fmt.allocPrint(std.testing.allocator, "{{\"workspace_root\":\"{s}\",\"path\":\"a.txt\",\"operation\":\"find_replace\",\"find\":\"world\",\"replace\":\"zig\"}}", .{root});
+    defer std.testing.allocator.free(args);
+    var result = try applyExecute("call", args, null, null, null, std.testing.allocator);
+    defer result.deinit(std.testing.allocator);
+    const data = try tmp.dir.readFileAlloc(common.defaultIo(), "a.txt", std.testing.allocator, .limited(1024));
+    defer std.testing.allocator.free(data);
+    try std.testing.expectEqualStrings("hello zig\n", data);
+}
+
+test "edit line replace insert delete" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const cwd = try std.process.currentPathAlloc(common.defaultIo(), std.testing.allocator);
+    defer std.testing.allocator.free(cwd);
+    const root = try std.Io.Dir.path.join(std.testing.allocator, &.{ cwd, ".zig-cache", "tmp", tmp.sub_path[0..] });
+    defer std.testing.allocator.free(root);
+    try tmp.dir.writeFile(common.defaultIo(), .{ .sub_path = "a.txt", .data = "one\ntwo\nthree\n" });
+    const args = try std.fmt.allocPrint(std.testing.allocator, "{{\"workspace_root\":\"{s}\",\"path\":\"a.txt\",\"operation\":\"line_replace\",\"start_line\":2,\"end_line\":2,\"content\":\"TWO\"}}", .{root});
+    defer std.testing.allocator.free(args);
+    var result = try applyExecute("call", args, null, null, null, std.testing.allocator);
+    defer result.deinit(std.testing.allocator);
+    const data = try tmp.dir.readFileAlloc(common.defaultIo(), "a.txt", std.testing.allocator, .limited(1024));
+    defer std.testing.allocator.free(data);
+    try std.testing.expectEqualStrings("one\nTWO\nthree\n", data);
+}

--- a/zig/src/tools/file.zig
+++ b/zig/src/tools/file.zig
@@ -7,15 +7,15 @@ pub const schema_read =
     \\{"type":"object","properties":{"workspace_root":{"type":"string"},"path":{"type":"string"},"offset":{"type":"integer","minimum":0},"limit":{"type":"integer","minimum":0}},"required":["workspace_root","path"],"additionalProperties":false}
 ;
 pub const schema_write =
-    \\{"type":"object","properties":{"workspace_root":{"type":"string"},"path":{"type":"string"},"content":{"type":"string"}},"required":["workspace_root","path","content"],"additionalProperties":false}
+    \\{"type":"object","properties":{"workspace_root":{"type":"string"},"path":{"type":"string"},"content":{"type":"string"},"compact_output":{"type":"boolean"}},"required":["workspace_root","path","content"],"additionalProperties":false}
 ;
 pub const schema_stat =
-    \\{"type":"object","properties":{"workspace_root":{"type":"string"},"path":{"type":"string"}},"required":["workspace_root","path"],"additionalProperties":false}
+    \\{"type":"object","properties":{"workspace_root":{"type":"string"},"path":{"type":"string"},"compact_output":{"type":"boolean"}},"required":["workspace_root","path"],"additionalProperties":false}
 ;
 
-pub const read_tool = agent.AgentTool{ .label = "File Read", .name = "file_read", .description = "Read a text file from the workspace, optionally by byte range.", .parameters_schema_json = schema_read, .execute = readExecute };
-pub const write_tool = agent.AgentTool{ .label = "File Write", .name = "file_write", .description = "Create or overwrite a file in the workspace.", .parameters_schema_json = schema_write, .execute = writeExecute };
-pub const stat_tool = agent.AgentTool{ .label = "File Stat", .name = "file_stat", .description = "Return file metadata for a workspace path.", .parameters_schema_json = schema_stat, .execute = statExecute };
+pub const read_tool = agent.AgentTool{ .label = "File Read", .name = "file_read", .description = "Read a text file from the workspace, optionally by byte range. Output includes per-line content hashes as line_no:hash|content for hash-anchored edits.", .short_description = "Read file with line hashes.", .parameters_schema_json = schema_read, .execute = readExecute };
+pub const write_tool = agent.AgentTool{ .label = "File Write", .name = "file_write", .description = "Create or overwrite a file in the workspace.", .short_description = "Write file content.", .parameters_schema_json = schema_write, .execute = writeExecute };
+pub const stat_tool = agent.AgentTool{ .label = "File Stat", .name = "file_stat", .description = "Return file metadata for a workspace path.", .short_description = "Stat file path.", .parameters_schema_json = schema_stat, .execute = statExecute };
 
 pub fn readExecute(tool_call_id: []const u8, args_json: []const u8, cancel_token: ?ai_types.CancelToken, on_update_ctx: ?*anyopaque, on_update: ?agent.ToolUpdateCallback, allocator: std.mem.Allocator) anyerror!agent.AgentToolResult {
     _ = tool_call_id;
@@ -29,27 +29,24 @@ pub fn readExecute(tool_call_id: []const u8, args_json: []const u8, cancel_token
     const workspace_root = try common.requiredString(obj, "workspace_root");
     const path = try common.requiredString(obj, "path");
     const offset = common.optionalUsize(obj, "offset", 0);
-    const limit = common.optionalUsize(obj, "limit", common.max_file_bytes);
+    const limit = @min(common.optionalUsize(obj, "limit", common.max_file_bytes), common.max_file_bytes);
 
     var file = try common.openWorkspaceFile(allocator, workspace_root, path);
     defer file.close(common.defaultIo());
     const st = try file.stat(common.defaultIo());
     if (offset > st.size) return error.RangeOutOfBounds;
+    const line_no_base = try lineNumberAtOffset(allocator, file, offset);
     const remaining: usize = @intCast(st.size - offset);
     const read_len = @min(limit, remaining);
     const text = try allocator.alloc(u8, read_len);
-    errdefer allocator.free(text);
+    defer allocator.free(text);
     const bytes_read = try file.readPositionalAll(common.defaultIo(), text, offset);
     if (common.isBinary(text[0..bytes_read])) return error.BinaryFileRejected;
-    if (bytes_read != text.len) {
-        const resized = try allocator.realloc(text, bytes_read);
-        const details = try common.jsonString(allocator, .{ .ok = true, .path = path, .duration_ms = common.durationMs(start_ms), .raw_bytes = st.size, .returned_bytes = bytes_read, .offset = offset, .limit = limit });
-        errdefer allocator.free(details);
-        return common.makeTextResultOwned(allocator, resized, details);
-    }
-    const details = try common.jsonString(allocator, .{ .ok = true, .path = path, .duration_ms = common.durationMs(start_ms), .raw_bytes = st.size, .returned_bytes = text.len, .offset = offset, .limit = limit });
+    const hashed = try formatWithLineHashesFrom(allocator, text[0..bytes_read], line_no_base);
+    errdefer allocator.free(hashed);
+    const details = try common.jsonString(allocator, .{ .ok = true, .path = path, .duration_ms = common.durationMs(start_ms), .raw_bytes = st.size, .returned_bytes = hashed.len, .saved_bytes = if (st.size > hashed.len) st.size - hashed.len else 0, .compressed = false, .offset = offset, .limit = limit });
     errdefer allocator.free(details);
-    return common.makeTextResultOwned(allocator, text, details);
+    return common.makeTextResultOwned(allocator, hashed, details);
 }
 
 pub fn writeExecute(tool_call_id: []const u8, args_json: []const u8, cancel_token: ?ai_types.CancelToken, on_update_ctx: ?*anyopaque, on_update: ?agent.ToolUpdateCallback, allocator: std.mem.Allocator) anyerror!agent.AgentToolResult {
@@ -64,10 +61,15 @@ pub fn writeExecute(tool_call_id: []const u8, args_json: []const u8, cancel_toke
     const workspace_root = try common.requiredString(obj, "workspace_root");
     const path = try common.requiredString(obj, "path");
     const content = try common.requiredString(obj, "content");
+    const compact = common.optionalBool(obj, "compact_output", false);
     try common.writeWorkspaceFile(allocator, workspace_root, path, content);
-    const details = try common.jsonString(allocator, .{ .ok = true, .path = path, .duration_ms = common.durationMs(start_ms), .raw_bytes = content.len, .written_bytes = content.len });
+    const text = if (compact)
+        try std.fmt.allocPrint(allocator, "ok {d} {s}", .{ content.len, path })
+    else
+        try std.fmt.allocPrint(allocator, "wrote {d} bytes to {s}", .{ content.len, path });
+    errdefer allocator.free(text);
+    const details = try common.jsonString(allocator, .{ .ok = true, .path = path, .duration_ms = common.durationMs(start_ms), .raw_bytes = content.len, .returned_bytes = text.len, .saved_bytes = content.len -| text.len, .compressed = false, .written_bytes = content.len });
     errdefer allocator.free(details);
-    const text = try std.fmt.allocPrint(allocator, "wrote {d} bytes to {s}", .{ content.len, path });
     return common.makeTextResultOwned(allocator, text, details);
 }
 
@@ -82,11 +84,52 @@ pub fn statExecute(tool_call_id: []const u8, args_json: []const u8, cancel_token
     const obj = parsed.value.object;
     const workspace_root = try common.requiredString(obj, "workspace_root");
     const path = try common.requiredString(obj, "path");
+    const compact = common.optionalBool(obj, "compact_output", false);
     const st = try common.statWorkspaceFile(allocator, workspace_root, path);
-    const details = try common.jsonString(allocator, .{ .ok = true, .path = path, .duration_ms = common.durationMs(start_ms), .raw_bytes = 0, .size = st.size, .kind = @tagName(st.kind), .mtime_ns = st.mtime.toNanoseconds() });
+    const text = if (compact)
+        try std.fmt.allocPrint(allocator, "{s} {s} {d}", .{ path, @tagName(st.kind), st.size })
+    else
+        try std.fmt.allocPrint(allocator, "{s}: {s}, {d} bytes", .{ path, @tagName(st.kind), st.size });
+    errdefer allocator.free(text);
+    const details = try common.jsonString(allocator, .{ .ok = true, .path = path, .duration_ms = common.durationMs(start_ms), .raw_bytes = text.len, .returned_bytes = text.len, .saved_bytes = 0, .compressed = false, .size = st.size, .kind = @tagName(st.kind), .mtime_ns = st.mtime.toNanoseconds() });
     errdefer allocator.free(details);
-    const text = try std.fmt.allocPrint(allocator, "{s}: {s}, {d} bytes", .{ path, @tagName(st.kind), st.size });
     return common.makeTextResultOwned(allocator, text, details);
+}
+
+pub fn formatWithLineHashes(allocator: std.mem.Allocator, content: []const u8) ![]u8 {
+    return formatWithLineHashesFrom(allocator, content, 1);
+}
+
+fn formatWithLineHashesFrom(allocator: std.mem.Allocator, content: []const u8, first_line_no: usize) ![]u8 {
+    var out = std.ArrayList(u8).empty;
+    errdefer out.deinit(allocator);
+    var line_no: usize = first_line_no;
+    var start: usize = 0;
+    while (start <= content.len) {
+        const end = std.mem.indexOfScalarPos(u8, content, start, '\n') orelse content.len;
+        if (start == content.len and end == content.len) break;
+        const line = content[start..end];
+        const hash = common.lineHash(line);
+        const formatted = try std.fmt.allocPrint(allocator, "{d}:{s}|{s}\n", .{ line_no, &hash, line });
+        defer allocator.free(formatted);
+        try out.appendSlice(allocator, formatted);
+        line_no += 1;
+        if (end == content.len) break;
+        start = end + 1;
+    }
+    return out.toOwnedSlice(allocator);
+}
+
+fn lineNumberAtOffset(allocator: std.mem.Allocator, file: std.Io.File, offset: usize) !usize {
+    if (offset == 0) return 1;
+    const prefix = try allocator.alloc(u8, @min(offset, common.max_file_bytes));
+    defer allocator.free(prefix);
+    const bytes_read = try file.readPositionalAll(common.defaultIo(), prefix, 0);
+    var line_no: usize = 1;
+    for (prefix[0..bytes_read]) |c| {
+        if (c == '\n') line_no += 1;
+    }
+    return line_no;
 }
 
 test "file read write stat" {
@@ -104,7 +147,8 @@ test "file read write stat" {
     defer std.testing.allocator.free(read_args);
     var rd = try readExecute("call", read_args, null, null, null, std.testing.allocator);
     defer rd.deinit(std.testing.allocator);
-    try std.testing.expectEqualStrings("hello", rd.content.slice()[0].text.text);
+    try std.testing.expect(std.mem.indexOf(u8, rd.content.slice()[0].text.text, "1:") != null);
+    try std.testing.expect(std.mem.indexOf(u8, rd.content.slice()[0].text.text, "|hello") != null);
     var st = try statExecute("call", read_args, null, null, null, std.testing.allocator);
     defer st.deinit(std.testing.allocator);
     try std.testing.expect(std.mem.indexOf(u8, st.getDetailsJson().?, "\"size\":5") != null);
@@ -126,8 +170,27 @@ test "file read supports byte ranges without loading full file" {
     defer std.testing.allocator.free(args);
     var result = try readExecute("call", args, null, null, null, std.testing.allocator);
     defer result.deinit(std.testing.allocator);
-    try std.testing.expectEqualStrings("range", result.content.slice()[0].text.text);
-    try std.testing.expect(std.mem.indexOf(u8, result.getDetailsJson().?, "\"returned_bytes\":5") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.content.slice()[0].text.text, "1:0000000000000000|range") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.content.slice()[0].text.text, "|range") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.getDetailsJson().?, "\"limit\":5") != null);
+}
+
+test "file read clamps requested range limit" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const cwd = try std.process.currentPathAlloc(common.defaultIo(), std.testing.allocator);
+    defer std.testing.allocator.free(cwd);
+    const root = try std.Io.Dir.path.join(std.testing.allocator, &.{ cwd, ".zig-cache", "tmp", tmp.sub_path[0..] });
+    defer std.testing.allocator.free(root);
+    const big = try std.testing.allocator.alloc(u8, common.max_file_bytes + 1024);
+    defer std.testing.allocator.free(big);
+    @memset(big, 'a');
+    try tmp.dir.writeFile(common.defaultIo(), .{ .sub_path = "big.txt", .data = big });
+    const args = try std.fmt.allocPrint(std.testing.allocator, "{{\"workspace_root\":\"{s}\",\"path\":\"big.txt\",\"limit\":{d}}}", .{ root, common.max_file_bytes + 1024 });
+    defer std.testing.allocator.free(args);
+    var result = try readExecute("call", args, null, null, null, std.testing.allocator);
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(std.mem.indexOf(u8, result.getDetailsJson().?, "\"limit\":16777216") != null);
 }
 
 test "file read rejects missing binary and workspace escape" {
@@ -154,4 +217,18 @@ test "file read rejects missing binary and workspace escape" {
     const traversal_args = try std.fmt.allocPrint(std.testing.allocator, "{{\"workspace_root\":\"{s}\",\"path\":\"{s}/../outside.txt\"}}", .{ root, root });
     defer std.testing.allocator.free(traversal_args);
     try std.testing.expectError(error.PathEscapesWorkspace, readExecute("call", traversal_args, null, null, null, std.testing.allocator));
+}
+
+test "file compact output mode" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const cwd = try std.process.currentPathAlloc(common.defaultIo(), std.testing.allocator);
+    defer std.testing.allocator.free(cwd);
+    const root = try std.Io.Dir.path.join(std.testing.allocator, &.{ cwd, ".zig-cache", "tmp", tmp.sub_path[0..] });
+    defer std.testing.allocator.free(root);
+    const args = try std.fmt.allocPrint(std.testing.allocator, "{{\"workspace_root\":\"{s}\",\"path\":\"a.txt\",\"content\":\"hello\",\"compact_output\":true}}", .{root});
+    defer std.testing.allocator.free(args);
+    var result = try writeExecute("call", args, null, null, null, std.testing.allocator);
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expectEqualStrings("ok 5 a.txt", result.content.slice()[0].text.text);
 }

--- a/zig/src/tools/file.zig
+++ b/zig/src/tools/file.zig
@@ -56,7 +56,7 @@ pub fn writeExecute(tool_call_id: []const u8, args_json: []const u8, cancel_toke
     const workspace_root = try common.requiredString(obj, "workspace_root");
     const path = try common.requiredString(obj, "path");
     const content = try common.requiredString(obj, "content");
-    try common.writeWorkspaceFile(workspace_root, path, content);
+    try common.writeWorkspaceFile(allocator, workspace_root, path, content);
     const details = try common.jsonString(allocator, .{ .ok = true, .path = path, .duration_ms = common.durationMs(start_ms), .raw_bytes = content.len, .written_bytes = content.len });
     errdefer allocator.free(details);
     const text = try std.fmt.allocPrint(allocator, "wrote {d} bytes to {s}", .{ content.len, path });
@@ -74,7 +74,7 @@ pub fn statExecute(tool_call_id: []const u8, args_json: []const u8, cancel_token
     const obj = parsed.value.object;
     const workspace_root = try common.requiredString(obj, "workspace_root");
     const path = try common.requiredString(obj, "path");
-    const st = try common.statWorkspaceFile(workspace_root, path);
+    const st = try common.statWorkspaceFile(allocator, workspace_root, path);
     const details = try common.jsonString(allocator, .{ .ok = true, .path = path, .duration_ms = common.durationMs(start_ms), .raw_bytes = 0, .size = st.size, .kind = @tagName(st.kind), .mtime_ns = st.mtime.toNanoseconds() });
     errdefer allocator.free(details);
     const text = try std.fmt.allocPrint(allocator, "{s}: {s}, {d} bytes", .{ path, @tagName(st.kind), st.size });
@@ -102,7 +102,7 @@ test "file read write stat" {
     try std.testing.expect(std.mem.indexOf(u8, st.getDetailsJson().?, "\"size\":5") != null);
 }
 
-test "file read rejects missing and binary" {
+test "file read rejects missing binary and workspace escape" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
     const cwd = try std.process.currentPathAlloc(common.defaultIo(), std.testing.allocator);
@@ -116,4 +116,11 @@ test "file read rejects missing and binary" {
     const bin_args = try std.fmt.allocPrint(std.testing.allocator, "{{\"workspace_root\":\"{s}\",\"path\":\"bin.dat\"}}", .{root});
     defer std.testing.allocator.free(bin_args);
     try std.testing.expectError(error.BinaryFileRejected, readExecute("call", bin_args, null, null, null, std.testing.allocator));
+    const escape_args = try std.fmt.allocPrint(std.testing.allocator, "{{\"workspace_root\":\"{s}\",\"path\":\"{s}.outside\"}}", .{ root, root });
+    defer std.testing.allocator.free(escape_args);
+    try std.testing.expectError(error.PathEscapesWorkspace, readExecute("call", escape_args, null, null, null, std.testing.allocator));
+    try std.testing.expectError(error.PathEscapesWorkspace, statExecute("call", escape_args, null, null, null, std.testing.allocator));
+    const write_escape_args = try std.fmt.allocPrint(std.testing.allocator, "{{\"workspace_root\":\"{s}\",\"path\":\"{s}.outside\",\"content\":\"nope\"}}", .{ root, root });
+    defer std.testing.allocator.free(write_escape_args);
+    try std.testing.expectError(error.PathEscapesWorkspace, writeExecute("call", write_escape_args, null, null, null, std.testing.allocator));
 }

--- a/zig/src/tools/file.zig
+++ b/zig/src/tools/file.zig
@@ -123,4 +123,7 @@ test "file read rejects missing binary and workspace escape" {
     const write_escape_args = try std.fmt.allocPrint(std.testing.allocator, "{{\"workspace_root\":\"{s}\",\"path\":\"{s}.outside\",\"content\":\"nope\"}}", .{ root, root });
     defer std.testing.allocator.free(write_escape_args);
     try std.testing.expectError(error.PathEscapesWorkspace, writeExecute("call", write_escape_args, null, null, null, std.testing.allocator));
+    const traversal_args = try std.fmt.allocPrint(std.testing.allocator, "{{\"workspace_root\":\"{s}\",\"path\":\"{s}/../outside.txt\"}}", .{ root, root });
+    defer std.testing.allocator.free(traversal_args);
+    try std.testing.expectError(error.PathEscapesWorkspace, readExecute("call", traversal_args, null, null, null, std.testing.allocator));
 }

--- a/zig/src/tools/file.zig
+++ b/zig/src/tools/file.zig
@@ -1,0 +1,119 @@
+const std = @import("std");
+const ai_types = @import("ai_types");
+const agent = @import("agent");
+const common = @import("tools/common");
+
+pub const schema_read =
+    \\{"type":"object","properties":{"workspace_root":{"type":"string"},"path":{"type":"string"},"offset":{"type":"integer","minimum":0},"limit":{"type":"integer","minimum":0}},"required":["workspace_root","path"],"additionalProperties":false}
+;
+pub const schema_write =
+    \\{"type":"object","properties":{"workspace_root":{"type":"string"},"path":{"type":"string"},"content":{"type":"string"}},"required":["workspace_root","path","content"],"additionalProperties":false}
+;
+pub const schema_stat =
+    \\{"type":"object","properties":{"workspace_root":{"type":"string"},"path":{"type":"string"}},"required":["workspace_root","path"],"additionalProperties":false}
+;
+
+pub const read_tool = agent.AgentTool{ .label = "File Read", .name = "file_read", .description = "Read a text file from the workspace, optionally by byte range.", .parameters_schema_json = schema_read, .execute = readExecute };
+pub const write_tool = agent.AgentTool{ .label = "File Write", .name = "file_write", .description = "Create or overwrite a file in the workspace.", .parameters_schema_json = schema_write, .execute = writeExecute };
+pub const stat_tool = agent.AgentTool{ .label = "File Stat", .name = "file_stat", .description = "Return file metadata for a workspace path.", .parameters_schema_json = schema_stat, .execute = statExecute };
+
+pub fn readExecute(tool_call_id: []const u8, args_json: []const u8, cancel_token: ?ai_types.CancelToken, on_update_ctx: ?*anyopaque, on_update: ?agent.ToolUpdateCallback, allocator: std.mem.Allocator) anyerror!agent.AgentToolResult {
+    _ = tool_call_id;
+    _ = on_update_ctx;
+    _ = on_update;
+    if (common.isCancelled(cancel_token)) return error.Cancelled;
+    const start_ms = common.nowMs();
+    var parsed = try common.parseArgs(allocator, args_json);
+    defer parsed.deinit();
+    const obj = parsed.value.object;
+    const workspace_root = try common.requiredString(obj, "workspace_root");
+    const path = try common.requiredString(obj, "path");
+    const offset = common.optionalUsize(obj, "offset", 0);
+    const limit = common.optionalUsize(obj, "limit", common.max_file_bytes);
+
+    const data = try common.readWorkspaceFile(allocator, workspace_root, path, common.max_file_bytes);
+    defer allocator.free(data);
+    if (common.isBinary(data)) return error.BinaryFileRejected;
+    if (offset > data.len) return error.RangeOutOfBounds;
+    const end = @min(data.len, offset + @min(limit, data.len - offset));
+    const slice = data[offset..end];
+    const details = try common.jsonString(allocator, .{ .ok = true, .path = path, .duration_ms = common.durationMs(start_ms), .raw_bytes = data.len, .returned_bytes = slice.len, .offset = offset, .limit = limit });
+    errdefer allocator.free(details);
+    const text = try allocator.dupe(u8, slice);
+    errdefer allocator.free(text);
+    return common.makeTextResultOwned(allocator, text, details);
+}
+
+pub fn writeExecute(tool_call_id: []const u8, args_json: []const u8, cancel_token: ?ai_types.CancelToken, on_update_ctx: ?*anyopaque, on_update: ?agent.ToolUpdateCallback, allocator: std.mem.Allocator) anyerror!agent.AgentToolResult {
+    _ = tool_call_id;
+    _ = on_update_ctx;
+    _ = on_update;
+    if (common.isCancelled(cancel_token)) return error.Cancelled;
+    const start_ms = common.nowMs();
+    var parsed = try common.parseArgs(allocator, args_json);
+    defer parsed.deinit();
+    const obj = parsed.value.object;
+    const workspace_root = try common.requiredString(obj, "workspace_root");
+    const path = try common.requiredString(obj, "path");
+    const content = try common.requiredString(obj, "content");
+    try common.writeWorkspaceFile(workspace_root, path, content);
+    const details = try common.jsonString(allocator, .{ .ok = true, .path = path, .duration_ms = common.durationMs(start_ms), .raw_bytes = content.len, .written_bytes = content.len });
+    errdefer allocator.free(details);
+    const text = try std.fmt.allocPrint(allocator, "wrote {d} bytes to {s}", .{ content.len, path });
+    return common.makeTextResultOwned(allocator, text, details);
+}
+
+pub fn statExecute(tool_call_id: []const u8, args_json: []const u8, cancel_token: ?ai_types.CancelToken, on_update_ctx: ?*anyopaque, on_update: ?agent.ToolUpdateCallback, allocator: std.mem.Allocator) anyerror!agent.AgentToolResult {
+    _ = tool_call_id;
+    _ = on_update_ctx;
+    _ = on_update;
+    if (common.isCancelled(cancel_token)) return error.Cancelled;
+    const start_ms = common.nowMs();
+    var parsed = try common.parseArgs(allocator, args_json);
+    defer parsed.deinit();
+    const obj = parsed.value.object;
+    const workspace_root = try common.requiredString(obj, "workspace_root");
+    const path = try common.requiredString(obj, "path");
+    const st = try common.statWorkspaceFile(workspace_root, path);
+    const details = try common.jsonString(allocator, .{ .ok = true, .path = path, .duration_ms = common.durationMs(start_ms), .raw_bytes = 0, .size = st.size, .kind = @tagName(st.kind), .mtime_ns = st.mtime.toNanoseconds() });
+    errdefer allocator.free(details);
+    const text = try std.fmt.allocPrint(allocator, "{s}: {s}, {d} bytes", .{ path, @tagName(st.kind), st.size });
+    return common.makeTextResultOwned(allocator, text, details);
+}
+
+test "file read write stat" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const cwd = try std.process.currentPathAlloc(common.defaultIo(), std.testing.allocator);
+    defer std.testing.allocator.free(cwd);
+    const root = try std.Io.Dir.path.join(std.testing.allocator, &.{ cwd, ".zig-cache", "tmp", tmp.sub_path[0..] });
+    defer std.testing.allocator.free(root);
+    const write_args = try std.fmt.allocPrint(std.testing.allocator, "{{\"workspace_root\":\"{s}\",\"path\":\"a.txt\",\"content\":\"hello\"}}", .{root});
+    defer std.testing.allocator.free(write_args);
+    var wr = try writeExecute("call", write_args, null, null, null, std.testing.allocator);
+    defer wr.deinit(std.testing.allocator);
+    const read_args = try std.fmt.allocPrint(std.testing.allocator, "{{\"workspace_root\":\"{s}\",\"path\":\"a.txt\"}}", .{root});
+    defer std.testing.allocator.free(read_args);
+    var rd = try readExecute("call", read_args, null, null, null, std.testing.allocator);
+    defer rd.deinit(std.testing.allocator);
+    try std.testing.expectEqualStrings("hello", rd.content.slice()[0].text.text);
+    var st = try statExecute("call", read_args, null, null, null, std.testing.allocator);
+    defer st.deinit(std.testing.allocator);
+    try std.testing.expect(std.mem.indexOf(u8, st.getDetailsJson().?, "\"size\":5") != null);
+}
+
+test "file read rejects missing and binary" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const cwd = try std.process.currentPathAlloc(common.defaultIo(), std.testing.allocator);
+    defer std.testing.allocator.free(cwd);
+    const root = try std.Io.Dir.path.join(std.testing.allocator, &.{ cwd, ".zig-cache", "tmp", tmp.sub_path[0..] });
+    defer std.testing.allocator.free(root);
+    const missing_args = try std.fmt.allocPrint(std.testing.allocator, "{{\"workspace_root\":\"{s}\",\"path\":\"missing.txt\"}}", .{root});
+    defer std.testing.allocator.free(missing_args);
+    try std.testing.expectError(error.FileNotFound, readExecute("call", missing_args, null, null, null, std.testing.allocator));
+    try tmp.dir.writeFile(common.defaultIo(), .{ .sub_path = "bin.dat", .data = "a\x00b" });
+    const bin_args = try std.fmt.allocPrint(std.testing.allocator, "{{\"workspace_root\":\"{s}\",\"path\":\"bin.dat\"}}", .{root});
+    defer std.testing.allocator.free(bin_args);
+    try std.testing.expectError(error.BinaryFileRejected, readExecute("call", bin_args, null, null, null, std.testing.allocator));
+}

--- a/zig/src/tools/file.zig
+++ b/zig/src/tools/file.zig
@@ -31,16 +31,24 @@ pub fn readExecute(tool_call_id: []const u8, args_json: []const u8, cancel_token
     const offset = common.optionalUsize(obj, "offset", 0);
     const limit = common.optionalUsize(obj, "limit", common.max_file_bytes);
 
-    const data = try common.readWorkspaceFile(allocator, workspace_root, path, common.max_file_bytes);
-    defer allocator.free(data);
-    if (common.isBinary(data)) return error.BinaryFileRejected;
-    if (offset > data.len) return error.RangeOutOfBounds;
-    const end = @min(data.len, offset + @min(limit, data.len - offset));
-    const slice = data[offset..end];
-    const details = try common.jsonString(allocator, .{ .ok = true, .path = path, .duration_ms = common.durationMs(start_ms), .raw_bytes = data.len, .returned_bytes = slice.len, .offset = offset, .limit = limit });
-    errdefer allocator.free(details);
-    const text = try allocator.dupe(u8, slice);
+    var file = try common.openWorkspaceFile(allocator, workspace_root, path);
+    defer file.close(common.defaultIo());
+    const st = try file.stat(common.defaultIo());
+    if (offset > st.size) return error.RangeOutOfBounds;
+    const remaining: usize = @intCast(st.size - offset);
+    const read_len = @min(limit, remaining);
+    const text = try allocator.alloc(u8, read_len);
     errdefer allocator.free(text);
+    const bytes_read = try file.readPositionalAll(common.defaultIo(), text, offset);
+    if (common.isBinary(text[0..bytes_read])) return error.BinaryFileRejected;
+    if (bytes_read != text.len) {
+        const resized = try allocator.realloc(text, bytes_read);
+        const details = try common.jsonString(allocator, .{ .ok = true, .path = path, .duration_ms = common.durationMs(start_ms), .raw_bytes = st.size, .returned_bytes = bytes_read, .offset = offset, .limit = limit });
+        errdefer allocator.free(details);
+        return common.makeTextResultOwned(allocator, resized, details);
+    }
+    const details = try common.jsonString(allocator, .{ .ok = true, .path = path, .duration_ms = common.durationMs(start_ms), .raw_bytes = st.size, .returned_bytes = text.len, .offset = offset, .limit = limit });
+    errdefer allocator.free(details);
     return common.makeTextResultOwned(allocator, text, details);
 }
 
@@ -100,6 +108,26 @@ test "file read write stat" {
     var st = try statExecute("call", read_args, null, null, null, std.testing.allocator);
     defer st.deinit(std.testing.allocator);
     try std.testing.expect(std.mem.indexOf(u8, st.getDetailsJson().?, "\"size\":5") != null);
+}
+
+test "file read supports byte ranges without loading full file" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const cwd = try std.process.currentPathAlloc(common.defaultIo(), std.testing.allocator);
+    defer std.testing.allocator.free(cwd);
+    const root = try std.Io.Dir.path.join(std.testing.allocator, &.{ cwd, ".zig-cache", "tmp", tmp.sub_path[0..] });
+    defer std.testing.allocator.free(root);
+    const big = try std.testing.allocator.alloc(u8, common.max_file_bytes + 1024);
+    defer std.testing.allocator.free(big);
+    @memset(big, 'a');
+    @memcpy(big[common.max_file_bytes + 10 .. common.max_file_bytes + 15], "range");
+    try tmp.dir.writeFile(common.defaultIo(), .{ .sub_path = "big.txt", .data = big });
+    const args = try std.fmt.allocPrint(std.testing.allocator, "{{\"workspace_root\":\"{s}\",\"path\":\"big.txt\",\"offset\":{d},\"limit\":5}}", .{ root, common.max_file_bytes + 10 });
+    defer std.testing.allocator.free(args);
+    var result = try readExecute("call", args, null, null, null, std.testing.allocator);
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expectEqualStrings("range", result.content.slice()[0].text.text);
+    try std.testing.expect(std.mem.indexOf(u8, result.getDetailsJson().?, "\"returned_bytes\":5") != null);
 }
 
 test "file read rejects missing binary and workspace escape" {

--- a/zig/src/tools/file.zig
+++ b/zig/src/tools/file.zig
@@ -17,6 +17,8 @@ pub const read_tool = agent.AgentTool{ .label = "File Read", .name = "file_read"
 pub const write_tool = agent.AgentTool{ .label = "File Write", .name = "file_write", .description = "Create or overwrite a file in the workspace.", .short_description = "Write file content.", .parameters_schema_json = schema_write, .execute = writeExecute };
 pub const stat_tool = agent.AgentTool{ .label = "File Stat", .name = "file_stat", .description = "Return file metadata for a workspace path.", .short_description = "Stat file path.", .parameters_schema_json = schema_stat, .execute = statExecute };
 
+const max_hashed_output_bytes: usize = common.max_file_bytes;
+
 pub fn readExecute(tool_call_id: []const u8, args_json: []const u8, cancel_token: ?ai_types.CancelToken, on_update_ctx: ?*anyopaque, on_update: ?agent.ToolUpdateCallback, allocator: std.mem.Allocator) anyerror!agent.AgentToolResult {
     _ = tool_call_id;
     _ = on_update_ctx;
@@ -35,14 +37,13 @@ pub fn readExecute(tool_call_id: []const u8, args_json: []const u8, cancel_token
     defer file.close(common.defaultIo());
     const st = try file.stat(common.defaultIo());
     if (offset > st.size) return error.RangeOutOfBounds;
-    const line_no_base = try lineNumberAtOffset(allocator, file, offset);
-    const remaining: usize = @intCast(st.size - offset);
-    const read_len = @min(limit, remaining);
-    const text = try allocator.alloc(u8, read_len);
+    const file_size: usize = @intCast(st.size);
+    const range = try lineAlignedRange(allocator, file, file_size, offset, limit);
+    const text = try allocator.alloc(u8, range.len);
     defer allocator.free(text);
-    const bytes_read = try file.readPositionalAll(common.defaultIo(), text, offset);
+    const bytes_read = try file.readPositionalAll(common.defaultIo(), text, range.offset);
     if (common.isBinary(text[0..bytes_read])) return error.BinaryFileRejected;
-    const hashed = try formatWithLineHashesFrom(allocator, text[0..bytes_read], line_no_base);
+    const hashed = try formatWithLineHashesFrom(allocator, text[0..bytes_read], range.first_line_no);
     errdefer allocator.free(hashed);
     const details = try common.jsonString(allocator, .{ .ok = true, .path = path, .duration_ms = common.durationMs(start_ms), .raw_bytes = st.size, .returned_bytes = hashed.len, .saved_bytes = if (st.size > hashed.len) st.size - hashed.len else 0, .compressed = false, .offset = offset, .limit = limit });
     errdefer allocator.free(details);
@@ -112,12 +113,67 @@ fn formatWithLineHashesFrom(allocator: std.mem.Allocator, content: []const u8, f
         const hash = common.lineHash(line);
         const formatted = try std.fmt.allocPrint(allocator, "{d}:{s}|{s}\n", .{ line_no, &hash, line });
         defer allocator.free(formatted);
+        if (out.items.len + formatted.len > max_hashed_output_bytes) return error.StreamTooLong;
         try out.appendSlice(allocator, formatted);
         line_no += 1;
         if (end == content.len) break;
         start = end + 1;
     }
     return out.toOwnedSlice(allocator);
+}
+
+const LineAlignedRange = struct {
+    offset: usize,
+    len: usize,
+    first_line_no: usize,
+};
+
+fn lineAlignedRange(allocator: std.mem.Allocator, file: std.Io.File, file_size: usize, requested_offset: usize, requested_limit: usize) !LineAlignedRange {
+    const start = try lineStartAtOrBefore(allocator, file, requested_offset);
+    const requested_end = @min(file_size, requested_offset + @min(requested_limit, file_size - requested_offset));
+    const end = try lineEndAtOrAfter(allocator, file, file_size, requested_end);
+    return .{
+        .offset = start,
+        .len = end - start,
+        .first_line_no = try lineNumberAtOffset(allocator, file, start),
+    };
+}
+
+fn lineStartAtOrBefore(allocator: std.mem.Allocator, file: std.Io.File, offset: usize) !usize {
+    if (offset == 0) return 0;
+    const chunk_size: usize = 64 * 1024;
+    const buf = try allocator.alloc(u8, chunk_size);
+    defer allocator.free(buf);
+    var pos = offset;
+    while (pos > 0) {
+        const read_len = @min(buf.len, pos);
+        const chunk_start = pos - read_len;
+        const bytes_read = try file.readPositionalAll(common.defaultIo(), buf[0..read_len], chunk_start);
+        var i = bytes_read;
+        while (i > 0) {
+            i -= 1;
+            if (buf[i] == '\n') return chunk_start + i + 1;
+        }
+        if (bytes_read < read_len) break;
+        pos = chunk_start;
+    }
+    return 0;
+}
+
+fn lineEndAtOrAfter(allocator: std.mem.Allocator, file: std.Io.File, file_size: usize, offset: usize) !usize {
+    if (offset >= file_size) return file_size;
+    const chunk_size: usize = 64 * 1024;
+    const buf = try allocator.alloc(u8, chunk_size);
+    defer allocator.free(buf);
+    var pos = offset;
+    while (pos < file_size) {
+        const read_len = @min(buf.len, file_size - pos);
+        const bytes_read = try file.readPositionalAll(common.defaultIo(), buf[0..read_len], pos);
+        if (std.mem.indexOfScalar(u8, buf[0..bytes_read], '\n')) |idx| return pos + idx + 1;
+        if (bytes_read < read_len) break;
+        pos += bytes_read;
+    }
+    return file_size;
 }
 
 fn lineNumberAtOffset(allocator: std.mem.Allocator, file: std.Io.File, offset: usize) !usize {
@@ -168,18 +224,61 @@ test "file read supports byte ranges without loading full file" {
     defer std.testing.allocator.free(cwd);
     const root = try std.Io.Dir.path.join(std.testing.allocator, &.{ cwd, ".zig-cache", "tmp", tmp.sub_path[0..] });
     defer std.testing.allocator.free(root);
-    const big = try std.testing.allocator.alloc(u8, common.max_file_bytes + 1024);
+    const prefix_len = common.max_file_bytes + 4096;
+    const big = try std.testing.allocator.alloc(u8, prefix_len + 6);
     defer std.testing.allocator.free(big);
     @memset(big, 'a');
-    @memcpy(big[common.max_file_bytes + 10 .. common.max_file_bytes + 15], "range");
+    for (0..prefix_len) |i| {
+        if (i % 4096 == 4095) big[i] = '\n';
+    }
+    @memcpy(big[prefix_len .. prefix_len + 5], "range");
+    big[prefix_len + 5] = '\n';
     try tmp.dir.writeFile(common.defaultIo(), .{ .sub_path = "big.txt", .data = big });
-    const args = try std.fmt.allocPrint(std.testing.allocator, "{{\"workspace_root\":\"{s}\",\"path\":\"big.txt\",\"offset\":{d},\"limit\":5}}", .{ root, common.max_file_bytes + 10 });
+    const args = try std.fmt.allocPrint(std.testing.allocator, "{{\"workspace_root\":\"{s}\",\"path\":\"big.txt\",\"offset\":{d},\"limit\":5}}", .{ root, prefix_len });
     defer std.testing.allocator.free(args);
     var result = try readExecute("call", args, null, null, null, std.testing.allocator);
     defer result.deinit(std.testing.allocator);
-    try std.testing.expect(std.mem.indexOf(u8, result.content.slice()[0].text.text, "1:0000000000000000|range") == null);
     try std.testing.expect(std.mem.indexOf(u8, result.content.slice()[0].text.text, "|range") != null);
     try std.testing.expect(std.mem.indexOf(u8, result.getDetailsJson().?, "\"limit\":5") != null);
+}
+
+test "file read aligns ranged reads to full lines" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const cwd = try std.process.currentPathAlloc(common.defaultIo(), std.testing.allocator);
+    defer std.testing.allocator.free(cwd);
+    const root = try std.Io.Dir.path.join(std.testing.allocator, &.{ cwd, ".zig-cache", "tmp", tmp.sub_path[0..] });
+    defer std.testing.allocator.free(root);
+    try tmp.dir.writeFile(common.defaultIo(), .{ .sub_path = "lines.txt", .data = "alpha\nbravo\ncharlie\n" });
+    const args = try std.fmt.allocPrint(std.testing.allocator, "{{\"workspace_root\":\"{s}\",\"path\":\"lines.txt\",\"offset\":8,\"limit\":2}}", .{root});
+    defer std.testing.allocator.free(args);
+    var result = try readExecute("call", args, null, null, null, std.testing.allocator);
+    defer result.deinit(std.testing.allocator);
+    const body = result.content.slice()[0].text.text;
+    const expected_hash = common.lineHash("bravo");
+    const expected = try std.fmt.allocPrint(std.testing.allocator, "2:{s}|bravo\n", .{&expected_hash});
+    defer std.testing.allocator.free(expected);
+    try std.testing.expectEqualStrings(expected, body);
+}
+
+test "file read caps hashed output expansion" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const cwd = try std.process.currentPathAlloc(common.defaultIo(), std.testing.allocator);
+    defer std.testing.allocator.free(cwd);
+    const root = try std.Io.Dir.path.join(std.testing.allocator, &.{ cwd, ".zig-cache", "tmp", tmp.sub_path[0..] });
+    defer std.testing.allocator.free(root);
+    const lines = max_hashed_output_bytes / 20 + 1;
+    const data = try std.testing.allocator.alloc(u8, lines * 2);
+    defer std.testing.allocator.free(data);
+    for (0..lines) |i| {
+        data[i * 2] = 'x';
+        data[i * 2 + 1] = '\n';
+    }
+    try tmp.dir.writeFile(common.defaultIo(), .{ .sub_path = "tiny-lines.txt", .data = data });
+    const args = try std.fmt.allocPrint(std.testing.allocator, "{{\"workspace_root\":\"{s}\",\"path\":\"tiny-lines.txt\"}}", .{root});
+    defer std.testing.allocator.free(args);
+    try std.testing.expectError(error.StreamTooLong, readExecute("call", args, null, null, null, std.testing.allocator));
 }
 
 test "file read clamps requested range limit" {
@@ -195,9 +294,7 @@ test "file read clamps requested range limit" {
     try tmp.dir.writeFile(common.defaultIo(), .{ .sub_path = "big.txt", .data = big });
     const args = try std.fmt.allocPrint(std.testing.allocator, "{{\"workspace_root\":\"{s}\",\"path\":\"big.txt\",\"limit\":{d}}}", .{ root, common.max_file_bytes + 1024 });
     defer std.testing.allocator.free(args);
-    var result = try readExecute("call", args, null, null, null, std.testing.allocator);
-    defer result.deinit(std.testing.allocator);
-    try std.testing.expect(std.mem.indexOf(u8, result.getDetailsJson().?, "\"limit\":16777216") != null);
+    try std.testing.expectError(error.StreamTooLong, readExecute("call", args, null, null, null, std.testing.allocator));
 }
 
 test "file read rejects missing binary and workspace escape" {

--- a/zig/src/tools/file.zig
+++ b/zig/src/tools/file.zig
@@ -122,12 +122,19 @@ fn formatWithLineHashesFrom(allocator: std.mem.Allocator, content: []const u8, f
 
 fn lineNumberAtOffset(allocator: std.mem.Allocator, file: std.Io.File, offset: usize) !usize {
     if (offset == 0) return 1;
-    const prefix = try allocator.alloc(u8, @min(offset, common.max_file_bytes));
-    defer allocator.free(prefix);
-    const bytes_read = try file.readPositionalAll(common.defaultIo(), prefix, 0);
+    const chunk_size: usize = 64 * 1024;
+    const buf = try allocator.alloc(u8, chunk_size);
+    defer allocator.free(buf);
     var line_no: usize = 1;
-    for (prefix[0..bytes_read]) |c| {
-        if (c == '\n') line_no += 1;
+    var pos: usize = 0;
+    while (pos < offset) {
+        const read_len = @min(buf.len, offset - pos);
+        const bytes_read = try file.readPositionalAll(common.defaultIo(), buf[0..read_len], pos);
+        for (buf[0..bytes_read]) |c| {
+            if (c == '\n') line_no += 1;
+        }
+        if (bytes_read < read_len) break;
+        pos += bytes_read;
     }
     return line_no;
 }

--- a/zig/src/tools/makai.zig
+++ b/zig/src/tools/makai.zig
@@ -913,6 +913,7 @@ fn parseAgentTool(allocator: std.mem.Allocator, value: std.json.Value) !agent_lo
 
     const name_text = getStringField(tool_obj, "name") orelse return error.InvalidToolDefinition;
     const description_text = getStringField(tool_obj, "description") orelse "";
+    const short_description_text = getStringField(tool_obj, "short_description") orelse getStringField(outer_obj, "short_description");
     const label_text = getStringField(tool_obj, "label") orelse getStringField(outer_obj, "label") orelse name_text;
 
     const label = try allocator.dupe(u8, label_text);
@@ -921,6 +922,8 @@ fn parseAgentTool(allocator: std.mem.Allocator, value: std.json.Value) !agent_lo
     errdefer allocator.free(name);
     const description = try allocator.dupe(u8, description_text);
     errdefer allocator.free(description);
+    const short_description = if (short_description_text) |text| try allocator.dupe(u8, text) else null;
+    errdefer if (short_description) |text| allocator.free(text);
     const parameters_schema_json = try parseToolSchemaJson(allocator, tool_obj);
     errdefer allocator.free(parameters_schema_json);
 
@@ -928,6 +931,7 @@ fn parseAgentTool(allocator: std.mem.Allocator, value: std.json.Value) !agent_lo
         .label = label,
         .name = name,
         .description = description,
+        .short_description = short_description,
         .parameters_schema_json = parameters_schema_json,
         .execute = unavailableAgentToolExecute,
     };
@@ -959,6 +963,7 @@ fn deinitAgentToolFields(allocator: std.mem.Allocator, tool: *agent_loop.AgentTo
     allocator.free(tool.label);
     allocator.free(tool.name);
     allocator.free(tool.description);
+    if (tool.short_description) |short| allocator.free(short);
     allocator.free(tool.parameters_schema_json);
 }
 

--- a/zig/src/tools/process_runner.zig
+++ b/zig/src/tools/process_runner.zig
@@ -36,6 +36,7 @@ pub fn run(allocator: std.mem.Allocator, argv: []const []const u8, cwd: std.proc
     while (true) {
         if (common.isCancelled(cancel_token)) return error.Cancelled;
         if (common.durationMs(start_ms) >= timeout_ms) return error.Timeout;
+        const term = try pollTerm(&child);
         if (!pipes_closed) {
             multi_reader.fill(64, poll_timeout) catch |err| switch (err) {
                 error.Timeout => {},
@@ -44,16 +45,14 @@ pub fn run(allocator: std.mem.Allocator, argv: []const []const u8, cwd: std.proc
             };
             if (stdout_reader.buffered().len > common.process_output_bytes) return error.StreamTooLong;
             if (stderr_reader.buffered().len > common.process_output_bytes) return error.StreamTooLong;
-        } else {
-            if (try pollTerm(&child)) |term| {
-                try multi_reader.checkAnyError();
-                const stdout = try multi_reader.toOwnedSlice(0);
-                errdefer allocator.free(stdout);
-                const stderr = try multi_reader.toOwnedSlice(1);
-                errdefer allocator.free(stderr);
-                return .{ .term = term, .stdout = stdout, .stderr = stderr };
-            }
-            common.defaultIo().sleep(.fromMilliseconds(common.process_poll_ms), .boot) catch {};
+        } else common.defaultIo().sleep(.fromMilliseconds(common.process_poll_ms), .boot) catch {};
+        if (term) |t| {
+            if (pipes_closed) try multi_reader.checkAnyError();
+            const stdout = try multi_reader.toOwnedSlice(0);
+            errdefer allocator.free(stdout);
+            const stderr = try multi_reader.toOwnedSlice(1);
+            errdefer allocator.free(stderr);
+            return .{ .term = t, .stdout = stdout, .stderr = stderr };
         }
     }
 }
@@ -102,8 +101,44 @@ fn statusToTerm(status: u32) std.process.Child.Term {
 }
 
 fn pollTermWindows(child: *std.process.Child) !?std.process.Child.Term {
-    _ = child;
-    return null;
+    if (child.id == null) return null;
+    const windows = std.os.windows;
+    const handle = child.id.?;
+    const minimal_timeout: windows.LARGE_INTEGER = -1;
+    return switch (windows.ntdll.NtWaitForSingleObject(handle, .FALSE, &minimal_timeout)) {
+        windows.NTSTATUS.WAIT_0 => {
+            var info: windows.PROCESS.BASIC_INFORMATION = undefined;
+            const term: std.process.Child.Term = switch (windows.ntdll.NtQueryInformationProcess(
+                handle,
+                .BasicInformation,
+                &info,
+                @sizeOf(windows.PROCESS.BASIC_INFORMATION),
+                null,
+            )) {
+                .SUCCESS => .{ .exited = @as(u8, @truncate(@intFromEnum(info.ExitStatus))) },
+                else => .{ .unknown = 0 },
+            };
+            windows.CloseHandle(handle);
+            child.id = null;
+            windows.CloseHandle(child.thread_handle);
+            child.thread_handle = undefined;
+            if (child.stdin) |stdin| {
+                stdin.close(common.defaultIo());
+                child.stdin = null;
+            }
+            if (child.stdout) |stdout| {
+                stdout.close(common.defaultIo());
+                child.stdout = null;
+            }
+            if (child.stderr) |stderr| {
+                stderr.close(common.defaultIo());
+                child.stderr = null;
+            }
+            return term;
+        },
+        .TIMEOUT => null,
+        else => |status| return windows.unexpectedStatus(status),
+    };
 }
 
 test "process runner honors cancellation" {
@@ -125,6 +160,15 @@ test "process runner captures output beyond small std process defaults" {
     defer std.testing.allocator.free(result.stdout);
     defer std.testing.allocator.free(result.stderr);
     try std.testing.expect(result.stdout.len >= 70_000);
+}
+
+test "process runner returns after child exits with inherited background pipe" {
+    if (@import("builtin").os.tag == .windows) return error.SkipZigTest;
+    const argv = [_][]const u8{ "/bin/sh", "-c", "sleep 2 &" };
+    const result = try run(std.testing.allocator, &argv, .inherit, 1_000, null);
+    defer std.testing.allocator.free(result.stdout);
+    defer std.testing.allocator.free(result.stderr);
+    try std.testing.expectEqual(@as(u8, 0), result.term.exited);
 }
 
 test "process runner enforces timeout after pipe eof" {

--- a/zig/src/tools/process_runner.zig
+++ b/zig/src/tools/process_runner.zig
@@ -21,7 +21,7 @@ pub fn run(allocator: std.mem.Allocator, argv: []const []const u8, cwd: std.proc
         .stderr = .pipe,
         .create_no_window = true,
     });
-    defer child.kill(io);
+    defer cleanupChild(&child, io);
 
     var multi_reader_buffer: std.Io.File.MultiReader.Buffer(2) = undefined;
     var multi_reader: std.Io.File.MultiReader = undefined;
@@ -33,28 +33,49 @@ pub fn run(allocator: std.mem.Allocator, argv: []const []const u8, cwd: std.proc
     const poll_timeout: std.Io.Timeout = .{ .duration = .{ .raw = std.Io.Duration.fromMilliseconds(common.process_poll_ms), .clock = .boot } };
 
     var pipes_closed = false;
+    var term: ?std.process.Child.Term = null;
     while (true) {
         if (common.isCancelled(cancel_token)) return error.Cancelled;
         if (common.durationMs(start_ms) >= timeout_ms) return error.Timeout;
-        const term = try pollTerm(&child);
+        if (term == null) term = try pollTerm(&child);
         if (!pipes_closed) {
             multi_reader.fill(64, poll_timeout) catch |err| switch (err) {
-                error.Timeout => {},
+                error.Timeout => {
+                    if (term) |t| return finish(allocator, &multi_reader, t, false);
+                },
                 error.EndOfStream => pipes_closed = true,
                 else => |e| return e,
             };
             if (stdout_reader.buffered().len > common.process_output_bytes) return error.StreamTooLong;
             if (stderr_reader.buffered().len > common.process_output_bytes) return error.StreamTooLong;
         } else common.defaultIo().sleep(.fromMilliseconds(common.process_poll_ms), .boot) catch {};
-        if (term) |t| {
-            if (pipes_closed) try multi_reader.checkAnyError();
-            const stdout = try multi_reader.toOwnedSlice(0);
-            errdefer allocator.free(stdout);
-            const stderr = try multi_reader.toOwnedSlice(1);
-            errdefer allocator.free(stderr);
-            return .{ .term = t, .stdout = stdout, .stderr = stderr };
-        }
+        if (term) |t| if (pipes_closed) return finish(allocator, &multi_reader, t, true);
     }
+}
+
+fn cleanupChild(child: *std.process.Child, io: std.Io) void {
+    if (child.id != null) child.kill(io);
+    if (child.stdin) |stdin| {
+        stdin.close(io);
+        child.stdin = null;
+    }
+    if (child.stdout) |stdout| {
+        stdout.close(io);
+        child.stdout = null;
+    }
+    if (child.stderr) |stderr| {
+        stderr.close(io);
+        child.stderr = null;
+    }
+}
+
+fn finish(allocator: std.mem.Allocator, multi_reader: *std.Io.File.MultiReader, term: std.process.Child.Term, check_errors: bool) !ProcessResult {
+    if (check_errors) try multi_reader.checkAnyError();
+    const stdout = try multi_reader.toOwnedSlice(0);
+    errdefer allocator.free(stdout);
+    const stderr = try multi_reader.toOwnedSlice(1);
+    errdefer allocator.free(stderr);
+    return .{ .term = term, .stdout = stdout, .stderr = stderr };
 }
 
 fn pollTerm(child: *std.process.Child) !?std.process.Child.Term {
@@ -72,14 +93,6 @@ fn pollTermPosix(child: *std.process.Child) !?std.process.Child.Term {
             .SUCCESS => {
                 if (result == 0) return null;
                 child.id = null;
-                if (child.stdout) |stdout| {
-                    stdout.close(common.defaultIo());
-                    child.stdout = null;
-                }
-                if (child.stderr) |stderr| {
-                    stderr.close(common.defaultIo());
-                    child.stderr = null;
-                }
                 return statusToTerm(@bitCast(status));
             },
             .INTR => continue,
@@ -125,14 +138,6 @@ fn pollTermWindows(child: *std.process.Child) !?std.process.Child.Term {
             if (child.stdin) |stdin| {
                 stdin.close(common.defaultIo());
                 child.stdin = null;
-            }
-            if (child.stdout) |stdout| {
-                stdout.close(common.defaultIo());
-                child.stdout = null;
-            }
-            if (child.stderr) |stderr| {
-                stderr.close(common.defaultIo());
-                child.stderr = null;
             }
             return term;
         },

--- a/zig/src/tools/process_runner.zig
+++ b/zig/src/tools/process_runner.zig
@@ -1,0 +1,74 @@
+const std = @import("std");
+const ai_types = @import("ai_types");
+const common = @import("tools/common");
+
+pub const ProcessResult = struct {
+    term: std.process.Child.Term,
+    stdout: []u8,
+    stderr: []u8,
+};
+
+pub fn run(allocator: std.mem.Allocator, argv: []const []const u8, cwd: std.process.Child.Cwd, timeout_ms: u64, cancel_token: ?ai_types.CancelToken) !ProcessResult {
+    if (common.isCancelled(cancel_token)) return error.Cancelled;
+    const io = common.defaultIo();
+    const start_ms = common.nowMs();
+    var child = try std.process.spawn(io, .{
+        .argv = argv,
+        .cwd = cwd,
+        .stdin = .ignore,
+        .stdout = .pipe,
+        .stderr = .pipe,
+        .create_no_window = true,
+    });
+    defer child.kill(io);
+
+    var multi_reader_buffer: std.Io.File.MultiReader.Buffer(2) = undefined;
+    var multi_reader: std.Io.File.MultiReader = undefined;
+    multi_reader.init(allocator, io, multi_reader_buffer.toStreams(), &.{ child.stdout.?, child.stderr.? });
+    defer multi_reader.deinit();
+
+    const stdout_reader = multi_reader.reader(0);
+    const stderr_reader = multi_reader.reader(1);
+    const poll_timeout: std.Io.Timeout = .{ .duration = .{ .raw = std.Io.Duration.fromMilliseconds(common.process_poll_ms), .clock = .boot } };
+
+    while (true) {
+        if (common.isCancelled(cancel_token)) return error.Cancelled;
+        if (common.durationMs(start_ms) >= timeout_ms) return error.Timeout;
+        multi_reader.fill(64, poll_timeout) catch |err| switch (err) {
+            error.Timeout => continue,
+            error.EndOfStream => break,
+            else => |e| return e,
+        };
+        if (stdout_reader.buffered().len > common.process_output_bytes) return error.StreamTooLong;
+        if (stderr_reader.buffered().len > common.process_output_bytes) return error.StreamTooLong;
+    }
+
+    try multi_reader.checkAnyError();
+    const term = try child.wait(io);
+    const stdout = try multi_reader.toOwnedSlice(0);
+    errdefer allocator.free(stdout);
+    const stderr = try multi_reader.toOwnedSlice(1);
+    errdefer allocator.free(stderr);
+    return .{ .term = term, .stdout = stdout, .stderr = stderr };
+}
+
+test "process runner honors cancellation" {
+    var cancelled = std.atomic.Value(bool).init(true);
+    const token = ai_types.CancelToken{ .cancelled = &cancelled };
+    const argv = if (@import("builtin").os.tag == .windows)
+        [_][]const u8{ "cmd.exe", "/C", "ping -n 3 127.0.0.1 >NUL" }
+    else
+        [_][]const u8{ "/bin/sh", "-c", "sleep 2" };
+    try std.testing.expectError(error.Cancelled, run(std.testing.allocator, &argv, .inherit, 5_000, token));
+}
+
+test "process runner captures output beyond small std process defaults" {
+    const argv = if (@import("builtin").os.tag == .windows)
+        [_][]const u8{ "cmd.exe", "/C", "powershell -NoProfile -Command \"[Console]::Out.Write(('x' * 70000))\"" }
+    else
+        [_][]const u8{ "/bin/sh", "-c", "yes x | head -c 70000" };
+    const result = try run(std.testing.allocator, &argv, .inherit, 5_000, null);
+    defer std.testing.allocator.free(result.stdout);
+    defer std.testing.allocator.free(result.stderr);
+    try std.testing.expect(result.stdout.len >= 70_000);
+}

--- a/zig/src/tools/process_runner.zig
+++ b/zig/src/tools/process_runner.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const ai_types = @import("ai_types");
 const common = @import("tools/common");
 
@@ -31,25 +32,78 @@ pub fn run(allocator: std.mem.Allocator, argv: []const []const u8, cwd: std.proc
     const stderr_reader = multi_reader.reader(1);
     const poll_timeout: std.Io.Timeout = .{ .duration = .{ .raw = std.Io.Duration.fromMilliseconds(common.process_poll_ms), .clock = .boot } };
 
+    var pipes_closed = false;
     while (true) {
         if (common.isCancelled(cancel_token)) return error.Cancelled;
         if (common.durationMs(start_ms) >= timeout_ms) return error.Timeout;
-        multi_reader.fill(64, poll_timeout) catch |err| switch (err) {
-            error.Timeout => continue,
-            error.EndOfStream => break,
-            else => |e| return e,
-        };
-        if (stdout_reader.buffered().len > common.process_output_bytes) return error.StreamTooLong;
-        if (stderr_reader.buffered().len > common.process_output_bytes) return error.StreamTooLong;
+        if (!pipes_closed) {
+            multi_reader.fill(64, poll_timeout) catch |err| switch (err) {
+                error.Timeout => {},
+                error.EndOfStream => pipes_closed = true,
+                else => |e| return e,
+            };
+            if (stdout_reader.buffered().len > common.process_output_bytes) return error.StreamTooLong;
+            if (stderr_reader.buffered().len > common.process_output_bytes) return error.StreamTooLong;
+        } else {
+            if (try pollTerm(&child)) |term| {
+                try multi_reader.checkAnyError();
+                const stdout = try multi_reader.toOwnedSlice(0);
+                errdefer allocator.free(stdout);
+                const stderr = try multi_reader.toOwnedSlice(1);
+                errdefer allocator.free(stderr);
+                return .{ .term = term, .stdout = stdout, .stderr = stderr };
+            }
+            common.defaultIo().sleep(.fromMilliseconds(common.process_poll_ms), .boot) catch {};
+        }
     }
+}
 
-    try multi_reader.checkAnyError();
-    const term = try child.wait(io);
-    const stdout = try multi_reader.toOwnedSlice(0);
-    errdefer allocator.free(stdout);
-    const stderr = try multi_reader.toOwnedSlice(1);
-    errdefer allocator.free(stderr);
-    return .{ .term = term, .stdout = stdout, .stderr = stderr };
+fn pollTerm(child: *std.process.Child) !?std.process.Child.Term {
+    if (builtin.os.tag == .windows) return pollTermWindows(child);
+    return pollTermPosix(child);
+}
+
+fn pollTermPosix(child: *std.process.Child) !?std.process.Child.Term {
+    if (child.id == null) return null;
+    var status: if (builtin.link_libc) c_int else u32 = undefined;
+    const pid = child.id.?;
+    while (true) {
+        const result = std.posix.system.waitpid(pid, &status, std.posix.W.NOHANG);
+        switch (std.posix.errno(result)) {
+            .SUCCESS => {
+                if (result == 0) return null;
+                child.id = null;
+                if (child.stdout) |stdout| {
+                    stdout.close(common.defaultIo());
+                    child.stdout = null;
+                }
+                if (child.stderr) |stderr| {
+                    stderr.close(common.defaultIo());
+                    child.stderr = null;
+                }
+                return statusToTerm(@bitCast(status));
+            },
+            .INTR => continue,
+            .CHILD => return null,
+            else => |err| return std.posix.unexpectedErrno(err),
+        }
+    }
+}
+
+fn statusToTerm(status: u32) std.process.Child.Term {
+    return if (std.posix.W.IFEXITED(status))
+        .{ .exited = std.posix.W.EXITSTATUS(status) }
+    else if (std.posix.W.IFSIGNALED(status))
+        .{ .signal = std.posix.W.TERMSIG(status) }
+    else if (std.posix.W.IFSTOPPED(status))
+        .{ .stopped = std.posix.W.STOPSIG(status) }
+    else
+        .{ .unknown = status };
+}
+
+fn pollTermWindows(child: *std.process.Child) !?std.process.Child.Term {
+    _ = child;
+    return null;
 }
 
 test "process runner honors cancellation" {
@@ -66,9 +120,15 @@ test "process runner captures output beyond small std process defaults" {
     const argv = if (@import("builtin").os.tag == .windows)
         [_][]const u8{ "cmd.exe", "/C", "powershell -NoProfile -Command \"[Console]::Out.Write(('x' * 70000))\"" }
     else
-        [_][]const u8{ "/bin/sh", "-c", "yes x | head -c 70000" };
+        [_][]const u8{ "/bin/sh", "-c", "python3 - <<'PY'\nimport sys\nsys.stdout.write('x' * 70000)\nPY" };
     const result = try run(std.testing.allocator, &argv, .inherit, 5_000, null);
     defer std.testing.allocator.free(result.stdout);
     defer std.testing.allocator.free(result.stderr);
     try std.testing.expect(result.stdout.len >= 70_000);
+}
+
+test "process runner enforces timeout after pipe eof" {
+    if (@import("builtin").os.tag == .windows) return error.SkipZigTest;
+    const argv = [_][]const u8{ "/bin/sh", "-c", "exec >/dev/null 2>&1; sleep 2" };
+    try std.testing.expectError(error.Timeout, run(std.testing.allocator, &argv, .inherit, 100, null));
 }

--- a/zig/src/tools/registry.zig
+++ b/zig/src/tools/registry.zig
@@ -44,7 +44,7 @@ pub fn defaultTools() []const agent.AgentTool {
         file.write_tool,
         file.stat_tool,
         edit.apply_tool,
-        search.regex_tool,
+        search.text_tool,
         workspace.info_tool,
         workspace.list_tool,
         workspace.git_status_tool,

--- a/zig/src/tools/registry.zig
+++ b/zig/src/tools/registry.zig
@@ -5,6 +5,7 @@ const file = @import("tools/file");
 const edit = @import("tools/edit");
 const search = @import("tools/search");
 const workspace = @import("tools/workspace");
+const artifact = @import("tools/artifact");
 
 pub const ToolRegistry = struct {
     tools: std.ArrayList(agent.AgentTool) = .empty,
@@ -58,6 +59,7 @@ pub fn defaultTools() []const agent.AgentTool {
         workspace.info_tool,
         workspace.list_tool,
         workspace.git_status_tool,
+        artifact.retrieve_tool,
     };
 }
 
@@ -67,10 +69,12 @@ test "registry registers resolves and lists defaults" {
     try registry.registerDefaults(std.testing.allocator);
     try std.testing.expect(registry.resolve("shell_execute") != null);
     try std.testing.expect(registry.resolve("file_read") != null);
-    try std.testing.expectEqual(@as(usize, 9), registry.list().len);
+    try std.testing.expect(registry.resolve("artifact_retrieve") != null);
+    try std.testing.expectEqual(@as(usize, 10), registry.list().len);
+    for (registry.list()) |tool| try std.testing.expect(tool.short_description != null);
     try std.testing.expectError(error.DuplicateTool, registry.register(std.testing.allocator, shell.execute_tool));
-    const replacement = agent.AgentTool{ .label = "Replacement Shell", .name = "shell_execute", .description = "Replacement shell tool.", .parameters_schema_json = shell.schema_execute, .execute = shell.execute };
+    const replacement = agent.AgentTool{ .label = "Replacement Shell", .name = "shell_execute", .description = "Replacement shell tool.", .short_description = "Replacement shell", .parameters_schema_json = shell.schema_execute, .execute = shell.execute };
     try registry.replaceOrRegister(std.testing.allocator, replacement);
     try std.testing.expectEqualStrings("Replacement Shell", registry.resolve("shell_execute").?.label);
-    try std.testing.expectEqual(@as(usize, 9), registry.list().len);
+    try std.testing.expectEqual(@as(usize, 10), registry.list().len);
 }

--- a/zig/src/tools/registry.zig
+++ b/zig/src/tools/registry.zig
@@ -23,6 +23,16 @@ pub const ToolRegistry = struct {
         try self.tools.append(allocator, tool);
     }
 
+    pub fn replaceOrRegister(self: *ToolRegistry, allocator: std.mem.Allocator, tool: agent.AgentTool) !void {
+        for (self.tools.items) |*existing| {
+            if (std.mem.eql(u8, existing.name, tool.name)) {
+                existing.* = tool;
+                return;
+            }
+        }
+        try self.tools.append(allocator, tool);
+    }
+
     pub fn registerDefaults(self: *ToolRegistry, allocator: std.mem.Allocator) !void {
         for (defaultTools()) |tool| try self.register(allocator, tool);
     }
@@ -59,4 +69,8 @@ test "registry registers resolves and lists defaults" {
     try std.testing.expect(registry.resolve("file_read") != null);
     try std.testing.expectEqual(@as(usize, 9), registry.list().len);
     try std.testing.expectError(error.DuplicateTool, registry.register(std.testing.allocator, shell.execute_tool));
+    const replacement = agent.AgentTool{ .label = "Replacement Shell", .name = "shell_execute", .description = "Replacement shell tool.", .parameters_schema_json = shell.schema_execute, .execute = shell.execute };
+    try registry.replaceOrRegister(std.testing.allocator, replacement);
+    try std.testing.expectEqualStrings("Replacement Shell", registry.resolve("shell_execute").?.label);
+    try std.testing.expectEqual(@as(usize, 9), registry.list().len);
 }

--- a/zig/src/tools/registry.zig
+++ b/zig/src/tools/registry.zig
@@ -1,0 +1,62 @@
+const std = @import("std");
+const agent = @import("agent");
+const shell = @import("tools/shell");
+const file = @import("tools/file");
+const edit = @import("tools/edit");
+const search = @import("tools/search");
+const workspace = @import("tools/workspace");
+
+pub const ToolRegistry = struct {
+    tools: std.ArrayList(agent.AgentTool) = .empty,
+
+    pub fn init() ToolRegistry {
+        return .{};
+    }
+
+    pub fn deinit(self: *ToolRegistry, allocator: std.mem.Allocator) void {
+        self.tools.deinit(allocator);
+        self.* = undefined;
+    }
+
+    pub fn register(self: *ToolRegistry, allocator: std.mem.Allocator, tool: agent.AgentTool) !void {
+        if (self.resolve(tool.name) != null) return error.DuplicateTool;
+        try self.tools.append(allocator, tool);
+    }
+
+    pub fn registerDefaults(self: *ToolRegistry, allocator: std.mem.Allocator) !void {
+        for (defaultTools()) |tool| try self.register(allocator, tool);
+    }
+
+    pub fn resolve(self: *const ToolRegistry, name: []const u8) ?agent.AgentTool {
+        for (self.tools.items) |tool| if (std.mem.eql(u8, tool.name, name)) return tool;
+        return null;
+    }
+
+    pub fn list(self: *const ToolRegistry) []const agent.AgentTool {
+        return self.tools.items;
+    }
+};
+
+pub fn defaultTools() []const agent.AgentTool {
+    return &.{
+        shell.execute_tool,
+        file.read_tool,
+        file.write_tool,
+        file.stat_tool,
+        edit.apply_tool,
+        search.regex_tool,
+        workspace.info_tool,
+        workspace.list_tool,
+        workspace.git_status_tool,
+    };
+}
+
+test "registry registers resolves and lists defaults" {
+    var registry = ToolRegistry.init();
+    defer registry.deinit(std.testing.allocator);
+    try registry.registerDefaults(std.testing.allocator);
+    try std.testing.expect(registry.resolve("shell_execute") != null);
+    try std.testing.expect(registry.resolve("file_read") != null);
+    try std.testing.expectEqual(@as(usize, 9), registry.list().len);
+    try std.testing.expectError(error.DuplicateTool, registry.register(std.testing.allocator, shell.execute_tool));
+}

--- a/zig/src/tools/search.zig
+++ b/zig/src/tools/search.zig
@@ -7,13 +7,12 @@ pub const schema_text =
     \\{"type":"object","properties":{"workspace_root":{"type":"string"},"query":{"type":"string"},"glob":{"type":"string"},"max_results":{"type":"integer","minimum":0}},"required":["workspace_root","query"],"additionalProperties":false}
 ;
 
-pub const text_tool = agent.AgentTool{ .label = "Text Search", .name = "search_text", .description = "Search workspace text files using literal text plus '.' wildcard and '.*' gaps, optional glob substring filter, and return file:line:content results.", .parameters_schema_json = schema_text, .execute = textExecute };
+pub const text_tool = agent.AgentTool{ .label = "Text Search", .name = "search_text", .description = "Search workspace text files using literal text plus '.' wildcard and '.*' gaps, optional glob substring filter, and return file:line:content results. Large result sets are stored as artifacts.", .short_description = "Search text; large results become artifact.", .parameters_schema_json = schema_text, .execute = textExecute };
 pub const regex_tool = text_tool;
 
 const Match = struct { path: []u8, line: usize, content: []u8 };
 
 pub fn textExecute(tool_call_id: []const u8, args_json: []const u8, cancel_token: ?ai_types.CancelToken, on_update_ctx: ?*anyopaque, on_update: ?agent.ToolUpdateCallback, allocator: std.mem.Allocator) anyerror!agent.AgentToolResult {
-    _ = tool_call_id;
     _ = on_update_ctx;
     _ = on_update;
     if (common.isCancelled(cancel_token)) return error.Cancelled;
@@ -83,10 +82,12 @@ pub fn textExecute(tool_call_id: []const u8, args_json: []const u8, cancel_token
         try out.appendSlice(allocator, line);
     }
     const text = try out.toOwnedSlice(allocator);
-    errdefer allocator.free(text);
+    defer allocator.free(text);
     const details = try common.jsonString(allocator, .{ .ok = true, .query = query, .duration_ms = common.durationMs(start_ms), .raw_bytes = text.len, .returned_bytes = text.len, .match_count = matches.items.len, .scanned_files = scanned_files, .skipped_oversized_files = skipped_oversized_files, .skipped_read_error_files = skipped_read_error_files });
-    errdefer allocator.free(details);
-    return common.makeTextResultOwned(allocator, text, details);
+    defer allocator.free(details);
+    const made = try common.makeTextResultWithArtifact(allocator, .{ .tool_name = "search_text", .call_id = tool_call_id, .text = text, .details_json = details });
+    defer if (made.artifact_path) |path| allocator.free(path);
+    return made.result;
 }
 
 fn lessMatch(_: void, a: Match, b: Match) bool {

--- a/zig/src/tools/search.zig
+++ b/zig/src/tools/search.zig
@@ -3,15 +3,16 @@ const ai_types = @import("ai_types");
 const agent = @import("agent");
 const common = @import("tools/common");
 
-pub const schema_regex =
+pub const schema_text =
     \\{"type":"object","properties":{"workspace_root":{"type":"string"},"query":{"type":"string"},"glob":{"type":"string"},"max_results":{"type":"integer","minimum":0}},"required":["workspace_root","query"],"additionalProperties":false}
 ;
 
-pub const regex_tool = agent.AgentTool{ .label = "Regex Search", .name = "search_regex", .description = "Search workspace text files using a regex, optional glob substring filter, and return file:line:content results.", .parameters_schema_json = schema_regex, .execute = regexExecute };
+pub const text_tool = agent.AgentTool{ .label = "Text Search", .name = "search_text", .description = "Search workspace text files using literal text plus '.' wildcard and '.*' gaps, optional glob substring filter, and return file:line:content results.", .parameters_schema_json = schema_text, .execute = textExecute };
+pub const regex_tool = text_tool;
 
 const Match = struct { path: []u8, line: usize, content: []u8 };
 
-pub fn regexExecute(tool_call_id: []const u8, args_json: []const u8, cancel_token: ?ai_types.CancelToken, on_update_ctx: ?*anyopaque, on_update: ?agent.ToolUpdateCallback, allocator: std.mem.Allocator) anyerror!agent.AgentToolResult {
+pub fn textExecute(tool_call_id: []const u8, args_json: []const u8, cancel_token: ?ai_types.CancelToken, on_update_ctx: ?*anyopaque, on_update: ?agent.ToolUpdateCallback, allocator: std.mem.Allocator) anyerror!agent.AgentToolResult {
     _ = tool_call_id;
     _ = on_update_ctx;
     _ = on_update;
@@ -49,7 +50,8 @@ pub fn regexExecute(tool_call_id: []const u8, args_json: []const u8, cancel_toke
         var line_no: usize = 1;
         var line_it = std.mem.splitScalar(u8, data, '\n');
         while (line_it.next()) |line| {
-            if (regexLikeMatch(query, line)) {
+            if (common.isCancelled(cancel_token)) return error.Cancelled;
+            if (textLikeMatch(query, line)) {
                 try matches.append(allocator, .{ .path = try allocator.dupe(u8, entry.path), .line = line_no, .content = try allocator.dupe(u8, line) });
                 if (matches.items.len >= max) break;
             }
@@ -78,9 +80,9 @@ fn lessMatch(_: void, a: Match, b: Match) bool {
     return a.line < b.line;
 }
 
-fn regexLikeMatch(pattern: []const u8, text: []const u8) bool {
-    // Minimal regex surface for local TUI search bootstrap: literal substring,
-    // `.` wildcard, and `.*` gaps. Full indexing/regex engine belongs later.
+fn textLikeMatch(pattern: []const u8, text: []const u8) bool {
+    // Minimal text search surface for local TUI search bootstrap: literal substring,
+    // `.` wildcard, and `.*` gaps. Full indexing belongs later.
     var start: usize = 0;
     while (start <= text.len) : (start += 1) {
         if (matchFromIterative(pattern, text[start..])) return true;
@@ -124,7 +126,7 @@ fn globMatches(pattern: []const u8, path: []const u8) bool {
     return std.mem.indexOf(u8, path, cleaned) != null;
 }
 
-test "search regex returns file line content and empty results" {
+test "search text returns file line content and empty results" {
     var tmp = std.testing.tmpDir(.{ .iterate = true });
     defer tmp.cleanup();
     const cwd = try std.process.currentPathAlloc(common.defaultIo(), std.testing.allocator);
@@ -135,12 +137,12 @@ test "search regex returns file line content and empty results" {
     try tmp.dir.writeFile(common.defaultIo(), .{ .sub_path = "b.txt", .data = "nothing\n" });
     const args = try std.fmt.allocPrint(std.testing.allocator, "{{\"workspace_root\":\"{s}\",\"query\":\"needle\",\"glob\":\"*.zig\"}}", .{root});
     defer std.testing.allocator.free(args);
-    var result = try regexExecute("call", args, null, null, null, std.testing.allocator);
+    var result = try textExecute("call", args, null, null, null, std.testing.allocator);
     defer result.deinit(std.testing.allocator);
     try std.testing.expectEqualStrings("a.zig:1:const needle = 1;\n", result.content.slice()[0].text.text);
     const empty_args = try std.fmt.allocPrint(std.testing.allocator, "{{\"workspace_root\":\"{s}\",\"query\":\"absent\"}}", .{root});
     defer std.testing.allocator.free(empty_args);
-    var empty = try regexExecute("call", empty_args, null, null, null, std.testing.allocator);
+    var empty = try textExecute("call", empty_args, null, null, null, std.testing.allocator);
     defer empty.deinit(std.testing.allocator);
     try std.testing.expectEqualStrings("", empty.content.slice()[0].text.text);
     const long_line = try std.testing.allocator.alloc(u8, 1024 * 1024);
@@ -149,7 +151,10 @@ test "search regex returns file line content and empty results" {
     try tmp.dir.writeFile(common.defaultIo(), .{ .sub_path = "long.txt", .data = long_line });
     const long_args = try std.fmt.allocPrint(std.testing.allocator, "{{\"workspace_root\":\"{s}\",\"query\":\".*z\",\"glob\":\"*.txt\"}}", .{root});
     defer std.testing.allocator.free(long_args);
-    var long = try regexExecute("call", long_args, null, null, null, std.testing.allocator);
+    var long = try textExecute("call", long_args, null, null, null, std.testing.allocator);
     defer long.deinit(std.testing.allocator);
     try std.testing.expectEqualStrings("", long.content.slice()[0].text.text);
+    var cancelled = std.atomic.Value(bool).init(true);
+    const token = ai_types.CancelToken{ .cancelled = &cancelled };
+    try std.testing.expectError(error.Cancelled, textExecute("call", long_args, token, null, null, std.testing.allocator));
 }

--- a/zig/src/tools/search.zig
+++ b/zig/src/tools/search.zig
@@ -1,0 +1,129 @@
+const std = @import("std");
+const ai_types = @import("ai_types");
+const agent = @import("agent");
+const common = @import("tools/common");
+
+pub const schema_regex =
+    \\{"type":"object","properties":{"workspace_root":{"type":"string"},"query":{"type":"string"},"glob":{"type":"string"},"max_results":{"type":"integer","minimum":0}},"required":["workspace_root","query"],"additionalProperties":false}
+;
+
+pub const regex_tool = agent.AgentTool{ .label = "Regex Search", .name = "search_regex", .description = "Search workspace text files using a regex, optional glob substring filter, and return file:line:content results.", .parameters_schema_json = schema_regex, .execute = regexExecute };
+
+const Match = struct { path: []u8, line: usize, content: []u8 };
+
+pub fn regexExecute(tool_call_id: []const u8, args_json: []const u8, cancel_token: ?ai_types.CancelToken, on_update_ctx: ?*anyopaque, on_update: ?agent.ToolUpdateCallback, allocator: std.mem.Allocator) anyerror!agent.AgentToolResult {
+    _ = tool_call_id;
+    _ = on_update_ctx;
+    _ = on_update;
+    if (common.isCancelled(cancel_token)) return error.Cancelled;
+    const start_ms = common.nowMs();
+    var parsed = try common.parseArgs(allocator, args_json);
+    defer parsed.deinit();
+    const obj = parsed.value.object;
+    const workspace_root = try common.requiredString(obj, "workspace_root");
+    const query = try common.requiredString(obj, "query");
+    const glob = common.optionalString(obj, "glob");
+    const max = @min(common.optionalUsize(obj, "max_results", 50), common.max_results);
+    var root = try common.openWorkspace(workspace_root, true);
+    defer root.close(common.defaultIo());
+    var walker = try root.walk(allocator);
+    defer walker.deinit();
+
+    var matches = std.ArrayList(Match).empty;
+    defer {
+        for (matches.items) |m| {
+            allocator.free(m.path);
+            allocator.free(m.content);
+        }
+        matches.deinit(allocator);
+    }
+
+    while (try walker.next(common.defaultIo())) |entry| {
+        if (common.isCancelled(cancel_token)) return error.Cancelled;
+        if (matches.items.len >= max) break;
+        if (entry.kind != .file) continue;
+        if (glob) |g| if (!globMatches(g, entry.path)) continue;
+        const data = root.readFileAlloc(common.defaultIo(), entry.path, allocator, .limited(1024 * 1024)) catch continue;
+        defer allocator.free(data);
+        if (common.isBinary(data)) continue;
+        var line_no: usize = 1;
+        var line_it = std.mem.splitScalar(u8, data, '\n');
+        while (line_it.next()) |line| {
+            if (regexLikeMatch(query, line)) {
+                try matches.append(allocator, .{ .path = try allocator.dupe(u8, entry.path), .line = line_no, .content = try allocator.dupe(u8, line) });
+                if (matches.items.len >= max) break;
+            }
+            line_no += 1;
+        }
+    }
+
+    std.mem.sort(Match, matches.items, {}, lessMatch);
+    var out = std.ArrayList(u8).empty;
+    errdefer out.deinit(allocator);
+    for (matches.items) |m| {
+        const line = try std.fmt.allocPrint(allocator, "{s}:{d}:{s}\n", .{ m.path, m.line, m.content });
+        defer allocator.free(line);
+        try out.appendSlice(allocator, line);
+    }
+    const text = try out.toOwnedSlice(allocator);
+    errdefer allocator.free(text);
+    const details = try common.jsonString(allocator, .{ .ok = true, .query = query, .duration_ms = common.durationMs(start_ms), .raw_bytes = text.len, .returned_bytes = text.len, .match_count = matches.items.len });
+    errdefer allocator.free(details);
+    return common.makeTextResultOwned(allocator, text, details);
+}
+
+fn lessMatch(_: void, a: Match, b: Match) bool {
+    const order = std.mem.order(u8, a.path, b.path);
+    if (order != .eq) return order == .lt;
+    return a.line < b.line;
+}
+
+fn regexLikeMatch(pattern: []const u8, text: []const u8) bool {
+    // Minimal regex surface for local TUI search bootstrap: literal substring,
+    // `.` wildcard, and `.*` gaps. Full indexing/regex engine belongs later.
+    return matchFrom(pattern, text) or blk: {
+        for (text, 0..) |_, i| if (matchFrom(pattern, text[i..])) break :blk true;
+        break :blk false;
+    };
+}
+
+fn matchFrom(pattern: []const u8, text: []const u8) bool {
+    if (pattern.len == 0) return true;
+    if (std.mem.startsWith(u8, pattern, ".*")) {
+        if (matchFrom(pattern[2..], text)) return true;
+        return text.len > 0 and matchFrom(pattern, text[1..]);
+    }
+    if (text.len == 0) return false;
+    if (pattern[0] == '.' or pattern[0] == text[0]) return matchFrom(pattern[1..], text[1..]);
+    return false;
+}
+
+fn globMatches(pattern: []const u8, path: []const u8) bool {
+    if (pattern.len == 0 or std.mem.eql(u8, pattern, "**/*")) return true;
+    var cleaned = pattern;
+    if (std.mem.startsWith(u8, cleaned, "**/")) cleaned = cleaned[3..];
+    if (std.mem.startsWith(u8, cleaned, "*")) cleaned = cleaned[1..];
+    if (std.mem.endsWith(u8, cleaned, "*")) cleaned = cleaned[0 .. cleaned.len - 1];
+    return std.mem.indexOf(u8, path, cleaned) != null;
+}
+
+test "search regex returns file line content and empty results" {
+    var tmp = std.testing.tmpDir(.{ .iterate = true });
+    defer tmp.cleanup();
+    const cwd = try std.process.currentPathAlloc(common.defaultIo(), std.testing.allocator);
+    defer std.testing.allocator.free(cwd);
+    const root = try std.Io.Dir.path.join(std.testing.allocator, &.{ cwd, ".zig-cache", "tmp", tmp.sub_path[0..] });
+    defer std.testing.allocator.free(root);
+    try tmp.dir.writeFile(common.defaultIo(), .{ .sub_path = "a.zig", .data = "const needle = 1;\n" });
+    try tmp.dir.writeFile(common.defaultIo(), .{ .sub_path = "b.txt", .data = "nothing\n" });
+    const args = try std.fmt.allocPrint(std.testing.allocator, "{{\"workspace_root\":\"{s}\",\"query\":\"needle\",\"glob\":\"*.zig\"}}", .{root});
+    defer std.testing.allocator.free(args);
+    var result = try regexExecute("call", args, null, null, null, std.testing.allocator);
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expectEqualStrings("a.zig:1:const needle = 1;\n", result.content.slice()[0].text.text);
+    const empty_args = try std.fmt.allocPrint(std.testing.allocator, "{{\"workspace_root\":\"{s}\",\"query\":\"absent\"}}", .{root});
+    defer std.testing.allocator.free(empty_args);
+    var empty = try regexExecute("call", empty_args, null, null, null, std.testing.allocator);
+    defer empty.deinit(std.testing.allocator);
+    try std.testing.expectEqualStrings("", empty.content.slice()[0].text.text);
+}

--- a/zig/src/tools/search.zig
+++ b/zig/src/tools/search.zig
@@ -31,6 +31,9 @@ pub fn textExecute(tool_call_id: []const u8, args_json: []const u8, cancel_token
     defer walker.deinit();
 
     var matches = std.ArrayList(Match).empty;
+    var scanned_files: usize = 0;
+    var skipped_oversized_files: usize = 0;
+    var skipped_read_error_files: usize = 0;
     defer {
         for (matches.items) |m| {
             allocator.free(m.path);
@@ -44,7 +47,19 @@ pub fn textExecute(tool_call_id: []const u8, args_json: []const u8, cancel_token
         if (matches.items.len >= max) break;
         if (entry.kind != .file) continue;
         if (glob) |g| if (!globMatches(g, entry.path)) continue;
-        const data = root.readFileAlloc(common.defaultIo(), entry.path, allocator, .limited(1024 * 1024)) catch continue;
+        scanned_files += 1;
+        const st = root.statFile(common.defaultIo(), entry.path, .{ .follow_symlinks = false }) catch {
+            skipped_read_error_files += 1;
+            continue;
+        };
+        if (st.size >= 1024 * 1024) {
+            skipped_oversized_files += 1;
+            continue;
+        }
+        const data = root.readFileAlloc(common.defaultIo(), entry.path, allocator, .limited(1024 * 1024)) catch {
+            skipped_read_error_files += 1;
+            continue;
+        };
         defer allocator.free(data);
         if (common.isBinary(data)) continue;
         var line_no: usize = 1;
@@ -69,7 +84,7 @@ pub fn textExecute(tool_call_id: []const u8, args_json: []const u8, cancel_token
     }
     const text = try out.toOwnedSlice(allocator);
     errdefer allocator.free(text);
-    const details = try common.jsonString(allocator, .{ .ok = true, .query = query, .duration_ms = common.durationMs(start_ms), .raw_bytes = text.len, .returned_bytes = text.len, .match_count = matches.items.len });
+    const details = try common.jsonString(allocator, .{ .ok = true, .query = query, .duration_ms = common.durationMs(start_ms), .raw_bytes = text.len, .returned_bytes = text.len, .match_count = matches.items.len, .scanned_files = scanned_files, .skipped_oversized_files = skipped_oversized_files, .skipped_read_error_files = skipped_read_error_files });
     errdefer allocator.free(details);
     return common.makeTextResultOwned(allocator, text, details);
 }
@@ -154,6 +169,7 @@ test "search text returns file line content and empty results" {
     var long = try textExecute("call", long_args, null, null, null, std.testing.allocator);
     defer long.deinit(std.testing.allocator);
     try std.testing.expectEqualStrings("", long.content.slice()[0].text.text);
+    try std.testing.expect(std.mem.indexOf(u8, long.getDetailsJson().?, "\"skipped_oversized_files\":1") != null);
     var cancelled = std.atomic.Value(bool).init(true);
     const token = ai_types.CancelToken{ .cancelled = &cancelled };
     try std.testing.expectError(error.Cancelled, textExecute("call", long_args, token, null, null, std.testing.allocator));

--- a/zig/src/tools/search.zig
+++ b/zig/src/tools/search.zig
@@ -81,21 +81,38 @@ fn lessMatch(_: void, a: Match, b: Match) bool {
 fn regexLikeMatch(pattern: []const u8, text: []const u8) bool {
     // Minimal regex surface for local TUI search bootstrap: literal substring,
     // `.` wildcard, and `.*` gaps. Full indexing/regex engine belongs later.
-    return matchFrom(pattern, text) or blk: {
-        for (text, 0..) |_, i| if (matchFrom(pattern, text[i..])) break :blk true;
-        break :blk false;
-    };
+    var start: usize = 0;
+    while (start <= text.len) : (start += 1) {
+        if (matchFromIterative(pattern, text[start..])) return true;
+        if (start == text.len) break;
+    }
+    return false;
 }
 
-fn matchFrom(pattern: []const u8, text: []const u8) bool {
-    if (pattern.len == 0) return true;
-    if (std.mem.startsWith(u8, pattern, ".*")) {
-        if (matchFrom(pattern[2..], text)) return true;
-        return text.len > 0 and matchFrom(pattern, text[1..]);
+fn matchFromIterative(pattern: []const u8, text: []const u8) bool {
+    var pattern_index: usize = 0;
+    var text_index: usize = 0;
+    var star_pattern_index: ?usize = null;
+    var star_text_index: usize = 0;
+
+    while (text_index < text.len) {
+        if (pattern_index == pattern.len) return true;
+        if (pattern_index + 1 < pattern.len and pattern[pattern_index] == '.' and pattern[pattern_index + 1] == '*') {
+            star_pattern_index = pattern_index;
+            pattern_index += 2;
+            star_text_index = text_index;
+        } else if (pattern_index < pattern.len and (pattern[pattern_index] == '.' or pattern[pattern_index] == text[text_index])) {
+            pattern_index += 1;
+            text_index += 1;
+        } else if (star_pattern_index) |star| {
+            pattern_index = star + 2;
+            star_text_index += 1;
+            text_index = star_text_index;
+        } else return false;
     }
-    if (text.len == 0) return false;
-    if (pattern[0] == '.' or pattern[0] == text[0]) return matchFrom(pattern[1..], text[1..]);
-    return false;
+
+    while (pattern_index + 1 < pattern.len and pattern[pattern_index] == '.' and pattern[pattern_index + 1] == '*') pattern_index += 2;
+    return pattern_index == pattern.len;
 }
 
 fn globMatches(pattern: []const u8, path: []const u8) bool {
@@ -126,4 +143,13 @@ test "search regex returns file line content and empty results" {
     var empty = try regexExecute("call", empty_args, null, null, null, std.testing.allocator);
     defer empty.deinit(std.testing.allocator);
     try std.testing.expectEqualStrings("", empty.content.slice()[0].text.text);
+    const long_line = try std.testing.allocator.alloc(u8, 1024 * 1024);
+    defer std.testing.allocator.free(long_line);
+    @memset(long_line, 'a');
+    try tmp.dir.writeFile(common.defaultIo(), .{ .sub_path = "long.txt", .data = long_line });
+    const long_args = try std.fmt.allocPrint(std.testing.allocator, "{{\"workspace_root\":\"{s}\",\"query\":\".*z\",\"glob\":\"*.txt\"}}", .{root});
+    defer std.testing.allocator.free(long_args);
+    var long = try regexExecute("call", long_args, null, null, null, std.testing.allocator);
+    defer long.deinit(std.testing.allocator);
+    try std.testing.expectEqualStrings("", long.content.slice()[0].text.text);
 }

--- a/zig/src/tools/shell.zig
+++ b/zig/src/tools/shell.zig
@@ -1,0 +1,113 @@
+const std = @import("std");
+const ai_types = @import("ai_types");
+const agent = @import("agent");
+const common = @import("tools/common");
+
+pub const schema_execute =
+    \\{"type":"object","properties":{"workspace_root":{"type":"string"},"command":{"type":"string"},"timeout_ms":{"type":"integer","minimum":1}},"required":["workspace_root","command"],"additionalProperties":false}
+;
+
+pub const execute_tool = agent.AgentTool{
+    .label = "Shell Execute",
+    .name = "shell_execute",
+    .description = "Run a shell command in the workspace and return stdout, stderr, exit status, duration, and byte counts.",
+    .parameters_schema_json = schema_execute,
+    .execute = execute,
+};
+
+pub fn execute(
+    tool_call_id: []const u8,
+    args_json: []const u8,
+    cancel_token: ?ai_types.CancelToken,
+    on_update_ctx: ?*anyopaque,
+    on_update: ?agent.ToolUpdateCallback,
+    allocator: std.mem.Allocator,
+) anyerror!agent.AgentToolResult {
+    _ = tool_call_id;
+    _ = on_update_ctx;
+    _ = on_update;
+    if (common.isCancelled(cancel_token)) return error.Cancelled;
+
+    const start_ms = common.nowMs();
+    var parsed = try common.parseArgs(allocator, args_json);
+    defer parsed.deinit();
+    const obj = parsed.value.object;
+    const workspace_root = try common.requiredString(obj, "workspace_root");
+    const command = try common.requiredString(obj, "command");
+    const timeout_ms = common.optionalU64(obj, "timeout_ms", 30_000);
+
+    var dir = try common.openWorkspace(workspace_root, false);
+    defer dir.close(common.defaultIo());
+
+    const argv = [_][]const u8{ "/bin/sh", "-c", command };
+    const result = std.process.run(allocator, common.defaultIo(), .{
+        .argv = &argv,
+        .cwd = .{ .dir = dir },
+        .timeout = .{ .duration = .{ .raw = .fromMilliseconds(@intCast(timeout_ms)), .clock = .boot } },
+    }) catch |err| {
+        const duration_ms = common.durationMs(start_ms);
+        const details = try common.jsonString(allocator, .{
+            .ok = false,
+            .err = @errorName(err),
+            .duration_ms = duration_ms,
+            .stdout_bytes = 0,
+            .stderr_bytes = 0,
+            .raw_bytes = 0,
+        });
+        errdefer allocator.free(details);
+        const text = try std.fmt.allocPrint(allocator, "shell command failed: {s}", .{@errorName(err)});
+        return common.makeTextResultOwned(allocator, text, details);
+    };
+    defer allocator.free(result.stdout);
+    defer allocator.free(result.stderr);
+
+    const exit_code: ?u8 = switch (result.term) {
+        .exited => |code| code,
+        else => null,
+    };
+    const signal: ?u32 = switch (result.term) {
+        .signal => |sig| @intFromEnum(sig),
+        else => null,
+    };
+    const duration_ms = common.durationMs(start_ms);
+    const raw_bytes = result.stdout.len + result.stderr.len;
+    const details = try common.jsonString(allocator, .{
+        .ok = exit_code == 0,
+        .exit_code = exit_code,
+        .signal = signal,
+        .duration_ms = duration_ms,
+        .stdout_bytes = result.stdout.len,
+        .stderr_bytes = result.stderr.len,
+        .raw_bytes = raw_bytes,
+    });
+    errdefer allocator.free(details);
+
+    const text = try std.fmt.allocPrint(allocator,
+        \\stdout:
+        \\{s}
+        \\stderr:
+        \\{s}
+    , .{ result.stdout, result.stderr });
+    return common.makeTextResultOwned(allocator, text, details);
+}
+
+test "shell execute captures stdout" {
+    const cwd = try std.process.currentPathAlloc(common.defaultIo(), std.testing.allocator);
+    defer std.testing.allocator.free(cwd);
+    const args = try std.fmt.allocPrint(std.testing.allocator, "{{\"workspace_root\":\"{s}\",\"command\":\"echo hello\"}}", .{cwd});
+    defer std.testing.allocator.free(args);
+    var result = try execute("call", args, null, null, null, std.testing.allocator);
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(std.mem.indexOf(u8, result.content.slice()[0].text.text, "hello") != null);
+    try std.testing.expect(result.getDetailsJson().?.len > 0);
+}
+
+test "shell execute reports timeout" {
+    const cwd = try std.process.currentPathAlloc(common.defaultIo(), std.testing.allocator);
+    defer std.testing.allocator.free(cwd);
+    const args = try std.fmt.allocPrint(std.testing.allocator, "{{\"workspace_root\":\"{s}\",\"command\":\"sleep 1\",\"timeout_ms\":1}}", .{cwd});
+    defer std.testing.allocator.free(args);
+    var result = try execute("call", args, null, null, null, std.testing.allocator);
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(std.mem.indexOf(u8, result.getDetailsJson().?, "Timeout") != null);
+}

--- a/zig/src/tools/shell.zig
+++ b/zig/src/tools/shell.zig
@@ -39,7 +39,10 @@ pub fn execute(
     var dir = try common.openWorkspace(workspace_root, false);
     defer dir.close(common.defaultIo());
 
-    const argv = [_][]const u8{ "/bin/sh", "-c", command };
+    const argv = if (@import("builtin").os.tag == .windows)
+        [_][]const u8{ "cmd.exe", "/C", command }
+    else
+        [_][]const u8{ "/bin/sh", "-c", command };
     const result = std.process.run(allocator, common.defaultIo(), .{
         .argv = &argv,
         .cwd = .{ .dir = dir },

--- a/zig/src/tools/shell.zig
+++ b/zig/src/tools/shell.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const ai_types = @import("ai_types");
 const agent = @import("agent");
 const common = @import("tools/common");
+const process_runner = @import("tools/process_runner");
 
 pub const schema_execute =
     \\{"type":"object","properties":{"workspace_root":{"type":"string"},"command":{"type":"string"},"timeout_ms":{"type":"integer","minimum":1}},"required":["workspace_root","command"],"additionalProperties":false}
@@ -43,11 +44,7 @@ pub fn execute(
         [_][]const u8{ "cmd.exe", "/C", command }
     else
         [_][]const u8{ "/bin/sh", "-c", command };
-    const result = std.process.run(allocator, common.defaultIo(), .{
-        .argv = &argv,
-        .cwd = .{ .dir = dir },
-        .timeout = .{ .duration = .{ .raw = .fromMilliseconds(@intCast(timeout_ms)), .clock = .boot } },
-    }) catch |err| {
+    const result = process_runner.run(allocator, &argv, .{ .dir = dir }, timeout_ms, cancel_token) catch |err| {
         const duration_ms = common.durationMs(start_ms);
         const details = try common.jsonString(allocator, .{
             .ok = false,

--- a/zig/src/tools/shell.zig
+++ b/zig/src/tools/shell.zig
@@ -5,13 +5,14 @@ const common = @import("tools/common");
 const process_runner = @import("tools/process_runner");
 
 pub const schema_execute =
-    \\{"type":"object","properties":{"workspace_root":{"type":"string"},"command":{"type":"string"},"timeout_ms":{"type":"integer","minimum":1}},"required":["workspace_root","command"],"additionalProperties":false}
+    \\{"type":"object","properties":{"workspace_root":{"type":"string"},"command":{"type":"string"},"timeout_ms":{"type":"integer","minimum":1},"compact_output":{"type":"boolean"}},"required":["workspace_root","command"],"additionalProperties":false}
 ;
 
 pub const execute_tool = agent.AgentTool{
     .label = "Shell Execute",
     .name = "shell_execute",
-    .description = "Run a shell command in the workspace and return stdout, stderr, exit status, duration, and byte counts.",
+    .description = "Run a shell command in the workspace and return stdout, stderr, exit status, duration, and byte counts. Large output is stored as a retrievable artifact.",
+    .short_description = "Run shell command; large output becomes artifact.",
     .parameters_schema_json = schema_execute,
     .execute = execute,
 };
@@ -24,7 +25,6 @@ pub fn execute(
     on_update: ?agent.ToolUpdateCallback,
     allocator: std.mem.Allocator,
 ) anyerror!agent.AgentToolResult {
-    _ = tool_call_id;
     _ = on_update_ctx;
     _ = on_update;
     if (common.isCancelled(cancel_token)) return error.Cancelled;
@@ -35,6 +35,7 @@ pub fn execute(
     const obj = parsed.value.object;
     const workspace_root = try common.requiredString(obj, "workspace_root");
     const command = try common.requiredString(obj, "command");
+    const compact = common.optionalBool(obj, "compact_output", false);
     const timeout_ms = @min(common.optionalU64(obj, "timeout_ms", 30_000), @as(u64, std.math.maxInt(i64)));
 
     var dir = try common.openWorkspace(workspace_root, false);
@@ -72,6 +73,14 @@ pub fn execute(
     };
     const duration_ms = common.durationMs(start_ms);
     const raw_bytes = result.stdout.len + result.stderr.len;
+    if (compact and exit_code == 0) {
+        const text = try std.fmt.allocPrint(allocator, "ok stdout={d} stderr={d}", .{ result.stdout.len, result.stderr.len });
+        errdefer allocator.free(text);
+        const details = try common.jsonString(allocator, .{ .ok = true, .exit_code = exit_code, .signal = signal, .duration_ms = duration_ms, .stdout_bytes = result.stdout.len, .stderr_bytes = result.stderr.len, .raw_bytes = raw_bytes, .returned_bytes = text.len, .saved_bytes = raw_bytes -| text.len, .compressed = false });
+        errdefer allocator.free(details);
+        return common.makeTextResultOwned(allocator, text, details);
+    }
+
     const details = try common.jsonString(allocator, .{
         .ok = exit_code == 0,
         .exit_code = exit_code,
@@ -81,7 +90,7 @@ pub fn execute(
         .stderr_bytes = result.stderr.len,
         .raw_bytes = raw_bytes,
     });
-    errdefer allocator.free(details);
+    defer allocator.free(details);
 
     const text = try std.fmt.allocPrint(allocator,
         \\stdout:
@@ -89,7 +98,10 @@ pub fn execute(
         \\stderr:
         \\{s}
     , .{ result.stdout, result.stderr });
-    return common.makeTextResultOwned(allocator, text, details);
+    defer allocator.free(text);
+    const made = try common.makeTextResultWithArtifact(allocator, .{ .tool_name = "shell_execute", .call_id = tool_call_id, .text = text, .details_json = details });
+    defer if (made.artifact_path) |path| allocator.free(path);
+    return made.result;
 }
 
 test "shell execute captures stdout" {
@@ -101,6 +113,22 @@ test "shell execute captures stdout" {
     defer result.deinit(std.testing.allocator);
     try std.testing.expect(std.mem.indexOf(u8, result.content.slice()[0].text.text, "hello") != null);
     try std.testing.expect(result.getDetailsJson().?.len > 0);
+}
+
+test "shell execute stores large output as artifact and supports compact output" {
+    const cwd = try std.process.currentPathAlloc(common.defaultIo(), std.testing.allocator);
+    defer std.testing.allocator.free(cwd);
+    const large_args = try std.fmt.allocPrint(std.testing.allocator, "{{\"workspace_root\":\"{s}\",\"command\":\"python3 - <<'PY'\\nimport sys\\nsys.stdout.write('x' * 5000)\\nPY\"}}", .{cwd});
+    defer std.testing.allocator.free(large_args);
+    var large = try execute("call-large", large_args, null, null, null, std.testing.allocator);
+    defer large.deinit(std.testing.allocator);
+    try std.testing.expect(std.mem.indexOf(u8, large.content.slice()[0].text.text, "output stored as artifact") != null);
+    try std.testing.expect(std.mem.indexOf(u8, large.getDetailsJson().?, "\"compressed\":true") != null);
+    const compact_args = try std.fmt.allocPrint(std.testing.allocator, "{{\"workspace_root\":\"{s}\",\"command\":\"echo ok\",\"compact_output\":true}}", .{cwd});
+    defer std.testing.allocator.free(compact_args);
+    var compact = try execute("call-compact", compact_args, null, null, null, std.testing.allocator);
+    defer compact.deinit(std.testing.allocator);
+    try std.testing.expect(std.mem.startsWith(u8, compact.content.slice()[0].text.text, "ok stdout="));
 }
 
 test "shell execute reports timeout and clamps large timeout" {

--- a/zig/src/tools/shell.zig
+++ b/zig/src/tools/shell.zig
@@ -45,6 +45,7 @@ pub fn execute(
     else
         [_][]const u8{ "/bin/sh", "-c", command };
     const result = process_runner.run(allocator, &argv, .{ .dir = dir }, timeout_ms, cancel_token) catch |err| {
+        if (err == error.Cancelled) return err;
         const duration_ms = common.durationMs(start_ms);
         const details = try common.jsonString(allocator, .{
             .ok = false,

--- a/zig/src/tools/shell.zig
+++ b/zig/src/tools/shell.zig
@@ -34,7 +34,7 @@ pub fn execute(
     const obj = parsed.value.object;
     const workspace_root = try common.requiredString(obj, "workspace_root");
     const command = try common.requiredString(obj, "command");
-    const timeout_ms = common.optionalU64(obj, "timeout_ms", 30_000);
+    const timeout_ms = @min(common.optionalU64(obj, "timeout_ms", 30_000), @as(u64, std.math.maxInt(i64)));
 
     var dir = try common.openWorkspace(workspace_root, false);
     defer dir.close(common.defaultIo());
@@ -105,7 +105,7 @@ test "shell execute captures stdout" {
     try std.testing.expect(result.getDetailsJson().?.len > 0);
 }
 
-test "shell execute reports timeout" {
+test "shell execute reports timeout and clamps large timeout" {
     const cwd = try std.process.currentPathAlloc(common.defaultIo(), std.testing.allocator);
     defer std.testing.allocator.free(cwd);
     const args = try std.fmt.allocPrint(std.testing.allocator, "{{\"workspace_root\":\"{s}\",\"command\":\"sleep 1\",\"timeout_ms\":1}}", .{cwd});
@@ -113,4 +113,9 @@ test "shell execute reports timeout" {
     var result = try execute("call", args, null, null, null, std.testing.allocator);
     defer result.deinit(std.testing.allocator);
     try std.testing.expect(std.mem.indexOf(u8, result.getDetailsJson().?, "Timeout") != null);
+    const huge_args = try std.fmt.allocPrint(std.testing.allocator, "{{\"workspace_root\":\"{s}\",\"command\":\"echo ok\",\"timeout_ms\":\"18446744073709551615\"}}", .{cwd});
+    defer std.testing.allocator.free(huge_args);
+    var huge = try execute("call", huge_args, null, null, null, std.testing.allocator);
+    defer huge.deinit(std.testing.allocator);
+    try std.testing.expect(std.mem.indexOf(u8, huge.content.slice()[0].text.text, "ok") != null);
 }

--- a/zig/src/tools/workspace.zig
+++ b/zig/src/tools/workspace.zig
@@ -91,6 +91,7 @@ pub fn gitStatusExecute(tool_call_id: []const u8, args_json: []const u8, cancel_
     defer dir.close(common.defaultIo());
     const argv = [_][]const u8{ "git", "status", "--short" };
     const result = process_runner.run(allocator, &argv, .{ .dir = dir }, timeout_ms, cancel_token) catch |err| {
+        if (err == error.Cancelled) return err;
         const details = try common.jsonString(allocator, .{ .ok = false, .err = @errorName(err), .duration_ms = common.durationMs(start_ms), .raw_bytes = 0 });
         errdefer allocator.free(details);
         const text = try std.fmt.allocPrint(allocator, "git status failed: {s}", .{@errorName(err)});

--- a/zig/src/tools/workspace.zig
+++ b/zig/src/tools/workspace.zig
@@ -9,7 +9,9 @@ pub const schema_info =
 pub const schema_list =
     \\{"type":"object","properties":{"workspace_root":{"type":"string"},"max_results":{"type":"integer","minimum":0}},"required":["workspace_root"],"additionalProperties":false}
 ;
-pub const schema_git_status = schema_info;
+pub const schema_git_status =
+    \\{"type":"object","properties":{"workspace_root":{"type":"string"},"timeout_ms":{"type":"integer","minimum":1}},"required":["workspace_root"],"additionalProperties":false}
+;
 
 pub const info_tool = agent.AgentTool{ .label = "Workspace Info", .name = "workspace_info", .description = "Return workspace root metadata and detected project root.", .parameters_schema_json = schema_info, .execute = infoExecute };
 pub const list_tool = agent.AgentTool{ .label = "Workspace List", .name = "workspace_list", .description = "List files under workspace root.", .parameters_schema_json = schema_list, .execute = listExecute };
@@ -81,11 +83,13 @@ pub fn gitStatusExecute(tool_call_id: []const u8, args_json: []const u8, cancel_
     const start_ms = common.nowMs();
     var parsed = try common.parseArgs(allocator, args_json);
     defer parsed.deinit();
-    const workspace_root = try common.requiredString(parsed.value.object, "workspace_root");
+    const obj = parsed.value.object;
+    const workspace_root = try common.requiredString(obj, "workspace_root");
+    const timeout_ms = @min(common.optionalU64(obj, "timeout_ms", 30_000), @as(u64, std.math.maxInt(i64)));
     var dir = try common.openWorkspace(workspace_root, false);
     defer dir.close(common.defaultIo());
     const argv = [_][]const u8{ "git", "status", "--short" };
-    const result = std.process.run(allocator, common.defaultIo(), .{ .argv = &argv, .cwd = .{ .dir = dir }, .timeout = .{ .duration = .{ .raw = .fromMilliseconds(5000), .clock = .boot } } }) catch |err| {
+    const result = std.process.run(allocator, common.defaultIo(), .{ .argv = &argv, .cwd = .{ .dir = dir }, .timeout = .{ .duration = .{ .raw = .fromMilliseconds(@intCast(timeout_ms)), .clock = .boot } } }) catch |err| {
         const details = try common.jsonString(allocator, .{ .ok = false, .err = @errorName(err), .duration_ms = common.durationMs(start_ms), .raw_bytes = 0 });
         errdefer allocator.free(details);
         const text = try std.fmt.allocPrint(allocator, "git status failed: {s}", .{@errorName(err)});

--- a/zig/src/tools/workspace.zig
+++ b/zig/src/tools/workspace.zig
@@ -14,9 +14,9 @@ pub const schema_git_status =
     \\{"type":"object","properties":{"workspace_root":{"type":"string"},"timeout_ms":{"type":"integer","minimum":1}},"required":["workspace_root"],"additionalProperties":false}
 ;
 
-pub const info_tool = agent.AgentTool{ .label = "Workspace Info", .name = "workspace_info", .description = "Return workspace root metadata and detected project root.", .parameters_schema_json = schema_info, .execute = infoExecute };
-pub const list_tool = agent.AgentTool{ .label = "Workspace List", .name = "workspace_list", .description = "List files under workspace root.", .parameters_schema_json = schema_list, .execute = listExecute };
-pub const git_status_tool = agent.AgentTool{ .label = "Git Status", .name = "workspace_git_status", .description = "Return git status for workspace root.", .parameters_schema_json = schema_git_status, .execute = gitStatusExecute };
+pub const info_tool = agent.AgentTool{ .label = "Workspace Info", .name = "workspace_info", .description = "Return workspace root metadata and detected project root.", .short_description = "Show workspace path info.", .parameters_schema_json = schema_info, .execute = infoExecute };
+pub const list_tool = agent.AgentTool{ .label = "Workspace List", .name = "workspace_list", .description = "List files under workspace root.", .short_description = "List workspace files.", .parameters_schema_json = schema_list, .execute = listExecute };
+pub const git_status_tool = agent.AgentTool{ .label = "Git Status", .name = "workspace_git_status", .description = "Return git status for workspace root.", .short_description = "Show git status.", .parameters_schema_json = schema_git_status, .execute = gitStatusExecute };
 
 pub fn infoExecute(tool_call_id: []const u8, args_json: []const u8, cancel_token: ?ai_types.CancelToken, on_update_ctx: ?*anyopaque, on_update: ?agent.ToolUpdateCallback, allocator: std.mem.Allocator) anyerror!agent.AgentToolResult {
     _ = tool_call_id;

--- a/zig/src/tools/workspace.zig
+++ b/zig/src/tools/workspace.zig
@@ -81,8 +81,10 @@ pub fn gitStatusExecute(tool_call_id: []const u8, args_json: []const u8, cancel_
     var parsed = try common.parseArgs(allocator, args_json);
     defer parsed.deinit();
     const workspace_root = try common.requiredString(parsed.value.object, "workspace_root");
+    var dir = try common.openWorkspace(workspace_root, false);
+    defer dir.close(common.defaultIo());
     const argv = [_][]const u8{ "git", "status", "--short" };
-    const result = std.process.run(allocator, common.defaultIo(), .{ .argv = &argv, .cwd = .{ .path = workspace_root }, .timeout = .{ .duration = .{ .raw = .fromMilliseconds(5000), .clock = .boot } } }) catch |err| {
+    const result = std.process.run(allocator, common.defaultIo(), .{ .argv = &argv, .cwd = .{ .dir = dir }, .timeout = .{ .duration = .{ .raw = .fromMilliseconds(5000), .clock = .boot } } }) catch |err| {
         const details = try common.jsonString(allocator, .{ .ok = false, .err = @errorName(err), .duration_ms = common.durationMs(start_ms), .raw_bytes = 0 });
         errdefer allocator.free(details);
         const text = try std.fmt.allocPrint(allocator, "git status failed: {s}", .{@errorName(err)});
@@ -108,15 +110,18 @@ fn detectProjectRoot(allocator: std.mem.Allocator, workspace_root: []const u8) !
         const git_path = try std.Io.Dir.path.join(allocator, &.{ current, ".git" });
         defer allocator.free(git_path);
         std.Io.Dir.cwd().access(common.defaultIo(), git_path, .{}) catch |err| switch (err) {
-            error.FileNotFound => {},
+            error.FileNotFound => {
+                if (std.Io.Dir.path.dirname(current)) |parent| {
+                    if (std.mem.eql(u8, parent, current)) return current;
+                    const next = try allocator.dupe(u8, parent);
+                    allocator.free(current);
+                    current = next;
+                    continue;
+                } else return current;
+            },
             else => return current,
         };
-        if (std.Io.Dir.path.dirname(current)) |parent| {
-            if (std.mem.eql(u8, parent, current)) return current;
-            const next = try allocator.dupe(u8, parent);
-            allocator.free(current);
-            current = next;
-        } else return current;
+        return current;
     }
 }
 
@@ -133,7 +138,7 @@ test "workspace info list and git status" {
     defer std.testing.allocator.free(args);
     var info = try infoExecute("call", args, null, null, null, std.testing.allocator);
     defer info.deinit(std.testing.allocator);
-    try std.testing.expect(std.mem.indexOf(u8, info.content.slice()[0].text.text, "project_root") != null);
+    try std.testing.expect(std.mem.indexOf(u8, info.content.slice()[0].text.text, root) != null);
     var list = try listExecute("call", args, null, null, null, std.testing.allocator);
     defer list.deinit(std.testing.allocator);
     try std.testing.expect(std.mem.indexOf(u8, list.content.slice()[0].text.text, "a.txt") != null);

--- a/zig/src/tools/workspace.zig
+++ b/zig/src/tools/workspace.zig
@@ -1,0 +1,143 @@
+const std = @import("std");
+const ai_types = @import("ai_types");
+const agent = @import("agent");
+const common = @import("tools/common");
+
+pub const schema_info =
+    \\{"type":"object","properties":{"workspace_root":{"type":"string"}},"required":["workspace_root"],"additionalProperties":false}
+;
+pub const schema_list =
+    \\{"type":"object","properties":{"workspace_root":{"type":"string"},"max_results":{"type":"integer","minimum":0}},"required":["workspace_root"],"additionalProperties":false}
+;
+pub const schema_git_status = schema_info;
+
+pub const info_tool = agent.AgentTool{ .label = "Workspace Info", .name = "workspace_info", .description = "Return workspace root metadata and detected project root.", .parameters_schema_json = schema_info, .execute = infoExecute };
+pub const list_tool = agent.AgentTool{ .label = "Workspace List", .name = "workspace_list", .description = "List files under workspace root.", .parameters_schema_json = schema_list, .execute = listExecute };
+pub const git_status_tool = agent.AgentTool{ .label = "Git Status", .name = "workspace_git_status", .description = "Return git status for workspace root.", .parameters_schema_json = schema_git_status, .execute = gitStatusExecute };
+
+pub fn infoExecute(tool_call_id: []const u8, args_json: []const u8, cancel_token: ?ai_types.CancelToken, on_update_ctx: ?*anyopaque, on_update: ?agent.ToolUpdateCallback, allocator: std.mem.Allocator) anyerror!agent.AgentToolResult {
+    _ = tool_call_id;
+    _ = on_update_ctx;
+    _ = on_update;
+    if (common.isCancelled(cancel_token)) return error.Cancelled;
+    const start_ms = common.nowMs();
+    var parsed = try common.parseArgs(allocator, args_json);
+    defer parsed.deinit();
+    const workspace_root = try common.requiredString(parsed.value.object, "workspace_root");
+    var dir = try common.openWorkspace(workspace_root, false);
+    defer dir.close(common.defaultIo());
+    const project_root = try detectProjectRoot(allocator, workspace_root);
+    defer allocator.free(project_root);
+    const details = try common.jsonString(allocator, .{ .ok = true, .workspace_root = workspace_root, .project_root = project_root, .duration_ms = common.durationMs(start_ms), .raw_bytes = 0 });
+    errdefer allocator.free(details);
+    const text = try std.fmt.allocPrint(allocator, "workspace_root: {s}\nproject_root: {s}", .{ workspace_root, project_root });
+    return common.makeTextResultOwned(allocator, text, details);
+}
+
+pub fn listExecute(tool_call_id: []const u8, args_json: []const u8, cancel_token: ?ai_types.CancelToken, on_update_ctx: ?*anyopaque, on_update: ?agent.ToolUpdateCallback, allocator: std.mem.Allocator) anyerror!agent.AgentToolResult {
+    _ = tool_call_id;
+    _ = on_update_ctx;
+    _ = on_update;
+    if (common.isCancelled(cancel_token)) return error.Cancelled;
+    const start_ms = common.nowMs();
+    var parsed = try common.parseArgs(allocator, args_json);
+    defer parsed.deinit();
+    const obj = parsed.value.object;
+    const workspace_root = try common.requiredString(obj, "workspace_root");
+    const max = @min(common.optionalUsize(obj, "max_results", 200), 1000);
+    var root = try common.openWorkspace(workspace_root, true);
+    defer root.close(common.defaultIo());
+    var walker = try root.walk(allocator);
+    defer walker.deinit();
+    var paths = std.ArrayList([]u8).empty;
+    defer {
+        for (paths.items) |p| allocator.free(p);
+        paths.deinit(allocator);
+    }
+    while (try walker.next(common.defaultIo())) |entry| {
+        if (paths.items.len >= max) break;
+        if (entry.kind == .file) try paths.append(allocator, try allocator.dupe(u8, entry.path));
+    }
+    std.mem.sort([]u8, paths.items, {}, lessPath);
+    var out = std.ArrayList(u8).empty;
+    errdefer out.deinit(allocator);
+    for (paths.items) |p| {
+        try out.appendSlice(allocator, p);
+        try out.append(allocator, '\n');
+    }
+    const text = try out.toOwnedSlice(allocator);
+    errdefer allocator.free(text);
+    const details = try common.jsonString(allocator, .{ .ok = true, .duration_ms = common.durationMs(start_ms), .raw_bytes = text.len, .returned_bytes = text.len, .file_count = paths.items.len });
+    errdefer allocator.free(details);
+    return common.makeTextResultOwned(allocator, text, details);
+}
+
+pub fn gitStatusExecute(tool_call_id: []const u8, args_json: []const u8, cancel_token: ?ai_types.CancelToken, on_update_ctx: ?*anyopaque, on_update: ?agent.ToolUpdateCallback, allocator: std.mem.Allocator) anyerror!agent.AgentToolResult {
+    _ = tool_call_id;
+    _ = on_update_ctx;
+    _ = on_update;
+    if (common.isCancelled(cancel_token)) return error.Cancelled;
+    const start_ms = common.nowMs();
+    var parsed = try common.parseArgs(allocator, args_json);
+    defer parsed.deinit();
+    const workspace_root = try common.requiredString(parsed.value.object, "workspace_root");
+    const argv = [_][]const u8{ "git", "status", "--short" };
+    const result = std.process.run(allocator, common.defaultIo(), .{ .argv = &argv, .cwd = .{ .path = workspace_root }, .timeout = .{ .duration = .{ .raw = .fromMilliseconds(5000), .clock = .boot } } }) catch |err| {
+        const details = try common.jsonString(allocator, .{ .ok = false, .err = @errorName(err), .duration_ms = common.durationMs(start_ms), .raw_bytes = 0 });
+        errdefer allocator.free(details);
+        const text = try std.fmt.allocPrint(allocator, "git status failed: {s}", .{@errorName(err)});
+        return common.makeTextResultOwned(allocator, text, details);
+    };
+    defer allocator.free(result.stdout);
+    defer allocator.free(result.stderr);
+    const text = try std.fmt.allocPrint(allocator, "{s}{s}", .{ result.stdout, result.stderr });
+    errdefer allocator.free(text);
+    const details = try common.jsonString(allocator, .{ .ok = result.term == .exited and result.term.exited == 0, .duration_ms = common.durationMs(start_ms), .raw_bytes = text.len, .returned_bytes = text.len });
+    errdefer allocator.free(details);
+    return common.makeTextResultOwned(allocator, text, details);
+}
+
+fn lessPath(_: void, a: []u8, b: []u8) bool {
+    return std.mem.order(u8, a, b) == .lt;
+}
+
+fn detectProjectRoot(allocator: std.mem.Allocator, workspace_root: []const u8) ![]u8 {
+    var current = try allocator.dupe(u8, workspace_root);
+    errdefer allocator.free(current);
+    while (true) {
+        const git_path = try std.Io.Dir.path.join(allocator, &.{ current, ".git" });
+        defer allocator.free(git_path);
+        std.Io.Dir.cwd().access(common.defaultIo(), git_path, .{}) catch |err| switch (err) {
+            error.FileNotFound => {},
+            else => return current,
+        };
+        if (std.Io.Dir.path.dirname(current)) |parent| {
+            if (std.mem.eql(u8, parent, current)) return current;
+            const next = try allocator.dupe(u8, parent);
+            allocator.free(current);
+            current = next;
+        } else return current;
+    }
+}
+
+test "workspace info list and git status" {
+    var tmp = std.testing.tmpDir(.{ .iterate = true });
+    defer tmp.cleanup();
+    const cwd = try std.process.currentPathAlloc(common.defaultIo(), std.testing.allocator);
+    defer std.testing.allocator.free(cwd);
+    const root = try std.Io.Dir.path.join(std.testing.allocator, &.{ cwd, ".zig-cache", "tmp", tmp.sub_path[0..] });
+    defer std.testing.allocator.free(root);
+    try tmp.dir.createDir(common.defaultIo(), ".git", .default_dir);
+    try tmp.dir.writeFile(common.defaultIo(), .{ .sub_path = "a.txt", .data = "x" });
+    const args = try std.fmt.allocPrint(std.testing.allocator, "{{\"workspace_root\":\"{s}\"}}", .{root});
+    defer std.testing.allocator.free(args);
+    var info = try infoExecute("call", args, null, null, null, std.testing.allocator);
+    defer info.deinit(std.testing.allocator);
+    try std.testing.expect(std.mem.indexOf(u8, info.content.slice()[0].text.text, "project_root") != null);
+    var list = try listExecute("call", args, null, null, null, std.testing.allocator);
+    defer list.deinit(std.testing.allocator);
+    try std.testing.expect(std.mem.indexOf(u8, list.content.slice()[0].text.text, "a.txt") != null);
+    var status = try gitStatusExecute("call", args, null, null, null, std.testing.allocator);
+    defer status.deinit(std.testing.allocator);
+    try std.testing.expect(status.getDetailsJson().?.len > 0);
+}

--- a/zig/src/tools/workspace.zig
+++ b/zig/src/tools/workspace.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const ai_types = @import("ai_types");
 const agent = @import("agent");
 const common = @import("tools/common");
+const process_runner = @import("tools/process_runner");
 
 pub const schema_info =
     \\{"type":"object","properties":{"workspace_root":{"type":"string"}},"required":["workspace_root"],"additionalProperties":false}
@@ -89,7 +90,7 @@ pub fn gitStatusExecute(tool_call_id: []const u8, args_json: []const u8, cancel_
     var dir = try common.openWorkspace(workspace_root, false);
     defer dir.close(common.defaultIo());
     const argv = [_][]const u8{ "git", "status", "--short" };
-    const result = std.process.run(allocator, common.defaultIo(), .{ .argv = &argv, .cwd = .{ .dir = dir }, .timeout = .{ .duration = .{ .raw = .fromMilliseconds(@intCast(timeout_ms)), .clock = .boot } } }) catch |err| {
+    const result = process_runner.run(allocator, &argv, .{ .dir = dir }, timeout_ms, cancel_token) catch |err| {
         const details = try common.jsonString(allocator, .{ .ok = false, .err = @errorName(err), .duration_ms = common.durationMs(start_ms), .raw_bytes = 0 });
         errdefer allocator.free(details);
         const text = try std.fmt.allocPrint(allocator, "git status failed: {s}", .{@errorName(err)});

--- a/zig/src/tools/workspace.zig
+++ b/zig/src/tools/workspace.zig
@@ -55,6 +55,7 @@ pub fn listExecute(tool_call_id: []const u8, args_json: []const u8, cancel_token
         paths.deinit(allocator);
     }
     while (try walker.next(common.defaultIo())) |entry| {
+        if (common.isCancelled(cancel_token)) return error.Cancelled;
         if (paths.items.len >= max) break;
         if (entry.kind == .file) try paths.append(allocator, try allocator.dupe(u8, entry.path));
     }
@@ -142,6 +143,9 @@ test "workspace info list and git status" {
     var list = try listExecute("call", args, null, null, null, std.testing.allocator);
     defer list.deinit(std.testing.allocator);
     try std.testing.expect(std.mem.indexOf(u8, list.content.slice()[0].text.text, "a.txt") != null);
+    var cancelled = std.atomic.Value(bool).init(true);
+    const token = ai_types.CancelToken{ .cancelled = &cancelled };
+    try std.testing.expectError(error.Cancelled, listExecute("call", args, token, null, null, std.testing.allocator));
     var status = try gitStatusExecute("call", args, null, null, null, std.testing.allocator);
     defer status.deinit(std.testing.allocator);
     try std.testing.expect(status.getDetailsJson().?.len > 0);

--- a/zig/src/tui/runtime.zig
+++ b/zig/src/tui/runtime.zig
@@ -136,8 +136,9 @@ pub const TuiRuntime = struct {
                 if (self.started) return;
                 const protocol = self.protocol orelse return error.NoProtocolConfigured;
                 self.rebuildWrappedTools();
-                self.local_agent = agent.Agent.init(self.allocator, .{ .protocol = protocol });
+                self.local_agent = agent.Agent.init(self.allocator, .{ .protocol = protocol, .compact_tool_output = self.compact_output });
                 self.local_agent.?.subscribeWithContext(self, onAgentEvent);
+                self.local_agent.?.setCompactToolOutput(self.compact_output);
                 if (self.selected_model_index) |idx| self.local_agent.?.setModel(self.models[idx]);
                 self.local_agent.?.setTools(self.wrapped_tools);
                 self.started = true;

--- a/zig/src/tui/runtime.zig
+++ b/zig/src/tui/runtime.zig
@@ -5,6 +5,7 @@ const event_stream = @import("event_stream");
 const agent = @import("agent");
 const agent_protocol_client = @import("agent_protocol_client");
 const session = @import("tui_session");
+const local_tools = @import("tools/registry");
 const OwnedSlice = @import("owned_slice").OwnedSlice;
 
 pub const TuiSession = session.TuiSession;
@@ -51,6 +52,7 @@ pub const TuiRuntime = struct {
     local_agent: ?agent.Agent = null,
     remote_client: ?agent_protocol_client.AgentProtocolClient = null,
     event_stream: TuiEventStream,
+    tool_registry: local_tools.ToolRegistry,
     original_tools: []agent.AgentTool,
     wrapped_tools: []agent.AgentTool,
     approval_contexts: []ApprovalContext,
@@ -67,13 +69,18 @@ pub const TuiRuntime = struct {
         const models = try allocator.dupe(ai_types.Model, options.models);
         errdefer allocator.free(models);
 
-        const original_tools = try allocator.dupe(agent.AgentTool, options.tools);
+        var tool_registry = local_tools.ToolRegistry.init();
+        errdefer tool_registry.deinit(allocator);
+        try tool_registry.registerDefaults(allocator);
+        for (options.tools) |tool| try tool_registry.register(allocator, tool);
+
+        const original_tools = try allocator.dupe(agent.AgentTool, tool_registry.list());
         errdefer allocator.free(original_tools);
 
-        const wrapped_tools = try allocator.alloc(agent.AgentTool, options.tools.len);
+        const wrapped_tools = try allocator.alloc(agent.AgentTool, original_tools.len);
         errdefer allocator.free(wrapped_tools);
 
-        const approval_contexts = try allocator.alloc(ApprovalContext, options.tools.len);
+        const approval_contexts = try allocator.alloc(ApprovalContext, original_tools.len);
         errdefer allocator.free(approval_contexts);
 
         var selected: ?usize = null;
@@ -96,6 +103,7 @@ pub const TuiRuntime = struct {
             .models = models,
             .selected_model_index = selected,
             .event_stream = TuiEventStream.init(allocator),
+            .tool_registry = tool_registry,
             .original_tools = original_tools,
             .wrapped_tools = wrapped_tools,
             .approval_contexts = approval_contexts,
@@ -113,6 +121,7 @@ pub const TuiRuntime = struct {
         self.allocator.free(self.approval_contexts);
         self.allocator.free(self.wrapped_tools);
         self.allocator.free(self.original_tools);
+        self.tool_registry.deinit(self.allocator);
         self.allocator.free(self.models);
         self.* = undefined;
     }
@@ -381,7 +390,6 @@ pub const TuiRuntime = struct {
             else => {},
         }
     }
-
 };
 
 fn notifyToolApproval(ctx: ?*anyopaque, request: agent.ToolApprovalRequest, allocator: std.mem.Allocator) void {
@@ -644,6 +652,15 @@ fn collectUntilEnd(tui_session: *TuiSession, saw_turn_start: *bool, saw_message_
             else => {},
         }
     }
+}
+
+test "runtime registers default local tools" {
+    var mock = MockProtocolCtx{};
+    var runtime = try TuiRuntime.init(std.testing.allocator, .{ .protocol = makeProtocol(&mock), .run_async = false });
+    defer runtime.deinit();
+    try std.testing.expect(runtime.tool_registry.resolve("shell_execute") != null);
+    try std.testing.expect(runtime.tool_registry.resolve("file_read") != null);
+    try std.testing.expect(runtime.original_tools.len >= 9);
 }
 
 test "runtime submit turn emits normalized events" {

--- a/zig/src/tui/runtime.zig
+++ b/zig/src/tui/runtime.zig
@@ -72,7 +72,7 @@ pub const TuiRuntime = struct {
         var tool_registry = local_tools.ToolRegistry.init();
         errdefer tool_registry.deinit(allocator);
         try tool_registry.registerDefaults(allocator);
-        for (options.tools) |tool| try tool_registry.register(allocator, tool);
+        for (options.tools) |tool| try tool_registry.replaceOrRegister(allocator, tool);
 
         const original_tools = try allocator.dupe(agent.AgentTool, tool_registry.list());
         errdefer allocator.free(original_tools);
@@ -654,12 +654,14 @@ fn collectUntilEnd(tui_session: *TuiSession, saw_turn_start: *bool, saw_message_
     }
 }
 
-test "runtime registers default local tools" {
+test "runtime registers default local tools and allows overrides" {
     var mock = MockProtocolCtx{};
-    var runtime = try TuiRuntime.init(std.testing.allocator, .{ .protocol = makeProtocol(&mock), .run_async = false });
+    const replacement = agent.AgentTool{ .label = "Wrapped Shell", .name = "shell_execute", .description = "Wrapped shell tool", .parameters_schema_json = "{}", .execute = demoTool };
+    var runtime = try TuiRuntime.init(std.testing.allocator, .{ .protocol = makeProtocol(&mock), .tools = &.{replacement}, .run_async = false });
     defer runtime.deinit();
     try std.testing.expect(runtime.tool_registry.resolve("shell_execute") != null);
     try std.testing.expect(runtime.tool_registry.resolve("file_read") != null);
+    try std.testing.expectEqualStrings("Wrapped Shell", runtime.tool_registry.resolve("shell_execute").?.label);
     try std.testing.expect(runtime.original_tools.len >= 9);
 }
 

--- a/zig/src/tui/runtime.zig
+++ b/zig/src/tui/runtime.zig
@@ -40,6 +40,7 @@ pub const TuiRuntimeOptions = struct {
     tools: []const agent.AgentTool = &.{},
     tool_approval_ctx: ?*anyopaque = null,
     tool_approval_callback: ?ToolApprovalCallback = null,
+    compact_output: bool = false,
     run_async: bool = true,
 };
 
@@ -63,6 +64,7 @@ pub const TuiRuntime = struct {
     started: bool = false,
     stream_active: bool = false,
     last_turn_stop_reason: ?ai_types.StopReason = null,
+    compact_output: bool = false,
     run_async: bool = true,
 
     pub fn init(allocator: std.mem.Allocator, options: TuiRuntimeOptions) !TuiRuntime {
@@ -109,6 +111,7 @@ pub const TuiRuntime = struct {
             .approval_contexts = approval_contexts,
             .tool_approval_ctx = options.tool_approval_ctx,
             .tool_approval_callback = options.tool_approval_callback,
+            .compact_output = options.compact_output,
             .run_async = options.run_async,
         };
         return runtime;
@@ -281,6 +284,7 @@ pub const TuiRuntime = struct {
                 .label = tool.label,
                 .name = tool.name,
                 .description = tool.description,
+                .short_description = tool.short_description,
                 .parameters_schema_json = tool.parameters_schema_json,
                 .execute = tool.execute,
                 .approval_ctx = &self.approval_contexts[i],


### PR DESCRIPTION
## Summary
- Add local AgentTool implementations for shell execution, file read/write/stat, structured edits, regex-like search, and workspace metadata/git status.
- Add a tool registry and register default local tools through the TUI runtime facade.
- Add unit coverage for each local tool plus runtime default registration.

## Test plan
- [x] ./scripts/check-zig-patterns.sh
- [x] cd zig && zig build test-unit-tui
- [x] cd zig && zig build test-unit-agent
- [x] cd zig && zig build test