### PR TITLE
Add retained TUI shell state and views

### DIFF
--- a/zig/build.zig
+++ b/zig/build.zig
@@ -860,6 +860,42 @@ pub fn build(b: *std.Build) void {
         },
     });
 
+    const tui_state_mod = b.createModule(.{
+        .root_source_file = b.path("src/tui/state.zig"),
+        .target = target,
+        .optimize = optimize,
+        .imports = &.{
+            .{ .name = "tui_runtime", .module = tui_runtime_mod },
+            .{ .name = "owned_slice", .module = owned_slice_mod },
+        },
+    });
+
+    const tui_view_transcript_mod = b.createModule(.{ .root_source_file = b.path("src/tui/views/transcript.zig"), .target = target, .optimize = optimize, .imports = &.{ .{ .name = "tui_state", .module = tui_state_mod } } });
+    const tui_view_composer_mod = b.createModule(.{ .root_source_file = b.path("src/tui/views/composer.zig"), .target = target, .optimize = optimize, .imports = &.{ .{ .name = "tui_state", .module = tui_state_mod } } });
+    const tui_view_status_bar_mod = b.createModule(.{ .root_source_file = b.path("src/tui/views/status_bar.zig"), .target = target, .optimize = optimize, .imports = &.{ .{ .name = "tui_state", .module = tui_state_mod } } });
+    const tui_view_tool_panel_mod = b.createModule(.{ .root_source_file = b.path("src/tui/views/tool_panel.zig"), .target = target, .optimize = optimize, .imports = &.{ .{ .name = "tui_state", .module = tui_state_mod } } });
+    const tui_view_approval_mod = b.createModule(.{ .root_source_file = b.path("src/tui/views/approval.zig"), .target = target, .optimize = optimize, .imports = &.{ .{ .name = "tui_state", .module = tui_state_mod } } });
+    const tui_view_preview_mod = b.createModule(.{ .root_source_file = b.path("src/tui/views/preview.zig"), .target = target, .optimize = optimize, .imports = &.{ .{ .name = "tui_state", .module = tui_state_mod } } });
+    const tui_view_session_picker_mod = b.createModule(.{ .root_source_file = b.path("src/tui/views/session_picker.zig"), .target = target, .optimize = optimize, .imports = &.{ .{ .name = "tui_state", .module = tui_state_mod } } });
+
+    const tui_app_mod = b.createModule(.{
+        .root_source_file = b.path("src/tui/app.zig"),
+        .target = target,
+        .optimize = optimize,
+        .imports = &.{
+            .{ .name = "zigzag", .module = zigzag_mod },
+            .{ .name = "tui_runtime", .module = tui_runtime_mod },
+            .{ .name = "tui_state", .module = tui_state_mod },
+            .{ .name = "tui_view_transcript", .module = tui_view_transcript_mod },
+            .{ .name = "tui_view_composer", .module = tui_view_composer_mod },
+            .{ .name = "tui_view_status_bar", .module = tui_view_status_bar_mod },
+            .{ .name = "tui_view_tool_panel", .module = tui_view_tool_panel_mod },
+            .{ .name = "tui_view_approval", .module = tui_view_approval_mod },
+            .{ .name = "tui_view_preview", .module = tui_view_preview_mod },
+            .{ .name = "tui_view_session_picker", .module = tui_view_session_picker_mod },
+        },
+    });
+
     const tui_tests_mock_provider_mod = b.createModule(.{
         .root_source_file = b.path("src/tui/tests/mock_provider.zig"),
         .target = target,
@@ -1239,6 +1275,9 @@ pub fn build(b: *std.Build) void {
     const agent_provider_protocol_bridge_test = b.addTest(.{ .root_module = agent_provider_protocol_bridge_mod });
     const tui_session_test = b.addTest(.{ .root_module = tui_session_mod });
     const tui_runtime_test = b.addTest(.{ .root_module = tui_runtime_mod });
+    const tui_state_test = b.addTest(.{ .root_module = tui_state_mod });
+    const tui_app_test = b.addTest(.{ .root_module = tui_app_mod });
+    const tui_view_transcript_test = b.addTest(.{ .root_module = tui_view_transcript_mod });
     const tui_tests_scenarios_test = b.addTest(.{ .root_module = tui_tests_scenarios_mod });
     const tui_tests_mock_transport_test = b.addTest(.{ .root_module = tui_tests_mock_transport_mod });
     const tools_common_test = b.addTest(.{ .root_module = tools_common_mod });
@@ -1362,6 +1401,11 @@ pub fn build(b: *std.Build) void {
     const run_step = b.step("run", "Run the Makai CLI");
     run_step.dependOn(&run_cmd.step);
 
+    const run_tui_cmd = b.addRunArtifact(makai_cli);
+    run_tui_cmd.addArg("--tui");
+    const run_tui_step = b.step("run-tui", "Run the Makai TUI");
+    run_tui_step.dependOn(&run_tui_cmd.step);
+
     const test_step = b.step("test", "Run tests");
     test_step.dependOn(&b.addRunArtifact(owned_slice_test).step);
     test_step.dependOn(&b.addRunArtifact(string_builder_test).step);
@@ -1424,6 +1468,9 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(&b.addRunArtifact(agent_provider_protocol_bridge_test).step);
     test_step.dependOn(&b.addRunArtifact(tui_session_test).step);
     test_step.dependOn(&b.addRunArtifact(tui_runtime_test).step);
+    test_step.dependOn(&b.addRunArtifact(tui_state_test).step);
+    test_step.dependOn(&b.addRunArtifact(tui_app_test).step);
+    test_step.dependOn(&b.addRunArtifact(tui_view_transcript_test).step);
     test_step.dependOn(&b.addRunArtifact(tui_tests_scenarios_test).step);
     test_step.dependOn(&b.addRunArtifact(tui_tests_mock_transport_test).step);
     test_step.dependOn(&b.addRunArtifact(tools_process_runner_test).step);
@@ -1567,6 +1614,9 @@ pub fn build(b: *std.Build) void {
     const test_unit_tui_step = b.step("test-unit-tui", "Run TUI runtime unit tests");
     test_unit_tui_step.dependOn(&b.addRunArtifact(tui_session_test).step);
     test_unit_tui_step.dependOn(&b.addRunArtifact(tui_runtime_test).step);
+    test_unit_tui_step.dependOn(&b.addRunArtifact(tui_state_test).step);
+    test_unit_tui_step.dependOn(&b.addRunArtifact(tui_app_test).step);
+    test_unit_tui_step.dependOn(&b.addRunArtifact(tui_view_transcript_test).step);
     test_unit_tui_step.dependOn(&b.addRunArtifact(tui_tests_scenarios_test).step);
     test_unit_tui_step.dependOn(&b.addRunArtifact(tui_tests_mock_transport_test).step);
     test_unit_tui_step.dependOn(&b.addRunArtifact(tools_common_test).step);

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -885,6 +885,10 @@ pub fn build(b: *std.Build) void {
         .imports = &.{
             .{ .name = "compat", .module = compat_mod },
             .{ .name = "zigzag", .module = zigzag_mod },
+            .{ .name = "ai_types", .module = ai_types_mod },
+            .{ .name = "api_registry", .module = api_registry_mod },
+            .{ .name = "register_builtins", .module = register_builtins_mod },
+            .{ .name = "agent", .module = agent_mod },
             .{ .name = "tui_runtime", .module = tui_runtime_mod },
             .{ .name = "tui_state", .module = tui_state_mod },
             .{ .name = "tui_view_transcript", .module = tui_view_transcript_mod },

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -883,6 +883,7 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
         .imports = &.{
+            .{ .name = "compat", .module = compat_mod },
             .{ .name = "zigzag", .module = zigzag_mod },
             .{ .name = "tui_runtime", .module = tui_runtime_mod },
             .{ .name = "tui_state", .module = tui_state_mod },
@@ -1278,6 +1279,12 @@ pub fn build(b: *std.Build) void {
     const tui_state_test = b.addTest(.{ .root_module = tui_state_mod });
     const tui_app_test = b.addTest(.{ .root_module = tui_app_mod });
     const tui_view_transcript_test = b.addTest(.{ .root_module = tui_view_transcript_mod });
+    const tui_view_composer_test = b.addTest(.{ .root_module = tui_view_composer_mod });
+    const tui_view_status_bar_test = b.addTest(.{ .root_module = tui_view_status_bar_mod });
+    const tui_view_tool_panel_test = b.addTest(.{ .root_module = tui_view_tool_panel_mod });
+    const tui_view_approval_test = b.addTest(.{ .root_module = tui_view_approval_mod });
+    const tui_view_preview_test = b.addTest(.{ .root_module = tui_view_preview_mod });
+    const tui_view_session_picker_test = b.addTest(.{ .root_module = tui_view_session_picker_mod });
     const tui_tests_scenarios_test = b.addTest(.{ .root_module = tui_tests_scenarios_mod });
     const tui_tests_mock_transport_test = b.addTest(.{ .root_module = tui_tests_mock_transport_mod });
     const tools_common_test = b.addTest(.{ .root_module = tools_common_mod });
@@ -1358,7 +1365,7 @@ pub fn build(b: *std.Build) void {
             .{ .name = "api_registry", .module = api_registry_mod },
             .{ .name = "event_stream", .module = event_stream_mod },
             .{ .name = "agent_loop", .module = agent_loop_mod },
-            .{ .name = "agent_bridge", .module = agent_provider_protocol_bridge_mod },
+            .{ .name = "agent_bridge", .module = agent_mod },
             .{ .name = "transport", .module = transport_mod },
             .{ .name = "model_ref", .module = protocol_model_ref_mod },
             .{ .name = "json_writer", .module = json_writer_mod },
@@ -1379,7 +1386,7 @@ pub fn build(b: *std.Build) void {
             .{ .name = "auth_cli", .module = auth_cli_mod },
             .{ .name = "transports/in_process", .module = in_process_transport_mod },
             .{ .name = "stdio", .module = stdio_transport_mod },
-            .{ .name = "zigzag", .module = zigzag_mod },
+            .{ .name = "tui_app", .module = tui_app_mod },
             .{ .name = "compat", .module = compat_mod },
         },
     });
@@ -1471,6 +1478,12 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(&b.addRunArtifact(tui_state_test).step);
     test_step.dependOn(&b.addRunArtifact(tui_app_test).step);
     test_step.dependOn(&b.addRunArtifact(tui_view_transcript_test).step);
+    test_step.dependOn(&b.addRunArtifact(tui_view_composer_test).step);
+    test_step.dependOn(&b.addRunArtifact(tui_view_status_bar_test).step);
+    test_step.dependOn(&b.addRunArtifact(tui_view_tool_panel_test).step);
+    test_step.dependOn(&b.addRunArtifact(tui_view_approval_test).step);
+    test_step.dependOn(&b.addRunArtifact(tui_view_preview_test).step);
+    test_step.dependOn(&b.addRunArtifact(tui_view_session_picker_test).step);
     test_step.dependOn(&b.addRunArtifact(tui_tests_scenarios_test).step);
     test_step.dependOn(&b.addRunArtifact(tui_tests_mock_transport_test).step);
     test_step.dependOn(&b.addRunArtifact(tools_process_runner_test).step);
@@ -1617,6 +1630,12 @@ pub fn build(b: *std.Build) void {
     test_unit_tui_step.dependOn(&b.addRunArtifact(tui_state_test).step);
     test_unit_tui_step.dependOn(&b.addRunArtifact(tui_app_test).step);
     test_unit_tui_step.dependOn(&b.addRunArtifact(tui_view_transcript_test).step);
+    test_unit_tui_step.dependOn(&b.addRunArtifact(tui_view_composer_test).step);
+    test_unit_tui_step.dependOn(&b.addRunArtifact(tui_view_status_bar_test).step);
+    test_unit_tui_step.dependOn(&b.addRunArtifact(tui_view_tool_panel_test).step);
+    test_unit_tui_step.dependOn(&b.addRunArtifact(tui_view_approval_test).step);
+    test_unit_tui_step.dependOn(&b.addRunArtifact(tui_view_preview_test).step);
+    test_unit_tui_step.dependOn(&b.addRunArtifact(tui_view_session_picker_test).step);
     test_unit_tui_step.dependOn(&b.addRunArtifact(tui_tests_scenarios_test).step);
     test_unit_tui_step.dependOn(&b.addRunArtifact(tui_tests_mock_transport_test).step);
     test_unit_tui_step.dependOn(&b.addRunArtifact(tools_common_test).step);

--- a/zig/src/tools/makai.zig
+++ b/zig/src/tools/makai.zig
@@ -21,7 +21,7 @@ const model_ref = @import("model_ref");
 const json_writer = @import("json_writer");
 const in_process = @import("transports/in_process");
 const stdio = @import("stdio");
-const zz = @import("zigzag");
+const tui_app = @import("tui_app");
 
 pub const VERSION = "0.0.1";
 
@@ -1814,138 +1814,15 @@ fn printUsage(file: std.Io.File) !void {
         \\Commands:
         \\  --version        Print binary version
         \\  --stdio          Start stdio mode
-        \\  --tui            Start ZigZag terminal UI preview
+        \\  --tui            Start terminal UI shell
         \\  auth providers   List oauth-capable providers
         \\  auth login       Run OAuth flow and persist credentials
         \\
     );
 }
 
-const TuiModel = struct {
-    composer: ?zz.TextInput = null,
-    transcript: ?zz.RichLog = null,
-    status: ?zz.StatusBar = null,
-    outbound_events: usize = 0,
-    status_right_buf: [32]u8 = undefined,
-    status_right: []const u8 = "",
-
-    pub const Msg = union(enum) {
-        key: zz.KeyEvent,
-        stream_delta: []const u8,
-        stream_done: void,
-        tick: struct {
-            timestamp: u64,
-            delta: u64,
-        },
-        quit: void,
-    };
-
-    pub fn init(self: *TuiModel, ctx: *zz.Context) zz.Cmd(Msg) {
-        self.deinit();
-        self.outbound_events = 0;
-        self.status_right = "";
-
-        var composer = zz.TextInput.init(ctx.persistent_allocator);
-        composer.setPrompt("> ");
-        composer.setPlaceholder("Ask Makai...");
-        composer.setSuggestions(&.{ "summarize", "test", "review", "auth providers" });
-        self.composer = composer;
-
-        var transcript = zz.RichLog.init(ctx.persistent_allocator, 1024);
-        transcript.show_timestamps = false;
-        transcript.append(ctx.io, .info, "Makai ZigZag TUI preview") catch {};
-        transcript.append(ctx.io, .info, "Enter submits composer, Ctrl+C quits") catch {};
-        self.transcript = transcript;
-
-        self.status = zz.StatusBar.init(ctx.persistent_allocator);
-        self.refreshStatus() catch {};
-        return .{ .every = std.time.ns_per_s };
-    }
-
-    pub fn deinit(self: *TuiModel) void {
-        if (self.composer) |*composer| {
-            composer.deinit();
-            self.composer = null;
-        }
-        if (self.transcript) |*transcript| {
-            transcript.deinit();
-            self.transcript = null;
-        }
-        if (self.status) |*status| {
-            status.deinit();
-            self.status = null;
-        }
-    }
-
-    pub fn update(self: *TuiModel, msg: Msg, ctx: *zz.Context) zz.Cmd(Msg) {
-        switch (msg) {
-            .key => |key| {
-                if (key.modifiers.ctrl) {
-                    switch (key.key) {
-                        .char => |c| if (c == 'c') return .quit,
-                        else => {},
-                    }
-                }
-                switch (key.key) {
-                    .enter => {
-                        const text = if (self.composer) |*composer| composer.getValue() else "";
-                        if (text.len > 0) {
-                            if (self.transcript) |*transcript| transcript.append(ctx.io, .info, text) catch {};
-                            self.outbound_events += 1;
-                            if (self.composer) |*composer| composer.setValue("") catch {};
-                            self.refreshStatus() catch {};
-                        }
-                    },
-                    .up, .page_up => if (self.transcript) |*transcript| transcript.scrollUp(1),
-                    .down, .page_down => if (self.transcript) |*transcript| transcript.scrollDown(1) catch {},
-                    else => if (self.composer) |*composer| composer.handleKey(key),
-                }
-            },
-            .stream_delta => |delta| {
-                if (self.transcript) |*transcript| transcript.append(ctx.io, .debug, delta) catch {};
-                self.refreshStatus() catch {};
-            },
-            .stream_done => {
-                if (self.transcript) |*transcript| transcript.append(ctx.io, .info, "stream complete") catch {};
-                self.refreshStatus() catch {};
-            },
-            .tick => self.refreshStatus() catch {},
-            .quit => return .quit,
-        }
-        return .none;
-    }
-
-    pub fn view(self: *TuiModel, ctx: *const zz.Context) []const u8 {
-        const width: u16 = @max(ctx.width, 20);
-        const height: u16 = @max(ctx.height, 5);
-        if (self.transcript) |*transcript| transcript.setSize(width, height -| 3);
-        if (self.composer) |*composer| composer.setWidth(width);
-        if (self.status) |*status| status.setWidth(width);
-
-        const transcript_view = if (self.transcript) |*transcript| transcript.view(ctx.allocator) catch "" else "";
-        const input_view = if (self.composer) |*composer| composer.view(ctx.allocator) catch "" else "";
-        const status_view = if (self.status) |*status| status.view(ctx.allocator) catch "" else "";
-        return std.fmt.allocPrint(ctx.allocator, "{s}\n{s}\n{s}", .{ transcript_view, input_view, status_view }) catch "";
-    }
-
-    fn refreshStatus(self: *TuiModel) !void {
-        self.status_right = try std.fmt.bufPrint(&self.status_right_buf, "events:{d}", .{self.outbound_events});
-        if (self.status) |*status| {
-            try status.setLeft("Makai", null);
-            try status.setCenter("ZigZag TUI", null);
-            try status.setRight(self.status_right, null);
-        }
-    }
-};
-
 fn runTui(allocator: std.mem.Allocator, io: std.Io) !void {
-    var environ_map = try compat.createEnvMap(allocator);
-    defer environ_map.deinit();
-
-    var program = zz.Program(TuiModel).init(allocator, io, &environ_map);
-    program.model = .{};
-    defer program.deinit();
-    try program.run();
+    try tui_app.run(allocator, io);
 }
 
 /// Production auth-server options for the CLI wrapper. Real OAuth flows are

--- a/zig/src/tui/app.zig
+++ b/zig/src/tui/app.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const compat = @import("compat");
 const zz = @import("zigzag");
 const tui_runtime = @import("tui_runtime");
 const tui_state = @import("tui_state");
@@ -86,9 +87,17 @@ const TuiModel = struct {
 
     pub fn init(self: *TuiModel, ctx: *zz.Context) zz.Cmd(Msg) {
         self.deinit();
-        self.app = App.init(ctx.persistent_allocator, self.options) catch App.initWithoutRuntime(ctx.persistent_allocator);
+        self.app = App.init(ctx.persistent_allocator, self.options) catch |err| blk: {
+            var fallback = App.initWithoutRuntime(ctx.persistent_allocator);
+            fallback.state.status.setError(ctx.persistent_allocator, @errorName(err)) catch {};
+            fallback.state.appendTranscript(.@"error", @errorName(err)) catch {};
+            break :blk fallback;
+        };
         if (self.app) |*app| {
-            app.start() catch {};
+            app.start() catch |err| {
+                app.state.status.setError(app.allocator, @errorName(err)) catch {};
+                app.state.appendTranscript(.@"error", @errorName(err)) catch {};
+            };
             app.state.appendTranscript(.system, "Makai TUI") catch {};
             app.state.appendTranscript(.system, "Enter submits composer, Ctrl+C or /quit exits") catch {};
         }
@@ -126,9 +135,16 @@ const TuiModel = struct {
                     .enter => {
                         const text = app.state.composer.text();
                         if (std.mem.eql(u8, std.mem.trim(u8, text, " \t\r\n"), "/quit")) return .quit;
-                        app.submit(text) catch |err| if (err == error.QuitRequested) return .quit else {};
+                        app.submit(text) catch |err| {
+                            if (err == error.QuitRequested) return .quit;
+                            app.state.status.setError(app.allocator, @errorName(err)) catch {};
+                            app.state.appendTranscript(.@"error", @errorName(err)) catch {};
+                        };
                         app.state.composer.clear();
-                        app.drainEvents() catch {};
+                        app.drainEvents() catch |err| {
+                            app.state.status.setError(app.allocator, @errorName(err)) catch {};
+                            app.state.appendTranscript(.@"error", @errorName(err)) catch {};
+                        };
                     },
                     .backspace => {
                         if (app.state.composer.buffer.items.len > 0) _ = app.state.composer.buffer.pop();
@@ -184,7 +200,7 @@ const TuiModel = struct {
 };
 
 pub fn run(allocator: std.mem.Allocator, io: std.Io) !void {
-    var environ_map = try std.process.getEnvMap(allocator);
+    var environ_map = try compat.createEnvMap(allocator);
     defer environ_map.deinit();
 
     var program = zz.Program(TuiModel).init(allocator, io, &environ_map);

--- a/zig/src/tui/app.zig
+++ b/zig/src/tui/app.zig
@@ -1,6 +1,10 @@
 const std = @import("std");
 const compat = @import("compat");
 const zz = @import("zigzag");
+const ai_types = @import("ai_types");
+const api_registry = @import("api_registry");
+const register_builtins = @import("register_builtins");
+const agent = @import("agent");
 const tui_runtime = @import("tui_runtime");
 const tui_state = @import("tui_state");
 const transcript_view = @import("tui_view_transcript");
@@ -11,17 +15,74 @@ const approval_view = @import("tui_view_approval");
 const preview_view = @import("tui_view_preview");
 const session_picker_view = @import("tui_view_session_picker");
 
+pub const ApprovalWaiter = struct {
+    allocator: std.mem.Allocator,
+    mutex: std.atomic.Mutex = .unlocked,
+    tool_call_id: []u8 = &.{},
+    decision: ?tui_runtime.ToolApprovalDecision = null,
+
+    pub fn deinit(self: *ApprovalWaiter) void {
+        if (self.tool_call_id.len > 0) self.allocator.free(self.tool_call_id);
+        self.* = undefined;
+    }
+};
+
+pub const ProductionRuntime = struct {
+    allocator: std.mem.Allocator,
+    registry: api_registry.ApiRegistry,
+    bridge: agent.InProcessProviderProtocolBridge,
+    models: []ai_types.Model,
+
+    pub fn init(allocator: std.mem.Allocator) !ProductionRuntime {
+        var registry = api_registry.ApiRegistry.init(allocator);
+        errdefer registry.deinit();
+        try register_builtins.registerBuiltInApiProviders(&registry);
+        var runtime = ProductionRuntime{
+            .allocator = allocator,
+            .registry = registry,
+            .bridge = undefined,
+            .models = try allocator.alloc(ai_types.Model, 1),
+        };
+        runtime.bridge = agent.InProcessProviderProtocolBridge.init(&runtime.registry);
+        runtime.models[0] = defaultModel();
+        return runtime;
+    }
+
+    pub fn options(self: *ProductionRuntime) tui_runtime.TuiRuntimeOptions {
+        return .{
+            .protocol = (&self.bridge).protocolClient(),
+            .models = self.models,
+            .run_async = true,
+            .compact_output = true,
+        };
+    }
+
+    pub fn deinit(self: *ProductionRuntime) void {
+        self.allocator.free(self.models);
+        self.registry.deinit();
+        self.* = undefined;
+    }
+};
+
 pub const App = struct {
     allocator: std.mem.Allocator,
     state: tui_state.AppState,
     runtime: ?tui_runtime.TuiRuntime = null,
     session: ?tui_runtime.TuiSession = null,
+    approval_waiter: ?*ApprovalWaiter = null,
 
     pub fn init(allocator: std.mem.Allocator, options: tui_runtime.TuiRuntimeOptions) !App {
+        var runtime_options = options;
+        const approval_waiter = try allocator.create(ApprovalWaiter);
+        errdefer allocator.destroy(approval_waiter);
+        approval_waiter.* = .{ .allocator = allocator };
+        runtime_options.tool_approval_ctx = approval_waiter;
+        runtime_options.tool_approval_callback = approvalCallback;
         var app = App{
             .allocator = allocator,
             .state = tui_state.AppState.init(allocator),
-            .runtime = try tui_runtime.TuiRuntime.init(allocator, options),
+            .runtime = try tui_runtime.TuiRuntime.init(allocator, runtime_options),
+            .approval_waiter = approval_waiter,
         };
         errdefer app.deinit();
         app.session = app.runtime.?.createSession();
@@ -35,6 +96,10 @@ pub const App = struct {
 
     pub fn deinit(self: *App) void {
         if (self.runtime) |*runtime| runtime.deinit();
+        if (self.approval_waiter) |waiter| {
+            waiter.deinit();
+            self.allocator.destroy(waiter);
+        }
         self.state.deinit();
         self.* = undefined;
     }
@@ -73,7 +138,54 @@ pub const App = struct {
             };
         }
     }
+
+    pub fn recordError(self: *App, message: []const u8) !void {
+        try self.state.status.setError(self.allocator, message);
+        try self.state.appendTranscript(.@"error", message);
+    }
+
+    pub fn decideApproval(self: *App, approved: bool, always: bool) !void {
+        const id = self.state.approval.tool_call_id;
+        const decision: tui_runtime.ToolApprovalDecision = if (approved) .approve else .reject;
+        if (self.approval_waiter) |waiter| {
+            while (!waiter.mutex.tryLock()) std.atomic.spinLoopHint();
+            defer waiter.mutex.unlock();
+            if (waiter.tool_call_id.len > 0 and (id.len == 0 or std.mem.eql(u8, waiter.tool_call_id, id))) {
+                waiter.decision = decision;
+            }
+        }
+        if (self.session) |*session| {
+            if (id.len > 0) try session.decideToolApproval(id, decision);
+        }
+        self.state.setApprovalDecision(approved, always);
+    }
 };
+
+fn approvalCallback(ctx: ?*anyopaque, request: tui_runtime.ToolApprovalRequest) tui_runtime.ToolApprovalDecision {
+    const waiter: *ApprovalWaiter = @ptrCast(@alignCast(ctx.?));
+    while (!waiter.mutex.tryLock()) std.atomic.spinLoopHint();
+    if (waiter.tool_call_id.len > 0) waiter.allocator.free(waiter.tool_call_id);
+    waiter.tool_call_id = waiter.allocator.dupe(u8, request.tool_call_id) catch {
+        waiter.mutex.unlock();
+        return .approve;
+    };
+    waiter.decision = null;
+    waiter.mutex.unlock();
+    while (true) {
+        while (!waiter.mutex.tryLock()) std.atomic.spinLoopHint();
+        const decision = waiter.decision;
+        waiter.mutex.unlock();
+        if (decision) |value| {
+            while (!waiter.mutex.tryLock()) std.atomic.spinLoopHint();
+            if (waiter.tool_call_id.len > 0) waiter.allocator.free(waiter.tool_call_id);
+            waiter.tool_call_id = &.{};
+            waiter.decision = null;
+            waiter.mutex.unlock();
+            return value;
+        }
+        compat.time.sleepNs(1 * std.time.ns_per_ms);
+    }
+}
 
 const TuiModel = struct {
     app: ?App = null,
@@ -121,18 +233,22 @@ const TuiModel = struct {
                 if (app.state.mode == .approval) {
                     switch (key.key) {
                         .char => |c| switch (c) {
-                            'a' => app.state.setApprovalDecision(true, false),
-                            'A' => app.state.setApprovalDecision(true, true),
-                            'd' => app.state.setApprovalDecision(false, false),
+                            'a' => app.decideApproval(true, false) catch |err| app.recordError(@errorName(err)) catch {},
+                            'A' => app.decideApproval(true, true) catch |err| app.recordError(@errorName(err)) catch {},
+                            'd' => app.decideApproval(false, false) catch |err| app.recordError(@errorName(err)) catch {},
                             else => {},
                         },
-                        .escape => app.state.setApprovalDecision(false, false),
+                        .escape => app.decideApproval(false, false) catch |err| app.recordError(@errorName(err)) catch {},
                         else => {},
                     }
                     return .none;
                 }
                 switch (key.key) {
                     .enter => {
+                        if (key.modifiers.shift) {
+                            app.state.composer.buffer.append(app.allocator, '\n') catch |err| app.recordError(@errorName(err)) catch {};
+                            return .none;
+                        }
                         const text = app.state.composer.text();
                         if (std.mem.eql(u8, std.mem.trim(u8, text, " \t\r\n"), "/quit")) return .quit;
                         app.submit(text) catch |err| {
@@ -146,9 +262,7 @@ const TuiModel = struct {
                             app.state.appendTranscript(.@"error", @errorName(err)) catch {};
                         };
                     },
-                    .backspace => {
-                        if (app.state.composer.buffer.items.len > 0) _ = app.state.composer.buffer.pop();
-                    },
+                    .backspace => deleteLastCodepoint(app),
                     .char => |c| appendChar(app, c) catch {},
                     .space => app.state.composer.buffer.append(app.allocator, ' ') catch {},
                     .up, .page_up => app.state.transcript_scroll += 1,
@@ -189,6 +303,14 @@ const TuiModel = struct {
         try app.state.composer.buffer.appendSlice(app.allocator, buf[0..len]);
     }
 
+    fn deleteLastCodepoint(app: *App) void {
+        const text = app.state.composer.buffer.items;
+        if (text.len == 0) return;
+        var idx = text.len - 1;
+        while (idx > 0 and (text[idx] & 0b1100_0000) == 0b1000_0000) idx -= 1;
+        app.state.composer.buffer.shrinkRetainingCapacity(idx);
+    }
+
     fn countLines(text: []const u8) usize {
         if (text.len == 0) return 0;
         var count: usize = 1;
@@ -199,12 +321,30 @@ const TuiModel = struct {
     }
 };
 
+fn defaultModel() ai_types.Model {
+    return .{
+        .id = "claude-sonnet-4-5",
+        .name = "Claude Sonnet 4.5",
+        .api = "anthropic-messages",
+        .provider = "anthropic",
+        .base_url = "https://api.anthropic.com/v1/messages",
+        .reasoning = true,
+        .input = &.{"text"},
+        .cost = .{ .input = 3.0, .output = 15.0, .cache_read = 0.30, .cache_write = 3.75 },
+        .context_window = 200_000,
+        .max_tokens = 8192,
+    };
+}
+
 pub fn run(allocator: std.mem.Allocator, io: std.Io) !void {
     var environ_map = try compat.createEnvMap(allocator);
     defer environ_map.deinit();
 
+    var production = try ProductionRuntime.init(allocator);
+    defer production.deinit();
+
     var program = zz.Program(TuiModel).init(allocator, io, &environ_map);
-    program.model = .{ .options = .{} };
+    program.model = .{ .options = production.options() };
     defer program.deinit();
     try program.run();
 }

--- a/zig/src/tui/app.zig
+++ b/zig/src/tui/app.zig
@@ -1,0 +1,202 @@
+const std = @import("std");
+const zz = @import("zigzag");
+const tui_runtime = @import("tui_runtime");
+const tui_state = @import("tui_state");
+const transcript_view = @import("tui_view_transcript");
+const composer_view = @import("tui_view_composer");
+const status_bar_view = @import("tui_view_status_bar");
+const tool_panel_view = @import("tui_view_tool_panel");
+const approval_view = @import("tui_view_approval");
+const preview_view = @import("tui_view_preview");
+const session_picker_view = @import("tui_view_session_picker");
+
+pub const App = struct {
+    allocator: std.mem.Allocator,
+    state: tui_state.AppState,
+    runtime: ?tui_runtime.TuiRuntime = null,
+    session: ?tui_runtime.TuiSession = null,
+
+    pub fn init(allocator: std.mem.Allocator, options: tui_runtime.TuiRuntimeOptions) !App {
+        var app = App{
+            .allocator = allocator,
+            .state = tui_state.AppState.init(allocator),
+            .runtime = try tui_runtime.TuiRuntime.init(allocator, options),
+        };
+        errdefer app.deinit();
+        app.session = app.runtime.?.createSession();
+        if (app.runtime.?.currentModel()) |model| try app.state.status.setModel(allocator, model.id, model.provider);
+        return app;
+    }
+
+    pub fn initWithoutRuntime(allocator: std.mem.Allocator) App {
+        return .{ .allocator = allocator, .state = tui_state.AppState.init(allocator) };
+    }
+
+    pub fn deinit(self: *App) void {
+        if (self.runtime) |*runtime| runtime.deinit();
+        self.state.deinit();
+        self.* = undefined;
+    }
+
+    pub fn start(self: *App) !void {
+        if (self.session) |*session| {
+            session.start() catch |err| {
+                try self.state.status.setError(self.allocator, @errorName(err));
+                try self.state.appendTranscript(.@"error", @errorName(err));
+                return;
+            };
+        } else {
+            try self.state.status.setError(self.allocator, "no runtime configured");
+        }
+    }
+
+    pub fn drainEvents(self: *App) !void {
+        var session = &(self.session orelse return);
+        while (session.popEvent()) |event| {
+            var ev = event;
+            defer ev.deinit(self.allocator);
+            try self.state.applyEvent(ev);
+        }
+    }
+
+    pub fn submit(self: *App, text: []const u8) !void {
+        const trimmed = std.mem.trim(u8, text, " \t\r\n");
+        if (trimmed.len == 0) return;
+        if (std.mem.eql(u8, trimmed, "/quit")) return error.QuitRequested;
+        try self.state.appendUserMessage(trimmed);
+        if (self.session) |*session| {
+            session.submitTurn(trimmed) catch |err| {
+                try self.state.status.setError(self.allocator, @errorName(err));
+                try self.state.appendTranscript(.@"error", @errorName(err));
+                return;
+            };
+        }
+    }
+};
+
+const TuiModel = struct {
+    app: ?App = null,
+    options: tui_runtime.TuiRuntimeOptions = .{},
+
+    pub const Msg = union(enum) {
+        key: zz.KeyEvent,
+        tick: struct { timestamp: u64, delta: u64 },
+        quit: void,
+    };
+
+    pub fn init(self: *TuiModel, ctx: *zz.Context) zz.Cmd(Msg) {
+        self.deinit();
+        self.app = App.init(ctx.persistent_allocator, self.options) catch App.initWithoutRuntime(ctx.persistent_allocator);
+        if (self.app) |*app| {
+            app.start() catch {};
+            app.state.appendTranscript(.system, "Makai TUI") catch {};
+            app.state.appendTranscript(.system, "Enter submits composer, Ctrl+C or /quit exits") catch {};
+        }
+        return .{ .every = 50 * std.time.ns_per_ms };
+    }
+
+    pub fn deinit(self: *TuiModel) void {
+        if (self.app) |*app| app.deinit();
+        self.app = null;
+    }
+
+    pub fn update(self: *TuiModel, msg: Msg, ctx: *zz.Context) zz.Cmd(Msg) {
+        _ = ctx;
+        const app = &(self.app orelse return .none);
+        switch (msg) {
+            .key => |key| {
+                if (key.modifiers.ctrl) switch (key.key) {
+                    .char => |c| if (c == 'c') return .quit,
+                    else => {},
+                };
+                if (app.state.mode == .approval) {
+                    switch (key.key) {
+                        .char => |c| switch (c) {
+                            'a' => app.state.setApprovalDecision(true, false),
+                            'A' => app.state.setApprovalDecision(true, true),
+                            'd' => app.state.setApprovalDecision(false, false),
+                            else => {},
+                        },
+                        .escape => app.state.setApprovalDecision(false, false),
+                        else => {},
+                    }
+                    return .none;
+                }
+                switch (key.key) {
+                    .enter => {
+                        const text = app.state.composer.text();
+                        if (std.mem.eql(u8, std.mem.trim(u8, text, " \t\r\n"), "/quit")) return .quit;
+                        app.submit(text) catch |err| if (err == error.QuitRequested) return .quit else {};
+                        app.state.composer.clear();
+                        app.drainEvents() catch {};
+                    },
+                    .backspace => {
+                        if (app.state.composer.buffer.items.len > 0) _ = app.state.composer.buffer.pop();
+                    },
+                    .char => |c| appendChar(app, c) catch {},
+                    .space => app.state.composer.buffer.append(app.allocator, ' ') catch {},
+                    .up, .page_up => app.state.transcript_scroll += 1,
+                    .down, .page_down => app.state.transcript_scroll -|= 1,
+                    .escape => app.state.mode = .normal,
+                    else => {},
+                }
+            },
+            .tick => app.drainEvents() catch {},
+            .quit => return .quit,
+        }
+        return .none;
+    }
+
+    pub fn view(self: *TuiModel, ctx: *const zz.Context) []const u8 {
+        const app = &(self.app orelse return "Makai TUI failed to initialize");
+        const width: usize = @max(ctx.width, 20);
+        const height: usize = @max(ctx.height, 8);
+        const status = status_bar_view.render(ctx.allocator, &app.state, .{ .width = width }) catch "";
+        const composer = composer_view.render(ctx.allocator, &app.state, .{ .width = width }) catch "";
+        const tool_height: usize = if (app.state.tools.items.len > 0) @min(@as(usize, 8), height / 4) else 2;
+        const tools = tool_panel_view.render(ctx.allocator, &app.state, .{ .width = width, .height = tool_height }) catch "";
+        const extra = switch (app.state.mode) {
+            .approval => approval_view.render(ctx.allocator, &app.state, .{ .width = width }) catch "",
+            .preview => preview_view.render(ctx.allocator, &app.state, .{ .width = width, .height = height / 2 }) catch "",
+            .session_picker => session_picker_view.render(ctx.allocator, &app.state, .{ .height = height / 2 }) catch "",
+            .normal => "",
+        };
+        const fixed = countLines(status) + countLines(composer) + countLines(tools) + countLines(extra) + 4;
+        const transcript_height = if (height > fixed) height - fixed else 3;
+        const transcript = transcript_view.render(ctx.allocator, &app.state, .{ .width = width, .height = transcript_height }) catch "";
+        return std.fmt.allocPrint(ctx.allocator, "{s}\n{s}\n{s}\n{s}\n{s}", .{ transcript, tools, extra, composer, status }) catch "";
+    }
+
+    fn appendChar(app: *App, c: u21) !void {
+        var buf: [4]u8 = undefined;
+        const len = try std.unicode.utf8Encode(c, &buf);
+        try app.state.composer.buffer.appendSlice(app.allocator, buf[0..len]);
+    }
+
+    fn countLines(text: []const u8) usize {
+        if (text.len == 0) return 0;
+        var count: usize = 1;
+        for (text) |c| {
+            if (c == '\n') count += 1;
+        }
+        return count;
+    }
+};
+
+pub fn run(allocator: std.mem.Allocator, io: std.Io) !void {
+    var environ_map = try std.process.getEnvMap(allocator);
+    defer environ_map.deinit();
+
+    var program = zz.Program(TuiModel).init(allocator, io, &environ_map);
+    program.model = .{ .options = .{} };
+    defer program.deinit();
+    try program.run();
+}
+
+test "App submit appends user transcript without runtime" {
+    var app = App.initWithoutRuntime(std.testing.allocator);
+    defer app.deinit();
+    try app.submit("hello");
+    try std.testing.expectEqual(@as(usize, 1), app.state.transcript.items.len);
+    try std.testing.expectEqualStrings("hello", app.state.transcript.items[0].text.items);
+}

--- a/zig/src/tui/runtime.zig
+++ b/zig/src/tui/runtime.zig
@@ -16,6 +16,11 @@ pub const ToolApprovalCallback = session.ToolApprovalCallback;
 pub const ToolApprovalDecision = session.ToolApprovalDecision;
 pub const ToolApprovalRequest = session.ToolApprovalRequest;
 
+const ApprovalDecisionState = struct {
+    tool_call_id: []u8 = &.{},
+    decision: ?ToolApprovalDecision = null,
+};
+
 const ApprovalContext = struct {
     runtime: *TuiRuntime,
     callback_ctx: ?*anyopaque,
@@ -57,6 +62,8 @@ pub const TuiRuntime = struct {
     original_tools: []agent.AgentTool,
     wrapped_tools: []agent.AgentTool,
     approval_contexts: []ApprovalContext,
+    pending_approval: ApprovalDecisionState = .{},
+    approval_mutex: std.atomic.Mutex = .unlocked,
     tool_approval_ctx: ?*anyopaque,
     tool_approval_callback: ?ToolApprovalCallback,
     cancelled: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
@@ -121,6 +128,7 @@ pub const TuiRuntime = struct {
         self.stop();
         self.event_stream.deinit();
         if (self.remote_client) |*client| client.deinit();
+        self.clearPendingApproval();
         self.allocator.free(self.approval_contexts);
         self.allocator.free(self.wrapped_tools);
         self.allocator.free(self.original_tools);
@@ -169,6 +177,7 @@ pub const TuiRuntime = struct {
                 .submit_turn = sessionSubmitTurn,
                 .switch_model = sessionSwitchModel,
                 .current_model = sessionCurrentModel,
+                .decide_tool_approval = sessionDecideToolApproval,
                 .stream_events = sessionStreamEvents,
             },
         };
@@ -255,10 +264,47 @@ pub const TuiRuntime = struct {
     pub fn cancel(self: *TuiRuntime) void {
         self.cancelled.store(true, .release);
         if (self.local_agent) |*local| local.abort();
+        while (!self.approval_mutex.tryLock()) std.atomic.spinLoopHint();
+        self.approval_mutex.unlock();
     }
 
     pub fn streamEvents(self: *TuiRuntime) *TuiEventStream {
         return &self.event_stream;
+    }
+
+    pub fn decideToolApproval(self: *TuiRuntime, tool_call_id: []const u8, decision: ToolApprovalDecision) !void {
+        while (!self.approval_mutex.tryLock()) std.atomic.spinLoopHint();
+        defer self.approval_mutex.unlock();
+        if (self.pending_approval.tool_call_id.len > 0 and !std.mem.eql(u8, self.pending_approval.tool_call_id, tool_call_id)) return error.ToolApprovalNotPending;
+        if (self.pending_approval.tool_call_id.len == 0) {
+            self.pending_approval.tool_call_id = try self.allocator.dupe(u8, tool_call_id);
+        }
+        self.pending_approval.decision = decision;
+    }
+
+    fn clearPendingApproval(self: *TuiRuntime) void {
+        while (!self.approval_mutex.tryLock()) std.atomic.spinLoopHint();
+        defer self.approval_mutex.unlock();
+        if (self.pending_approval.tool_call_id.len > 0) self.allocator.free(self.pending_approval.tool_call_id);
+        self.pending_approval = .{};
+    }
+
+    fn waitForToolApproval(self: *TuiRuntime, request: ToolApprovalRequest) ToolApprovalDecision {
+        while (!self.approval_mutex.tryLock()) std.atomic.spinLoopHint();
+        if (self.pending_approval.tool_call_id.len > 0) self.allocator.free(self.pending_approval.tool_call_id);
+        self.pending_approval = .{ .tool_call_id = self.allocator.dupe(u8, request.tool_call_id) catch {
+            self.approval_mutex.unlock();
+            return .approve;
+        } };
+        self.approval_mutex.unlock();
+        while (!self.cancelled.load(.acquire)) {
+            while (!self.approval_mutex.tryLock()) std.atomic.spinLoopHint();
+            const decision = self.pending_approval.decision;
+            self.approval_mutex.unlock();
+            if (decision) |value| return value;
+            compat.time.sleepNs(1 * std.time.ns_per_ms);
+        }
+        return .reject;
     }
 
     fn resetEventStreamForTurn(self: *TuiRuntime) void {
@@ -419,16 +465,18 @@ fn approveTool(ctx: ?*anyopaque, request: agent.ToolApprovalRequest) agent.ToolA
             .reject, .reject_always => return .reject,
         }
     }
+    const approval_request = ToolApprovalRequest{
+        .tool_call_id = request.tool_call_id,
+        .tool_name = request.tool_name,
+        .args_json = request.args_json,
+    };
     if (approval_ctx.callback) |callback| {
-        return switch (callback(approval_ctx.callback_ctx, .{
-            .tool_call_id = request.tool_call_id,
-            .tool_name = request.tool_name,
-            .args_json = request.args_json,
-        })) {
+        return switch (callback(approval_ctx.callback_ctx, approval_request)) {
             .approve => .approve,
             .reject => .reject,
         };
     }
+    _ = approval_ctx.runtime;
     return .approve;
 }
 
@@ -460,6 +508,11 @@ fn sessionSwitchModel(ctx: ?*anyopaque, model_id: []const u8) anyerror!void {
 fn sessionCurrentModel(ctx: ?*anyopaque) ?ai_types.Model {
     const self: *TuiRuntime = @ptrCast(@alignCast(ctx.?));
     return self.currentModel();
+}
+
+fn sessionDecideToolApproval(ctx: ?*anyopaque, tool_call_id: []const u8, decision: ToolApprovalDecision) anyerror!void {
+    const self: *TuiRuntime = @ptrCast(@alignCast(ctx.?));
+    try self.decideToolApproval(tool_call_id, decision);
 }
 
 fn sessionStreamEvents(ctx: ?*anyopaque) *TuiEventStream {
@@ -944,6 +997,7 @@ test "preserves original tool approval when wrapping" {
 
 test "preserves original tool approval UI when wrapping" {
     var original_ctx = OriginalApprovalUiCtx{};
+    var approval_ctx = ApprovalCtx{ .decision = .approve };
     const tools = [_]agent.AgentTool{.{
         .label = "Demo",
         .name = "demo_tool",
@@ -959,6 +1013,8 @@ test "preserves original tool approval UI when wrapping" {
         .protocol = makeProtocol(&mock),
         .models = &models,
         .tools = &tools,
+        .tool_approval_ctx = &approval_ctx,
+        .tool_approval_callback = approvalCallback,
         .run_async = false,
     });
     defer runtime.deinit();

--- a/zig/src/tui/session.zig
+++ b/zig/src/tui/session.zig
@@ -115,6 +115,7 @@ pub const TuiSessionOps = struct {
     submit_turn: *const fn (ctx: ?*anyopaque, text: []const u8) anyerror!void = undefined,
     switch_model: *const fn (ctx: ?*anyopaque, model_id: []const u8) anyerror!void = undefined,
     current_model: *const fn (ctx: ?*anyopaque) ?ai_types.Model = undefined,
+    decide_tool_approval: *const fn (ctx: ?*anyopaque, tool_call_id: []const u8, decision: ToolApprovalDecision) anyerror!void = undefined,
     stream_events: *const fn (ctx: ?*anyopaque) *TuiEventStream = undefined,
 };
 
@@ -144,6 +145,10 @@ pub const TuiSession = struct {
 
     pub fn currentModel(self: *TuiSession) ?ai_types.Model {
         return self.ops.current_model(self.ctx);
+    }
+
+    pub fn decideToolApproval(self: *TuiSession, tool_call_id: []const u8, decision: ToolApprovalDecision) !void {
+        try self.ops.decide_tool_approval(self.ctx, tool_call_id, decision);
     }
 
     pub fn streamEvents(self: *TuiSession) *TuiEventStream {

--- a/zig/src/tui/state.zig
+++ b/zig/src/tui/state.zig
@@ -435,3 +435,47 @@ test "Composer submission stores history and user transcript" {
     try std.testing.expectEqual(TranscriptKind.user, state.transcript.items[0].kind);
     try std.testing.expectEqualStrings("hello makai", state.transcript.items[0].text.items);
 }
+
+test "AppState applies thinking tool call and lifecycle events" {
+    var state = AppState.init(std.testing.allocator);
+    defer state.deinit();
+
+    try state.applyEvent(.agent_start);
+    try std.testing.expect(state.status.streaming);
+    try std.testing.expectEqual(TranscriptKind.system, state.transcript.items[0].kind);
+
+    var thinking_event = tui_runtime.TuiEvent{ .thinking_delta = .{ .content_index = 0, .delta = try ownedText("plan") } };
+    defer thinking_event.deinit(std.testing.allocator);
+    try state.applyEvent(thinking_event);
+
+    var call_event = tui_runtime.TuiEvent{ .tool_call_delta = .{ .content_index = 1, .delta = try ownedText("{\"name\":\"shell\"}") } };
+    defer call_event.deinit(std.testing.allocator);
+    try state.applyEvent(call_event);
+
+    try std.testing.expectEqual(TranscriptKind.thinking, state.transcript.items[1].kind);
+    try std.testing.expectEqualStrings("plan", state.transcript.items[1].text.items);
+    try std.testing.expectEqual(TranscriptKind.tool, state.transcript.items[2].kind);
+    try std.testing.expectEqualStrings("{\"name\":\"shell\"}", state.transcript.items[2].text.items);
+
+    try state.applyEvent(tui_runtime.TuiEvent{ .agent_end = .{ .reason = .cancelled } });
+    try std.testing.expect(!state.status.streaming);
+    try std.testing.expectEqualStrings("agent cancelled", state.transcript.items[state.transcript.items.len - 1].text.items);
+}
+
+test "AppState appends tool execution updates" {
+    var state = AppState.init(std.testing.allocator);
+    defer state.deinit();
+
+    var update_event = tui_runtime.TuiEvent{ .tool_execution_update = .{
+        .tool_call_id = try ownedText("call-3"),
+        .tool_name = try ownedText("search"),
+        .args_json = try ownedText("{\"query\":\"tui\"}"),
+        .partial_result_json = try ownedText("{\"match\":1}"),
+    } };
+    defer update_event.deinit(std.testing.allocator);
+    try state.applyEvent(update_event);
+
+    try std.testing.expectEqual(@as(usize, 1), state.tools.items.len);
+    try std.testing.expectEqual(ToolStatus.running, state.tools.items[0].status);
+    try std.testing.expectEqualStrings("{\"match\":1}", state.tools.items[0].output.items);
+}

--- a/zig/src/tui/state.zig
+++ b/zig/src/tui/state.zig
@@ -1,0 +1,437 @@
+const std = @import("std");
+const tui_runtime = @import("tui_runtime");
+
+pub const AppMode = enum {
+    normal,
+    approval,
+    preview,
+    session_picker,
+};
+
+pub const TranscriptKind = enum {
+    user,
+    assistant,
+    thinking,
+    tool,
+    system,
+    @"error",
+};
+
+pub const ToolStatus = enum {
+    pending,
+    running,
+    done,
+    @"error",
+};
+
+pub const ApprovalStatus = enum {
+    none,
+    pending,
+    approved,
+    rejected,
+};
+
+pub const PreviewKind = enum {
+    diff,
+    file,
+    artifact,
+};
+
+pub const TranscriptEntry = struct {
+    kind: TranscriptKind,
+    text: std.ArrayList(u8) = .empty,
+
+    pub fn init(allocator: std.mem.Allocator, kind: TranscriptKind, text: []const u8) !TranscriptEntry {
+        var entry = TranscriptEntry{ .kind = kind };
+        try entry.text.appendSlice(allocator, text);
+        return entry;
+    }
+
+    pub fn deinit(self: *TranscriptEntry, allocator: std.mem.Allocator) void {
+        self.text.deinit(allocator);
+        self.* = undefined;
+    }
+};
+
+pub const ToolEntry = struct {
+    id: []u8,
+    name: []u8,
+    args_json: []u8,
+    output: std.ArrayList(u8) = .empty,
+    status: ToolStatus = .pending,
+    expanded: bool = false,
+
+    pub fn init(allocator: std.mem.Allocator, id: []const u8, name: []const u8, args_json: []const u8, status: ToolStatus) !ToolEntry {
+        return .{
+            .id = try allocator.dupe(u8, id),
+            .name = try allocator.dupe(u8, name),
+            .args_json = try allocator.dupe(u8, args_json),
+            .status = status,
+        };
+    }
+
+    pub fn deinit(self: *ToolEntry, allocator: std.mem.Allocator) void {
+        allocator.free(self.id);
+        allocator.free(self.name);
+        allocator.free(self.args_json);
+        self.output.deinit(allocator);
+        self.* = undefined;
+    }
+};
+
+pub const ApprovalState = struct {
+    status: ApprovalStatus = .none,
+    tool_call_id: []u8 = &.{},
+    tool_name: []u8 = &.{},
+    args_json: []u8 = &.{},
+    always: bool = false,
+
+    pub fn deinit(self: *ApprovalState, allocator: std.mem.Allocator) void {
+        if (self.tool_call_id.len > 0) allocator.free(self.tool_call_id);
+        if (self.tool_name.len > 0) allocator.free(self.tool_name);
+        if (self.args_json.len > 0) allocator.free(self.args_json);
+        self.* = .{};
+    }
+
+    pub fn setPending(self: *ApprovalState, allocator: std.mem.Allocator, tool_call_id: []const u8, tool_name: []const u8, args_json: []const u8) !void {
+        self.deinit(allocator);
+        self.* = .{
+            .status = .pending,
+            .tool_call_id = try allocator.dupe(u8, tool_call_id),
+            .tool_name = try allocator.dupe(u8, tool_name),
+            .args_json = try allocator.dupe(u8, args_json),
+        };
+    }
+};
+
+pub const StatusState = struct {
+    model: []u8 = &.{},
+    provider: []u8 = &.{},
+    session_id: []u8 = &.{},
+    context_used: usize = 0,
+    context_limit: usize = 0,
+    turn_count: usize = 0,
+    streaming: bool = false,
+    last_error: []u8 = &.{},
+
+    pub fn deinit(self: *StatusState, allocator: std.mem.Allocator) void {
+        if (self.model.len > 0) allocator.free(self.model);
+        if (self.provider.len > 0) allocator.free(self.provider);
+        if (self.session_id.len > 0) allocator.free(self.session_id);
+        if (self.last_error.len > 0) allocator.free(self.last_error);
+        self.* = .{};
+    }
+
+    pub fn setModel(self: *StatusState, allocator: std.mem.Allocator, model: []const u8, provider: []const u8) !void {
+        if (self.model.len > 0) allocator.free(self.model);
+        if (self.provider.len > 0) allocator.free(self.provider);
+        self.model = try allocator.dupe(u8, model);
+        self.provider = try allocator.dupe(u8, provider);
+    }
+
+    pub fn setError(self: *StatusState, allocator: std.mem.Allocator, message: []const u8) !void {
+        if (self.last_error.len > 0) allocator.free(self.last_error);
+        self.last_error = try allocator.dupe(u8, message);
+    }
+};
+
+pub const PreviewState = struct {
+    kind: PreviewKind = .file,
+    title: []u8 = &.{},
+    content: []u8 = &.{},
+    scroll: usize = 0,
+
+    pub fn deinit(self: *PreviewState, allocator: std.mem.Allocator) void {
+        if (self.title.len > 0) allocator.free(self.title);
+        if (self.content.len > 0) allocator.free(self.content);
+        self.* = .{};
+    }
+
+    pub fn set(self: *PreviewState, allocator: std.mem.Allocator, kind: PreviewKind, title: []const u8, content: []const u8) !void {
+        self.deinit(allocator);
+        self.* = .{
+            .kind = kind,
+            .title = try allocator.dupe(u8, title),
+            .content = try allocator.dupe(u8, content),
+            .scroll = 0,
+        };
+    }
+};
+
+pub const SessionEntry = struct {
+    id: []u8,
+    label: []u8,
+
+    pub fn init(allocator: std.mem.Allocator, id: []const u8, label: []const u8) !SessionEntry {
+        return .{ .id = try allocator.dupe(u8, id), .label = try allocator.dupe(u8, label) };
+    }
+
+    pub fn deinit(self: *SessionEntry, allocator: std.mem.Allocator) void {
+        allocator.free(self.id);
+        allocator.free(self.label);
+        self.* = undefined;
+    }
+};
+
+pub const ComposerState = struct {
+    buffer: std.ArrayList(u8) = .empty,
+    history: std.ArrayList([]u8) = .empty,
+    history_index: ?usize = null,
+
+    pub fn deinit(self: *ComposerState, allocator: std.mem.Allocator) void {
+        self.buffer.deinit(allocator);
+        for (self.history.items) |item| allocator.free(item);
+        self.history.deinit(allocator);
+        self.* = undefined;
+    }
+
+    pub fn clear(self: *ComposerState) void {
+        self.buffer.clearRetainingCapacity();
+        self.history_index = null;
+    }
+
+    pub fn text(self: ComposerState) []const u8 {
+        return self.buffer.items;
+    }
+};
+
+pub const AppState = struct {
+    allocator: std.mem.Allocator,
+    mode: AppMode = .normal,
+    transcript: std.ArrayList(TranscriptEntry) = .empty,
+    tools: std.ArrayList(ToolEntry) = .empty,
+    sessions: std.ArrayList(SessionEntry) = .empty,
+    composer: ComposerState = .{},
+    approval: ApprovalState = .{},
+    status: StatusState = .{},
+    preview: PreviewState = .{},
+    transcript_scroll: usize = 0,
+    tool_scroll: usize = 0,
+    session_index: usize = 0,
+
+    pub fn init(allocator: std.mem.Allocator) AppState {
+        return .{ .allocator = allocator };
+    }
+
+    pub fn deinit(self: *AppState) void {
+        for (self.transcript.items) |*entry| entry.deinit(self.allocator);
+        self.transcript.deinit(self.allocator);
+        for (self.tools.items) |*tool| tool.deinit(self.allocator);
+        self.tools.deinit(self.allocator);
+        for (self.sessions.items) |*session| session.deinit(self.allocator);
+        self.sessions.deinit(self.allocator);
+        self.composer.deinit(self.allocator);
+        self.approval.deinit(self.allocator);
+        self.status.deinit(self.allocator);
+        self.preview.deinit(self.allocator);
+        self.* = undefined;
+    }
+
+    pub fn appendTranscript(self: *AppState, kind: TranscriptKind, text: []const u8) !void {
+        try self.transcript.append(self.allocator, try TranscriptEntry.init(self.allocator, kind, text));
+    }
+
+    pub fn appendUserMessage(self: *AppState, text: []const u8) !void {
+        try self.appendTranscript(.user, text);
+    }
+
+    pub fn submitComposer(self: *AppState) !?[]u8 {
+        const raw = std.mem.trim(u8, self.composer.buffer.items, " \t\r\n");
+        if (raw.len == 0) {
+            self.composer.clear();
+            return null;
+        }
+        const submitted = try self.allocator.dupe(u8, raw);
+        errdefer self.allocator.free(submitted);
+        try self.composer.history.append(self.allocator, try self.allocator.dupe(u8, submitted));
+        self.composer.clear();
+        try self.appendUserMessage(submitted);
+        return submitted;
+    }
+
+    pub fn applyEvent(self: *AppState, event: tui_runtime.TuiEvent) !void {
+        switch (event) {
+            .agent_start => {
+                self.status.streaming = true;
+                try self.appendTranscript(.system, "agent started");
+            },
+            .turn_start => {
+                self.status.streaming = true;
+                self.status.turn_count += 1;
+            },
+            .message_start => |payload| switch (payload.role) {
+                .assistant => try self.ensureTrailingEntry(.assistant),
+                .user => try self.ensureTrailingEntry(.user),
+                .tool_result => try self.ensureTrailingEntry(.tool),
+            },
+            .text_delta => |payload| try self.appendDelta(.assistant, payload.delta.slice()),
+            .thinking_delta => |payload| try self.appendDelta(.thinking, payload.delta.slice()),
+            .tool_call_delta => |payload| try self.appendDelta(.tool, payload.delta.slice()),
+            .message_end => {},
+            .tool_approval_requested => |payload| {
+                try self.approval.setPending(self.allocator, payload.tool_call_id.slice(), payload.tool_name.slice(), payload.args_json.slice());
+                self.mode = .approval;
+                _ = try self.upsertTool(payload.tool_call_id.slice(), payload.tool_name.slice(), payload.args_json.slice(), .pending);
+            },
+            .tool_execution_start => |payload| {
+                const tool = try self.upsertTool(payload.tool_call_id.slice(), payload.tool_name.slice(), payload.args_json.slice(), .running);
+                tool.expanded = true;
+                try self.appendTranscript(.tool, payload.tool_name.slice());
+            },
+            .tool_execution_update => |payload| {
+                const tool = try self.upsertTool(payload.tool_call_id.slice(), payload.tool_name.slice(), payload.args_json.slice(), .running);
+                if (tool.output.items.len > 0) try tool.output.append(self.allocator, '\n');
+                try tool.output.appendSlice(self.allocator, payload.partial_result_json.slice());
+            },
+            .tool_execution_end => |payload| {
+                const status: ToolStatus = if (payload.is_error) .@"error" else .done;
+                const tool = try self.upsertTool(payload.tool_call_id.slice(), payload.tool_name.slice(), "", status);
+                if (tool.output.items.len > 0) try tool.output.append(self.allocator, '\n');
+                try tool.output.appendSlice(self.allocator, payload.result_json.slice());
+                if (payload.is_error) try self.status.setError(self.allocator, payload.result_json.slice());
+            },
+            .turn_end => self.status.streaming = false,
+            .agent_end => |payload| {
+                self.status.streaming = false;
+                switch (payload.reason) {
+                    .completed => {},
+                    .cancelled => try self.appendTranscript(.system, "agent cancelled"),
+                    .@"error" => try self.status.setError(self.allocator, "agent error"),
+                }
+            },
+            .@"error" => |payload| {
+                try self.status.setError(self.allocator, payload.message.slice());
+                try self.appendTranscript(.@"error", payload.message.slice());
+            },
+        }
+    }
+
+    pub fn setApprovalDecision(self: *AppState, approved: bool, always: bool) void {
+        self.approval.status = if (approved) .approved else .rejected;
+        self.approval.always = always;
+        self.mode = .normal;
+    }
+
+    pub fn toggleToolExpanded(self: *AppState, index: usize) void {
+        if (index >= self.tools.items.len) return;
+        self.tools.items[index].expanded = !self.tools.items[index].expanded;
+    }
+
+    pub fn setPreview(self: *AppState, kind: PreviewKind, title: []const u8, content: []const u8) !void {
+        try self.preview.set(self.allocator, kind, title, content);
+        self.mode = .preview;
+    }
+
+    pub fn addSession(self: *AppState, id: []const u8, label: []const u8) !void {
+        try self.sessions.append(self.allocator, try SessionEntry.init(self.allocator, id, label));
+    }
+
+    fn ensureTrailingEntry(self: *AppState, kind: TranscriptKind) !void {
+        if (self.transcript.items.len > 0 and self.transcript.items[self.transcript.items.len - 1].kind == kind) return;
+        try self.appendTranscript(kind, "");
+    }
+
+    fn appendDelta(self: *AppState, kind: TranscriptKind, delta: []const u8) !void {
+        try self.ensureTrailingEntry(kind);
+        try self.transcript.items[self.transcript.items.len - 1].text.appendSlice(self.allocator, delta);
+    }
+
+    fn findTool(self: *AppState, id: []const u8) ?*ToolEntry {
+        for (self.tools.items) |*tool| {
+            if (std.mem.eql(u8, tool.id, id)) return tool;
+        }
+        return null;
+    }
+
+    fn upsertTool(self: *AppState, id: []const u8, name: []const u8, args_json: []const u8, status: ToolStatus) !*ToolEntry {
+        if (self.findTool(id)) |tool| {
+            tool.status = status;
+            if (args_json.len > 0 and !std.mem.eql(u8, tool.args_json, args_json)) {
+                self.allocator.free(tool.args_json);
+                tool.args_json = try self.allocator.dupe(u8, args_json);
+            }
+            return tool;
+        }
+        try self.tools.append(self.allocator, try ToolEntry.init(self.allocator, id, name, args_json, status));
+        return &self.tools.items[self.tools.items.len - 1];
+    }
+};
+
+fn ownedText(text: []const u8) !@import("owned_slice").OwnedSlice(u8) {
+    return @import("owned_slice").OwnedSlice(u8).initOwned(try std.testing.allocator.dupe(u8, text));
+}
+
+test "AppState applies transcript and tool events" {
+    var state = AppState.init(std.testing.allocator);
+    defer state.deinit();
+
+    var text_event = tui_runtime.TuiEvent{ .text_delta = .{ .content_index = 0, .delta = try ownedText("hello") } };
+    defer text_event.deinit(std.testing.allocator);
+    try state.applyEvent(text_event);
+
+    try std.testing.expectEqual(@as(usize, 1), state.transcript.items.len);
+    try std.testing.expectEqual(TranscriptKind.assistant, state.transcript.items[0].kind);
+    try std.testing.expectEqualStrings("hello", state.transcript.items[0].text.items);
+
+    var start_event = tui_runtime.TuiEvent{ .tool_execution_start = .{
+        .tool_call_id = try ownedText("call-1"),
+        .tool_name = try ownedText("shell_command"),
+        .args_json = try ownedText("{\"command\":\"pwd\"}"),
+    } };
+    defer start_event.deinit(std.testing.allocator);
+    try state.applyEvent(start_event);
+
+    var end_event = tui_runtime.TuiEvent{ .tool_execution_end = .{
+        .tool_call_id = try ownedText("call-1"),
+        .tool_name = try ownedText("shell_command"),
+        .result_json = try ownedText("{\"ok\":true}"),
+        .is_error = false,
+    } };
+    defer end_event.deinit(std.testing.allocator);
+    try state.applyEvent(end_event);
+
+    try std.testing.expectEqual(@as(usize, 1), state.tools.items.len);
+    try std.testing.expectEqual(ToolStatus.done, state.tools.items[0].status);
+    try std.testing.expect(std.mem.indexOf(u8, state.tools.items[0].output.items, "ok") != null);
+}
+
+test "AppState approval flow transitions pending to approved and rejected" {
+    var state = AppState.init(std.testing.allocator);
+    defer state.deinit();
+
+    var approval_event = tui_runtime.TuiEvent{ .tool_approval_requested = .{
+        .tool_call_id = try ownedText("call-2"),
+        .tool_name = try ownedText("edit_file"),
+        .args_json = try ownedText("{\"path\":\"README.md\"}"),
+    } };
+    defer approval_event.deinit(std.testing.allocator);
+    try state.applyEvent(approval_event);
+
+    try std.testing.expectEqual(AppMode.approval, state.mode);
+    try std.testing.expectEqual(ApprovalStatus.pending, state.approval.status);
+    try std.testing.expectEqualStrings("edit_file", state.approval.tool_name);
+
+    state.setApprovalDecision(true, true);
+    try std.testing.expectEqual(AppMode.normal, state.mode);
+    try std.testing.expectEqual(ApprovalStatus.approved, state.approval.status);
+    try std.testing.expect(state.approval.always);
+
+    state.setApprovalDecision(false, false);
+    try std.testing.expectEqual(ApprovalStatus.rejected, state.approval.status);
+    try std.testing.expect(!state.approval.always);
+}
+
+test "Composer submission stores history and user transcript" {
+    var state = AppState.init(std.testing.allocator);
+    defer state.deinit();
+
+    try state.composer.buffer.appendSlice(std.testing.allocator, " hello makai ");
+    const submitted = (try state.submitComposer()).?;
+    defer std.testing.allocator.free(submitted);
+
+    try std.testing.expectEqualStrings("hello makai", submitted);
+    try std.testing.expectEqual(@as(usize, 1), state.composer.history.items.len);
+    try std.testing.expectEqual(@as(usize, 1), state.transcript.items.len);
+    try std.testing.expectEqual(TranscriptKind.user, state.transcript.items[0].kind);
+    try std.testing.expectEqualStrings("hello makai", state.transcript.items[0].text.items);
+}

--- a/zig/src/tui/views/approval.zig
+++ b/zig/src/tui/views/approval.zig
@@ -1,0 +1,18 @@
+const std = @import("std");
+const tui_state = @import("tui_state");
+
+pub const Options = struct {
+    width: usize = 80,
+};
+
+pub fn render(allocator: std.mem.Allocator, state: *const tui_state.AppState, options: Options) ![]u8 {
+    _ = options;
+    var out: std.Io.Writer.Allocating = .init(allocator);
+    const writer = &out.writer;
+    if (state.approval.status != .pending) return out.toOwnedSlice();
+    try writer.writeAll("Approval required\n");
+    try writer.print("Tool: {s}\n", .{state.approval.tool_name});
+    try writer.print("Args: {s}\n", .{state.approval.args_json});
+    try writer.writeAll("[a] allow  [d] deny  [A] always allow");
+    return out.toOwnedSlice();
+}

--- a/zig/src/tui/views/approval.zig
+++ b/zig/src/tui/views/approval.zig
@@ -16,3 +16,16 @@ pub fn render(allocator: std.mem.Allocator, state: *const tui_state.AppState, op
     try writer.writeAll("[a] allow  [d] deny  [A] always allow");
     return out.toOwnedSlice();
 }
+
+test "approval renders pending request" {
+    var state = tui_state.AppState.init(std.testing.allocator);
+    defer state.deinit();
+    try state.approval.setPending(std.testing.allocator, "call-1", "edit_file", "{\"path\":\"README.md\"}");
+
+    const text = try render(std.testing.allocator, &state, .{ .width = 80 });
+    defer std.testing.allocator.free(text);
+
+    try std.testing.expect(std.mem.indexOf(u8, text, "Approval required") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "edit_file") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "always allow") != null);
+}

--- a/zig/src/tui/views/composer.zig
+++ b/zig/src/tui/views/composer.zig
@@ -20,3 +20,17 @@ pub fn render(allocator: std.mem.Allocator, state: *const tui_state.AppState, op
     try writer.writeAll("\nEnter submit • Shift+Enter newline • Ctrl+C quit • /quit quit");
     return out.toOwnedSlice();
 }
+
+test "composer renders placeholder and text" {
+    var state = tui_state.AppState.init(std.testing.allocator);
+    defer state.deinit();
+
+    const placeholder = try render(std.testing.allocator, &state, .{ .width = 20 });
+    defer std.testing.allocator.free(placeholder);
+    try std.testing.expect(std.mem.indexOf(u8, placeholder, "Ask Makai") != null);
+
+    try state.composer.buffer.appendSlice(std.testing.allocator, "hello world");
+    const text = try render(std.testing.allocator, &state, .{ .width = 20 });
+    defer std.testing.allocator.free(text);
+    try std.testing.expect(std.mem.indexOf(u8, text, "> hello world") != null);
+}

--- a/zig/src/tui/views/composer.zig
+++ b/zig/src/tui/views/composer.zig
@@ -1,0 +1,22 @@
+const std = @import("std");
+const tui_state = @import("tui_state");
+
+pub const Options = struct {
+    width: usize = 80,
+};
+
+pub fn render(allocator: std.mem.Allocator, state: *const tui_state.AppState, options: Options) ![]u8 {
+    var out: std.Io.Writer.Allocating = .init(allocator);
+    const writer = &out.writer;
+    const text = state.composer.text();
+    try writer.writeAll("> ");
+    if (text.len == 0) {
+        try writer.writeAll("Ask Makai…");
+    } else {
+        const max = options.width -| 2;
+        try writer.writeAll(text[0..@min(max, text.len)]);
+        if (text.len > max) try writer.writeAll("…");
+    }
+    try writer.writeAll("\nEnter submit • Shift+Enter newline • Ctrl+C quit • /quit quit");
+    return out.toOwnedSlice();
+}

--- a/zig/src/tui/views/preview.zig
+++ b/zig/src/tui/views/preview.zig
@@ -1,0 +1,39 @@
+const std = @import("std");
+const tui_state = @import("tui_state");
+
+pub const Options = struct {
+    width: usize = 80,
+    height: usize = 20,
+};
+
+pub fn render(allocator: std.mem.Allocator, state: *const tui_state.AppState, options: Options) ![]u8 {
+    var out: std.Io.Writer.Allocating = .init(allocator);
+    const writer = &out.writer;
+    if (state.preview.content.len == 0) {
+        try writer.writeAll("No preview");
+        return out.toOwnedSlice();
+    }
+    try writer.print("{s}: {s}\n", .{ kindText(state.preview.kind), state.preview.title });
+    var row: usize = 1;
+    var skipped: usize = 0;
+    var lines = std.mem.splitScalar(u8, state.preview.content, '\n');
+    while (lines.next()) |line| {
+        if (skipped < state.preview.scroll) {
+            skipped += 1;
+            continue;
+        }
+        if (row >= options.height) break;
+        if (row > 1) try writer.writeByte('\n');
+        try writer.writeAll(line[0..@min(options.width, line.len)]);
+        row += 1;
+    }
+    return out.toOwnedSlice();
+}
+
+fn kindText(kind: tui_state.PreviewKind) []const u8 {
+    return switch (kind) {
+        .diff => "Diff",
+        .file => "File",
+        .artifact => "Artifact",
+    };
+}

--- a/zig/src/tui/views/preview.zig
+++ b/zig/src/tui/views/preview.zig
@@ -37,3 +37,15 @@ fn kindText(kind: tui_state.PreviewKind) []const u8 {
         .artifact => "Artifact",
     };
 }
+
+test "preview renders title and content" {
+    var state = tui_state.AppState.init(std.testing.allocator);
+    defer state.deinit();
+    try state.setPreview(.diff, "patch.diff", "+hello\n-world");
+
+    const text = try render(std.testing.allocator, &state, .{ .width = 80, .height = 4 });
+    defer std.testing.allocator.free(text);
+
+    try std.testing.expect(std.mem.indexOf(u8, text, "Diff: patch.diff") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "+hello") != null);
+}

--- a/zig/src/tui/views/session_picker.zig
+++ b/zig/src/tui/views/session_picker.zig
@@ -20,3 +20,17 @@ pub fn render(allocator: std.mem.Allocator, state: *const tui_state.AppState, op
     }
     return out.toOwnedSlice();
 }
+
+test "session picker renders selected session" {
+    var state = tui_state.AppState.init(std.testing.allocator);
+    defer state.deinit();
+    try state.addSession("s1", "First");
+    try state.addSession("s2", "Second");
+    state.session_index = 1;
+
+    const text = try render(std.testing.allocator, &state, .{ .height = 4 });
+    defer std.testing.allocator.free(text);
+
+    try std.testing.expect(std.mem.indexOf(u8, text, "First (s1)") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "> Second (s2)") != null);
+}

--- a/zig/src/tui/views/session_picker.zig
+++ b/zig/src/tui/views/session_picker.zig
@@ -1,0 +1,22 @@
+const std = @import("std");
+const tui_state = @import("tui_state");
+
+pub const Options = struct {
+    height: usize = 12,
+};
+
+pub fn render(allocator: std.mem.Allocator, state: *const tui_state.AppState, options: Options) ![]u8 {
+    var out: std.Io.Writer.Allocating = .init(allocator);
+    const writer = &out.writer;
+    try writer.writeAll("Sessions\n");
+    if (state.sessions.items.len == 0) {
+        try writer.writeAll("  no saved sessions");
+        return out.toOwnedSlice();
+    }
+    for (state.sessions.items, 0..) |session, i| {
+        if (i >= options.height) break;
+        try writer.print("{s} {s} ({s})", .{ if (i == state.session_index) ">" else " ", session.label, session.id });
+        if (i + 1 < state.sessions.items.len and i + 1 < options.height) try writer.writeByte('\n');
+    }
+    return out.toOwnedSlice();
+}

--- a/zig/src/tui/views/status_bar.zig
+++ b/zig/src/tui/views/status_bar.zig
@@ -21,9 +21,22 @@ pub fn render(allocator: std.mem.Allocator, state: *const tui_state.AppState, op
     }
     const items = out.written();
     if (items.len > options.width) {
-        const clipped = try allocator.alloc(u8, options.width);
-        @memcpy(clipped, items[0..options.width]);
+        const clipped = try allocator.dupe(u8, items[0..options.width]);
+        out.deinit();
         return clipped;
     }
     return out.toOwnedSlice();
+}
+
+test "status bar renders model and clips width" {
+    var state = tui_state.AppState.init(std.testing.allocator);
+    defer state.deinit();
+    try state.status.setModel(std.testing.allocator, "claude", "anthropic");
+    state.status.streaming = true;
+
+    const text = try render(std.testing.allocator, &state, .{ .width = 24 });
+    defer std.testing.allocator.free(text);
+
+    try std.testing.expectEqual(@as(usize, 24), text.len);
+    try std.testing.expect(std.mem.indexOf(u8, text, "anthropic") != null);
 }

--- a/zig/src/tui/views/status_bar.zig
+++ b/zig/src/tui/views/status_bar.zig
@@ -1,0 +1,29 @@
+const std = @import("std");
+const tui_state = @import("tui_state");
+
+pub const Options = struct {
+    width: usize = 80,
+};
+
+pub fn render(allocator: std.mem.Allocator, state: *const tui_state.AppState, options: Options) ![]u8 {
+    var out: std.Io.Writer.Allocating = .init(allocator);
+    const writer = &out.writer;
+    const model = if (state.status.model.len > 0) state.status.model else "no-model";
+    const provider = if (state.status.provider.len > 0) state.status.provider else "no-provider";
+    const session = if (state.status.session_id.len > 0) state.status.session_id else "local";
+    const stream = if (state.status.streaming) "streaming" else "idle";
+    try writer.print(" {s}/{s} • session:{s} • turns:{d} • {s}", .{ provider, model, session, state.status.turn_count, stream });
+    if (state.status.context_limit > 0) {
+        try writer.print(" • ctx:{d}/{d}", .{ state.status.context_used, state.status.context_limit });
+    }
+    if (state.status.last_error.len > 0) {
+        try writer.print(" • error:{s}", .{state.status.last_error});
+    }
+    const items = out.written();
+    if (items.len > options.width) {
+        const clipped = try allocator.alloc(u8, options.width);
+        @memcpy(clipped, items[0..options.width]);
+        return clipped;
+    }
+    return out.toOwnedSlice();
+}

--- a/zig/src/tui/views/tool_panel.zig
+++ b/zig/src/tui/views/tool_panel.zig
@@ -45,3 +45,17 @@ fn writeOneLine(writer: *std.Io.Writer, text: []const u8, width: usize) !void {
     try writer.writeAll(line[0..@min(width, line.len)]);
     if (line.len > width or nl < text.len) try writer.writeAll("…");
 }
+
+test "tool panel renders tool status and output" {
+    var state = tui_state.AppState.init(std.testing.allocator);
+    defer state.deinit();
+    try state.tools.append(std.testing.allocator, try tui_state.ToolEntry.init(std.testing.allocator, "call-1", "shell_command", "{\"command\":\"pwd\"}", .running));
+    state.tools.items[0].expanded = true;
+    try state.tools.items[0].output.appendSlice(std.testing.allocator, "ok");
+
+    const text = try render(std.testing.allocator, &state, .{ .width = 80, .height = 4 });
+    defer std.testing.allocator.free(text);
+
+    try std.testing.expect(std.mem.indexOf(u8, text, "[running] shell_command") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "ok") != null);
+}

--- a/zig/src/tui/views/tool_panel.zig
+++ b/zig/src/tui/views/tool_panel.zig
@@ -1,0 +1,47 @@
+const std = @import("std");
+const tui_state = @import("tui_state");
+
+pub const Options = struct {
+    width: usize = 80,
+    height: usize = 8,
+};
+
+pub fn render(allocator: std.mem.Allocator, state: *const tui_state.AppState, options: Options) ![]u8 {
+    var out: std.Io.Writer.Allocating = .init(allocator);
+    const writer = &out.writer;
+    try writer.writeAll("Tools");
+    if (state.tools.items.len == 0) {
+        try writer.writeAll("\n  none");
+        return out.toOwnedSlice();
+    }
+
+    var rows: usize = 1;
+    for (state.tools.items) |tool| {
+        if (rows >= options.height) break;
+        try writer.print("\n  [{s}] {s}", .{ statusText(tool.status), tool.name });
+        rows += 1;
+        if (tool.expanded and rows < options.height) {
+            try writer.writeAll(" ");
+            try writeOneLine(writer, if (tool.output.items.len > 0) tool.output.items else tool.args_json, options.width -| 4);
+            rows += 1;
+        }
+    }
+    return out.toOwnedSlice();
+}
+
+fn statusText(status: tui_state.ToolStatus) []const u8 {
+    return switch (status) {
+        .pending => "pending",
+        .running => "running",
+        .done => "done",
+        .@"error" => "error",
+    };
+}
+
+fn writeOneLine(writer: *std.Io.Writer, text: []const u8, width: usize) !void {
+    if (width == 0) return;
+    const nl = std.mem.indexOfScalar(u8, text, '\n') orelse text.len;
+    const line = text[0..nl];
+    try writer.writeAll(line[0..@min(width, line.len)]);
+    if (line.len > width or nl < text.len) try writer.writeAll("…");
+}

--- a/zig/src/tui/views/transcript.zig
+++ b/zig/src/tui/views/transcript.zig
@@ -1,0 +1,74 @@
+const std = @import("std");
+const tui_state = @import("tui_state");
+
+const AppState = tui_state.AppState;
+const TranscriptKind = tui_state.TranscriptKind;
+
+pub const Options = struct {
+    width: usize = 80,
+    height: usize = 20,
+};
+
+pub fn render(allocator: std.mem.Allocator, state: *const AppState, options: Options) ![]u8 {
+    var out: std.Io.Writer.Allocating = .init(allocator);
+    const writer = &out.writer;
+
+    const total = state.transcript.items.len;
+    const visible = @min(options.height, total);
+    const max_start = total - visible;
+    const start = max_start -| state.transcript_scroll;
+
+    if (total == 0) {
+        try writer.writeAll("Makai ready. Type message, /quit exits.");
+        return out.toOwnedSlice();
+    }
+
+    for (state.transcript.items[start..], 0..) |entry, i| {
+        if (i >= visible) break;
+        if (i > 0) try writer.writeByte('\n');
+        try writer.print("{s} ", .{label(entry.kind)});
+        try writeClipped(writer, entry.text.items, options.width -| label(entry.kind).len -| 1);
+    }
+
+    return out.toOwnedSlice();
+}
+
+fn label(kind: TranscriptKind) []const u8 {
+    return switch (kind) {
+        .user => "You:",
+        .assistant => "AI:",
+        .thinking => "Think:",
+        .tool => "Tool:",
+        .system => "Sys:",
+        .@"error" => "Err:",
+    };
+}
+
+fn writeClipped(writer: *std.Io.Writer, text: []const u8, width: usize) !void {
+    if (width == 0) return;
+    var line_len: usize = 0;
+    var iter = std.mem.splitScalar(u8, text, '\n');
+    while (iter.next()) |line| {
+        if (line_len > 0) try writer.writeAll(" / ");
+        const take = @min(width, line.len);
+        try writer.writeAll(line[0..take]);
+        line_len += take;
+        if (take < line.len) {
+            try writer.writeAll("…");
+            break;
+        }
+    }
+}
+
+test "transcript renders labels" {
+    var state = AppState.init(std.testing.allocator);
+    defer state.deinit();
+    try state.appendUserMessage("hello");
+    try state.appendTranscript(.assistant, "world");
+
+    const text = try render(std.testing.allocator, &state, .{ .width = 80, .height = 10 });
+    defer std.testing.allocator.free(text);
+
+    try std.testing.expect(std.mem.indexOf(u8, text, "You: hello") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "AI: world") != null);
+}


### PR DESCRIPTION
## Summary
- Add retained TUI `AppState` with transcript, composer, tool, approval, preview, and session picker state.
- Add dedicated TUI view modules that render from state behind the TUI runtime facade.
- Wire new TUI modules into `test-unit-tui`/full tests and add a `zig build run-tui` step.

## Test plan
- [x] `zig build test-unit-tui`
- [x] `zig build test`
- [x] `zig build run-tui` smoke attempted; process started and was stopped manually because it is interactive.