### PR TITLE
Add token-efficient tool runtime helpers

### DIFF
--- a/zig/build.zig
+++ b/zig/build.zig
@@ -752,6 +752,104 @@ pub fn build(b: *std.Build) void {
         },
     });
 
+    const tools_common_mod = b.createModule(.{
+        .root_source_file = b.path("src/tools/common.zig"),
+        .target = target,
+        .optimize = optimize,
+        .imports = &.{
+            .{ .name = "compat", .module = compat_mod },
+            .{ .name = "ai_types", .module = ai_types_mod },
+            .{ .name = "agent_types", .module = agent_types_mod },
+            .{ .name = "owned_slice", .module = owned_slice_mod },
+        },
+    });
+
+    const tools_artifact_mod = b.createModule(.{
+        .root_source_file = b.path("src/tools/artifact.zig"),
+        .target = target,
+        .optimize = optimize,
+        .imports = &.{
+            .{ .name = "ai_types", .module = ai_types_mod },
+            .{ .name = "agent_types", .module = agent_types_mod },
+            .{ .name = "tools/common", .module = tools_common_mod },
+            .{ .name = "owned_slice", .module = owned_slice_mod },
+        },
+    });
+
+    const tools_file_mod = b.createModule(.{
+        .root_source_file = b.path("src/tools/file.zig"),
+        .target = target,
+        .optimize = optimize,
+        .imports = &.{
+            .{ .name = "compat", .module = compat_mod },
+            .{ .name = "ai_types", .module = ai_types_mod },
+            .{ .name = "agent_types", .module = agent_types_mod },
+            .{ .name = "tools/common", .module = tools_common_mod },
+        },
+    });
+
+    const tools_edit_mod = b.createModule(.{
+        .root_source_file = b.path("src/tools/edit.zig"),
+        .target = target,
+        .optimize = optimize,
+        .imports = &.{
+            .{ .name = "compat", .module = compat_mod },
+            .{ .name = "ai_types", .module = ai_types_mod },
+            .{ .name = "agent_types", .module = agent_types_mod },
+            .{ .name = "tools/common", .module = tools_common_mod },
+        },
+    });
+
+    const tools_shell_mod = b.createModule(.{
+        .root_source_file = b.path("src/tools/shell.zig"),
+        .target = target,
+        .optimize = optimize,
+        .imports = &.{
+            .{ .name = "ai_types", .module = ai_types_mod },
+            .{ .name = "agent_types", .module = agent_types_mod },
+            .{ .name = "tools/common", .module = tools_common_mod },
+        },
+    });
+
+    const tools_search_mod = b.createModule(.{
+        .root_source_file = b.path("src/tools/search.zig"),
+        .target = target,
+        .optimize = optimize,
+        .imports = &.{
+            .{ .name = "compat", .module = compat_mod },
+            .{ .name = "ai_types", .module = ai_types_mod },
+            .{ .name = "agent_types", .module = agent_types_mod },
+            .{ .name = "tools/common", .module = tools_common_mod },
+        },
+    });
+
+    const tools_workspace_mod = b.createModule(.{
+        .root_source_file = b.path("src/tools/workspace.zig"),
+        .target = target,
+        .optimize = optimize,
+        .imports = &.{
+            .{ .name = "compat", .module = compat_mod },
+            .{ .name = "ai_types", .module = ai_types_mod },
+            .{ .name = "agent_types", .module = agent_types_mod },
+            .{ .name = "tools/common", .module = tools_common_mod },
+        },
+    });
+
+    const tools_registry_mod = b.createModule(.{
+        .root_source_file = b.path("src/tools/registry.zig"),
+        .target = target,
+        .optimize = optimize,
+        .imports = &.{
+            .{ .name = "agent_types", .module = agent_types_mod },
+            .{ .name = "tools/artifact", .module = tools_artifact_mod },
+            .{ .name = "tools/file", .module = tools_file_mod },
+            .{ .name = "tools/edit", .module = tools_edit_mod },
+            .{ .name = "tools/shell", .module = tools_shell_mod },
+            .{ .name = "tools/search", .module = tools_search_mod },
+            .{ .name = "tools/workspace", .module = tools_workspace_mod },
+        },
+    });
+
     const agent_loop_mod = b.createModule(.{
         .root_source_file = b.path("src/agent/agent_loop.zig"),
         .target = target,
@@ -1148,6 +1246,14 @@ pub fn build(b: *std.Build) void {
 
     // Agent tests
     const agent_types_test = b.addTest(.{ .root_module = agent_types_mod });
+    const tools_common_test = b.addTest(.{ .root_module = tools_common_mod });
+    const tools_artifact_test = b.addTest(.{ .root_module = tools_artifact_mod });
+    const tools_file_test = b.addTest(.{ .root_module = tools_file_mod });
+    const tools_edit_test = b.addTest(.{ .root_module = tools_edit_mod });
+    const tools_shell_test = b.addTest(.{ .root_module = tools_shell_mod });
+    const tools_search_test = b.addTest(.{ .root_module = tools_search_mod });
+    const tools_workspace_test = b.addTest(.{ .root_module = tools_workspace_mod });
+    const tools_registry_test = b.addTest(.{ .root_module = tools_registry_mod });
 
     const agent_loop_test = b.addTest(.{ .root_module = agent_loop_mod });
 
@@ -1315,6 +1421,14 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(&b.addRunArtifact(refresh_lock_test).step);
     test_step.dependOn(&b.addRunArtifact(oauth_test).step);
     test_step.dependOn(&b.addRunArtifact(agent_types_test).step);
+    test_step.dependOn(&b.addRunArtifact(tools_common_test).step);
+    test_step.dependOn(&b.addRunArtifact(tools_artifact_test).step);
+    test_step.dependOn(&b.addRunArtifact(tools_file_test).step);
+    test_step.dependOn(&b.addRunArtifact(tools_edit_test).step);
+    test_step.dependOn(&b.addRunArtifact(tools_shell_test).step);
+    test_step.dependOn(&b.addRunArtifact(tools_search_test).step);
+    test_step.dependOn(&b.addRunArtifact(tools_workspace_test).step);
+    test_step.dependOn(&b.addRunArtifact(tools_registry_test).step);
     test_step.dependOn(&b.addRunArtifact(agent_loop_test).step);
     test_step.dependOn(&b.addRunArtifact(agent_mod_test).step);
     test_step.dependOn(&b.addRunArtifact(agent_provider_protocol_bridge_test).step);
@@ -1412,6 +1526,14 @@ pub fn build(b: *std.Build) void {
 
     const test_unit_agent_step = b.step("test-unit-agent", "Run agent unit tests");
     test_unit_agent_step.dependOn(&b.addRunArtifact(agent_types_test).step);
+    test_unit_agent_step.dependOn(&b.addRunArtifact(tools_common_test).step);
+    test_unit_agent_step.dependOn(&b.addRunArtifact(tools_artifact_test).step);
+    test_unit_agent_step.dependOn(&b.addRunArtifact(tools_file_test).step);
+    test_unit_agent_step.dependOn(&b.addRunArtifact(tools_edit_test).step);
+    test_unit_agent_step.dependOn(&b.addRunArtifact(tools_shell_test).step);
+    test_unit_agent_step.dependOn(&b.addRunArtifact(tools_search_test).step);
+    test_unit_agent_step.dependOn(&b.addRunArtifact(tools_workspace_test).step);
+    test_unit_agent_step.dependOn(&b.addRunArtifact(tools_registry_test).step);
     test_unit_agent_step.dependOn(&b.addRunArtifact(agent_loop_test).step);
     test_unit_agent_step.dependOn(&b.addRunArtifact(agent_mod_test).step);
     test_unit_agent_step.dependOn(&b.addRunArtifact(agent_provider_protocol_bridge_test).step);

--- a/zig/src/agent/types.zig
+++ b/zig/src/agent/types.zig
@@ -240,6 +240,7 @@ pub const AgentTool = struct {
     label: []const u8, // Human-readable label for UI
     name: []const u8,
     description: []const u8,
+    short_description: ?[]const u8 = null,
     parameters_schema_json: []const u8,
     execute: ToolExecuteFn,
     approval_ctx: ?*anyopaque = null,
@@ -252,7 +253,7 @@ pub const AgentTool = struct {
         _ = allocator;
         return .{
             .name = self.name,
-            .description = self.description,
+            .description = self.short_description orelse self.description,
             .parameters_schema_json = self.parameters_schema_json,
         };
     }
@@ -660,13 +661,14 @@ test "AgentTool.toTool conversion" {
         .label = "Test Tool",
         .name = "test_tool",
         .description = "A test tool",
+        .short_description = "Test compact",
         .parameters_schema_json = "{}",
         .execute = undefined, // Would be a real function in practice
     };
 
     const converted = try tool.toTool(std.testing.allocator);
     try std.testing.expectEqualStrings("test_tool", converted.name);
-    try std.testing.expectEqualStrings("A test tool", converted.description);
+    try std.testing.expectEqualStrings("Test compact", converted.description);
 }
 
 test "QueueMode enum values" {

--- a/zig/src/tools/artifact.zig
+++ b/zig/src/tools/artifact.zig
@@ -1,0 +1,53 @@
+const std = @import("std");
+const ai_types = @import("ai_types");
+const agent_types = @import("agent_types");
+const common = @import("tools/common");
+const OwnedSlice = @import("owned_slice").OwnedSlice;
+
+pub fn retrieveTool() agent_types.AgentTool {
+    return .{
+        .label = "Artifact Retrieve",
+        .name = "artifact_retrieve",
+        .description = "Retrieve full tool output previously stored as a local artifact. Use when a tool result summary references an artifact path and complete output is needed.",
+        .short_description = "Retrieve stored full tool output by artifact path.",
+        .parameters_schema_json = "{\"type\":\"object\",\"properties\":{\"reference\":{\"type\":\"string\"}},\"required\":[\"reference\"]}",
+        .execute = executeRetrieve,
+    };
+}
+
+pub fn executeRetrieve(
+    tool_call_id: []const u8,
+    args_json: []const u8,
+    cancel_token: ?ai_types.CancelToken,
+    on_update_ctx: ?*anyopaque,
+    on_update: ?agent_types.ToolUpdateCallback,
+    allocator: std.mem.Allocator,
+) anyerror!agent_types.AgentToolResult {
+    _ = tool_call_id;
+    _ = cancel_token;
+    _ = on_update_ctx;
+    _ = on_update;
+
+    const parsed = try std.json.parseFromSlice(std.json.Value, allocator, args_json, .{});
+    defer parsed.deinit();
+    if (parsed.value != .object) return error.InvalidArguments;
+    const reference_value = parsed.value.object.get("reference") orelse return error.InvalidArguments;
+    if (reference_value != .string) return error.InvalidArguments;
+
+    const data = try common.retrieveArtifact(allocator, reference_value.string, 64 * 1024 * 1024);
+    defer allocator.free(data);
+    const details = try common.telemetryDetails(allocator, data.len, data.len, false);
+    defer allocator.free(details);
+    return common.makeTextResult(allocator, data, details);
+}
+
+test "artifact_retrieve loads stored output" {
+    const allocator = std.testing.allocator;
+    const path = try common.storeArtifact(allocator, "artifact-test", "full output");
+    defer allocator.free(path);
+    const args = try std.fmt.allocPrint(allocator, "{{\"reference\":\"{s}\"}}", .{path});
+    defer allocator.free(args);
+    var result = try executeRetrieve("call", args, null, null, null, allocator);
+    defer result.deinit(allocator);
+    try std.testing.expectEqualStrings("full output", result.content.slice()[0].text.text);
+}

--- a/zig/src/tools/common.zig
+++ b/zig/src/tools/common.zig
@@ -1,0 +1,171 @@
+const std = @import("std");
+const compat = @import("compat");
+const ai_types = @import("ai_types");
+const agent_types = @import("agent_types");
+const OwnedSlice = @import("owned_slice").OwnedSlice;
+
+pub const tool_output_threshold: usize = 4 * 1024;
+pub const snippet_bytes: usize = 512;
+
+pub const ToolRuntimeConfig = struct {
+    compact_output: bool = false,
+    artifact_dir: ?[]const u8 = null,
+};
+
+pub const TextResultOptions = struct {
+    tool_name: []const u8,
+    call_id: []const u8,
+    text: []const u8,
+    stderr: []const u8 = "",
+    details_json: []const u8 = "",
+    compact_output: bool = false,
+    force_artifact: bool = false,
+};
+
+pub const TextResult = struct {
+    result: agent_types.AgentToolResult,
+    raw_bytes: usize,
+    returned_bytes: usize,
+    compressed: bool,
+    artifact_path: ?[]const u8 = null,
+
+    pub fn deinit(self: *TextResult, allocator: std.mem.Allocator) void {
+        self.result.deinit(allocator);
+        if (self.artifact_path) |path| allocator.free(path);
+    }
+};
+
+pub fn lineHash(line: []const u8) [2]u8 {
+    var hasher = std.hash.Wyhash.init(0);
+    hasher.update(line);
+    const value = hasher.final();
+    const byte: u8 = @truncate(value >> 56);
+    return hexByte(byte);
+}
+
+pub fn lineHashAlloc(allocator: std.mem.Allocator, line: []const u8) ![]u8 {
+    const hash = lineHash(line);
+    return allocator.dupe(u8, &hash);
+}
+
+pub fn countLines(text: []const u8) usize {
+    if (text.len == 0) return 0;
+    var count: usize = 1;
+    for (text) |c| {
+        if (c == '\n') count += 1;
+    }
+    if (text[text.len - 1] == '\n') count -= 1;
+    return count;
+}
+
+pub fn makeTextResult(allocator: std.mem.Allocator, text: []const u8, details_json: []const u8) !agent_types.AgentToolResult {
+    const content = try allocator.alloc(ai_types.UserContentPart, 1);
+    errdefer allocator.free(content);
+    content[0] = .{ .text = .{ .text = try allocator.dupe(u8, text) } };
+    errdefer allocator.free(content[0].text.text);
+
+    return .{
+        .content = OwnedSlice(ai_types.UserContentPart).initOwned(content),
+        .details_json = OwnedSlice(u8).initOwned(try allocator.dupe(u8, details_json)),
+    };
+}
+
+pub fn makeTextResultWithArtifact(allocator: std.mem.Allocator, options: TextResultOptions) !TextResult {
+    const raw_bytes = options.text.len + options.stderr.len;
+    const should_store = options.force_artifact or options.text.len > tool_output_threshold;
+    if (!should_store) {
+        const body = if (options.stderr.len > 0)
+            try std.fmt.allocPrint(allocator, "{s}\nstderr:\n{s}", .{ options.text, options.stderr })
+        else
+            try allocator.dupe(u8, options.text);
+        defer allocator.free(body);
+        const result = try makeTextResult(allocator, body, options.details_json);
+        const returned_bytes = body.len + options.details_json.len;
+        return .{ .result = result, .raw_bytes = raw_bytes, .returned_bytes = returned_bytes, .compressed = false };
+    }
+
+    const key = try std.fmt.allocPrint(allocator, "{s}:{s}", .{ options.tool_name, options.call_id });
+    defer allocator.free(key);
+    const artifact_path = try storeArtifact(allocator, key, options.text);
+    errdefer allocator.free(artifact_path);
+
+    const summary = try summarizeArtifactBackedOutput(allocator, options.text, options.stderr, artifact_path);
+    defer allocator.free(summary);
+
+    const details = if (options.details_json.len > 0)
+        try std.fmt.allocPrint(allocator, "{{\"raw_bytes\":{d},\"returned_bytes\":{d},\"saved_bytes\":{d},\"compressed\":true,\"artifact_path\":\"{s}\",\"details\":{s}}}", .{ raw_bytes, summary.len, raw_bytes -| summary.len, artifact_path, options.details_json })
+    else
+        try std.fmt.allocPrint(allocator, "{{\"raw_bytes\":{d},\"returned_bytes\":{d},\"saved_bytes\":{d},\"compressed\":true,\"artifact_path\":\"{s}\"}}", .{ raw_bytes, summary.len, raw_bytes -| summary.len, artifact_path });
+    defer allocator.free(details);
+
+    const result = try makeTextResult(allocator, summary, details);
+    const returned_bytes = summary.len + details.len;
+    return .{ .result = result, .raw_bytes = raw_bytes, .returned_bytes = returned_bytes, .compressed = true, .artifact_path = artifact_path };
+}
+
+pub fn storeArtifact(allocator: std.mem.Allocator, key: []const u8, data: []const u8) ![]u8 {
+    const cwd = compat.fs.getCwd();
+    try compat.fs.createDir(cwd, ".makai/tool-artifacts");
+    const safe = try sanitizeKey(allocator, key);
+    defer allocator.free(safe);
+    const path = try std.fmt.allocPrint(allocator, ".makai/tool-artifacts/{s}.txt", .{safe});
+    errdefer allocator.free(path);
+    try compat.fs.writeFile(cwd, path, data);
+    return path;
+}
+
+pub fn retrieveArtifact(allocator: std.mem.Allocator, reference: []const u8, max_bytes: usize) ![]u8 {
+    return compat.fs.readFileAlloc(allocator, compat.fs.getCwd(), reference, max_bytes);
+}
+
+pub fn telemetryDetails(allocator: std.mem.Allocator, raw_bytes: usize, returned_bytes: usize, compressed: bool) ![]u8 {
+    return std.fmt.allocPrint(allocator, "{{\"raw_bytes\":{d},\"returned_bytes\":{d},\"saved_bytes\":{d},\"compressed\":{s}}}", .{ raw_bytes, returned_bytes, raw_bytes -| returned_bytes, if (compressed) "true" else "false" });
+}
+
+fn summarizeArtifactBackedOutput(allocator: std.mem.Allocator, text: []const u8, stderr: []const u8, artifact_path: []const u8) ![]u8 {
+    const head = text[0..@min(text.len, snippet_bytes)];
+    const tail_start = if (text.len > snippet_bytes) text.len - snippet_bytes else 0;
+    const tail = text[tail_start..];
+    if (stderr.len > 0) {
+        return std.fmt.allocPrint(allocator,
+            "output stored as artifact\nbytes: {d}\nlines: {d}\nartifact: {s}\nhead:\n{s}\ntail:\n{s}\nstderr:\n{s}",
+            .{ text.len, countLines(text), artifact_path, head, tail, stderr },
+        );
+    }
+    return std.fmt.allocPrint(allocator,
+        "output stored as artifact\nbytes: {d}\nlines: {d}\nartifact: {s}\nhead:\n{s}\ntail:\n{s}",
+        .{ text.len, countLines(text), artifact_path, head, tail },
+    );
+}
+
+fn sanitizeKey(allocator: std.mem.Allocator, key: []const u8) ![]u8 {
+    var out = try allocator.alloc(u8, key.len);
+    for (key, 0..) |c, i| {
+        out[i] = if (std.ascii.isAlphanumeric(c) or c == '-' or c == '_') c else '_';
+    }
+    return out;
+}
+
+fn hexByte(value: u8) [2]u8 {
+    const alphabet = "0123456789abcdef";
+    return .{ alphabet[value >> 4], alphabet[value & 0x0f] };
+}
+
+test "lineHash changes with content" {
+    try std.testing.expect(!std.mem.eql(u8, &lineHash("one"), &lineHash("two")));
+}
+
+test "makeTextResultWithArtifact stores and summarizes large output" {
+    const allocator = std.testing.allocator;
+    const buf = try allocator.alloc(u8, tool_output_threshold + 10);
+    defer allocator.free(buf);
+    @memset(buf, 'x');
+    var made = try makeTextResultWithArtifact(allocator, .{ .tool_name = "test", .call_id = "call", .text = buf });
+    defer made.deinit(allocator);
+    try std.testing.expect(made.compressed);
+    try std.testing.expect(made.artifact_path != null);
+    try std.testing.expect(std.mem.indexOf(u8, made.result.content.slice()[0].text.text, "output stored as artifact") != null);
+    const full = try retrieveArtifact(allocator, made.artifact_path.?, buf.len + 1);
+    defer allocator.free(full);
+    try std.testing.expectEqualStrings(buf, full);
+}

--- a/zig/src/tools/edit.zig
+++ b/zig/src/tools/edit.zig
@@ -1,0 +1,229 @@
+const std = @import("std");
+const compat = @import("compat");
+const ai_types = @import("ai_types");
+const agent_types = @import("agent_types");
+const common = @import("tools/common");
+
+pub fn editTool() agent_types.AgentTool {
+    return .{
+        .label = "File Edit",
+        .name = "file_edit",
+        .description = "Edit text files using find_replace, line_replace, insert, delete, hash_replace, or hash_range_replace. Hash operations reject stale reads before mutation.",
+        .short_description = "Edit file; supports hash-anchored replacements.",
+        .parameters_schema_json = "{\"type\":\"object\",\"properties\":{\"path\":{\"type\":\"string\"},\"operation\":{\"type\":\"string\"},\"line\":{\"type\":\"integer\"},\"line_hash\":{\"type\":\"string\"},\"start_line\":{\"type\":\"integer\"},\"start_hash\":{\"type\":\"string\"},\"end_line\":{\"type\":\"integer\"},\"end_hash\":{\"type\":\"string\"},\"new_content\":{\"type\":\"string\"},\"old\":{\"type\":\"string\"}},\"required\":[\"path\",\"operation\"]}",
+        .execute = executeEdit,
+    };
+}
+
+pub fn executeEdit(
+    tool_call_id: []const u8,
+    args_json: []const u8,
+    cancel_token: ?ai_types.CancelToken,
+    on_update_ctx: ?*anyopaque,
+    on_update: ?agent_types.ToolUpdateCallback,
+    allocator: std.mem.Allocator,
+) anyerror!agent_types.AgentToolResult {
+    _ = tool_call_id;
+    _ = cancel_token;
+    _ = on_update_ctx;
+    _ = on_update;
+    const args = try parseArgs(allocator, args_json);
+    defer args.deinit();
+    const original = try compat.fs.readFileAlloc(allocator, compat.fs.getCwd(), args.path, 64 * 1024 * 1024);
+    defer allocator.free(original);
+    const edited = try applyEdit(allocator, original, args);
+    defer allocator.free(edited);
+    try compat.fs.writeFile(compat.fs.getCwd(), args.path, edited);
+    const body = try std.fmt.allocPrint(allocator, "ok {d} {s}", .{ edited.len, args.path });
+    defer allocator.free(body);
+    const details = try common.telemetryDetails(allocator, original.len, body.len, false);
+    defer allocator.free(details);
+    return common.makeTextResult(allocator, body, details);
+}
+
+pub fn applyEdit(allocator: std.mem.Allocator, original: []const u8, args: ParsedArgs) ![]u8 {
+    if (std.mem.eql(u8, args.operation, "hash_replace")) {
+        const line_no = args.line orelse return error.InvalidArguments;
+        const expected = args.line_hash orelse return error.InvalidArguments;
+        const new_content = args.new_content orelse return error.InvalidArguments;
+        const line = getLine(original, line_no) orelse return error.LineOutOfRange;
+        const actual = common.lineHash(line);
+        if (!std.mem.eql(u8, expected, &actual)) return error.StaleHash;
+        return replaceLine(allocator, original, line_no, new_content);
+    }
+    if (std.mem.eql(u8, args.operation, "hash_range_replace")) {
+        const start_line = args.start_line orelse return error.InvalidArguments;
+        const end_line = args.end_line orelse return error.InvalidArguments;
+        const start_hash = args.start_hash orelse return error.InvalidArguments;
+        const end_hash = args.end_hash orelse return error.InvalidArguments;
+        const new_content = args.new_content orelse return error.InvalidArguments;
+        const first = getLine(original, start_line) orelse return error.LineOutOfRange;
+        const last = getLine(original, end_line) orelse return error.LineOutOfRange;
+        const actual_start = common.lineHash(first);
+        const actual_end = common.lineHash(last);
+        if (!std.mem.eql(u8, start_hash, &actual_start) or !std.mem.eql(u8, end_hash, &actual_end)) return error.StaleHash;
+        return replaceRange(allocator, original, start_line, end_line, new_content);
+    }
+    if (std.mem.eql(u8, args.operation, "line_replace")) {
+        return replaceLine(allocator, original, args.line orelse return error.InvalidArguments, args.new_content orelse return error.InvalidArguments);
+    }
+    if (std.mem.eql(u8, args.operation, "find_replace")) {
+        const old = args.old orelse return error.InvalidArguments;
+        const new_content = args.new_content orelse return error.InvalidArguments;
+        const idx = std.mem.indexOf(u8, original, old) orelse return error.PatternNotFound;
+        var out = std.ArrayList(u8).empty;
+        errdefer out.deinit(allocator);
+        try out.appendSlice(allocator, original[0..idx]);
+        try out.appendSlice(allocator, new_content);
+        try out.appendSlice(allocator, original[idx + old.len ..]);
+        return out.toOwnedSlice(allocator);
+    }
+    if (std.mem.eql(u8, args.operation, "insert")) {
+        return insertBeforeLine(allocator, original, args.line orelse return error.InvalidArguments, args.new_content orelse return error.InvalidArguments);
+    }
+    if (std.mem.eql(u8, args.operation, "delete")) {
+        const line = args.line orelse return error.InvalidArguments;
+        return replaceRange(allocator, original, line, line, "");
+    }
+    return error.InvalidOperation;
+}
+
+pub const ParsedArgs = struct {
+    parsed: ?std.json.Parsed(std.json.Value) = null,
+    path: []const u8 = "",
+    operation: []const u8,
+    line: ?usize = null,
+    line_hash: ?[]const u8 = null,
+    start_line: ?usize = null,
+    start_hash: ?[]const u8 = null,
+    end_line: ?usize = null,
+    end_hash: ?[]const u8 = null,
+    old: ?[]const u8 = null,
+    new_content: ?[]const u8 = null,
+
+    fn deinit(self: *const ParsedArgs) void {
+        if (self.parsed) |parsed| parsed.deinit();
+    }
+};
+
+fn parseArgs(allocator: std.mem.Allocator, args_json: []const u8) !ParsedArgs {
+    const parsed = try std.json.parseFromSlice(std.json.Value, allocator, args_json, .{});
+    errdefer parsed.deinit();
+    if (parsed.value != .object) return error.InvalidArguments;
+    const obj = parsed.value.object;
+    return .{
+        .parsed = parsed,
+        .path = try reqString(obj, "path"),
+        .operation = try reqString(obj, "operation"),
+        .line = optUsize(obj, "line"),
+        .line_hash = optString(obj, "line_hash"),
+        .start_line = optUsize(obj, "start_line"),
+        .start_hash = optString(obj, "start_hash"),
+        .end_line = optUsize(obj, "end_line"),
+        .end_hash = optString(obj, "end_hash"),
+        .old = optString(obj, "old"),
+        .new_content = optString(obj, "new_content"),
+    };
+}
+
+fn reqString(obj: std.json.ObjectMap, key: []const u8) ![]const u8 {
+    const value = obj.get(key) orelse return error.InvalidArguments;
+    if (value != .string) return error.InvalidArguments;
+    return value.string;
+}
+
+fn optString(obj: std.json.ObjectMap, key: []const u8) ?[]const u8 {
+    const value = obj.get(key) orelse return null;
+    return if (value == .string) value.string else null;
+}
+
+fn optUsize(obj: std.json.ObjectMap, key: []const u8) ?usize {
+    const value = obj.get(key) orelse return null;
+    return if (value == .integer and value.integer > 0) @intCast(value.integer) else null;
+}
+
+fn getLine(text: []const u8, line_no: usize) ?[]const u8 {
+    var current: usize = 1;
+    var start: usize = 0;
+    while (start <= text.len) {
+        const end = std.mem.indexOfScalarPos(u8, text, start, '\n') orelse text.len;
+        if (current == line_no) return text[start..end];
+        if (end == text.len) break;
+        start = end + 1;
+        current += 1;
+    }
+    return null;
+}
+
+fn lineBounds(text: []const u8, line_no: usize) ?struct { start: usize, end_with_newline: usize, end_without_newline: usize } {
+    var current: usize = 1;
+    var start: usize = 0;
+    while (start <= text.len) {
+        const end = std.mem.indexOfScalarPos(u8, text, start, '\n') orelse text.len;
+        if (current == line_no) return .{ .start = start, .end_without_newline = end, .end_with_newline = if (end < text.len) end + 1 else end };
+        if (end == text.len) break;
+        start = end + 1;
+        current += 1;
+    }
+    return null;
+}
+
+fn replaceLine(allocator: std.mem.Allocator, text: []const u8, line_no: usize, replacement: []const u8) ![]u8 {
+    return replaceRange(allocator, text, line_no, line_no, replacement);
+}
+
+fn replaceRange(allocator: std.mem.Allocator, text: []const u8, start_line: usize, end_line: usize, replacement: []const u8) ![]u8 {
+    if (end_line < start_line) return error.InvalidArguments;
+    const start = lineBounds(text, start_line) orelse return error.LineOutOfRange;
+    const end = lineBounds(text, end_line) orelse return error.LineOutOfRange;
+    var out = std.ArrayList(u8).empty;
+    errdefer out.deinit(allocator);
+    try out.appendSlice(allocator, text[0..start.start]);
+    try out.appendSlice(allocator, replacement);
+    if (replacement.len > 0 and end.end_with_newline < text.len and (replacement[replacement.len - 1] != '\n')) try out.append(allocator, '\n');
+    try out.appendSlice(allocator, text[end.end_with_newline..]);
+    return out.toOwnedSlice(allocator);
+}
+
+fn insertBeforeLine(allocator: std.mem.Allocator, text: []const u8, line_no: usize, insertion: []const u8) ![]u8 {
+    const bounds = lineBounds(text, line_no) orelse return error.LineOutOfRange;
+    var out = std.ArrayList(u8).empty;
+    errdefer out.deinit(allocator);
+    try out.appendSlice(allocator, text[0..bounds.start]);
+    try out.appendSlice(allocator, insertion);
+    if (insertion.len > 0 and insertion[insertion.len - 1] != '\n') try out.append(allocator, '\n');
+    try out.appendSlice(allocator, text[bounds.start..]);
+    return out.toOwnedSlice(allocator);
+}
+
+test "hash_replace rejects stale hash" {
+    const allocator = std.testing.allocator;
+    const args = ParsedArgs{ .operation = "hash_replace", .line = 1, .line_hash = "00", .new_content = "new" };
+    try std.testing.expectError(error.StaleHash, applyEdit(allocator, "old\n", args));
+}
+
+test "hash_replace detects concurrent modification" {
+    const allocator = std.testing.allocator;
+    const read_hash = common.lineHash("before");
+    const args = ParsedArgs{ .operation = "hash_replace", .line = 1, .line_hash = &read_hash, .new_content = "after" };
+    try std.testing.expectError(error.StaleHash, applyEdit(allocator, "changed\n", args));
+}
+
+test "hash_range_replace verifies both endpoints" {
+    const allocator = std.testing.allocator;
+    const h1 = common.lineHash("one");
+    const h3 = common.lineHash("three");
+    const args = ParsedArgs{ .operation = "hash_range_replace", .start_line = 1, .start_hash = &h1, .end_line = 3, .end_hash = &h3, .new_content = "merged" };
+    const out = try applyEdit(allocator, "one\ntwo\nthree\nfour\n", args);
+    defer allocator.free(out);
+    try std.testing.expectEqualStrings("merged\nfour\n", out);
+}
+
+test "hash collision tolerance still checks current matching hash" {
+    const allocator = std.testing.allocator;
+    const hash = common.lineHash("same");
+    const args = ParsedArgs{ .operation = "hash_replace", .line = 1, .line_hash = &hash, .new_content = "new" };
+    const out = try applyEdit(allocator, "same\n", args);
+    defer allocator.free(out);
+    try std.testing.expectEqualStrings("new", out);
+}

--- a/zig/src/tools/file.zig
+++ b/zig/src/tools/file.zig
@@ -1,0 +1,176 @@
+const std = @import("std");
+const compat = @import("compat");
+const ai_types = @import("ai_types");
+const agent_types = @import("agent_types");
+const common = @import("tools/common");
+
+fn defaultIo() std.Io {
+    return if (@import("builtin").is_test)
+        std.testing.io
+    else
+        std.Io.Threaded.global_single_threaded.io();
+}
+
+pub fn readTool() agent_types.AgentTool {
+    return .{
+        .label = "File Read",
+        .name = "file_read",
+        .description = "Read a UTF-8 text file. Output includes per-line content hashes as line_no:hash|content for hash-anchored edits.",
+        .short_description = "Read file with line hashes.",
+        .parameters_schema_json = "{\"type\":\"object\",\"properties\":{\"path\":{\"type\":\"string\"}},\"required\":[\"path\"]}",
+        .execute = executeRead,
+    };
+}
+
+pub fn writeTool() agent_types.AgentTool {
+    return .{
+        .label = "File Write",
+        .name = "file_write",
+        .description = "Write full text content to a file, replacing any existing content.",
+        .short_description = "Write file content.",
+        .parameters_schema_json = "{\"type\":\"object\",\"properties\":{\"path\":{\"type\":\"string\"},\"content\":{\"type\":\"string\"},\"compact_output\":{\"type\":\"boolean\"}},\"required\":[\"path\",\"content\"]}",
+        .execute = executeWrite,
+    };
+}
+
+pub fn statTool() agent_types.AgentTool {
+    return .{
+        .label = "File Stat",
+        .name = "file_stat",
+        .description = "Return file size and kind for a path.",
+        .short_description = "Stat file path.",
+        .parameters_schema_json = "{\"type\":\"object\",\"properties\":{\"path\":{\"type\":\"string\"},\"compact_output\":{\"type\":\"boolean\"}},\"required\":[\"path\"]}",
+        .execute = executeStat,
+    };
+}
+
+pub fn executeRead(
+    tool_call_id: []const u8,
+    args_json: []const u8,
+    cancel_token: ?ai_types.CancelToken,
+    on_update_ctx: ?*anyopaque,
+    on_update: ?agent_types.ToolUpdateCallback,
+    allocator: std.mem.Allocator,
+) anyerror!agent_types.AgentToolResult {
+    _ = tool_call_id;
+    _ = cancel_token;
+    _ = on_update_ctx;
+    _ = on_update;
+    const args = try parseArgs(allocator, args_json);
+    defer args.deinit();
+    const content = try compat.fs.readFileAlloc(allocator, compat.fs.getCwd(), args.path, 64 * 1024 * 1024);
+    defer allocator.free(content);
+    const hashed = try formatWithLineHashes(allocator, content);
+    defer allocator.free(hashed);
+    const details = try common.telemetryDetails(allocator, content.len, hashed.len, false);
+    defer allocator.free(details);
+    return common.makeTextResult(allocator, hashed, details);
+}
+
+pub fn executeWrite(
+    tool_call_id: []const u8,
+    args_json: []const u8,
+    cancel_token: ?ai_types.CancelToken,
+    on_update_ctx: ?*anyopaque,
+    on_update: ?agent_types.ToolUpdateCallback,
+    allocator: std.mem.Allocator,
+) anyerror!agent_types.AgentToolResult {
+    _ = tool_call_id;
+    _ = cancel_token;
+    _ = on_update_ctx;
+    _ = on_update;
+    const args = try parseArgs(allocator, args_json);
+    defer args.deinit();
+    const content = args.content orelse return error.InvalidArguments;
+    try compat.fs.writeFile(compat.fs.getCwd(), args.path, content);
+    const body = if (args.compact_output)
+        try std.fmt.allocPrint(allocator, "ok {d} {s}", .{ content.len, args.path })
+    else
+        try std.fmt.allocPrint(allocator, "wrote {d} bytes to {s}", .{ content.len, args.path });
+    defer allocator.free(body);
+    const details = try common.telemetryDetails(allocator, content.len, body.len, false);
+    defer allocator.free(details);
+    return common.makeTextResult(allocator, body, details);
+}
+
+pub fn executeStat(
+    tool_call_id: []const u8,
+    args_json: []const u8,
+    cancel_token: ?ai_types.CancelToken,
+    on_update_ctx: ?*anyopaque,
+    on_update: ?agent_types.ToolUpdateCallback,
+    allocator: std.mem.Allocator,
+) anyerror!agent_types.AgentToolResult {
+    _ = tool_call_id;
+    _ = cancel_token;
+    _ = on_update_ctx;
+    _ = on_update;
+    const args = try parseArgs(allocator, args_json);
+    defer args.deinit();
+    const stat = try compat.fs.getCwd().statFile(defaultIo(), args.path, .{});
+    const kind = @tagName(stat.kind);
+    const body = if (args.compact_output)
+        try std.fmt.allocPrint(allocator, "{s} {s} {d}", .{ args.path, kind, stat.size })
+    else
+        try std.fmt.allocPrint(allocator, "path: {s}\nkind: {s}\nsize: {d}", .{ args.path, kind, stat.size });
+    defer allocator.free(body);
+    const details = try common.telemetryDetails(allocator, body.len, body.len, false);
+    defer allocator.free(details);
+    return common.makeTextResult(allocator, body, details);
+}
+
+pub fn formatWithLineHashes(allocator: std.mem.Allocator, content: []const u8) ![]u8 {
+    var out = std.ArrayList(u8).empty;
+    errdefer out.deinit(allocator);
+    var line_no: usize = 1;
+    var start: usize = 0;
+    while (start <= content.len) {
+        const end = std.mem.indexOfScalarPos(u8, content, start, '\n') orelse content.len;
+        if (start == content.len and end == content.len) break;
+        const line = content[start..end];
+        const hash = common.lineHash(line);
+        const formatted = try std.fmt.allocPrint(allocator, "{d}:{s}|{s}\n", .{ line_no, &hash, line });
+        defer allocator.free(formatted);
+        try out.appendSlice(allocator, formatted);
+        line_no += 1;
+        if (end == content.len) break;
+        start = end + 1;
+    }
+    return out.toOwnedSlice(allocator);
+}
+
+const ParsedArgs = struct {
+    parsed: std.json.Parsed(std.json.Value),
+    path: []const u8,
+    content: ?[]const u8 = null,
+    compact_output: bool = false,
+
+    fn deinit(self: *const ParsedArgs) void {
+        self.parsed.deinit();
+    }
+};
+
+fn parseArgs(allocator: std.mem.Allocator, args_json: []const u8) !ParsedArgs {
+    const parsed = try std.json.parseFromSlice(std.json.Value, allocator, args_json, .{});
+    errdefer parsed.deinit();
+    if (parsed.value != .object) return error.InvalidArguments;
+    const obj = parsed.value.object;
+    const path_value = obj.get("path") orelse return error.InvalidArguments;
+    if (path_value != .string) return error.InvalidArguments;
+    const content = if (obj.get("content")) |value| blk: {
+        if (value != .string) return error.InvalidArguments;
+        break :blk value.string;
+    } else null;
+    const compact = if (obj.get("compact_output")) |value| value == .bool and value.bool else false;
+    return .{ .parsed = parsed, .path = path_value.string, .content = content, .compact_output = compact };
+}
+
+test "file_read output includes line hashes" {
+    const allocator = std.testing.allocator;
+    const content = try formatWithLineHashes(allocator, "alpha\nbeta");
+    defer allocator.free(content);
+    try std.testing.expect(std.mem.indexOf(u8, content, "1:") != null);
+    try std.testing.expect(std.mem.indexOf(u8, content, "|alpha") != null);
+    try std.testing.expect(std.mem.indexOf(u8, content, "2:") != null);
+    try std.testing.expect(std.mem.indexOf(u8, content, "|beta") != null);
+}

--- a/zig/src/tools/makai.zig
+++ b/zig/src/tools/makai.zig
@@ -913,6 +913,7 @@ fn parseAgentTool(allocator: std.mem.Allocator, value: std.json.Value) !agent_lo
 
     const name_text = getStringField(tool_obj, "name") orelse return error.InvalidToolDefinition;
     const description_text = getStringField(tool_obj, "description") orelse "";
+    const short_description_text = getStringField(tool_obj, "short_description") orelse getStringField(outer_obj, "short_description");
     const label_text = getStringField(tool_obj, "label") orelse getStringField(outer_obj, "label") orelse name_text;
 
     const label = try allocator.dupe(u8, label_text);
@@ -921,6 +922,8 @@ fn parseAgentTool(allocator: std.mem.Allocator, value: std.json.Value) !agent_lo
     errdefer allocator.free(name);
     const description = try allocator.dupe(u8, description_text);
     errdefer allocator.free(description);
+    const short_description = if (short_description_text) |text| try allocator.dupe(u8, text) else null;
+    errdefer if (short_description) |text| allocator.free(text);
     const parameters_schema_json = try parseToolSchemaJson(allocator, tool_obj);
     errdefer allocator.free(parameters_schema_json);
 
@@ -928,6 +931,7 @@ fn parseAgentTool(allocator: std.mem.Allocator, value: std.json.Value) !agent_lo
         .label = label,
         .name = name,
         .description = description,
+        .short_description = short_description,
         .parameters_schema_json = parameters_schema_json,
         .execute = unavailableAgentToolExecute,
     };
@@ -959,6 +963,7 @@ fn deinitAgentToolFields(allocator: std.mem.Allocator, tool: *agent_loop.AgentTo
     allocator.free(tool.label);
     allocator.free(tool.name);
     allocator.free(tool.description);
+    if (tool.short_description) |short| allocator.free(short);
     allocator.free(tool.parameters_schema_json);
 }
 

--- a/zig/src/tools/registry.zig
+++ b/zig/src/tools/registry.zig
@@ -1,0 +1,52 @@
+const std = @import("std");
+const agent_types = @import("agent_types");
+const artifact = @import("tools/artifact");
+const file = @import("tools/file");
+const edit = @import("tools/edit");
+const shell = @import("tools/shell");
+const search = @import("tools/search");
+const workspace = @import("tools/workspace");
+
+pub fn defaultTools() []const agent_types.AgentTool {
+    return &[_]agent_types.AgentTool{
+        shell.shellTool(),
+        file.readTool(),
+        file.writeTool(),
+        file.statTool(),
+        edit.editTool(),
+        search.searchTool(),
+        workspace.infoTool(),
+        workspace.listTool(),
+        workspace.gitStatusTool(),
+        artifact.retrieveTool(),
+    };
+}
+
+pub fn listToolsJson(allocator: std.mem.Allocator, tools: []const agent_types.AgentTool) ![]u8 {
+    var out = std.ArrayList(u8).empty;
+    errdefer out.deinit(allocator);
+    try out.append(allocator, '[');
+    for (tools, 0..) |tool, i| {
+        if (i > 0) try out.append(allocator, ',');
+        const formatted = try std.json.Stringify.valueAlloc(allocator, .{
+            .name = tool.name,
+            .label = tool.label,
+            .description = tool.description,
+            .short_description = tool.short_description orelse tool.description,
+            .parameters_schema = tool.parameters_schema_json,
+        }, .{});
+        defer allocator.free(formatted);
+        try out.appendSlice(allocator, formatted);
+    }
+    try out.append(allocator, ']');
+    return out.toOwnedSlice(allocator);
+}
+
+test "default registry includes artifact_retrieve and short descriptions" {
+    const tools = defaultTools();
+    try std.testing.expectEqual(@as(usize, 10), tools.len);
+    for (tools) |tool| {
+        try std.testing.expect(tool.short_description != null);
+    }
+    try std.testing.expectEqualStrings("artifact_retrieve", tools[9].name);
+}

--- a/zig/src/tools/search.zig
+++ b/zig/src/tools/search.zig
@@ -1,0 +1,94 @@
+const std = @import("std");
+const compat = @import("compat");
+const ai_types = @import("ai_types");
+const agent_types = @import("agent_types");
+const common = @import("tools/common");
+
+fn defaultIo() std.Io {
+    return if (@import("builtin").is_test)
+        std.testing.io
+    else
+        std.Io.Threaded.global_single_threaded.io();
+}
+
+pub fn searchTool() agent_types.AgentTool {
+    return .{
+        .label = "Search Text",
+        .name = "search_text",
+        .description = "Search files for literal text under a root directory. Results use file:line:content format; large result sets are stored as artifacts.",
+        .short_description = "Search text; large results become artifact.",
+        .parameters_schema_json = "{\"type\":\"object\",\"properties\":{\"root\":{\"type\":\"string\"},\"query\":{\"type\":\"string\"}},\"required\":[\"root\",\"query\"]}",
+        .execute = executeSearch,
+    };
+}
+
+pub fn executeSearch(
+    tool_call_id: []const u8,
+    args_json: []const u8,
+    cancel_token: ?ai_types.CancelToken,
+    on_update_ctx: ?*anyopaque,
+    on_update: ?agent_types.ToolUpdateCallback,
+    allocator: std.mem.Allocator,
+) anyerror!agent_types.AgentToolResult {
+    _ = cancel_token;
+    _ = on_update_ctx;
+    _ = on_update;
+    const parsed = try parseArgs(allocator, args_json);
+    defer parsed.deinit();
+    var out = std.ArrayList(u8).empty;
+    defer out.deinit(allocator);
+    var dir = try compat.fs.getCwd().openDir(defaultIo(), parsed.root, .{ .iterate = true });
+    defer dir.close(defaultIo());
+    try searchDir(allocator, &out, dir, parsed.root, parsed.query);
+    const details = try common.telemetryDetails(allocator, out.items.len, out.items.len, false);
+    defer allocator.free(details);
+    const made = try common.makeTextResultWithArtifact(allocator, .{ .tool_name = "search_text", .call_id = tool_call_id, .text = out.items, .details_json = details });
+    defer if (made.artifact_path) |path| allocator.free(path);
+    return made.result;
+}
+
+fn searchDir(allocator: std.mem.Allocator, out: *std.ArrayList(u8), dir: compat.fs.Dir, prefix: []const u8, query: []const u8) !void {
+    var it = dir.iterate();
+    while (try it.next(defaultIo())) |entry| {
+        if (entry.kind == .directory) continue;
+        const path = try std.fs.path.join(allocator, &.{ prefix, entry.name });
+        defer allocator.free(path);
+        const data = compat.fs.readFileAlloc(allocator, compat.fs.getCwd(), path, 1024 * 1024) catch continue;
+        defer allocator.free(data);
+        var line_no: usize = 1;
+        var start: usize = 0;
+        while (start <= data.len) {
+            const end = std.mem.indexOfScalarPos(u8, data, start, '\n') orelse data.len;
+            const line = data[start..end];
+            if (std.mem.indexOf(u8, line, query) != null) {
+                const formatted = try std.fmt.allocPrint(allocator, "{s}:{d}:{s}\n", .{ path, line_no, line });
+                defer allocator.free(formatted);
+                try out.appendSlice(allocator, formatted);
+            }
+            if (end == data.len) break;
+            start = end + 1;
+            line_no += 1;
+        }
+    }
+}
+
+const ParsedArgs = struct {
+    parsed: std.json.Parsed(std.json.Value),
+    root: []const u8,
+    query: []const u8,
+
+    fn deinit(self: *const ParsedArgs) void {
+        self.parsed.deinit();
+    }
+};
+
+fn parseArgs(allocator: std.mem.Allocator, args_json: []const u8) !ParsedArgs {
+    const parsed = try std.json.parseFromSlice(std.json.Value, allocator, args_json, .{});
+    errdefer parsed.deinit();
+    if (parsed.value != .object) return error.InvalidArguments;
+    const obj = parsed.value.object;
+    const root = obj.get("root") orelse return error.InvalidArguments;
+    const query = obj.get("query") orelse return error.InvalidArguments;
+    if (root != .string or query != .string) return error.InvalidArguments;
+    return .{ .parsed = parsed, .root = root.string, .query = query.string };
+}

--- a/zig/src/tools/shell.zig
+++ b/zig/src/tools/shell.zig
@@ -1,0 +1,93 @@
+const std = @import("std");
+const ai_types = @import("ai_types");
+const agent_types = @import("agent_types");
+const common = @import("tools/common");
+
+fn defaultIo() std.Io {
+    return if (@import("builtin").is_test)
+        std.testing.io
+    else
+        std.Io.Threaded.global_single_threaded.io();
+}
+
+pub fn shellTool() agent_types.AgentTool {
+    return .{
+        .label = "Shell Execute",
+        .name = "shell_execute",
+        .description = "Execute a shell command and return stdout/stderr. Large stdout is stored as retrievable artifact; compact_output returns terse success metadata.",
+        .short_description = "Run shell command; large output becomes artifact.",
+        .parameters_schema_json = "{\"type\":\"object\",\"properties\":{\"command\":{\"type\":\"string\"},\"compact_output\":{\"type\":\"boolean\"}},\"required\":[\"command\"]}",
+        .execute = executeShell,
+    };
+}
+
+pub fn executeShell(
+    tool_call_id: []const u8,
+    args_json: []const u8,
+    cancel_token: ?ai_types.CancelToken,
+    on_update_ctx: ?*anyopaque,
+    on_update: ?agent_types.ToolUpdateCallback,
+    allocator: std.mem.Allocator,
+) anyerror!agent_types.AgentToolResult {
+    _ = cancel_token;
+    _ = on_update_ctx;
+    _ = on_update;
+    const parsed = try parseArgs(allocator, args_json);
+    defer parsed.deinit();
+    const output = try std.process.run(allocator, defaultIo(), .{
+        .argv = &.{ "/bin/sh", "-c", parsed.command },
+        .stdout_limit = .limited(64 * 1024 * 1024),
+        .stderr_limit = .limited(64 * 1024 * 1024),
+    });
+    defer allocator.free(output.stdout);
+    defer allocator.free(output.stderr);
+    const code: u8 = switch (output.term) { .exited => |c| c, else => 1 };
+    const raw_bytes = output.stdout.len + output.stderr.len;
+
+    if (parsed.compact_output and code == 0) {
+        const body = try std.fmt.allocPrint(allocator, "ok stdout={d} stderr={d}", .{ output.stdout.len, output.stderr.len });
+        defer allocator.free(body);
+        const details = try common.telemetryDetails(allocator, raw_bytes, body.len, false);
+        defer allocator.free(details);
+        return common.makeTextResult(allocator, body, details);
+    }
+
+    const body = if (code == 0)
+        try allocator.dupe(u8, output.stdout)
+    else
+        try std.fmt.allocPrint(allocator, "exit_code: {d}\nstderr:\n{s}\nstdout:\n{s}", .{ code, output.stderr, output.stdout });
+    defer allocator.free(body);
+    const details = try std.fmt.allocPrint(allocator, "{{\"exit_code\":{d}}}", .{code});
+    defer allocator.free(details);
+    const made = try common.makeTextResultWithArtifact(allocator, .{ .tool_name = "shell_execute", .call_id = tool_call_id, .text = body, .stderr = if (code == 0) output.stderr else "", .details_json = details });
+    defer if (made.artifact_path) |path| allocator.free(path);
+    return made.result;
+}
+
+const ParsedArgs = struct {
+    parsed: std.json.Parsed(std.json.Value),
+    command: []const u8,
+    compact_output: bool = false,
+
+    fn deinit(self: *const ParsedArgs) void {
+        self.parsed.deinit();
+    }
+};
+
+fn parseArgs(allocator: std.mem.Allocator, args_json: []const u8) !ParsedArgs {
+    const parsed = try std.json.parseFromSlice(std.json.Value, allocator, args_json, .{});
+    errdefer parsed.deinit();
+    if (parsed.value != .object) return error.InvalidArguments;
+    const obj = parsed.value.object;
+    const command = obj.get("command") orelse return error.InvalidArguments;
+    if (command != .string) return error.InvalidArguments;
+    const compact = if (obj.get("compact_output")) |value| value == .bool and value.bool else false;
+    return .{ .parsed = parsed, .command = command.string, .compact_output = compact };
+}
+
+test "shell compact success format" {
+    const allocator = std.testing.allocator;
+    const body = try std.fmt.allocPrint(allocator, "ok stdout={d} stderr={d}", .{ 3, 0 });
+    defer allocator.free(body);
+    try std.testing.expectEqualStrings("ok stdout=3 stderr=0", body);
+}

--- a/zig/src/tools/workspace.zig
+++ b/zig/src/tools/workspace.zig
@@ -1,0 +1,113 @@
+const std = @import("std");
+const compat = @import("compat");
+const ai_types = @import("ai_types");
+const agent_types = @import("agent_types");
+const common = @import("tools/common");
+
+fn defaultIo() std.Io {
+    return if (@import("builtin").is_test)
+        std.testing.io
+    else
+        std.Io.Threaded.global_single_threaded.io();
+}
+
+pub fn infoTool() agent_types.AgentTool {
+    return .{
+        .label = "Workspace Info",
+        .name = "workspace_info",
+        .description = "Return current workspace path and basic environment information.",
+        .short_description = "Show workspace path info.",
+        .parameters_schema_json = "{\"type\":\"object\",\"properties\":{\"compact_output\":{\"type\":\"boolean\"}}}",
+        .execute = executeInfo,
+    };
+}
+
+pub fn listTool() agent_types.AgentTool {
+    return .{
+        .label = "Workspace List",
+        .name = "workspace_list",
+        .description = "List entries in a workspace directory.",
+        .short_description = "List directory entries.",
+        .parameters_schema_json = "{\"type\":\"object\",\"properties\":{\"path\":{\"type\":\"string\"},\"compact_output\":{\"type\":\"boolean\"}}}",
+        .execute = executeList,
+    };
+}
+
+pub fn gitStatusTool() agent_types.AgentTool {
+    return .{
+        .label = "Git Status",
+        .name = "git_status",
+        .description = "Return git status in compact porcelain form.",
+        .short_description = "Show git status.",
+        .parameters_schema_json = "{\"type\":\"object\",\"properties\":{\"compact_output\":{\"type\":\"boolean\"}}}",
+        .execute = executeGitStatus,
+    };
+}
+
+pub fn executeInfo(tool_call_id: []const u8, args_json: []const u8, cancel_token: ?ai_types.CancelToken, on_update_ctx: ?*anyopaque, on_update: ?agent_types.ToolUpdateCallback, allocator: std.mem.Allocator) anyerror!agent_types.AgentToolResult {
+    _ = tool_call_id; _ = cancel_token; _ = on_update_ctx; _ = on_update;
+    const compact = compactFromArgs(allocator, args_json) catch false;
+    var buffer: [std.fs.max_path_bytes]u8 = undefined;
+    const len = try std.process.currentPath(defaultIo(), &buffer);
+    const cwd = buffer[0..len];
+    const body = if (compact) try std.fmt.allocPrint(allocator, "cwd {s}", .{cwd}) else try std.fmt.allocPrint(allocator, "cwd: {s}", .{cwd});
+    defer allocator.free(body);
+    const details = try common.telemetryDetails(allocator, body.len, body.len, false);
+    defer allocator.free(details);
+    return common.makeTextResult(allocator, body, details);
+}
+
+pub fn executeList(tool_call_id: []const u8, args_json: []const u8, cancel_token: ?ai_types.CancelToken, on_update_ctx: ?*anyopaque, on_update: ?agent_types.ToolUpdateCallback, allocator: std.mem.Allocator) anyerror!agent_types.AgentToolResult {
+    _ = tool_call_id; _ = cancel_token; _ = on_update_ctx; _ = on_update;
+    const parsed = try std.json.parseFromSlice(std.json.Value, allocator, args_json, .{});
+    defer parsed.deinit();
+    const obj = if (parsed.value == .object) parsed.value.object else return error.InvalidArguments;
+    const path = if (obj.get("path")) |v| if (v == .string) v.string else return error.InvalidArguments else ".";
+    const compact = if (obj.get("compact_output")) |v| v == .bool and v.bool else false;
+    var dir = try compat.fs.getCwd().openDir(defaultIo(), path, .{ .iterate = true });
+    defer dir.close(defaultIo());
+    var out = std.ArrayList(u8).empty;
+    defer out.deinit(allocator);
+    var it = dir.iterate();
+    while (try it.next(defaultIo())) |entry| {
+        const formatted = if (compact)
+            try std.fmt.allocPrint(allocator, "{s} {s}\n", .{ @tagName(entry.kind), entry.name })
+        else
+            try std.fmt.allocPrint(allocator, "{s}\t{s}\n", .{ @tagName(entry.kind), entry.name });
+        defer allocator.free(formatted);
+        try out.appendSlice(allocator, formatted);
+    }
+    const details = try common.telemetryDetails(allocator, out.items.len, out.items.len, false);
+    defer allocator.free(details);
+    return common.makeTextResult(allocator, out.items, details);
+}
+
+pub fn executeGitStatus(tool_call_id: []const u8, args_json: []const u8, cancel_token: ?ai_types.CancelToken, on_update_ctx: ?*anyopaque, on_update: ?agent_types.ToolUpdateCallback, allocator: std.mem.Allocator) anyerror!agent_types.AgentToolResult {
+    _ = tool_call_id; _ = args_json; _ = cancel_token; _ = on_update_ctx; _ = on_update;
+    const output = try std.process.run(allocator, defaultIo(), .{
+        .argv = &.{ "git", "status", "--short", "--branch" },
+        .stdout_limit = .limited(1024 * 1024),
+        .stderr_limit = .limited(1024 * 1024),
+    });
+    defer allocator.free(output.stdout);
+    defer allocator.free(output.stderr);
+    const body = if (output.stderr.len > 0) try std.fmt.allocPrint(allocator, "{s}\n{s}", .{ output.stdout, output.stderr }) else try allocator.dupe(u8, output.stdout);
+    defer allocator.free(body);
+    const details = try common.telemetryDetails(allocator, output.stdout.len + output.stderr.len, body.len, false);
+    defer allocator.free(details);
+    return common.makeTextResult(allocator, body, details);
+}
+
+fn compactFromArgs(allocator: std.mem.Allocator, args_json: []const u8) !bool {
+    const parsed = try std.json.parseFromSlice(std.json.Value, allocator, args_json, .{});
+    defer parsed.deinit();
+    if (parsed.value != .object) return false;
+    return if (parsed.value.object.get("compact_output")) |v| v == .bool and v.bool else false;
+}
+
+test "workspace compact info format" {
+    const allocator = std.testing.allocator;
+    var result = try executeInfo("call", "{\"compact_output\":true}", null, null, null, allocator);
+    defer result.deinit(allocator);
+    try std.testing.expect(std.mem.startsWith(u8, result.content.slice()[0].text.text, "cwd "));
+}

--- a/zig/src/tui/runtime.zig
+++ b/zig/src/tui/runtime.zig
@@ -39,6 +39,7 @@ pub const TuiRuntimeOptions = struct {
     tools: []const agent.AgentTool = &.{},
     tool_approval_ctx: ?*anyopaque = null,
     tool_approval_callback: ?ToolApprovalCallback = null,
+    compact_output: bool = false,
     run_async: bool = true,
 };
 
@@ -61,6 +62,7 @@ pub const TuiRuntime = struct {
     started: bool = false,
     stream_active: bool = false,
     last_turn_stop_reason: ?ai_types.StopReason = null,
+    compact_output: bool = false,
     run_async: bool = true,
 
     pub fn init(allocator: std.mem.Allocator, options: TuiRuntimeOptions) !TuiRuntime {
@@ -101,6 +103,7 @@ pub const TuiRuntime = struct {
             .approval_contexts = approval_contexts,
             .tool_approval_ctx = options.tool_approval_ctx,
             .tool_approval_callback = options.tool_approval_callback,
+            .compact_output = options.compact_output,
             .run_async = options.run_async,
         };
         return runtime;
@@ -272,6 +275,7 @@ pub const TuiRuntime = struct {
                 .label = tool.label,
                 .name = tool.name,
                 .description = tool.description,
+                .short_description = tool.short_description,
                 .parameters_schema_json = tool.parameters_schema_json,
                 .execute = tool.execute,
                 .approval_ctx = &self.approval_contexts[i],


### PR DESCRIPTION
## Summary
- Add local tool runtime modules for artifact-backed large outputs, artifact retrieval, compact output metadata, and short tool descriptions.
- Add hash-anchored file read/edit helpers with stale hash rejection before mutation.
- Wire new tool modules into Zig build/test steps and preserve short descriptions through agent/tool parsing.

## Test plan
- [x] ./scripts/check-zig-patterns.sh
- [x] cd zig && zig build test-unit-agent
- [x] cd zig && zig build test