### PR TITLE
Fix TUI approval teardown

### DIFF
--- a/zig/src/tui/app.zig
+++ b/zig/src/tui/app.zig
@@ -20,8 +20,17 @@ pub const ApprovalWaiter = struct {
     mutex: std.atomic.Mutex = .unlocked,
     tool_call_id: []u8 = &.{},
     decision: ?tui_runtime.ToolApprovalDecision = null,
+    shutting_down: bool = false,
+
+    pub fn cancel(self: *ApprovalWaiter) void {
+        while (!self.mutex.tryLock()) std.atomic.spinLoopHint();
+        defer self.mutex.unlock();
+        self.shutting_down = true;
+        self.decision = .reject;
+    }
 
     pub fn deinit(self: *ApprovalWaiter) void {
+        self.cancel();
         if (self.tool_call_id.len > 0) self.allocator.free(self.tool_call_id);
         self.* = undefined;
     }
@@ -95,6 +104,7 @@ pub const App = struct {
     }
 
     pub fn deinit(self: *App) void {
+        if (self.approval_waiter) |waiter| waiter.cancel();
         if (self.runtime) |*runtime| runtime.deinit();
         if (self.approval_waiter) |waiter| {
             waiter.deinit();
@@ -146,16 +156,20 @@ pub const App = struct {
 
     pub fn decideApproval(self: *App, approved: bool, always: bool) !void {
         const id = self.state.approval.tool_call_id;
-        const decision: tui_runtime.ToolApprovalDecision = if (approved) .approve else .reject;
+        const decision: tui_runtime.ToolApprovalDecision = if (approved) if (always) .approve_always else .approve else if (always) .reject_always else .reject;
+        var matched_waiter = false;
         if (self.approval_waiter) |waiter| {
             while (!waiter.mutex.tryLock()) std.atomic.spinLoopHint();
             defer waiter.mutex.unlock();
             if (waiter.tool_call_id.len > 0 and (id.len == 0 or std.mem.eql(u8, waiter.tool_call_id, id))) {
                 waiter.decision = decision;
+                matched_waiter = true;
             }
         }
-        if (self.session) |*session| {
-            if (id.len > 0) try session.decideToolApproval(id, decision);
+        if (!matched_waiter) {
+            if (self.session) |*session| {
+                if (id.len > 0) try session.decideToolApproval(id, decision);
+            }
         }
         self.state.setApprovalDecision(approved, always);
     }
@@ -174,6 +188,7 @@ fn approvalCallback(ctx: ?*anyopaque, request: tui_runtime.ToolApprovalRequest) 
     while (true) {
         while (!waiter.mutex.tryLock()) std.atomic.spinLoopHint();
         const decision = waiter.decision;
+        const shutting_down = waiter.shutting_down;
         waiter.mutex.unlock();
         if (decision) |value| {
             while (!waiter.mutex.tryLock()) std.atomic.spinLoopHint();
@@ -183,6 +198,7 @@ fn approvalCallback(ctx: ?*anyopaque, request: tui_runtime.ToolApprovalRequest) 
             waiter.mutex.unlock();
             return value;
         }
+        if (shutting_down) return .reject;
         compat.time.sleepNs(1 * std.time.ns_per_ms);
     }
 }

--- a/zig/src/tui/runtime.zig
+++ b/zig/src/tui/runtime.zig
@@ -19,6 +19,7 @@ pub const ToolApprovalRequest = session.ToolApprovalRequest;
 const ApprovalDecisionState = struct {
     tool_call_id: []u8 = &.{},
     decision: ?ToolApprovalDecision = null,
+    cancelled: bool = false,
 };
 
 const ApprovalContext = struct {
@@ -265,6 +266,8 @@ pub const TuiRuntime = struct {
         self.cancelled.store(true, .release);
         if (self.local_agent) |*local| local.abort();
         while (!self.approval_mutex.tryLock()) std.atomic.spinLoopHint();
+        self.pending_approval.cancelled = true;
+        self.pending_approval.decision = .reject;
         self.approval_mutex.unlock();
     }
 
@@ -280,6 +283,7 @@ pub const TuiRuntime = struct {
             self.pending_approval.tool_call_id = try self.allocator.dupe(u8, tool_call_id);
         }
         self.pending_approval.decision = decision;
+        self.pending_approval.cancelled = false;
     }
 
     fn clearPendingApproval(self: *TuiRuntime) void {
@@ -300,8 +304,10 @@ pub const TuiRuntime = struct {
         while (!self.cancelled.load(.acquire)) {
             while (!self.approval_mutex.tryLock()) std.atomic.spinLoopHint();
             const decision = self.pending_approval.decision;
+            const approval_cancelled = self.pending_approval.cancelled;
             self.approval_mutex.unlock();
             if (decision) |value| return value;
+            if (approval_cancelled) return .reject;
             compat.time.sleepNs(1 * std.time.ns_per_ms);
         }
         return .reject;
@@ -474,9 +480,10 @@ fn approveTool(ctx: ?*anyopaque, request: agent.ToolApprovalRequest) agent.ToolA
         return switch (callback(approval_ctx.callback_ctx, approval_request)) {
             .approve => .approve,
             .reject => .reject,
+            .approve_always => .approve_always,
+            .reject_always => .reject_always,
         };
     }
-    _ = approval_ctx.runtime;
     return .approve;
 }
 

--- a/zig/src/tui/session.zig
+++ b/zig/src/tui/session.zig
@@ -12,6 +12,8 @@ pub const TuiEndReason = enum {
 pub const ToolApprovalDecision = enum {
     approve,
     reject,
+    approve_always,
+    reject_always,
 };
 
 pub const ToolApprovalRequest = struct {


### PR DESCRIPTION
## Summary
- Restore the TUI approval teardown fixes that were pushed after PR #102 merged
- Prevent pending approval callbacks from blocking shutdown
- Preserve `approve_always`/`reject_always` through TUI approval decisions

## Test plan
- [x] `zig build test-unit-tui --summary all --test-timeout 3m -j1`
- [x] `zig build test --summary failures --test-timeout 3m -j1`