### PR TITLE
Add TUI config and session persistence

### DIFF
--- a/zig/build.zig
+++ b/zig/build.zig
@@ -834,6 +834,16 @@ pub fn build(b: *std.Build) void {
         },
     });
 
+    const tui_config_mod = b.createModule(.{
+        .root_source_file = b.path("src/tui/config.zig"),
+        .target = target,
+        .optimize = optimize,
+        .imports = &.{
+            .{ .name = "compat", .module = compat_mod },
+            .{ .name = "json/writer", .module = json_writer_mod },
+        },
+    });
+
     const tools_common_mod = b.createModule(.{ .root_source_file = b.path("src/tools/common.zig"), .target = target, .optimize = optimize, .imports = &.{ .{ .name = "ai_types", .module = ai_types_mod }, .{ .name = "agent", .module = agent_mod }, .{ .name = "artifact/store", .module = artifact_store_mod }, .{ .name = "compat", .module = compat_mod } } });
     const tools_process_runner_mod = b.createModule(.{ .root_source_file = b.path("src/tools/process_runner.zig"), .target = target, .optimize = optimize, .imports = &.{ .{ .name = "ai_types", .module = ai_types_mod }, .{ .name = "tools/common", .module = tools_common_mod } } });
     const tools_artifact_mod = b.createModule(.{ .root_source_file = b.path("src/tools/artifact.zig"), .target = target, .optimize = optimize, .imports = &.{ .{ .name = "ai_types", .module = ai_types_mod }, .{ .name = "agent", .module = agent_mod }, .{ .name = "tools/common", .module = tools_common_mod } } });
@@ -856,6 +866,21 @@ pub fn build(b: *std.Build) void {
             .{ .name = "agent_protocol_client", .module = protocol_agent_client_mod },
             .{ .name = "tui_session", .module = tui_session_mod },
             .{ .name = "tools/registry", .module = tools_registry_mod },
+            .{ .name = "owned_slice", .module = owned_slice_mod },
+        },
+    });
+
+    const tui_session_store_mod = b.createModule(.{
+        .root_source_file = b.path("src/tui/session_store.zig"),
+        .target = target,
+        .optimize = optimize,
+        .imports = &.{
+            .{ .name = "compat", .module = compat_mod },
+            .{ .name = "ai_types", .module = ai_types_mod },
+            .{ .name = "tui_session", .module = tui_session_mod },
+            .{ .name = "tui_runtime", .module = tui_runtime_mod },
+            .{ .name = "agent", .module = agent_mod },
+            .{ .name = "json/writer", .module = json_writer_mod },
             .{ .name = "owned_slice", .module = owned_slice_mod },
         },
     });
@@ -942,6 +967,8 @@ pub fn build(b: *std.Build) void {
             .{ .name = "compat", .module = compat_mod },
             .{ .name = "tui_runtime", .module = tui_runtime_mod },
             .{ .name = "tui_session", .module = tui_session_mod },
+            .{ .name = "tui_session_store", .module = tui_session_store_mod },
+            .{ .name = "owned_slice", .module = owned_slice_mod },
             .{ .name = "tui_tests_mock_provider", .module = tui_tests_mock_provider_mod },
             .{ .name = "tui_tests_mock_transport", .module = tui_tests_mock_transport_mod },
             .{ .name = "tui_tests_fixtures", .module = tui_tests_fixtures_mod },
@@ -1279,7 +1306,9 @@ pub fn build(b: *std.Build) void {
 
     const agent_provider_protocol_bridge_test = b.addTest(.{ .root_module = agent_provider_protocol_bridge_mod });
     const tui_session_test = b.addTest(.{ .root_module = tui_session_mod });
+    const tui_config_test = b.addTest(.{ .root_module = tui_config_mod });
     const tui_runtime_test = b.addTest(.{ .root_module = tui_runtime_mod });
+    const tui_session_store_test = b.addTest(.{ .root_module = tui_session_store_mod });
     const tui_state_test = b.addTest(.{ .root_module = tui_state_mod });
     const tui_app_test = b.addTest(.{ .root_module = tui_app_mod });
     const tui_view_transcript_test = b.addTest(.{ .root_module = tui_view_transcript_mod });
@@ -1478,7 +1507,9 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(&b.addRunArtifact(agent_mod_test).step);
     test_step.dependOn(&b.addRunArtifact(agent_provider_protocol_bridge_test).step);
     test_step.dependOn(&b.addRunArtifact(tui_session_test).step);
+    test_step.dependOn(&b.addRunArtifact(tui_config_test).step);
     test_step.dependOn(&b.addRunArtifact(tui_runtime_test).step);
+    test_step.dependOn(&b.addRunArtifact(tui_session_store_test).step);
     test_step.dependOn(&b.addRunArtifact(tui_state_test).step);
     test_step.dependOn(&b.addRunArtifact(tui_app_test).step);
     test_step.dependOn(&b.addRunArtifact(tui_view_transcript_test).step);
@@ -1597,7 +1628,9 @@ pub fn build(b: *std.Build) void {
     test_unit_agent_step.dependOn(&b.addRunArtifact(agent_mod_test).step);
     test_unit_agent_step.dependOn(&b.addRunArtifact(agent_provider_protocol_bridge_test).step);
     test_unit_agent_step.dependOn(&b.addRunArtifact(tui_session_test).step);
+    test_unit_agent_step.dependOn(&b.addRunArtifact(tui_config_test).step);
     test_unit_agent_step.dependOn(&b.addRunArtifact(tui_runtime_test).step);
+    test_unit_agent_step.dependOn(&b.addRunArtifact(tui_session_store_test).step);
     test_unit_agent_step.dependOn(&b.addRunArtifact(tools_common_test).step);
     test_unit_agent_step.dependOn(&b.addRunArtifact(tools_process_runner_test).step);
     test_unit_agent_step.dependOn(&b.addRunArtifact(tools_shell_test).step);
@@ -1630,7 +1663,9 @@ pub fn build(b: *std.Build) void {
 
     const test_unit_tui_step = b.step("test-unit-tui", "Run TUI runtime unit tests");
     test_unit_tui_step.dependOn(&b.addRunArtifact(tui_session_test).step);
+    test_unit_tui_step.dependOn(&b.addRunArtifact(tui_config_test).step);
     test_unit_tui_step.dependOn(&b.addRunArtifact(tui_runtime_test).step);
+    test_unit_tui_step.dependOn(&b.addRunArtifact(tui_session_store_test).step);
     test_unit_tui_step.dependOn(&b.addRunArtifact(tui_state_test).step);
     test_unit_tui_step.dependOn(&b.addRunArtifact(tui_app_test).step);
     test_unit_tui_step.dependOn(&b.addRunArtifact(tui_view_transcript_test).step);

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -866,6 +866,7 @@ pub fn build(b: *std.Build) void {
             .{ .name = "agent_protocol_client", .module = protocol_agent_client_mod },
             .{ .name = "tui_session", .module = tui_session_mod },
             .{ .name = "tools/registry", .module = tools_registry_mod },
+            .{ .name = "json/writer", .module = json_writer_mod },
             .{ .name = "owned_slice", .module = owned_slice_mod },
         },
     });

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -867,6 +867,7 @@ pub fn build(b: *std.Build) void {
             .{ .name = "tui_session", .module = tui_session_mod },
             .{ .name = "tools/registry", .module = tools_registry_mod },
             .{ .name = "json/writer", .module = json_writer_mod },
+            .{ .name = "json_writer", .module = json_writer_mod },
             .{ .name = "owned_slice", .module = owned_slice_mod },
         },
     });
@@ -882,6 +883,7 @@ pub fn build(b: *std.Build) void {
             .{ .name = "tui_runtime", .module = tui_runtime_mod },
             .{ .name = "agent", .module = agent_mod },
             .{ .name = "json/writer", .module = json_writer_mod },
+            .{ .name = "json_writer", .module = json_writer_mod },
             .{ .name = "owned_slice", .module = owned_slice_mod },
         },
     });
@@ -966,6 +968,7 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
         .imports = &.{
             .{ .name = "compat", .module = compat_mod },
+            .{ .name = "ai_types", .module = ai_types_mod },
             .{ .name = "tui_runtime", .module = tui_runtime_mod },
             .{ .name = "tui_session", .module = tui_session_mod },
             .{ .name = "tui_session_store", .module = tui_session_store_mod },

--- a/zig/src/agent/agent.zig
+++ b/zig/src/agent/agent.zig
@@ -301,7 +301,7 @@ pub const Agent = struct {
         return self._follow_up_mode;
     }
 
-    /// Replace all messages with the given slice.
+    /// Replace all messages with deep-cloned copies of the given slice.
     pub fn replaceMessages(self: *Agent, messages: []const ai_types.Message) !void {
         // Clear existing messages
         for (self._state.messages.items) |*msg| {
@@ -311,7 +311,7 @@ pub const Agent = struct {
 
         // Add new messages (deep copy)
         for (messages) |msg| {
-            try self._state.messages.append(self._allocator, msg);
+            try self._state.messages.append(self._allocator, try ai_types.cloneMessage(self._allocator, msg));
         }
     }
 

--- a/zig/src/json/writer.zig
+++ b/zig/src/json/writer.zig
@@ -122,6 +122,19 @@ pub const JsonWriter = struct {
                     // Other control characters
                     try self.buffer.print(self.allocator, "\\u{x:0>4}", .{c});
                 },
+                0x80...0xFF => {
+                    const len = std.unicode.utf8ByteSequenceLength(c) catch {
+                        try self.buffer.appendSlice(self.allocator, "\\ufffd");
+                        i += 1;
+                        continue;
+                    };
+                    if (i + len <= s.len and std.unicode.utf8ValidateSlice(s[i .. i + len])) {
+                        try self.buffer.appendSlice(self.allocator, s[i .. i + len]);
+                        i += len;
+                        continue;
+                    }
+                    try self.buffer.appendSlice(self.allocator, "\\ufffd");
+                },
                 else => try self.buffer.append(self.allocator, c),
             }
             i += 1;
@@ -214,6 +227,20 @@ test "utf8 string bytes are preserved" {
     try writer.endObject();
 
     try std.testing.expectEqualStrings("{\"text\":\"café 🚀\"}", getResult(&writer));
+}
+
+test "invalid utf8 bytes are replaced" {
+    const allocator = std.testing.allocator;
+    var buffer = std.ArrayList(u8).empty;
+    defer buffer.deinit(allocator);
+
+    var writer = JsonWriter.init(&buffer, allocator);
+    const invalid = [_]u8{ 'a', 0x80, 'b' };
+    try writer.beginObject();
+    try writer.writeStringField("text", &invalid);
+    try writer.endObject();
+
+    try std.testing.expectEqualStrings("{\"text\":\"a\\ufffdb\"}", getResult(&writer));
 }
 
 test "nested objects and arrays" {

--- a/zig/src/json/writer.zig
+++ b/zig/src/json/writer.zig
@@ -122,11 +122,6 @@ pub const JsonWriter = struct {
                     // Other control characters
                     try self.buffer.print(self.allocator, "\\u{x:0>4}", .{c});
                 },
-                0x80...0xFF => {
-                    // Non-ASCII bytes - escape as \uXXXX to ensure valid JSON
-                    // This handles potentially invalid UTF-8 sequences
-                    try self.buffer.print(self.allocator, "\\u{x:0>4}", .{c});
-                },
                 else => try self.buffer.append(self.allocator, c),
             }
             i += 1;
@@ -206,6 +201,19 @@ test "control characters escape as unicode sequences" {
     const expected = "{\"control\":\"A\\u0001B\"}";
 
     try std.testing.expectEqualStrings(expected, result);
+}
+
+test "utf8 string bytes are preserved" {
+    const allocator = std.testing.allocator;
+    var buffer = std.ArrayList(u8).empty;
+    defer buffer.deinit(allocator);
+
+    var writer = JsonWriter.init(&buffer, allocator);
+    try writer.beginObject();
+    try writer.writeStringField("text", "café 🚀");
+    try writer.endObject();
+
+    try std.testing.expectEqualStrings("{\"text\":\"café 🚀\"}", getResult(&writer));
 }
 
 test "nested objects and arrays" {

--- a/zig/src/tui/config.zig
+++ b/zig/src/tui/config.zig
@@ -27,12 +27,14 @@ pub const ModeSettings = struct {
     caveman_mode: bool = false,
 };
 
+const borrowed_empty_theme: []u8 = &.{};
+
 pub const UiSettings = struct {
-    theme: []u8 = &.{},
+    theme: []u8 = borrowed_empty_theme,
     show_tool_panel: bool = true,
 
     pub fn deinit(self: *UiSettings, allocator: std.mem.Allocator) void {
-        if (self.theme.len > 0) allocator.free(self.theme);
+        if (self.theme.ptr != borrowed_empty_theme.ptr) allocator.free(self.theme);
         self.* = .{};
     }
 };

--- a/zig/src/tui/config.zig
+++ b/zig/src/tui/config.zig
@@ -1,0 +1,283 @@
+const std = @import("std");
+const compat = @import("compat");
+const json_writer = @import("json/writer");
+
+fn tmpBase(allocator: std.mem.Allocator, tmp: *std.testing.TmpDir) ![]u8 {
+    const base = try std.fs.path.join(allocator, &.{ ".zig-cache", "tmp", &tmp.sub_path, "makai" });
+    errdefer allocator.free(base);
+    try compat.fs.createDir(compat.fs.getCwd(), base);
+    return base;
+}
+
+pub const ToolPermission = struct {
+    tool_name: []u8,
+    mode: Mode = .ask,
+
+    pub const Mode = enum { ask, allow, deny };
+
+    pub fn deinit(self: *ToolPermission, allocator: std.mem.Allocator) void {
+        allocator.free(self.tool_name);
+        self.* = undefined;
+    }
+};
+
+pub const ModeSettings = struct {
+    compact_output: bool = true,
+    vim_mode: bool = false,
+    caveman_mode: bool = false,
+};
+
+pub const UiSettings = struct {
+    theme: []u8 = &.{},
+    show_tool_panel: bool = true,
+
+    pub fn deinit(self: *UiSettings, allocator: std.mem.Allocator) void {
+        if (self.theme.len > 0) allocator.free(self.theme);
+        self.* = .{};
+    }
+};
+
+pub const Config = struct {
+    model: []u8,
+    provider: []u8,
+    workspace: []u8,
+    permissions: std.ArrayList(ToolPermission) = .empty,
+    mode: ModeSettings = .{},
+    ui: UiSettings = .{},
+
+    pub fn defaults(allocator: std.mem.Allocator) !Config {
+        return .{
+            .model = try allocator.dupe(u8, "claude-sonnet-4-5"),
+            .provider = try allocator.dupe(u8, "anthropic"),
+            .workspace = try allocator.dupe(u8, "."),
+            .ui = .{ .theme = try allocator.dupe(u8, "default") },
+        };
+    }
+
+    pub fn deinit(self: *Config, allocator: std.mem.Allocator) void {
+        allocator.free(self.model);
+        allocator.free(self.provider);
+        allocator.free(self.workspace);
+        for (self.permissions.items) |*permission| permission.deinit(allocator);
+        self.permissions.deinit(allocator);
+        self.ui.deinit(allocator);
+        self.* = undefined;
+    }
+};
+
+pub const Store = struct {
+    allocator: std.mem.Allocator,
+    base_dir: []u8,
+
+    pub fn init(allocator: std.mem.Allocator, base_dir: []const u8) !Store {
+        return .{ .allocator = allocator, .base_dir = try allocator.dupe(u8, base_dir) };
+    }
+
+    pub fn initDefault(allocator: std.mem.Allocator) !Store {
+        const home = std.process.getEnvVarOwned(allocator, "HOME") catch |err| switch (err) {
+            error.EnvironmentVariableNotFound => return error.HomeNotFound,
+            else => return err,
+        };
+        defer allocator.free(home);
+        const base = try std.fs.path.join(allocator, &.{ home, ".makai" });
+        defer allocator.free(base);
+        return init(allocator, base);
+    }
+
+    pub fn deinit(self: *Store) void {
+        self.allocator.free(self.base_dir);
+        self.* = undefined;
+    }
+
+    pub fn load(self: Store) !Config {
+        try compat.fs.createDir(compat.fs.getCwd(), self.base_dir);
+        const path = try std.fs.path.join(self.allocator, &.{ self.base_dir, "config.json" });
+        defer self.allocator.free(path);
+        const data = compat.fs.readFileAlloc(self.allocator, compat.fs.getCwd(), path, 1024 * 1024) catch |err| switch (err) {
+            error.FileNotFound => {
+                var cfg = try Config.defaults(self.allocator);
+                errdefer cfg.deinit(self.allocator);
+                try self.save(cfg);
+                return cfg;
+            },
+            else => return err,
+        };
+        defer self.allocator.free(data);
+        return parseConfig(self.allocator, data);
+    }
+
+    pub fn save(self: Store, cfg: Config) !void {
+        try compat.fs.createDir(compat.fs.getCwd(), self.base_dir);
+        const path = try std.fs.path.join(self.allocator, &.{ self.base_dir, "config.json" });
+        defer self.allocator.free(path);
+        const tmp = try std.fs.path.join(self.allocator, &.{ self.base_dir, "config.json.tmp" });
+        defer self.allocator.free(tmp);
+        const data = try serializeConfig(self.allocator, cfg);
+        defer self.allocator.free(data);
+        try compat.fs.atomicReplace(compat.fs.getCwd(), path, tmp, data);
+    }
+};
+
+fn parseConfig(allocator: std.mem.Allocator, data: []const u8) !Config {
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, data, .{});
+    defer parsed.deinit();
+    const obj = switch (parsed.value) {
+        .object => |o| o,
+        else => return error.InvalidConfig,
+    };
+
+    var cfg = Config{
+        .model = try dupStringField(allocator, obj, "model", "claude-sonnet-4-5"),
+        .provider = try dupStringField(allocator, obj, "provider", "anthropic"),
+        .workspace = try dupStringField(allocator, obj, "workspace", ""),
+        .ui = .{ .theme = try allocator.dupe(u8, "default") },
+    };
+    errdefer cfg.deinit(allocator);
+
+    if (cfg.workspace.len == 0) {
+        allocator.free(cfg.workspace);
+        cfg.workspace = try allocator.dupe(u8, ".");
+    }
+
+    if (obj.get("permissions")) |value| switch (value) {
+        .array => |arr| for (arr.items) |item| {
+            const perm_obj = switch (item) {
+                .object => |o| o,
+                else => continue,
+            };
+            const tool = stringField(perm_obj, "tool_name") orelse continue;
+            const mode_text = stringField(perm_obj, "mode") orelse "ask";
+            try cfg.permissions.append(allocator, .{
+                .tool_name = try allocator.dupe(u8, tool),
+                .mode = parsePermissionMode(mode_text),
+            });
+        },
+        else => {},
+    };
+
+    if (obj.get("mode")) |value| switch (value) {
+        .object => |mode_obj| {
+            cfg.mode.compact_output = boolField(mode_obj, "compact_output", cfg.mode.compact_output);
+            cfg.mode.vim_mode = boolField(mode_obj, "vim_mode", cfg.mode.vim_mode);
+            cfg.mode.caveman_mode = boolField(mode_obj, "caveman_mode", cfg.mode.caveman_mode);
+        },
+        else => {},
+    };
+
+    if (obj.get("ui")) |value| switch (value) {
+        .object => |ui_obj| {
+            if (stringField(ui_obj, "theme")) |theme| {
+                if (cfg.ui.theme.len > 0) allocator.free(cfg.ui.theme);
+                cfg.ui.theme = try allocator.dupe(u8, theme);
+            }
+            cfg.ui.show_tool_panel = boolField(ui_obj, "show_tool_panel", cfg.ui.show_tool_panel);
+        },
+        else => {},
+    };
+
+    return cfg;
+}
+
+fn serializeConfig(allocator: std.mem.Allocator, cfg: Config) ![]u8 {
+    var buf: std.ArrayList(u8) = .empty;
+    errdefer buf.deinit(allocator);
+    var w = json_writer.JsonWriter.init(&buf, allocator);
+    try w.beginObject();
+    try w.writeStringField("model", cfg.model);
+    try w.writeStringField("provider", cfg.provider);
+    try w.writeStringField("workspace", cfg.workspace);
+    try w.writeKey("permissions");
+    try w.beginArray();
+    for (cfg.permissions.items) |permission| {
+        try w.beginObject();
+        try w.writeStringField("tool_name", permission.tool_name);
+        try w.writeStringField("mode", @tagName(permission.mode));
+        try w.endObject();
+    }
+    try w.endArray();
+    try w.writeKey("mode");
+    try w.beginObject();
+    try w.writeBoolField("compact_output", cfg.mode.compact_output);
+    try w.writeBoolField("vim_mode", cfg.mode.vim_mode);
+    try w.writeBoolField("caveman_mode", cfg.mode.caveman_mode);
+    try w.endObject();
+    try w.writeKey("ui");
+    try w.beginObject();
+    try w.writeStringField("theme", cfg.ui.theme);
+    try w.writeBoolField("show_tool_panel", cfg.ui.show_tool_panel);
+    try w.endObject();
+    try w.endObject();
+    try buf.append(allocator, '\n');
+    return buf.toOwnedSlice(allocator);
+}
+
+fn dupStringField(allocator: std.mem.Allocator, obj: std.json.ObjectMap, key: []const u8, default: []const u8) ![]u8 {
+    return try allocator.dupe(u8, stringField(obj, key) orelse default);
+}
+
+fn stringField(obj: std.json.ObjectMap, key: []const u8) ?[]const u8 {
+    const value = obj.get(key) orelse return null;
+    return switch (value) {
+        .string => |s| s,
+        else => null,
+    };
+}
+
+fn boolField(obj: std.json.ObjectMap, key: []const u8, default: bool) bool {
+    const value = obj.get(key) orelse return default;
+    return switch (value) {
+        .bool => |b| b,
+        else => default,
+    };
+}
+
+fn parsePermissionMode(value: []const u8) ToolPermission.Mode {
+    if (std.mem.eql(u8, value, "allow")) return .allow;
+    if (std.mem.eql(u8, value, "deny")) return .deny;
+    return .ask;
+}
+
+test "save config reload preserves model and provider" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const base = try tmpBase(std.testing.allocator, &tmp);
+    defer std.testing.allocator.free(base);
+
+    var store = try Store.init(std.testing.allocator, base);
+    defer store.deinit();
+
+    var cfg = try Config.defaults(std.testing.allocator);
+    defer cfg.deinit(std.testing.allocator);
+    std.testing.allocator.free(cfg.model);
+    cfg.model = try std.testing.allocator.dupe(u8, "model-b");
+    std.testing.allocator.free(cfg.provider);
+    cfg.provider = try std.testing.allocator.dupe(u8, "openai");
+    try cfg.permissions.append(std.testing.allocator, .{ .tool_name = try std.testing.allocator.dupe(u8, "shell_execute"), .mode = .deny });
+    try store.save(cfg);
+
+    var loaded = try store.load();
+    defer loaded.deinit(std.testing.allocator);
+    try std.testing.expectEqualStrings("model-b", loaded.model);
+    try std.testing.expectEqualStrings("openai", loaded.provider);
+    try std.testing.expectEqual(@as(usize, 1), loaded.permissions.items.len);
+    try std.testing.expectEqual(ToolPermission.Mode.deny, loaded.permissions.items[0].mode);
+}
+
+test "missing config creates defaults" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const base = try tmpBase(std.testing.allocator, &tmp);
+    defer std.testing.allocator.free(base);
+
+    var store = try Store.init(std.testing.allocator, base);
+    defer store.deinit();
+    var cfg = try store.load();
+    defer cfg.deinit(std.testing.allocator);
+    try std.testing.expectEqualStrings("claude-sonnet-4-5", cfg.model);
+
+    const path = try std.fs.path.join(std.testing.allocator, &.{ base, "config.json" });
+    defer std.testing.allocator.free(path);
+    const data = try compat.fs.readFileAlloc(std.testing.allocator, compat.fs.getCwd(), path, 1024);
+    defer std.testing.allocator.free(data);
+    try std.testing.expect(std.mem.indexOf(u8, data, "claude-sonnet-4-5") != null);
+}

--- a/zig/src/tui/runtime.zig
+++ b/zig/src/tui/runtime.zig
@@ -6,7 +6,7 @@ const agent = @import("agent");
 const agent_protocol_client = @import("agent_protocol_client");
 const session = @import("tui_session");
 const local_tools = @import("tools/registry");
-const json_writer = @import("json/writer");
+const json_writer = @import("json_writer");
 const OwnedSlice = @import("owned_slice").OwnedSlice;
 
 pub const TuiSession = session.TuiSession;
@@ -414,6 +414,7 @@ pub const TuiRuntime = struct {
                 defer self.allocator.free(tool_calls_json);
                 payload.content_json = try self.dupeOwned(content_json);
                 payload.tool_calls_json = try self.dupeOwned(tool_calls_json);
+                payload.stop_reason = m.stop_reason;
             },
             .tool_result => |m| {
                 payload.tool_call_id = try self.dupeOwned(m.tool_call_id);

--- a/zig/src/tui/runtime.zig
+++ b/zig/src/tui/runtime.zig
@@ -6,6 +6,7 @@ const agent = @import("agent");
 const agent_protocol_client = @import("agent_protocol_client");
 const session = @import("tui_session");
 const local_tools = @import("tools/registry");
+const json_writer = @import("json/writer");
 const OwnedSlice = @import("owned_slice").OwnedSlice;
 
 pub const TuiSession = session.TuiSession;
@@ -399,36 +400,43 @@ pub const TuiRuntime = struct {
     fn messageEndPayload(self: *TuiRuntime, message: ai_types.Message) !@TypeOf(@as(TuiEvent, undefined).message_end) {
         var payload: @TypeOf(@as(TuiEvent, undefined).message_end) = .{ .role = messageRole(message) };
         switch (message) {
-            .user => |m| switch (m.content) {
-                .text => |text| payload.text = try self.dupeOwned(text),
-                .parts => |parts| for (parts) |part| switch (part) {
-                    .text => |text| {
-                        payload.text = try self.dupeOwned(text.text);
-                        break;
-                    },
-                    else => {},
-                },
+            .user => |m| {
+                payload.text = try self.dupeOwned(firstUserContentText(m.content));
+                const content_json = try serializeUserContent(self.allocator, m.content);
+                defer self.allocator.free(content_json);
+                payload.content_json = try self.dupeOwned(content_json);
             },
-            .assistant => |m| for (m.content) |block| switch (block) {
-                .text => |text| {
-                    payload.text = try self.dupeOwned(text.text);
-                    break;
-                },
-                .tool_call => |tool| {
-                    payload.tool_call_id = try self.dupeOwned(tool.id);
-                    payload.tool_name = try self.dupeOwned(tool.name);
-                    payload.args_json = try self.dupeOwned(tool.arguments_json);
-                    break;
-                },
-                else => {},
+            .assistant => |m| {
+                payload.text = try self.dupeOwned(assistantText(m.content));
+                const content_json = try serializeAssistantContent(self.allocator, m.content);
+                defer self.allocator.free(content_json);
+                const tool_calls_json = try serializeToolCalls(self.allocator, m.content);
+                defer self.allocator.free(tool_calls_json);
+                payload.content_json = try self.dupeOwned(content_json);
+                payload.tool_calls_json = try self.dupeOwned(tool_calls_json);
             },
             .tool_result => |m| {
                 payload.tool_call_id = try self.dupeOwned(m.tool_call_id);
                 payload.tool_name = try self.dupeOwned(m.tool_name);
                 payload.text = try self.dupeOwned(firstUserPartText(m.content));
+                const content_json = try serializeUserParts(self.allocator, m.content);
+                defer self.allocator.free(content_json);
+                const artifacts_json = try serializeArtifacts(self.allocator, m.artifacts.slice());
+                defer self.allocator.free(artifacts_json);
+                payload.content_json = try self.dupeOwned(content_json);
+                payload.details_json = try self.dupeOwned(m.details_json.slice());
+                payload.artifacts_json = try self.dupeOwned(artifacts_json);
+                payload.is_error = m.is_error;
             },
         }
         return payload;
+    }
+
+    fn firstUserContentText(content: ai_types.UserContent) []const u8 {
+        return switch (content) {
+            .text => |text| text,
+            .parts => |parts| firstUserPartText(parts),
+        };
     }
 
     fn firstUserPartText(parts: []const ai_types.UserContentPart) []const u8 {
@@ -437,6 +445,131 @@ pub const TuiRuntime = struct {
             else => {},
         };
         return "";
+    }
+
+    fn assistantText(content: []const ai_types.AssistantContent) []const u8 {
+        for (content) |block| switch (block) {
+            .text => |text| return text.text,
+            else => {},
+        };
+        return "";
+    }
+
+    fn serializeUserContent(allocator: std.mem.Allocator, content: ai_types.UserContent) ![]u8 {
+        return switch (content) {
+            .text => |text| blk: {
+                var buf: std.ArrayList(u8) = .empty;
+                errdefer buf.deinit(allocator);
+                var w = json_writer.JsonWriter.init(&buf, allocator);
+                try w.beginArray();
+                try writeUserTextPart(&w, text, null);
+                try w.endArray();
+                break :blk try buf.toOwnedSlice(allocator);
+            },
+            .parts => |parts| serializeUserParts(allocator, parts),
+        };
+    }
+
+    fn serializeUserParts(allocator: std.mem.Allocator, parts: []const ai_types.UserContentPart) ![]u8 {
+        var buf: std.ArrayList(u8) = .empty;
+        errdefer buf.deinit(allocator);
+        var w = json_writer.JsonWriter.init(&buf, allocator);
+        try w.beginArray();
+        for (parts) |part| switch (part) {
+            .text => |text| try writeUserTextPart(&w, text.text, text.text_signature),
+            .image => |image| try writeImagePart(&w, image),
+        };
+        try w.endArray();
+        return buf.toOwnedSlice(allocator);
+    }
+
+    fn serializeAssistantContent(allocator: std.mem.Allocator, content: []const ai_types.AssistantContent) ![]u8 {
+        var buf: std.ArrayList(u8) = .empty;
+        errdefer buf.deinit(allocator);
+        var w = json_writer.JsonWriter.init(&buf, allocator);
+        try w.beginArray();
+        for (content) |block| switch (block) {
+            .text => |text| try writeAssistantTextPart(&w, text),
+            .thinking => |thinking| try writeThinkingPart(&w, thinking),
+            .tool_call => |tool| try writeToolCallPart(&w, tool),
+            .image => |image| try writeImagePart(&w, image),
+        };
+        try w.endArray();
+        return buf.toOwnedSlice(allocator);
+    }
+
+    fn serializeToolCalls(allocator: std.mem.Allocator, content: []const ai_types.AssistantContent) ![]u8 {
+        var buf: std.ArrayList(u8) = .empty;
+        errdefer buf.deinit(allocator);
+        var w = json_writer.JsonWriter.init(&buf, allocator);
+        try w.beginArray();
+        for (content) |block| switch (block) {
+            .tool_call => |tool| try writeToolCallPart(&w, tool),
+            else => {},
+        };
+        try w.endArray();
+        return buf.toOwnedSlice(allocator);
+    }
+
+    fn serializeArtifacts(allocator: std.mem.Allocator, artifacts: []const ai_types.ArtifactReference) ![]u8 {
+        var buf: std.ArrayList(u8) = .empty;
+        errdefer buf.deinit(allocator);
+        var w = json_writer.JsonWriter.init(&buf, allocator);
+        try w.beginArray();
+        for (artifacts) |artifact| {
+            try w.beginObject();
+            try w.writeStringField("artifact_id", artifact.artifact_id);
+            try w.writeStringField("uri", artifact.uri.slice());
+            try w.writeStringField("mime_type", artifact.mime_type.slice());
+            if (artifact.byte_size) |size| try w.writeIntField("byte_size", size);
+            try w.writeStringField("sha256", artifact.sha256.slice());
+            try w.writeStringField("description", artifact.description.slice());
+            try w.endObject();
+        }
+        try w.endArray();
+        return buf.toOwnedSlice(allocator);
+    }
+
+    fn writeUserTextPart(w: *json_writer.JsonWriter, text: []const u8, signature: ?[]const u8) !void {
+        try w.beginObject();
+        try w.writeStringField("type", "text");
+        try w.writeStringField("text", text);
+        if (signature) |sig| try w.writeStringField("text_signature", sig);
+        try w.endObject();
+    }
+
+    fn writeAssistantTextPart(w: *json_writer.JsonWriter, text: ai_types.TextContent) !void {
+        try w.beginObject();
+        try w.writeStringField("type", "text");
+        try w.writeStringField("text", text.text);
+        if (text.text_signature) |sig| try w.writeStringField("text_signature", sig);
+        try w.endObject();
+    }
+
+    fn writeThinkingPart(w: *json_writer.JsonWriter, thinking: ai_types.ThinkingContent) !void {
+        try w.beginObject();
+        try w.writeStringField("type", "thinking");
+        try w.writeStringField("thinking", thinking.thinking);
+        if (thinking.thinking_signature) |sig| try w.writeStringField("thinking_signature", sig);
+        try w.endObject();
+    }
+
+    fn writeToolCallPart(w: *json_writer.JsonWriter, tool: ai_types.ToolCall) !void {
+        try w.beginObject();
+        try w.writeStringField("type", "tool_call");
+        try w.writeStringField("id", tool.id);
+        try w.writeStringField("name", tool.name);
+        try w.writeStringField("arguments_json", tool.arguments_json);
+        if (tool.thought_signature) |sig| try w.writeStringField("thought_signature", sig);
+        try w.endObject();
+    }
+
+    fn writeImagePart(w: *json_writer.JsonWriter, image: ai_types.ImageContent) !void {
+        try w.beginObject();
+        try w.writeStringField("type", "image");
+        try w.writeStringField("data", image.data);
+        try w.writeStringField("mime_type", image.mime_type);
+        try w.endObject();
     }
 
     fn onAgentEvent(ctx: ?*anyopaque, event: agent.AgentEvent) void {

--- a/zig/src/tui/runtime.zig
+++ b/zig/src/tui/runtime.zig
@@ -396,6 +396,49 @@ pub const TuiRuntime = struct {
         };
     }
 
+    fn messageEndPayload(self: *TuiRuntime, message: ai_types.Message) !@TypeOf(@as(TuiEvent, undefined).message_end) {
+        var payload: @TypeOf(@as(TuiEvent, undefined).message_end) = .{ .role = messageRole(message) };
+        switch (message) {
+            .user => |m| switch (m.content) {
+                .text => |text| payload.text = try self.dupeOwned(text),
+                .parts => |parts| for (parts) |part| switch (part) {
+                    .text => |text| {
+                        payload.text = try self.dupeOwned(text.text);
+                        break;
+                    },
+                    else => {},
+                },
+            },
+            .assistant => |m| for (m.content) |block| switch (block) {
+                .text => |text| {
+                    payload.text = try self.dupeOwned(text.text);
+                    break;
+                },
+                .tool_call => |tool| {
+                    payload.tool_call_id = try self.dupeOwned(tool.id);
+                    payload.tool_name = try self.dupeOwned(tool.name);
+                    payload.args_json = try self.dupeOwned(tool.arguments_json);
+                    break;
+                },
+                else => {},
+            },
+            .tool_result => |m| {
+                payload.tool_call_id = try self.dupeOwned(m.tool_call_id);
+                payload.tool_name = try self.dupeOwned(m.tool_name);
+                payload.text = try self.dupeOwned(firstUserPartText(m.content));
+            },
+        }
+        return payload;
+    }
+
+    fn firstUserPartText(parts: []const ai_types.UserContentPart) []const u8 {
+        for (parts) |part| switch (part) {
+            .text => |text| return text.text,
+            else => {},
+        };
+        return "";
+    }
+
     fn onAgentEvent(ctx: ?*anyopaque, event: agent.AgentEvent) void {
         const self: *TuiRuntime = @ptrCast(@alignCast(ctx.?));
         self.handleAgentEvent(event) catch |err| {
@@ -409,7 +452,7 @@ pub const TuiRuntime = struct {
             .turn_start => self.push(.turn_start),
             .message_start => |payload| self.push(.{ .message_start = .{ .role = messageRole(payload.message) } }),
             .message_update => |payload| try self.pushMessageUpdate(payload.event),
-            .message_end => |payload| self.push(.{ .message_end = .{ .role = messageRole(payload.message) } }),
+            .message_end => |payload| self.push(.{ .message_end = try self.messageEndPayload(payload.message) }),
             .tool_execution_start => |payload| self.push(.{ .tool_execution_start = .{
                 .tool_call_id = try self.dupeOwned(payload.tool_call_id),
                 .tool_name = try self.dupeOwned(payload.tool_name),

--- a/zig/src/tui/runtime.zig
+++ b/zig/src/tui/runtime.zig
@@ -241,6 +241,18 @@ pub const TuiRuntime = struct {
         }
     }
 
+    pub fn replaceMessages(self: *TuiRuntime, messages: []const ai_types.Message) !void {
+        switch (self.backend) {
+            .remote => return error.NotImplemented,
+            .local => {
+                if (!self.started) try self.start();
+                const local = &(self.local_agent orelse return error.RuntimeNotStarted);
+                if (self.run_async) local.waitForIdle();
+                try local.replaceMessages(messages);
+            },
+        }
+    }
+
     pub fn resumeSession(self: *TuiRuntime) !void {
         switch (self.backend) {
             .remote => return error.NotImplemented,

--- a/zig/src/tui/session.zig
+++ b/zig/src/tui/session.zig
@@ -37,9 +37,14 @@ pub const TuiEvent = union(enum) {
     message_end: struct {
         role: MessageRole,
         text: OwnedSlice(u8) = OwnedSlice(u8).initBorrowed(""),
+        content_json: OwnedSlice(u8) = OwnedSlice(u8).initBorrowed(""),
         tool_call_id: OwnedSlice(u8) = OwnedSlice(u8).initBorrowed(""),
         tool_name: OwnedSlice(u8) = OwnedSlice(u8).initBorrowed(""),
         args_json: OwnedSlice(u8) = OwnedSlice(u8).initBorrowed(""),
+        tool_calls_json: OwnedSlice(u8) = OwnedSlice(u8).initBorrowed(""),
+        details_json: OwnedSlice(u8) = OwnedSlice(u8).initBorrowed(""),
+        artifacts_json: OwnedSlice(u8) = OwnedSlice(u8).initBorrowed(""),
+        is_error: bool = false,
     },
     tool_approval_requested: struct {
         tool_call_id: OwnedSlice(u8),
@@ -80,9 +85,13 @@ pub const TuiEvent = union(enum) {
             .tool_call_delta => |*p| p.delta.deinit(allocator),
             .message_end => |*p| {
                 p.text.deinit(allocator);
+                p.content_json.deinit(allocator);
                 p.tool_call_id.deinit(allocator);
                 p.tool_name.deinit(allocator);
                 p.args_json.deinit(allocator);
+                p.tool_calls_json.deinit(allocator);
+                p.details_json.deinit(allocator);
+                p.artifacts_json.deinit(allocator);
             },
             .tool_approval_requested => |*p| {
                 p.tool_call_id.deinit(allocator);

--- a/zig/src/tui/session.zig
+++ b/zig/src/tui/session.zig
@@ -44,6 +44,7 @@ pub const TuiEvent = union(enum) {
         tool_calls_json: OwnedSlice(u8) = OwnedSlice(u8).initBorrowed(""),
         details_json: OwnedSlice(u8) = OwnedSlice(u8).initBorrowed(""),
         artifacts_json: OwnedSlice(u8) = OwnedSlice(u8).initBorrowed(""),
+        stop_reason: ai_types.StopReason = .stop,
         is_error: bool = false,
     },
     tool_approval_requested: struct {

--- a/zig/src/tui/session.zig
+++ b/zig/src/tui/session.zig
@@ -34,7 +34,13 @@ pub const TuiEvent = union(enum) {
     text_delta: struct { content_index: usize, delta: OwnedSlice(u8) },
     thinking_delta: struct { content_index: usize, delta: OwnedSlice(u8) },
     tool_call_delta: struct { content_index: usize, delta: OwnedSlice(u8) },
-    message_end: struct { role: MessageRole },
+    message_end: struct {
+        role: MessageRole,
+        text: OwnedSlice(u8) = OwnedSlice(u8).initBorrowed(""),
+        tool_call_id: OwnedSlice(u8) = OwnedSlice(u8).initBorrowed(""),
+        tool_name: OwnedSlice(u8) = OwnedSlice(u8).initBorrowed(""),
+        args_json: OwnedSlice(u8) = OwnedSlice(u8).initBorrowed(""),
+    },
     tool_approval_requested: struct {
         tool_call_id: OwnedSlice(u8),
         tool_name: OwnedSlice(u8),
@@ -72,6 +78,12 @@ pub const TuiEvent = union(enum) {
             .text_delta => |*p| p.delta.deinit(allocator),
             .thinking_delta => |*p| p.delta.deinit(allocator),
             .tool_call_delta => |*p| p.delta.deinit(allocator),
+            .message_end => |*p| {
+                p.text.deinit(allocator);
+                p.tool_call_id.deinit(allocator);
+                p.tool_name.deinit(allocator);
+                p.args_json.deinit(allocator);
+            },
             .tool_approval_requested => |*p| {
                 p.tool_call_id.deinit(allocator);
                 p.tool_name.deinit(allocator);

--- a/zig/src/tui/session_store.zig
+++ b/zig/src/tui/session_store.zig
@@ -34,14 +34,12 @@ fn appendFile(path: []const u8, data: []const u8) !void {
     const flags = std.posix.O{ .ACCMODE = .WRONLY, .CREAT = true, .APPEND = true, .CLOEXEC = true };
     const fd = try std.posix.openat(std.posix.AT.FDCWD, path, flags, 0o600);
     defer _ = std.posix.system.close(fd);
-    var written: usize = 0;
-    while (written < data.len) {
-        const rc = std.c.write(fd, data[written..].ptr, data.len - written);
+    while (true) {
+        const rc = std.c.write(fd, data.ptr, data.len);
         switch (std.c.errno(rc)) {
             .SUCCESS => {
-                const n: usize = @intCast(rc);
-                if (n == 0) return error.WriteFailed;
-                written += n;
+                if (@as(usize, @intCast(rc)) != data.len) return error.ShortWrite;
+                return;
             },
             .INTR => continue,
             .AGAIN => continue,
@@ -75,10 +73,11 @@ fn readJsonlRecords(allocator: std.mem.Allocator, path: []const u8, max_bytes: u
             error.ReadFailed => return reader.err.?,
             error.WriteFailed => return error.OutOfMemory,
         };
-        const line = std.mem.trim(u8, out.written(), " \t\r");
-        total += line.len;
+        const raw_line = out.written();
+        total += raw_line.len;
         if (total > max_bytes) return error.StreamTooLong;
-        if (line.len > max_jsonl_line_bytes) return error.StreamTooLong;
+        if (raw_line.len > max_jsonl_line_bytes) return error.StreamTooLong;
+        const line = std.mem.trim(u8, raw_line, " \t\r");
         if (line.len > 0) try onLine(ctx, line);
         if (reader.interface.buffered().len == 0) break;
         _ = reader.interface.takeByte() catch break;
@@ -89,12 +88,13 @@ fn readLastJsonlLines(allocator: std.mem.Allocator, path: []const u8, max_bytes:
     var file = try compat.fs.getCwd().openFile(defaultIo(), path, .{});
     defer file.close(defaultIo());
     const stat = try file.stat(defaultIo());
-    if (stat.size > max_bytes) return error.StreamTooLong;
-    var reader = file.reader(defaultIo(), &.{});
-    return reader.interface.allocRemaining(allocator, .limited(max_bytes)) catch |err| switch (err) {
-        error.ReadFailed => return reader.err.?,
-        else => return err,
-    };
+    const read_len: usize = @intCast(@min(stat.size, max_bytes));
+    const offset = stat.size - read_len;
+    const data = try allocator.alloc(u8, read_len);
+    errdefer allocator.free(data);
+    const read = try file.readPositionalAll(defaultIo(), data, offset);
+    if (read == data.len) return data;
+    return allocator.realloc(data, read);
 }
 
 pub const SessionMetadata = struct {
@@ -119,8 +119,10 @@ const ReplayState = struct {
     current_role: ?tui_session.TuiEvent.MessageRole = null,
     assistant_text: std.ArrayList(u8) = .empty,
     tool_call_json: std.ArrayList(u8) = .empty,
+    last_tool_result_id: []u8 = &.{},
 
     fn deinit(self: *ReplayState, allocator: std.mem.Allocator) void {
+        if (self.last_tool_result_id.len > 0) allocator.free(self.last_tool_result_id);
         self.assistant_text.deinit(allocator);
         self.tool_call_json.deinit(allocator);
         self.* = undefined;
@@ -374,12 +376,26 @@ fn replayEvent(allocator: std.mem.Allocator, messages: *std.ArrayList(ai_types.M
                 },
                 .tool_result => if (payload.tool_call_id.slice().len > 0 and payload.content_json.slice().len > 0) {
                     try messages.append(allocator, .{ .tool_result = try parseToolResultFromPayload(allocator, payload) });
+                    try rememberToolResult(allocator, replay, payload.tool_call_id.slice());
                 },
             }
         },
-        .tool_execution_end => |payload| try messages.append(allocator, .{ .tool_result = try toolResultMessage(allocator, payload) }),
+        .tool_execution_end => |payload| {
+            if (isDuplicateToolResult(replay, payload.tool_call_id.slice())) return;
+            try messages.append(allocator, .{ .tool_result = try toolResultMessage(allocator, payload) });
+            try rememberToolResult(allocator, replay, payload.tool_call_id.slice());
+        },
         else => {},
     }
+}
+
+fn isDuplicateToolResult(replay: *ReplayState, tool_call_id: []const u8) bool {
+    return tool_call_id.len > 0 and std.mem.eql(u8, replay.last_tool_result_id, tool_call_id);
+}
+
+fn rememberToolResult(allocator: std.mem.Allocator, replay: *ReplayState, tool_call_id: []const u8) !void {
+    if (replay.last_tool_result_id.len > 0) allocator.free(replay.last_tool_result_id);
+    replay.last_tool_result_id = try allocator.dupe(u8, tool_call_id);
 }
 
 fn updateMetadata(allocator: std.mem.Allocator, meta: *SessionMetadata, obj: std.json.ObjectMap) !void {
@@ -882,6 +898,39 @@ test "session metadata updates from last valid line" {
     try std.testing.expectEqual(@as(usize, 2), list.items[0].turn_count);
 }
 
+test "metadata loads from tail of large session file" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const base = try tmpBase(std.testing.allocator, &tmp);
+    defer std.testing.allocator.free(base);
+    var store = try Store.init(std.testing.allocator, base);
+    defer store.deinit();
+    var meta = try defaultMetadata(std.testing.allocator, "large-metadata");
+    defer meta.deinit(std.testing.allocator);
+    try replaceString(std.testing.allocator, &meta.model, "tail-model");
+    try replaceString(std.testing.allocator, &meta.provider, "tail-provider");
+    meta.last_active = 99;
+    meta.turn_count = 7;
+
+    const path = try sessionPath(std.testing.allocator, base, "large-metadata");
+    defer std.testing.allocator.free(path);
+    const padding = try std.testing.allocator.alloc(u8, metadata_max_bytes + 16);
+    defer std.testing.allocator.free(padding);
+    @memset(padding, ' ');
+    try appendFile(path, padding);
+    try appendFile(path, "\n");
+    try store.save(meta, tui_session.TuiEvent.turn_start);
+
+    var list = try store.list();
+    defer {
+        for (list.items) |*item| item.deinit(std.testing.allocator);
+        list.deinit(std.testing.allocator);
+    }
+    try std.testing.expectEqual(@as(usize, 1), list.items.len);
+    try std.testing.expectEqualStrings("tail-model", list.items[0].model);
+    try std.testing.expectEqual(@as(i64, 99), list.items[0].last_active);
+}
+
 fn contentJson(text: []const u8) !OwnedSlice(u8) {
     return owned(std.testing.allocator, text);
 }
@@ -988,4 +1037,56 @@ test "load skips malformed json but propagates replay errors" {
     try appendFile(path, "{bad json}\n");
     try appendFile(path, "{\"event\":{\"type\":\"message_end\",\"role\":\"assistant\",\"content_json\":\"{}\"}}\n");
     try std.testing.expectError(error.InvalidMessage, store.load("bad-replay"));
+}
+
+test "load counts raw JSONL line bytes against caps" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const base = try tmpBase(std.testing.allocator, &tmp);
+    defer std.testing.allocator.free(base);
+    const path = try sessionPath(std.testing.allocator, base, "raw-cap");
+    defer std.testing.allocator.free(path);
+    const padding = try std.testing.allocator.alloc(u8, max_jsonl_line_bytes + 1);
+    defer std.testing.allocator.free(padding);
+    @memset(padding, ' ');
+    try appendFile(path, padding);
+    try appendFile(path, "\n");
+    var store = try Store.init(std.testing.allocator, base);
+    defer store.deinit();
+    try std.testing.expectError(error.StreamTooLong, store.load("raw-cap"));
+}
+
+test "message_end and tool_execution_end do not duplicate tool result" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const base = try tmpBase(std.testing.allocator, &tmp);
+    defer std.testing.allocator.free(base);
+    var store = try Store.init(std.testing.allocator, base);
+    defer store.deinit();
+    var meta = try testMeta("tool-dedupe");
+    defer meta.deinit(std.testing.allocator);
+
+    var message_end = tui_session.TuiEvent{ .message_end = .{
+        .role = .tool_result,
+        .tool_call_id = try owned(std.testing.allocator, "call-1"),
+        .tool_name = try owned(std.testing.allocator, "demo"),
+        .content_json = try contentJson("[{\"type\":\"text\",\"text\":\"result\"}]"),
+    } };
+    defer message_end.deinit(std.testing.allocator);
+    try store.save(meta, message_end);
+
+    var tool_end = tui_session.TuiEvent{ .tool_execution_end = .{
+        .tool_call_id = try owned(std.testing.allocator, "call-1"),
+        .tool_name = try owned(std.testing.allocator, "demo"),
+        .result_json = try owned(std.testing.allocator, "result"),
+        .is_error = false,
+    } };
+    defer tool_end.deinit(std.testing.allocator);
+    try store.save(meta, tool_end);
+
+    var loaded = try store.load("tool-dedupe");
+    defer loaded.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 1), loaded.messages.items.len);
+    try std.testing.expect(loaded.messages.items[0] == .tool_result);
+    try std.testing.expectEqualStrings("call-1", loaded.messages.items[0].tool_result.tool_call_id);
 }

--- a/zig/src/tui/session_store.zig
+++ b/zig/src/tui/session_store.zig
@@ -28,6 +28,16 @@ fn appendFile(path: []const u8, data: []const u8) !void {
     try file.writePositionalAll(defaultIo(), data, stat.size);
 }
 
+fn readFileAllocUnlimited(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
+    var file = try compat.fs.getCwd().openFile(defaultIo(), path, .{});
+    defer file.close(defaultIo());
+    var reader = file.reader(defaultIo(), &.{});
+    return reader.interface.allocRemaining(allocator, .unlimited) catch |err| switch (err) {
+        error.ReadFailed => return reader.err.?,
+        else => return err,
+    };
+}
+
 pub const SessionMetadata = struct {
     session_id: []u8,
     model: []u8,
@@ -109,7 +119,7 @@ pub const Store = struct {
     pub fn load(self: Store, session_id: []const u8) !LoadedSession {
         const path = try sessionPath(self.allocator, self.base_dir, session_id);
         defer self.allocator.free(path);
-        const data = try compat.fs.readFileAlloc(self.allocator, compat.fs.getCwd(), path, 16 * 1024 * 1024);
+        const data = try readFileAllocUnlimited(self.allocator, path);
         defer self.allocator.free(data);
         var loaded = LoadedSession{ .metadata = try defaultMetadata(self.allocator, session_id) };
         errdefer loaded.deinit(self.allocator);
@@ -119,7 +129,10 @@ pub const Store = struct {
         while (it.next()) |line| {
             const trimmed = std.mem.trim(u8, line, " \t\r");
             if (trimmed.len == 0) continue;
-            applyLine(self.allocator, &loaded, &replay, trimmed) catch continue;
+            applyLine(self.allocator, &loaded, &replay, trimmed) catch |err| switch (err) {
+                error.InvalidRecord, error.InvalidEvent, error.SyntaxError, error.UnexpectedToken, error.InvalidNumber, error.DuplicateField, error.UnknownField, error.MissingField, error.LengthMismatch => continue,
+                else => return err,
+            };
         }
         return loaded;
     }
@@ -149,20 +162,17 @@ pub const Store = struct {
     fn loadMetadata(self: Store, session_id: []const u8) !SessionMetadata {
         const path = try sessionPath(self.allocator, self.base_dir, session_id);
         defer self.allocator.free(path);
-        const data = try compat.fs.readFileAlloc(self.allocator, compat.fs.getCwd(), path, 16 * 1024 * 1024);
+        const data = try readFileAllocUnlimited(self.allocator, path);
         defer self.allocator.free(data);
         var meta = try defaultMetadata(self.allocator, session_id);
         errdefer meta.deinit(self.allocator);
-        var last: []const u8 = "";
         var it = std.mem.splitScalar(u8, data, '\n');
         while (it.next()) |line| {
             const trimmed = std.mem.trim(u8, line, " \t\r");
-            if (trimmed.len > 0) last = trimmed;
-        }
-        if (last.len > 0) {
-            var parsed = try std.json.parseFromSlice(std.json.Value, self.allocator, last, .{});
+            if (trimmed.len == 0) continue;
+            var parsed = std.json.parseFromSlice(std.json.Value, self.allocator, trimmed, .{}) catch continue;
             defer parsed.deinit();
-            const obj = switch (parsed.value) { .object => |o| o, else => return meta };
+            const obj = switch (parsed.value) { .object => |o| o, else => continue };
             if (obj.get("metadata")) |value| switch (value) {
                 .object => |meta_obj| try updateMetadata(self.allocator, &meta, meta_obj),
                 else => {},
@@ -268,9 +278,19 @@ fn replayEvent(allocator: std.mem.Allocator, messages: *std.ArrayList(ai_types.M
                 replay.tool_call_json.clearRetainingCapacity();
             }
             switch (payload.role) {
-                .user => if (payload.text.slice().len > 0) try messages.append(allocator, try userMessage(allocator, payload.text.slice())),
+                .user => {
+                    if (payload.content_json.slice().len > 0) {
+                        try messages.append(allocator, .{ .user = .{ .content = try parseUserContent(allocator, payload.content_json.slice()), .timestamp = compat.time.nowMillis() } });
+                    } else if (payload.text.slice().len > 0) {
+                        try messages.append(allocator, try userMessage(allocator, payload.text.slice()));
+                    }
+                },
                 .assistant => {
-                    if (payload.tool_call_id.slice().len > 0) {
+                    if (payload.content_json.slice().len > 0) {
+                        try messages.append(allocator, .{ .assistant = try parseAssistantMessageFromContentJson(allocator, meta, payload.content_json.slice(), .stop) });
+                    } else if (payload.tool_calls_json.slice().len > 0) {
+                        try messages.append(allocator, .{ .assistant = try parseAssistantMessageFromContentJson(allocator, meta, payload.tool_calls_json.slice(), .tool_use) });
+                    } else if (payload.tool_call_id.slice().len > 0) {
                         try messages.append(allocator, .{ .assistant = try assistantToolCallMessage(allocator, meta, payload.tool_call_id.slice(), payload.tool_name.slice(), payload.args_json.slice()) });
                     } else if (payload.text.slice().len > 0) {
                         try messages.append(allocator, .{ .assistant = try assistantTextMessageWithMeta(allocator, meta, payload.text.slice(), .stop) });
@@ -280,8 +300,8 @@ fn replayEvent(allocator: std.mem.Allocator, messages: *std.ArrayList(ai_types.M
                         try messages.append(allocator, .{ .assistant = try assistantToolCallMessage(allocator, meta, "", "", replay.tool_call_json.items) });
                     }
                 },
-                .tool_result => if (payload.tool_call_id.slice().len > 0) {
-                    try messages.append(allocator, .{ .tool_result = try toolResultFromFields(allocator, payload.tool_call_id.slice(), payload.tool_name.slice(), payload.text.slice(), false) });
+                .tool_result => if (payload.tool_call_id.slice().len > 0 and payload.content_json.slice().len > 0) {
+                    try messages.append(allocator, .{ .tool_result = try parseToolResultFromPayload(allocator, payload) });
                 },
             }
         },
@@ -340,7 +360,19 @@ fn writeEvent(w: *json_writer.JsonWriter, event: tui_session.TuiEvent) !void {
         .text_delta => |p| { try w.writeStringField("type", "text_delta"); try w.writeIntField("content_index", p.content_index); try w.writeStringField("delta", p.delta.slice()); },
         .thinking_delta => |p| { try w.writeStringField("type", "thinking_delta"); try w.writeIntField("content_index", p.content_index); try w.writeStringField("delta", p.delta.slice()); },
         .tool_call_delta => |p| { try w.writeStringField("type", "tool_call_delta"); try w.writeIntField("content_index", p.content_index); try w.writeStringField("delta", p.delta.slice()); },
-        .message_end => |p| { try w.writeStringField("type", "message_end"); try w.writeStringField("role", @tagName(p.role)); try w.writeStringField("text", p.text.slice()); try w.writeStringField("tool_call_id", p.tool_call_id.slice()); try w.writeStringField("tool_name", p.tool_name.slice()); try w.writeStringField("args_json", p.args_json.slice()); },
+        .message_end => |p| {
+            try w.writeStringField("type", "message_end");
+            try w.writeStringField("role", @tagName(p.role));
+            try w.writeStringField("text", p.text.slice());
+            try w.writeStringField("content_json", p.content_json.slice());
+            try w.writeStringField("tool_call_id", p.tool_call_id.slice());
+            try w.writeStringField("tool_name", p.tool_name.slice());
+            try w.writeStringField("args_json", p.args_json.slice());
+            try w.writeStringField("tool_calls_json", p.tool_calls_json.slice());
+            try w.writeStringField("details_json", p.details_json.slice());
+            try w.writeStringField("artifacts_json", p.artifacts_json.slice());
+            try w.writeBoolField("is_error", p.is_error);
+        },
         .tool_approval_requested => |p| { try w.writeStringField("type", "tool_approval_requested"); try writeToolFields(w, p.tool_call_id.slice(), p.tool_name.slice(), p.args_json.slice()); },
         .tool_execution_start => |p| { try w.writeStringField("type", "tool_execution_start"); try writeToolFields(w, p.tool_call_id.slice(), p.tool_name.slice(), p.args_json.slice()); },
         .tool_execution_update => |p| { try w.writeStringField("type", "tool_execution_update"); try writeToolFields(w, p.tool_call_id.slice(), p.tool_name.slice(), p.args_json.slice()); try w.writeStringField("partial_result_json", p.partial_result_json.slice()); },
@@ -370,9 +402,14 @@ fn parseEvent(allocator: std.mem.Allocator, value: std.json.Value) !tui_session.
     if (std.mem.eql(u8, kind, "message_end")) return .{ .message_end = .{
         .role = parseRole(stringField(obj, "role") orelse "assistant"),
         .text = try owned(allocator, stringField(obj, "text") orelse ""),
+        .content_json = try owned(allocator, stringField(obj, "content_json") orelse ""),
         .tool_call_id = try owned(allocator, stringField(obj, "tool_call_id") orelse ""),
         .tool_name = try owned(allocator, stringField(obj, "tool_name") orelse ""),
         .args_json = try owned(allocator, stringField(obj, "args_json") orelse ""),
+        .tool_calls_json = try owned(allocator, stringField(obj, "tool_calls_json") orelse ""),
+        .details_json = try owned(allocator, stringField(obj, "details_json") orelse ""),
+        .artifacts_json = try owned(allocator, stringField(obj, "artifacts_json") orelse ""),
+        .is_error = boolField(obj, "is_error", false),
     } };
     if (std.mem.eql(u8, kind, "tool_approval_requested")) return .{ .tool_approval_requested = .{ .tool_call_id = try owned(allocator, stringField(obj, "tool_call_id") orelse ""), .tool_name = try owned(allocator, stringField(obj, "tool_name") orelse ""), .args_json = try owned(allocator, stringField(obj, "args_json") orelse "") } };
     if (std.mem.eql(u8, kind, "tool_execution_start")) return .{ .tool_execution_start = .{ .tool_call_id = try owned(allocator, stringField(obj, "tool_call_id") orelse ""), .tool_name = try owned(allocator, stringField(obj, "tool_name") orelse ""), .args_json = try owned(allocator, stringField(obj, "args_json") orelse "") } };
@@ -390,6 +427,150 @@ fn owned(allocator: std.mem.Allocator, value: []const u8) !OwnedSlice(u8) {
 
 fn userMessage(allocator: std.mem.Allocator, text: []const u8) !ai_types.Message {
     return .{ .user = .{ .content = .{ .text = try allocator.dupe(u8, text) }, .timestamp = compat.time.nowMillis() } };
+}
+
+fn parseUserContent(allocator: std.mem.Allocator, json: []const u8) !ai_types.UserContent {
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, json, .{});
+    defer parsed.deinit();
+    const arr = switch (parsed.value) { .array => |a| a, else => return error.InvalidMessage };
+    const parts = try allocator.alloc(ai_types.UserContentPart, arr.items.len);
+    var initialized: usize = 0;
+    errdefer {
+        for (parts[0..initialized]) |*part| part.deinit(allocator);
+        allocator.free(parts);
+    }
+    for (arr.items, 0..) |item, i| {
+        parts[i] = try parseUserContentPart(allocator, item);
+        initialized += 1;
+    }
+    return .{ .parts = parts };
+}
+
+fn parseUserParts(allocator: std.mem.Allocator, json: []const u8) ![]const ai_types.UserContentPart {
+    const content = try parseUserContent(allocator, json);
+    return switch (content) {
+        .parts => |parts| parts,
+        .text => unreachable,
+    };
+}
+
+fn parseUserContentPart(allocator: std.mem.Allocator, value: std.json.Value) !ai_types.UserContentPart {
+    const obj = switch (value) { .object => |o| o, else => return error.InvalidMessage };
+    const kind = stringField(obj, "type") orelse return error.InvalidMessage;
+    if (std.mem.eql(u8, kind, "text")) return .{ .text = .{
+        .text = try allocator.dupe(u8, stringField(obj, "text") orelse ""),
+        .text_signature = if (stringField(obj, "text_signature")) |sig| try allocator.dupe(u8, sig) else null,
+    } };
+    if (std.mem.eql(u8, kind, "image")) return .{ .image = .{
+        .data = try allocator.dupe(u8, stringField(obj, "data") orelse ""),
+        .mime_type = try allocator.dupe(u8, stringField(obj, "mime_type") orelse ""),
+    } };
+    return error.InvalidMessage;
+}
+
+fn parseAssistantMessageFromContentJson(allocator: std.mem.Allocator, meta: SessionMetadata, json: []const u8, fallback_stop_reason: ai_types.StopReason) !ai_types.AssistantMessage {
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, json, .{});
+    defer parsed.deinit();
+    const arr = switch (parsed.value) { .array => |a| a, else => return error.InvalidMessage };
+    const content = try allocator.alloc(ai_types.AssistantContent, arr.items.len);
+    var initialized: usize = 0;
+    var has_tool_call = false;
+    errdefer {
+        deinitAssistantContentPrefix(allocator, content[0..initialized]);
+        allocator.free(content);
+    }
+    for (arr.items, 0..) |item, i| {
+        content[i] = try parseAssistantContent(allocator, item);
+        if (content[i] == .tool_call) has_tool_call = true;
+        initialized += 1;
+    }
+    const stop_reason: ai_types.StopReason = if (has_tool_call) .tool_use else fallback_stop_reason;
+    return assistantMessage(allocator, meta, content, stop_reason);
+}
+
+fn parseAssistantContent(allocator: std.mem.Allocator, value: std.json.Value) !ai_types.AssistantContent {
+    const obj = switch (value) { .object => |o| o, else => return error.InvalidMessage };
+    const kind = stringField(obj, "type") orelse return error.InvalidMessage;
+    if (std.mem.eql(u8, kind, "text")) return .{ .text = .{
+        .text = try allocator.dupe(u8, stringField(obj, "text") orelse ""),
+        .text_signature = if (stringField(obj, "text_signature")) |sig| try allocator.dupe(u8, sig) else null,
+    } };
+    if (std.mem.eql(u8, kind, "thinking")) return .{ .thinking = .{
+        .thinking = try allocator.dupe(u8, stringField(obj, "thinking") orelse ""),
+        .thinking_signature = if (stringField(obj, "thinking_signature")) |sig| try allocator.dupe(u8, sig) else null,
+    } };
+    if (std.mem.eql(u8, kind, "tool_call")) return .{ .tool_call = .{
+        .id = try allocator.dupe(u8, stringField(obj, "id") orelse ""),
+        .name = try allocator.dupe(u8, stringField(obj, "name") orelse ""),
+        .arguments_json = try allocator.dupe(u8, stringField(obj, "arguments_json") orelse ""),
+        .thought_signature = if (stringField(obj, "thought_signature")) |sig| try allocator.dupe(u8, sig) else null,
+    } };
+    if (std.mem.eql(u8, kind, "image")) return .{ .image = .{
+        .data = try allocator.dupe(u8, stringField(obj, "data") orelse ""),
+        .mime_type = try allocator.dupe(u8, stringField(obj, "mime_type") orelse ""),
+    } };
+    return error.InvalidMessage;
+}
+
+fn parseToolResultFromPayload(allocator: std.mem.Allocator, payload: anytype) !ai_types.ToolResultMessage {
+    return .{
+        .tool_call_id = try allocator.dupe(u8, payload.tool_call_id.slice()),
+        .tool_name = try allocator.dupe(u8, payload.tool_name.slice()),
+        .content = try parseUserParts(allocator, payload.content_json.slice()),
+        .details_json = OwnedSlice(u8).initOwned(try allocator.dupe(u8, payload.details_json.slice())),
+        .artifacts = OwnedSlice(ai_types.ArtifactReference).initOwned(try parseArtifacts(allocator, payload.artifacts_json.slice())),
+        .is_error = payload.is_error,
+        .timestamp = compat.time.nowMillis(),
+    };
+}
+
+fn parseArtifacts(allocator: std.mem.Allocator, json: []const u8) ![]ai_types.ArtifactReference {
+    if (json.len == 0) return allocator.alloc(ai_types.ArtifactReference, 0);
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, json, .{});
+    defer parsed.deinit();
+    const arr = switch (parsed.value) { .array => |a| a, else => return error.InvalidMessage };
+    const artifacts = try allocator.alloc(ai_types.ArtifactReference, arr.items.len);
+    var initialized: usize = 0;
+    errdefer {
+        for (artifacts[0..initialized]) |*artifact| artifact.deinit(allocator);
+        allocator.free(artifacts);
+    }
+    for (arr.items, 0..) |item, i| {
+        const obj = switch (item) { .object => |o| o, else => return error.InvalidMessage };
+        artifacts[i] = .{
+            .artifact_id = try allocator.dupe(u8, stringField(obj, "artifact_id") orelse ""),
+            .uri = OwnedSlice(u8).initOwned(try allocator.dupe(u8, stringField(obj, "uri") orelse "")),
+            .mime_type = OwnedSlice(u8).initOwned(try allocator.dupe(u8, stringField(obj, "mime_type") orelse "")),
+            .byte_size = uintField(obj, "byte_size"),
+            .sha256 = OwnedSlice(u8).initOwned(try allocator.dupe(u8, stringField(obj, "sha256") orelse "")),
+            .description = OwnedSlice(u8).initOwned(try allocator.dupe(u8, stringField(obj, "description") orelse "")),
+        };
+        initialized += 1;
+    }
+    return artifacts;
+}
+
+fn deinitAssistantContentPrefix(allocator: std.mem.Allocator, content: []ai_types.AssistantContent) void {
+    for (content) |block| switch (block) {
+        .text => |text| {
+            allocator.free(text.text);
+            if (text.text_signature) |sig| allocator.free(sig);
+        },
+        .thinking => |thinking| {
+            allocator.free(thinking.thinking);
+            if (thinking.thinking_signature) |sig| allocator.free(sig);
+        },
+        .tool_call => |tool| {
+            allocator.free(tool.id);
+            allocator.free(tool.name);
+            allocator.free(tool.arguments_json);
+            if (tool.thought_signature) |sig| allocator.free(sig);
+        },
+        .image => |image| {
+            allocator.free(image.data);
+            allocator.free(image.mime_type);
+        },
+    };
 }
 
 fn assistantTextMessage(allocator: std.mem.Allocator, text: []const u8, stop_reason: ai_types.StopReason) !ai_types.AssistantMessage {
@@ -625,4 +806,111 @@ test "session metadata updates from last valid line" {
     try std.testing.expectEqual(@as(usize, 1), list.items.len);
     try std.testing.expectEqual(@as(i64, 30), list.items[0].last_active);
     try std.testing.expectEqual(@as(usize, 2), list.items[0].turn_count);
+}
+
+fn contentJson(text: []const u8) !OwnedSlice(u8) {
+    return owned(std.testing.allocator, text);
+}
+
+fn testMeta(session_id: []const u8) !SessionMetadata {
+    var meta = try defaultMetadata(std.testing.allocator, session_id);
+    try replaceString(std.testing.allocator, &meta.model, "model-a");
+    try replaceString(std.testing.allocator, &meta.provider, "provider-a");
+    return meta;
+}
+
+const user_parts_json = "[{\"type\":\"text\",\"text\":\"see this\"},{\"type\":\"image\",\"data\":\"base64data\",\"mime_type\":\"image/png\"}]";
+const assistant_mixed_json = "[{\"type\":\"text\",\"text\":\"I will call tools\"},{\"type\":\"tool_call\",\"id\":\"call-1\",\"name\":\"demo\",\"arguments_json\":\"{\\\"x\\\":1}\"}]";
+const assistant_image_json = "[{\"type\":\"image\",\"data\":\"assistant-image\",\"mime_type\":\"image/png\"}]";
+
+
+test "message_end replay preserves user image parts" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const base = try tmpBase(std.testing.allocator, &tmp);
+    defer std.testing.allocator.free(base);
+    var store = try Store.init(std.testing.allocator, base);
+    defer store.deinit();
+    var meta = try testMeta("user-parts");
+    defer meta.deinit(std.testing.allocator);
+
+    var event = tui_session.TuiEvent{ .message_end = .{ .role = .user, .text = try owned(std.testing.allocator, "see this"), .content_json = try contentJson(user_parts_json) } };
+    defer event.deinit(std.testing.allocator);
+    try store.save(meta, event);
+
+    var loaded = try store.load("user-parts");
+    defer loaded.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 1), loaded.messages.items.len);
+    const user = loaded.messages.items[0].user;
+    try std.testing.expect(user.content == .parts);
+    try std.testing.expectEqual(@as(usize, 2), user.content.parts.len);
+    try std.testing.expect(user.content.parts[1] == .image);
+    try std.testing.expectEqualStrings("base64data", user.content.parts[1].image.data);
+}
+
+
+test "message_end replay preserves mixed assistant text and tool calls" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const base = try tmpBase(std.testing.allocator, &tmp);
+    defer std.testing.allocator.free(base);
+    var store = try Store.init(std.testing.allocator, base);
+    defer store.deinit();
+    var meta = try testMeta("assistant-mixed");
+    defer meta.deinit(std.testing.allocator);
+
+    var event = tui_session.TuiEvent{ .message_end = .{ .role = .assistant, .text = try owned(std.testing.allocator, "I will call tools"), .content_json = try contentJson(assistant_mixed_json) } };
+    defer event.deinit(std.testing.allocator);
+    try store.save(meta, event);
+
+    var loaded = try store.load("assistant-mixed");
+    defer loaded.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 1), loaded.messages.items.len);
+    const assistant = loaded.messages.items[0].assistant;
+    try std.testing.expectEqual(@as(usize, 2), assistant.content.len);
+    try std.testing.expect(assistant.content[0] == .text);
+    try std.testing.expect(assistant.content[1] == .tool_call);
+    try std.testing.expectEqualStrings("call-1", assistant.content[1].tool_call.id);
+}
+
+
+test "message_end replay preserves assistant image content" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const base = try tmpBase(std.testing.allocator, &tmp);
+    defer std.testing.allocator.free(base);
+    var store = try Store.init(std.testing.allocator, base);
+    defer store.deinit();
+    var meta = try testMeta("assistant-image");
+    defer meta.deinit(std.testing.allocator);
+
+    var event = tui_session.TuiEvent{ .message_end = .{ .role = .assistant, .content_json = try contentJson(assistant_image_json) } };
+    defer event.deinit(std.testing.allocator);
+    try store.save(meta, event);
+
+    var loaded = try store.load("assistant-image");
+    defer loaded.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 1), loaded.messages.items.len);
+    const assistant = loaded.messages.items[0].assistant;
+    try std.testing.expectEqual(@as(usize, 1), assistant.content.len);
+    try std.testing.expect(assistant.content[0] == .image);
+    try std.testing.expectEqualStrings("assistant-image", assistant.content[0].image.data);
+}
+
+
+test "load skips malformed json but propagates replay errors" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const base = try tmpBase(std.testing.allocator, &tmp);
+    defer std.testing.allocator.free(base);
+    var store = try Store.init(std.testing.allocator, base);
+    defer store.deinit();
+    var meta = try testMeta("bad-replay");
+    defer meta.deinit(std.testing.allocator);
+    try store.save(meta, .turn_start);
+    const path = try sessionPath(std.testing.allocator, base, "bad-replay");
+    defer std.testing.allocator.free(path);
+    try appendFile(path, "{bad json}\n");
+    try appendFile(path, "{\"event\":{\"type\":\"message_end\",\"role\":\"assistant\",\"content_json\":\"{}\"}}\n");
+    try std.testing.expectError(error.InvalidMessage, store.load("bad-replay"));
 }

--- a/zig/src/tui/session_store.zig
+++ b/zig/src/tui/session_store.zig
@@ -4,7 +4,8 @@ const ai_types = @import("ai_types");
 const tui_session = @import("tui_session");
 const tui_runtime = @import("tui_runtime");
 const agent = @import("agent");
-const json_writer = @import("json/writer");
+const json_writer = @import("json_writer");
+const builtin = @import("builtin");
 const OwnedSlice = @import("owned_slice").OwnedSlice;
 
 fn tmpBase(allocator: std.mem.Allocator, tmp: *std.testing.TmpDir) ![]u8 {
@@ -22,17 +23,75 @@ fn defaultIo() std.Io {
 }
 
 fn appendFile(path: []const u8, data: []const u8) !void {
-    var file = try compat.fs.getCwd().createFile(defaultIo(), path, .{ .truncate = false, .read = true, .permissions = compat.fs.default_file_mode });
-    defer file.close(defaultIo());
-    const stat = try file.stat(defaultIo());
-    try file.writePositionalAll(defaultIo(), data, stat.size);
+    if (builtin.os.tag == .windows or builtin.os.tag == .wasi) {
+        var file = try compat.fs.getCwd().createFile(defaultIo(), path, .{ .truncate = false, .read = true, .lock = .exclusive, .permissions = compat.fs.default_file_mode });
+        defer file.close(defaultIo());
+        const stat = try file.stat(defaultIo());
+        try file.writePositionalAll(defaultIo(), data, stat.size);
+        return;
+    }
+
+    const flags = std.posix.O{ .ACCMODE = .WRONLY, .CREAT = true, .APPEND = true, .CLOEXEC = true };
+    const fd = try std.posix.openat(std.posix.AT.FDCWD, path, flags, 0o600);
+    defer _ = std.posix.system.close(fd);
+    var written: usize = 0;
+    while (written < data.len) {
+        const rc = std.c.write(fd, data[written..].ptr, data.len - written);
+        switch (std.c.errno(rc)) {
+            .SUCCESS => {
+                const n: usize = @intCast(rc);
+                if (n == 0) return error.WriteFailed;
+                written += n;
+            },
+            .INTR => continue,
+            .AGAIN => continue,
+            .FBIG => return error.FileTooBig,
+            .NOSPC => return error.NoSpaceLeft,
+            .DQUOT => return error.DiskQuota,
+            .IO => return error.InputOutput,
+            .BADF => return error.NotOpenForWriting,
+            .FAULT => return error.BadAddress,
+            .INVAL => return error.InvalidArgument,
+            else => return error.Unexpected,
+        }
+    }
 }
 
-fn readFileAllocUnlimited(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
+const load_max_bytes = 64 * 1024 * 1024;
+const metadata_max_bytes = 1024 * 1024;
+const max_jsonl_line_bytes = 8 * 1024 * 1024;
+
+fn readJsonlRecords(allocator: std.mem.Allocator, path: []const u8, max_bytes: usize, ctx: anytype, comptime onLine: fn (@TypeOf(ctx), []const u8) anyerror!void) !void {
     var file = try compat.fs.getCwd().openFile(defaultIo(), path, .{});
     defer file.close(defaultIo());
+    var file_buffer: [16 * 1024]u8 = undefined;
+    var reader = file.reader(defaultIo(), &file_buffer);
+    var out: std.Io.Writer.Allocating = .init(allocator);
+    defer out.deinit();
+    var total: usize = 0;
+    while (true) {
+        out.clearRetainingCapacity();
+        _ = reader.interface.streamDelimiterEnding(&out.writer, '\n') catch |err| switch (err) {
+            error.ReadFailed => return reader.err.?,
+            error.WriteFailed => return error.OutOfMemory,
+        };
+        const line = std.mem.trim(u8, out.written(), " \t\r");
+        total += line.len;
+        if (total > max_bytes) return error.StreamTooLong;
+        if (line.len > max_jsonl_line_bytes) return error.StreamTooLong;
+        if (line.len > 0) try onLine(ctx, line);
+        if (reader.interface.buffered().len == 0) break;
+        _ = reader.interface.takeByte() catch break;
+    }
+}
+
+fn readLastJsonlLines(allocator: std.mem.Allocator, path: []const u8, max_bytes: usize) ![]u8 {
+    var file = try compat.fs.getCwd().openFile(defaultIo(), path, .{});
+    defer file.close(defaultIo());
+    const stat = try file.stat(defaultIo());
+    if (stat.size > max_bytes) return error.StreamTooLong;
     var reader = file.reader(defaultIo(), &.{});
-    return reader.interface.allocRemaining(allocator, .unlimited) catch |err| switch (err) {
+    return reader.interface.allocRemaining(allocator, .limited(max_bytes)) catch |err| switch (err) {
         error.ReadFailed => return reader.err.?,
         else => return err,
     };
@@ -119,21 +178,12 @@ pub const Store = struct {
     pub fn load(self: Store, session_id: []const u8) !LoadedSession {
         const path = try sessionPath(self.allocator, self.base_dir, session_id);
         defer self.allocator.free(path);
-        const data = try readFileAllocUnlimited(self.allocator, path);
-        defer self.allocator.free(data);
         var loaded = LoadedSession{ .metadata = try defaultMetadata(self.allocator, session_id) };
         errdefer loaded.deinit(self.allocator);
         var replay = ReplayState{};
         defer replay.deinit(self.allocator);
-        var it = std.mem.splitScalar(u8, data, '\n');
-        while (it.next()) |line| {
-            const trimmed = std.mem.trim(u8, line, " \t\r");
-            if (trimmed.len == 0) continue;
-            applyLine(self.allocator, &loaded, &replay, trimmed) catch |err| switch (err) {
-                error.InvalidRecord, error.InvalidEvent, error.SyntaxError, error.UnexpectedToken, error.InvalidNumber, error.DuplicateField, error.UnknownField, error.MissingField, error.LengthMismatch => continue,
-                else => return err,
-            };
-        }
+        var ctx = LoadLineContext{ .allocator = self.allocator, .loaded = &loaded, .replay = &replay };
+        try readJsonlRecords(self.allocator, path, load_max_bytes, &ctx, loadLine);
         return loaded;
     }
 
@@ -162,19 +212,27 @@ pub const Store = struct {
     fn loadMetadata(self: Store, session_id: []const u8) !SessionMetadata {
         const path = try sessionPath(self.allocator, self.base_dir, session_id);
         defer self.allocator.free(path);
-        const data = try readFileAllocUnlimited(self.allocator, path);
+        const data = try readLastJsonlLines(self.allocator, path, metadata_max_bytes);
         defer self.allocator.free(data);
         var meta = try defaultMetadata(self.allocator, session_id);
         errdefer meta.deinit(self.allocator);
-        var it = std.mem.splitScalar(u8, data, '\n');
-        while (it.next()) |line| {
-            const trimmed = std.mem.trim(u8, line, " \t\r");
-            if (trimmed.len == 0) continue;
-            var parsed = std.json.parseFromSlice(std.json.Value, self.allocator, trimmed, .{}) catch continue;
+
+        var end = data.len;
+        while (end > 0) {
+            while (end > 0 and (data[end - 1] == '\n' or data[end - 1] == '\r' or data[end - 1] == ' ' or data[end - 1] == '\t')) end -= 1;
+            if (end == 0) break;
+            const start = if (std.mem.lastIndexOfScalar(u8, data[0..end], '\n')) |idx| idx + 1 else 0;
+            const line = std.mem.trim(u8, data[start..end], " \t\r");
+            end = if (start == 0) 0 else start - 1;
+            if (line.len == 0) continue;
+            var parsed = std.json.parseFromSlice(std.json.Value, self.allocator, line, .{}) catch continue;
             defer parsed.deinit();
             const obj = switch (parsed.value) { .object => |o| o, else => continue };
             if (obj.get("metadata")) |value| switch (value) {
-                .object => |meta_obj| try updateMetadata(self.allocator, &meta, meta_obj),
+                .object => |meta_obj| {
+                    try updateMetadata(self.allocator, &meta, meta_obj);
+                    break;
+                },
                 else => {},
             };
         }
@@ -185,6 +243,7 @@ pub const Store = struct {
         var loaded = try self.load(session_id);
         errdefer loaded.deinit(self.allocator);
         try runtime.start();
+        if (loaded.metadata.model.len > 0) try runtime.switchModel(loaded.metadata.model);
         try runtime.replaceMessages(loaded.messages.items);
         return loaded;
     }
@@ -225,6 +284,19 @@ fn cloneMetadata(allocator: std.mem.Allocator, meta: SessionMetadata) !SessionMe
         .last_active = meta.last_active,
         .turn_count = meta.turn_count,
         .working_dir = try allocator.dupe(u8, meta.working_dir),
+    };
+}
+
+const LoadLineContext = struct {
+    allocator: std.mem.Allocator,
+    loaded: *LoadedSession,
+    replay: *ReplayState,
+};
+
+fn loadLine(ctx: *LoadLineContext, line: []const u8) !void {
+    applyLine(ctx.allocator, ctx.loaded, ctx.replay, line) catch |err| switch (err) {
+        error.InvalidRecord, error.InvalidEvent, error.SyntaxError, error.UnexpectedToken, error.InvalidNumber, error.DuplicateField, error.UnknownField, error.MissingField, error.LengthMismatch => {},
+        else => return err,
     };
 }
 
@@ -287,9 +359,9 @@ fn replayEvent(allocator: std.mem.Allocator, messages: *std.ArrayList(ai_types.M
                 },
                 .assistant => {
                     if (payload.content_json.slice().len > 0) {
-                        try messages.append(allocator, .{ .assistant = try parseAssistantMessageFromContentJson(allocator, meta, payload.content_json.slice(), .stop) });
+                        try messages.append(allocator, .{ .assistant = try parseAssistantMessageFromContentJson(allocator, meta, payload.content_json.slice(), payload.stop_reason) });
                     } else if (payload.tool_calls_json.slice().len > 0) {
-                        try messages.append(allocator, .{ .assistant = try parseAssistantMessageFromContentJson(allocator, meta, payload.tool_calls_json.slice(), .tool_use) });
+                        try messages.append(allocator, .{ .assistant = try parseAssistantMessageFromContentJson(allocator, meta, payload.tool_calls_json.slice(), payload.stop_reason) });
                     } else if (payload.tool_call_id.slice().len > 0) {
                         try messages.append(allocator, .{ .assistant = try assistantToolCallMessage(allocator, meta, payload.tool_call_id.slice(), payload.tool_name.slice(), payload.args_json.slice()) });
                     } else if (payload.text.slice().len > 0) {
@@ -371,6 +443,7 @@ fn writeEvent(w: *json_writer.JsonWriter, event: tui_session.TuiEvent) !void {
             try w.writeStringField("tool_calls_json", p.tool_calls_json.slice());
             try w.writeStringField("details_json", p.details_json.slice());
             try w.writeStringField("artifacts_json", p.artifacts_json.slice());
+            try w.writeStringField("stop_reason", @tagName(p.stop_reason));
             try w.writeBoolField("is_error", p.is_error);
         },
         .tool_approval_requested => |p| { try w.writeStringField("type", "tool_approval_requested"); try writeToolFields(w, p.tool_call_id.slice(), p.tool_name.slice(), p.args_json.slice()); },
@@ -409,6 +482,7 @@ fn parseEvent(allocator: std.mem.Allocator, value: std.json.Value) !tui_session.
         .tool_calls_json = try owned(allocator, stringField(obj, "tool_calls_json") orelse ""),
         .details_json = try owned(allocator, stringField(obj, "details_json") orelse ""),
         .artifacts_json = try owned(allocator, stringField(obj, "artifacts_json") orelse ""),
+        .stop_reason = parseStopReason(stringField(obj, "stop_reason") orelse "stop"),
         .is_error = boolField(obj, "is_error", false),
     } };
     if (std.mem.eql(u8, kind, "tool_approval_requested")) return .{ .tool_approval_requested = .{ .tool_call_id = try owned(allocator, stringField(obj, "tool_call_id") orelse ""), .tool_name = try owned(allocator, stringField(obj, "tool_name") orelse ""), .args_json = try owned(allocator, stringField(obj, "args_json") orelse "") } };
@@ -450,7 +524,7 @@ fn parseUserParts(allocator: std.mem.Allocator, json: []const u8) ![]const ai_ty
     const content = try parseUserContent(allocator, json);
     return switch (content) {
         .parts => |parts| parts,
-        .text => unreachable,
+        .text => error.InvalidMessage,
     };
 }
 
@@ -484,7 +558,7 @@ fn parseAssistantMessageFromContentJson(allocator: std.mem.Allocator, meta: Sess
         if (content[i] == .tool_call) has_tool_call = true;
         initialized += 1;
     }
-    const stop_reason: ai_types.StopReason = if (has_tool_call) .tool_use else fallback_stop_reason;
+    const stop_reason: ai_types.StopReason = if (fallback_stop_reason == .stop and has_tool_call) .tool_use else fallback_stop_reason;
     return assistantMessage(allocator, meta, content, stop_reason);
 }
 
@@ -859,7 +933,7 @@ test "message_end replay preserves mixed assistant text and tool calls" {
     var meta = try testMeta("assistant-mixed");
     defer meta.deinit(std.testing.allocator);
 
-    var event = tui_session.TuiEvent{ .message_end = .{ .role = .assistant, .text = try owned(std.testing.allocator, "I will call tools"), .content_json = try contentJson(assistant_mixed_json) } };
+    var event = tui_session.TuiEvent{ .message_end = .{ .role = .assistant, .text = try owned(std.testing.allocator, "I will call tools"), .content_json = try contentJson(assistant_mixed_json), .stop_reason = .length } };
     defer event.deinit(std.testing.allocator);
     try store.save(meta, event);
 
@@ -871,6 +945,7 @@ test "message_end replay preserves mixed assistant text and tool calls" {
     try std.testing.expect(assistant.content[0] == .text);
     try std.testing.expect(assistant.content[1] == .tool_call);
     try std.testing.expectEqualStrings("call-1", assistant.content[1].tool_call.id);
+    try std.testing.expectEqual(ai_types.StopReason.length, assistant.stop_reason);
 }
 
 

--- a/zig/src/tui/session_store.zig
+++ b/zig/src/tui/session_store.zig
@@ -8,6 +8,19 @@ const json_writer = @import("json_writer");
 const builtin = @import("builtin");
 const OwnedSlice = @import("owned_slice").OwnedSlice;
 
+const ToolResultSource = enum { execution_end, message_end };
+
+const ToolResultReplayEntry = struct {
+    tool_call_id: []u8,
+    message_index: usize,
+    source: ToolResultSource,
+
+    fn deinit(self: *ToolResultReplayEntry, allocator: std.mem.Allocator) void {
+        allocator.free(self.tool_call_id);
+        self.* = undefined;
+    }
+};
+
 fn tmpBase(allocator: std.mem.Allocator, tmp: *std.testing.TmpDir) ![]u8 {
     const base = try std.fs.path.join(allocator, &.{ ".zig-cache", "tmp", &tmp.sub_path, "sessions" });
     errdefer allocator.free(base);
@@ -23,36 +36,11 @@ fn defaultIo() std.Io {
 }
 
 fn appendFile(path: []const u8, data: []const u8) !void {
-    if (builtin.os.tag == .windows or builtin.os.tag == .wasi) {
-        var file = try compat.fs.getCwd().createFile(defaultIo(), path, .{ .truncate = false, .read = true, .lock = .exclusive, .permissions = compat.fs.default_file_mode });
-        defer file.close(defaultIo());
-        const stat = try file.stat(defaultIo());
-        try file.writePositionalAll(defaultIo(), data, stat.size);
-        return;
-    }
-
-    const flags = std.posix.O{ .ACCMODE = .WRONLY, .CREAT = true, .APPEND = true, .CLOEXEC = true };
-    const fd = try std.posix.openat(std.posix.AT.FDCWD, path, flags, 0o600);
-    defer _ = std.posix.system.close(fd);
-    while (true) {
-        const rc = std.c.write(fd, data.ptr, data.len);
-        switch (std.c.errno(rc)) {
-            .SUCCESS => {
-                if (@as(usize, @intCast(rc)) != data.len) return error.ShortWrite;
-                return;
-            },
-            .INTR => continue,
-            .AGAIN => continue,
-            .FBIG => return error.FileTooBig,
-            .NOSPC => return error.NoSpaceLeft,
-            .DQUOT => return error.DiskQuota,
-            .IO => return error.InputOutput,
-            .BADF => return error.NotOpenForWriting,
-            .FAULT => return error.BadAddress,
-            .INVAL => return error.InvalidArgument,
-            else => return error.Unexpected,
-        }
-    }
+    _ = builtin;
+    var file = try compat.fs.getCwd().createFile(defaultIo(), path, .{ .truncate = false, .read = true, .lock = .exclusive, .permissions = compat.fs.default_file_mode });
+    defer file.close(defaultIo());
+    const stat = try file.stat(defaultIo());
+    try file.writePositionalAll(defaultIo(), data, stat.size);
 }
 
 const load_max_bytes = 64 * 1024 * 1024;
@@ -81,6 +69,8 @@ fn readJsonlRecords(allocator: std.mem.Allocator, path: []const u8, max_bytes: u
         if (line.len > 0) try onLine(ctx, line);
         if (reader.interface.buffered().len == 0) break;
         _ = reader.interface.takeByte() catch break;
+        total += 1;
+        if (total > max_bytes) return error.StreamTooLong;
     }
 }
 
@@ -119,10 +109,11 @@ const ReplayState = struct {
     current_role: ?tui_session.TuiEvent.MessageRole = null,
     assistant_text: std.ArrayList(u8) = .empty,
     tool_call_json: std.ArrayList(u8) = .empty,
-    last_tool_result_id: []u8 = &.{},
+    tool_results: std.ArrayList(ToolResultReplayEntry) = .empty,
 
     fn deinit(self: *ReplayState, allocator: std.mem.Allocator) void {
-        if (self.last_tool_result_id.len > 0) allocator.free(self.last_tool_result_id);
+        for (self.tool_results.items) |*entry| entry.deinit(allocator);
+        self.tool_results.deinit(allocator);
         self.assistant_text.deinit(allocator);
         self.tool_call_json.deinit(allocator);
         self.* = undefined;
@@ -367,35 +358,62 @@ fn replayEvent(allocator: std.mem.Allocator, messages: *std.ArrayList(ai_types.M
                     } else if (payload.tool_call_id.slice().len > 0) {
                         try messages.append(allocator, .{ .assistant = try assistantToolCallMessage(allocator, meta, payload.tool_call_id.slice(), payload.tool_name.slice(), payload.args_json.slice()) });
                     } else if (payload.text.slice().len > 0) {
-                        try messages.append(allocator, .{ .assistant = try assistantTextMessageWithMeta(allocator, meta, payload.text.slice(), .stop) });
+                        try messages.append(allocator, .{ .assistant = try assistantTextMessageWithMeta(allocator, meta, payload.text.slice(), payload.stop_reason) });
                     } else if (replay.assistant_text.items.len > 0) {
-                        try messages.append(allocator, .{ .assistant = try assistantTextMessageWithMeta(allocator, meta, replay.assistant_text.items, .stop) });
+                        try messages.append(allocator, .{ .assistant = try assistantTextMessageWithMeta(allocator, meta, replay.assistant_text.items, payload.stop_reason) });
                     } else if (replay.tool_call_json.items.len > 0) {
                         try messages.append(allocator, .{ .assistant = try assistantToolCallMessage(allocator, meta, "", "", replay.tool_call_json.items) });
                     }
                 },
                 .tool_result => if (payload.tool_call_id.slice().len > 0 and payload.content_json.slice().len > 0) {
-                    try messages.append(allocator, .{ .tool_result = try parseToolResultFromPayload(allocator, payload) });
-                    try rememberToolResult(allocator, replay, payload.tool_call_id.slice());
+                    const message = ai_types.Message{ .tool_result = try parseToolResultFromPayload(allocator, payload) };
+                    errdefer {
+                        var msg = message;
+                        msg.deinit(allocator);
+                    }
+                    try rememberToolResultMessage(allocator, messages, replay, payload.tool_call_id.slice(), message, .message_end);
                 },
             }
         },
         .tool_execution_end => |payload| {
-            if (isDuplicateToolResult(replay, payload.tool_call_id.slice())) return;
-            try messages.append(allocator, .{ .tool_result = try toolResultMessage(allocator, payload) });
-            try rememberToolResult(allocator, replay, payload.tool_call_id.slice());
+            const message = ai_types.Message{ .tool_result = try toolResultMessage(allocator, payload) };
+            errdefer {
+                var msg = message;
+                msg.deinit(allocator);
+            }
+            try rememberToolResultMessage(allocator, messages, replay, payload.tool_call_id.slice(), message, .execution_end);
         },
         else => {},
     }
 }
 
-fn isDuplicateToolResult(replay: *ReplayState, tool_call_id: []const u8) bool {
-    return tool_call_id.len > 0 and std.mem.eql(u8, replay.last_tool_result_id, tool_call_id);
+fn findToolResult(replay: *ReplayState, tool_call_id: []const u8) ?usize {
+    if (tool_call_id.len == 0) return null;
+    for (replay.tool_results.items, 0..) |entry, i| {
+        if (std.mem.eql(u8, entry.tool_call_id, tool_call_id)) return i;
+    }
+    return null;
 }
 
-fn rememberToolResult(allocator: std.mem.Allocator, replay: *ReplayState, tool_call_id: []const u8) !void {
-    if (replay.last_tool_result_id.len > 0) allocator.free(replay.last_tool_result_id);
-    replay.last_tool_result_id = try allocator.dupe(u8, tool_call_id);
+fn rememberToolResultMessage(allocator: std.mem.Allocator, messages: *std.ArrayList(ai_types.Message), replay: *ReplayState, tool_call_id: []const u8, message: ai_types.Message, source: ToolResultSource) !void {
+    if (findToolResult(replay, tool_call_id)) |entry_index| {
+        const entry = &replay.tool_results.items[entry_index];
+        if (entry.source == .execution_end and source == .message_end) {
+            messages.items[entry.message_index].deinit(allocator);
+            messages.items[entry.message_index] = message;
+            entry.source = source;
+        } else {
+            var unused = message;
+            unused.deinit(allocator);
+        }
+        return;
+    }
+
+    try messages.append(allocator, message);
+    errdefer _ = messages.pop();
+    const owned_id = try allocator.dupe(u8, tool_call_id);
+    errdefer allocator.free(owned_id);
+    try replay.tool_results.append(allocator, .{ .tool_call_id = owned_id, .message_index = messages.items.len - 1, .source = source });
 }
 
 fn updateMetadata(allocator: std.mem.Allocator, meta: *SessionMetadata, obj: std.json.ObjectMap) !void {
@@ -1089,4 +1107,80 @@ test "message_end and tool_execution_end do not duplicate tool result" {
     try std.testing.expectEqual(@as(usize, 1), loaded.messages.items.len);
     try std.testing.expect(loaded.messages.items[0] == .tool_result);
     try std.testing.expectEqualStrings("call-1", loaded.messages.items[0].tool_result.tool_call_id);
+}
+
+test "tool_execution_end before message_end keeps one rich tool result" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const base = try tmpBase(std.testing.allocator, &tmp);
+    defer std.testing.allocator.free(base);
+    var store = try Store.init(std.testing.allocator, base);
+    defer store.deinit();
+    var meta = try testMeta("tool-dedupe-normal-order");
+    defer meta.deinit(std.testing.allocator);
+
+    var tool_end = tui_session.TuiEvent{ .tool_execution_end = .{
+        .tool_call_id = try owned(std.testing.allocator, "call-1"),
+        .tool_name = try owned(std.testing.allocator, "demo"),
+        .result_json = try owned(std.testing.allocator, "fallback"),
+        .is_error = false,
+    } };
+    defer tool_end.deinit(std.testing.allocator);
+    try store.save(meta, tool_end);
+
+    var message_end = tui_session.TuiEvent{ .message_end = .{
+        .role = .tool_result,
+        .tool_call_id = try owned(std.testing.allocator, "call-1"),
+        .tool_name = try owned(std.testing.allocator, "demo"),
+        .content_json = try contentJson("[{\"type\":\"text\",\"text\":\"rich\"}]"),
+        .details_json = try owned(std.testing.allocator, "{\"rich\":true}"),
+    } };
+    defer message_end.deinit(std.testing.allocator);
+    try store.save(meta, message_end);
+
+    var loaded = try store.load("tool-dedupe-normal-order");
+    defer loaded.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 1), loaded.messages.items.len);
+    try std.testing.expect(loaded.messages.items[0] == .tool_result);
+    try std.testing.expectEqualStrings("call-1", loaded.messages.items[0].tool_result.tool_call_id);
+    try std.testing.expectEqualStrings("rich", loaded.messages.items[0].tool_result.content[0].text.text);
+    try std.testing.expectEqualStrings("{\"rich\":true}", loaded.messages.items[0].tool_result.details_json.slice());
+}
+
+test "assistant text fallback preserves stop reason" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const base = try tmpBase(std.testing.allocator, &tmp);
+    defer std.testing.allocator.free(base);
+    var store = try Store.init(std.testing.allocator, base);
+    defer store.deinit();
+    var meta = try testMeta("assistant-stop-reason");
+    defer meta.deinit(std.testing.allocator);
+
+    var event = tui_session.TuiEvent{ .message_end = .{ .role = .assistant, .text = try owned(std.testing.allocator, "partial"), .stop_reason = .aborted } };
+    defer event.deinit(std.testing.allocator);
+    try store.save(meta, event);
+
+    var loaded = try store.load("assistant-stop-reason");
+    defer loaded.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 1), loaded.messages.items.len);
+    try std.testing.expect(loaded.messages.items[0] == .assistant);
+    try std.testing.expectEqual(ai_types.StopReason.aborted, loaded.messages.items[0].assistant.stop_reason);
+}
+
+test "JSONL byte cap counts consumed delimiters" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const base = try tmpBase(std.testing.allocator, &tmp);
+    defer std.testing.allocator.free(base);
+    const path = try sessionPath(std.testing.allocator, base, "delimiter-cap");
+    defer std.testing.allocator.free(path);
+    try appendFile(path, "\n\n");
+
+    var loaded = LoadedSession{ .metadata = try defaultMetadata(std.testing.allocator, "delimiter-cap") };
+    defer loaded.deinit(std.testing.allocator);
+    var replay = ReplayState{};
+    defer replay.deinit(std.testing.allocator);
+    var ctx = LoadLineContext{ .allocator = std.testing.allocator, .loaded = &loaded, .replay = &replay };
+    try std.testing.expectError(error.StreamTooLong, readJsonlRecords(std.testing.allocator, path, 1, &ctx, loadLine));
 }

--- a/zig/src/tui/session_store.zig
+++ b/zig/src/tui/session_store.zig
@@ -1,0 +1,506 @@
+const std = @import("std");
+const compat = @import("compat");
+const ai_types = @import("ai_types");
+const tui_session = @import("tui_session");
+const tui_runtime = @import("tui_runtime");
+const agent = @import("agent");
+const json_writer = @import("json/writer");
+const OwnedSlice = @import("owned_slice").OwnedSlice;
+
+fn tmpBase(allocator: std.mem.Allocator, tmp: *std.testing.TmpDir) ![]u8 {
+    const base = try std.fs.path.join(allocator, &.{ ".zig-cache", "tmp", &tmp.sub_path, "sessions" });
+    errdefer allocator.free(base);
+    try compat.fs.createDir(compat.fs.getCwd(), base);
+    return base;
+}
+
+fn defaultIo() std.Io {
+    return if (@import("builtin").is_test)
+        std.testing.io
+    else
+        std.Io.Threaded.global_single_threaded.io();
+}
+
+fn appendFile(path: []const u8, data: []const u8) !void {
+    var file = try compat.fs.getCwd().createFile(defaultIo(), path, .{ .truncate = false, .read = true, .permissions = compat.fs.default_file_mode });
+    defer file.close(defaultIo());
+    const stat = try file.stat(defaultIo());
+    try file.writePositionalAll(defaultIo(), data, stat.size);
+}
+
+pub const SessionMetadata = struct {
+    session_id: []u8,
+    model: []u8,
+    provider: []u8,
+    created_at: i64,
+    last_active: i64,
+    turn_count: usize,
+    working_dir: []u8,
+
+    pub fn deinit(self: *SessionMetadata, allocator: std.mem.Allocator) void {
+        allocator.free(self.session_id);
+        allocator.free(self.model);
+        allocator.free(self.provider);
+        allocator.free(self.working_dir);
+        self.* = undefined;
+    }
+};
+
+pub const LoadedSession = struct {
+    metadata: SessionMetadata,
+    events: std.ArrayList(tui_session.TuiEvent) = .empty,
+    messages: std.ArrayList(ai_types.Message) = .empty,
+
+    pub fn deinit(self: *LoadedSession, allocator: std.mem.Allocator) void {
+        self.metadata.deinit(allocator);
+        for (self.events.items) |*event| event.deinit(allocator);
+        self.events.deinit(allocator);
+        for (self.messages.items) |*msg| msg.deinit(allocator);
+        self.messages.deinit(allocator);
+        self.* = undefined;
+    }
+};
+
+pub const Store = struct {
+    allocator: std.mem.Allocator,
+    base_dir: []u8,
+
+    pub fn init(allocator: std.mem.Allocator, base_dir: []const u8) !Store {
+        return .{ .allocator = allocator, .base_dir = try allocator.dupe(u8, base_dir) };
+    }
+
+    pub fn initDefault(allocator: std.mem.Allocator) !Store {
+        const home = std.process.getEnvVarOwned(allocator, "HOME") catch |err| switch (err) {
+            error.EnvironmentVariableNotFound => return error.HomeNotFound,
+            else => return err,
+        };
+        defer allocator.free(home);
+        const base = try std.fs.path.join(allocator, &.{ home, ".makai", "sessions" });
+        defer allocator.free(base);
+        return init(allocator, base);
+    }
+
+    pub fn deinit(self: *Store) void {
+        self.allocator.free(self.base_dir);
+        self.* = undefined;
+    }
+
+    pub fn save(self: Store, metadata: SessionMetadata, event: tui_session.TuiEvent) !void {
+        try compat.fs.createDir(compat.fs.getCwd(), self.base_dir);
+        const path = try sessionPath(self.allocator, self.base_dir, metadata.session_id);
+        defer self.allocator.free(path);
+        const line = try serializeEventRecord(self.allocator, metadata, event);
+        defer self.allocator.free(line);
+        try appendFile(path, line);
+    }
+
+    pub fn load(self: Store, session_id: []const u8) !LoadedSession {
+        const path = try sessionPath(self.allocator, self.base_dir, session_id);
+        defer self.allocator.free(path);
+        const data = try compat.fs.readFileAlloc(self.allocator, compat.fs.getCwd(), path, 16 * 1024 * 1024);
+        defer self.allocator.free(data);
+        var loaded = LoadedSession{ .metadata = try defaultMetadata(self.allocator, session_id) };
+        errdefer loaded.deinit(self.allocator);
+        var it = std.mem.splitScalar(u8, data, '\n');
+        while (it.next()) |line| {
+            const trimmed = std.mem.trim(u8, line, " \t\r");
+            if (trimmed.len == 0) continue;
+            applyLine(self.allocator, &loaded, trimmed) catch continue;
+        }
+        return loaded;
+    }
+
+    pub fn list(self: Store) !std.ArrayList(SessionMetadata) {
+        var result: std.ArrayList(SessionMetadata) = .empty;
+        errdefer {
+            for (result.items) |*meta| meta.deinit(self.allocator);
+            result.deinit(self.allocator);
+        }
+        var dir = compat.fs.getCwd().openDir(defaultIo(), self.base_dir, .{ .iterate = true }) catch |err| switch (err) {
+            error.FileNotFound => return result,
+            else => return err,
+        };
+        defer dir.close(defaultIo());
+        var iter = dir.iterate();
+        while (try iter.next(defaultIo())) |entry| {
+            if (entry.kind != .file or !std.mem.endsWith(u8, entry.name, ".jsonl")) continue;
+            const session_id = entry.name[0 .. entry.name.len - ".jsonl".len];
+            var loaded = self.load(session_id) catch continue;
+            defer loaded.deinit(self.allocator);
+            try result.append(self.allocator, try cloneMetadata(self.allocator, loaded.metadata));
+        }
+        return result;
+    }
+
+    pub fn resumeSession(self: Store, session_id: []const u8, runtime: *tui_runtime.TuiRuntime) !LoadedSession {
+        var loaded = try self.load(session_id);
+        errdefer loaded.deinit(self.allocator);
+        try runtime.start();
+        try runtime.replaceMessages(loaded.messages.items);
+        return loaded;
+    }
+};
+
+fn sessionPath(allocator: std.mem.Allocator, base_dir: []const u8, session_id: []const u8) ![]u8 {
+    const file_name = try std.fmt.allocPrint(allocator, "{s}.jsonl", .{session_id});
+    defer allocator.free(file_name);
+    return std.fs.path.join(allocator, &.{ base_dir, file_name });
+}
+
+fn defaultMetadata(allocator: std.mem.Allocator, session_id: []const u8) !SessionMetadata {
+    return .{
+        .session_id = try allocator.dupe(u8, session_id),
+        .model = try allocator.dupe(u8, ""),
+        .provider = try allocator.dupe(u8, ""),
+        .created_at = 0,
+        .last_active = 0,
+        .turn_count = 0,
+        .working_dir = try allocator.dupe(u8, ""),
+    };
+}
+
+fn cloneMetadata(allocator: std.mem.Allocator, meta: SessionMetadata) !SessionMetadata {
+    return .{
+        .session_id = try allocator.dupe(u8, meta.session_id),
+        .model = try allocator.dupe(u8, meta.model),
+        .provider = try allocator.dupe(u8, meta.provider),
+        .created_at = meta.created_at,
+        .last_active = meta.last_active,
+        .turn_count = meta.turn_count,
+        .working_dir = try allocator.dupe(u8, meta.working_dir),
+    };
+}
+
+fn applyLine(allocator: std.mem.Allocator, loaded: *LoadedSession, line: []const u8) !void {
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, line, .{});
+    defer parsed.deinit();
+    const obj = switch (parsed.value) {
+        .object => |o| o,
+        else => return error.InvalidRecord,
+    };
+    if (obj.get("metadata")) |meta_value| switch (meta_value) {
+        .object => |meta_obj| try updateMetadata(allocator, &loaded.metadata, meta_obj),
+        else => {},
+    };
+    if (obj.get("event")) |event_value| {
+        const event = try parseEvent(allocator, event_value);
+        errdefer {
+            var ev = event;
+            ev.deinit(allocator);
+        }
+        try loaded.events.append(allocator, event);
+    }
+    if (obj.get("message")) |message_value| {
+        const message = try parseMessage(allocator, message_value);
+        errdefer {
+            var msg = message;
+            msg.deinit(allocator);
+        }
+        try loaded.messages.append(allocator, message);
+    }
+}
+
+fn updateMetadata(allocator: std.mem.Allocator, meta: *SessionMetadata, obj: std.json.ObjectMap) !void {
+    if (stringField(obj, "session_id")) |v| try replaceString(allocator, &meta.session_id, v);
+    if (stringField(obj, "model")) |v| try replaceString(allocator, &meta.model, v);
+    if (stringField(obj, "provider")) |v| try replaceString(allocator, &meta.provider, v);
+    if (intField(obj, "created_at")) |v| meta.created_at = v;
+    if (intField(obj, "last_active")) |v| meta.last_active = v;
+    if (uintField(obj, "turn_count")) |v| meta.turn_count = v;
+    if (stringField(obj, "working_dir")) |v| try replaceString(allocator, &meta.working_dir, v);
+}
+
+fn replaceString(allocator: std.mem.Allocator, target: *[]u8, value: []const u8) !void {
+    if (target.len > 0) allocator.free(target.*);
+    target.* = try allocator.dupe(u8, value);
+}
+
+fn serializeEventRecord(allocator: std.mem.Allocator, metadata: SessionMetadata, event: tui_session.TuiEvent) ![]u8 {
+    var buf: std.ArrayList(u8) = .empty;
+    errdefer buf.deinit(allocator);
+    var w = json_writer.JsonWriter.init(&buf, allocator);
+    try w.beginObject();
+    try writeMetadata(&w, metadata);
+    try w.writeKey("event");
+    try writeEvent(&w, event);
+    if (messageFromEvent(allocator, event)) |message| {
+        var msg = message;
+        defer msg.deinit(allocator);
+        try w.writeKey("message");
+        try writeMessage(&w, msg);
+    } else |_| {}
+    try w.endObject();
+    try buf.append(allocator, '\n');
+    return buf.toOwnedSlice(allocator);
+}
+
+fn writeMetadata(w: *json_writer.JsonWriter, meta: SessionMetadata) !void {
+    try w.writeKey("metadata");
+    try w.beginObject();
+    try w.writeStringField("session_id", meta.session_id);
+    try w.writeStringField("model", meta.model);
+    try w.writeStringField("provider", meta.provider);
+    try w.writeIntField("created_at", meta.created_at);
+    try w.writeIntField("last_active", meta.last_active);
+    try w.writeIntField("turn_count", meta.turn_count);
+    try w.writeStringField("working_dir", meta.working_dir);
+    try w.endObject();
+}
+
+fn writeEvent(w: *json_writer.JsonWriter, event: tui_session.TuiEvent) !void {
+    try w.beginObject();
+    switch (event) {
+        .agent_start => try w.writeStringField("type", "agent_start"),
+        .turn_start => try w.writeStringField("type", "turn_start"),
+        .message_start => |p| { try w.writeStringField("type", "message_start"); try w.writeStringField("role", @tagName(p.role)); },
+        .text_delta => |p| { try w.writeStringField("type", "text_delta"); try w.writeIntField("content_index", p.content_index); try w.writeStringField("delta", p.delta.slice()); },
+        .thinking_delta => |p| { try w.writeStringField("type", "thinking_delta"); try w.writeIntField("content_index", p.content_index); try w.writeStringField("delta", p.delta.slice()); },
+        .tool_call_delta => |p| { try w.writeStringField("type", "tool_call_delta"); try w.writeIntField("content_index", p.content_index); try w.writeStringField("delta", p.delta.slice()); },
+        .message_end => |p| { try w.writeStringField("type", "message_end"); try w.writeStringField("role", @tagName(p.role)); },
+        .tool_approval_requested => |p| { try w.writeStringField("type", "tool_approval_requested"); try writeToolFields(w, p.tool_call_id.slice(), p.tool_name.slice(), p.args_json.slice()); },
+        .tool_execution_start => |p| { try w.writeStringField("type", "tool_execution_start"); try writeToolFields(w, p.tool_call_id.slice(), p.tool_name.slice(), p.args_json.slice()); },
+        .tool_execution_update => |p| { try w.writeStringField("type", "tool_execution_update"); try writeToolFields(w, p.tool_call_id.slice(), p.tool_name.slice(), p.args_json.slice()); try w.writeStringField("partial_result_json", p.partial_result_json.slice()); },
+        .tool_execution_end => |p| { try w.writeStringField("type", "tool_execution_end"); try w.writeStringField("tool_call_id", p.tool_call_id.slice()); try w.writeStringField("tool_name", p.tool_name.slice()); try w.writeStringField("result_json", p.result_json.slice()); try w.writeBoolField("is_error", p.is_error); },
+        .turn_end => |p| { try w.writeStringField("type", "turn_end"); try w.writeStringField("stop_reason", @tagName(p.stop_reason)); },
+        .agent_end => |p| { try w.writeStringField("type", "agent_end"); try w.writeStringField("reason", @tagName(p.reason)); },
+        .@"error" => |p| { try w.writeStringField("type", "error"); try w.writeStringField("message", p.message.slice()); },
+    }
+    try w.endObject();
+}
+
+fn writeToolFields(w: *json_writer.JsonWriter, id: []const u8, name: []const u8, args: []const u8) !void {
+    try w.writeStringField("tool_call_id", id);
+    try w.writeStringField("tool_name", name);
+    try w.writeStringField("args_json", args);
+}
+
+fn parseEvent(allocator: std.mem.Allocator, value: std.json.Value) !tui_session.TuiEvent {
+    const obj = switch (value) { .object => |o| o, else => return error.InvalidEvent };
+    const kind = stringField(obj, "type") orelse return error.InvalidEvent;
+    if (std.mem.eql(u8, kind, "agent_start")) return .agent_start;
+    if (std.mem.eql(u8, kind, "turn_start")) return .turn_start;
+    if (std.mem.eql(u8, kind, "message_start")) return .{ .message_start = .{ .role = parseRole(stringField(obj, "role") orelse "assistant") } };
+    if (std.mem.eql(u8, kind, "text_delta")) return .{ .text_delta = .{ .content_index = uintField(obj, "content_index") orelse 0, .delta = try owned(allocator, stringField(obj, "delta") orelse "") } };
+    if (std.mem.eql(u8, kind, "thinking_delta")) return .{ .thinking_delta = .{ .content_index = uintField(obj, "content_index") orelse 0, .delta = try owned(allocator, stringField(obj, "delta") orelse "") } };
+    if (std.mem.eql(u8, kind, "tool_call_delta")) return .{ .tool_call_delta = .{ .content_index = uintField(obj, "content_index") orelse 0, .delta = try owned(allocator, stringField(obj, "delta") orelse "") } };
+    if (std.mem.eql(u8, kind, "message_end")) return .{ .message_end = .{ .role = parseRole(stringField(obj, "role") orelse "assistant") } };
+    if (std.mem.eql(u8, kind, "tool_approval_requested")) return .{ .tool_approval_requested = .{ .tool_call_id = try owned(allocator, stringField(obj, "tool_call_id") orelse ""), .tool_name = try owned(allocator, stringField(obj, "tool_name") orelse ""), .args_json = try owned(allocator, stringField(obj, "args_json") orelse "") } };
+    if (std.mem.eql(u8, kind, "tool_execution_start")) return .{ .tool_execution_start = .{ .tool_call_id = try owned(allocator, stringField(obj, "tool_call_id") orelse ""), .tool_name = try owned(allocator, stringField(obj, "tool_name") orelse ""), .args_json = try owned(allocator, stringField(obj, "args_json") orelse "") } };
+    if (std.mem.eql(u8, kind, "tool_execution_update")) return .{ .tool_execution_update = .{ .tool_call_id = try owned(allocator, stringField(obj, "tool_call_id") orelse ""), .tool_name = try owned(allocator, stringField(obj, "tool_name") orelse ""), .args_json = try owned(allocator, stringField(obj, "args_json") orelse ""), .partial_result_json = try owned(allocator, stringField(obj, "partial_result_json") orelse "") } };
+    if (std.mem.eql(u8, kind, "tool_execution_end")) return .{ .tool_execution_end = .{ .tool_call_id = try owned(allocator, stringField(obj, "tool_call_id") orelse ""), .tool_name = try owned(allocator, stringField(obj, "tool_name") orelse ""), .result_json = try owned(allocator, stringField(obj, "result_json") orelse ""), .is_error = boolField(obj, "is_error", false) } };
+    if (std.mem.eql(u8, kind, "turn_end")) return .{ .turn_end = .{ .stop_reason = parseStopReason(stringField(obj, "stop_reason") orelse "stop") } };
+    if (std.mem.eql(u8, kind, "agent_end")) return .{ .agent_end = .{ .reason = parseEndReason(stringField(obj, "reason") orelse "completed") } };
+    if (std.mem.eql(u8, kind, "error")) return .{ .@"error" = .{ .message = try owned(allocator, stringField(obj, "message") orelse "") } };
+    return error.InvalidEvent;
+}
+
+fn owned(allocator: std.mem.Allocator, value: []const u8) !OwnedSlice(u8) {
+    return OwnedSlice(u8).initOwned(try allocator.dupe(u8, value));
+}
+
+fn messageFromEvent(allocator: std.mem.Allocator, event: tui_session.TuiEvent) !ai_types.Message {
+    return switch (event) {
+        .message_start => |p| switch (p.role) {
+            else => error.NoMessage,
+        },
+        .text_delta => |p| .{ .user = .{ .content = .{ .text = try allocator.dupe(u8, p.delta.slice()) }, .timestamp = compat.time.nowMillis() } },
+        .tool_execution_end => |p| .{ .tool_result = try toolResultMessage(allocator, p) },
+        else => error.NoMessage,
+    };
+}
+
+fn assistantTextMessage(allocator: std.mem.Allocator, text: []const u8, stop_reason: ai_types.StopReason) !ai_types.AssistantMessage {
+    const content = try allocator.alloc(ai_types.AssistantContent, 1);
+    errdefer allocator.free(content);
+    content[0] = .{ .text = .{ .text = try allocator.dupe(u8, text) } };
+    const api = try allocator.dupe(u8, "");
+    errdefer allocator.free(api);
+    const provider = try allocator.dupe(u8, "");
+    errdefer allocator.free(provider);
+    const model = try allocator.dupe(u8, "");
+    errdefer allocator.free(model);
+    return .{
+        .content = content,
+        .api = api,
+        .provider = provider,
+        .model = model,
+        .usage = .{},
+        .stop_reason = stop_reason,
+        .timestamp = compat.time.nowMillis(),
+        .is_owned = true,
+    };
+}
+
+fn toolResultMessage(allocator: std.mem.Allocator, p: anytype) !ai_types.ToolResultMessage {
+    const parts = try allocator.alloc(ai_types.UserContentPart, 1);
+    errdefer allocator.free(parts);
+    parts[0] = .{ .text = .{ .text = try allocator.dupe(u8, p.result_json.slice()) } };
+    return .{
+        .tool_call_id = try allocator.dupe(u8, p.tool_call_id.slice()),
+        .tool_name = try allocator.dupe(u8, p.tool_name.slice()),
+        .content = parts,
+        .details_json = OwnedSlice(u8).initOwned(try allocator.dupe(u8, p.result_json.slice())),
+        .is_error = p.is_error,
+        .timestamp = compat.time.nowMillis(),
+    };
+}
+
+fn writeMessage(w: *json_writer.JsonWriter, message: ai_types.Message) !void {
+    try w.beginObject();
+    switch (message) {
+        .user => |m| { try w.writeStringField("role", "user"); try w.writeStringField("text", switch (m.content) { .text => |t| t, .parts => "" }); try w.writeIntField("timestamp", m.timestamp); },
+        .assistant => |m| { try w.writeStringField("role", "assistant"); try w.writeStringField("text", assistantText(m.content)); try w.writeStringField("stop_reason", @tagName(m.stop_reason)); try w.writeIntField("timestamp", m.timestamp); },
+        .tool_result => |m| { try w.writeStringField("role", "tool_result"); try w.writeStringField("tool_call_id", m.tool_call_id); try w.writeStringField("tool_name", m.tool_name); try w.writeStringField("text", userPartsText(m.content)); try w.writeStringField("details_json", m.details_json.slice()); try w.writeBoolField("is_error", m.is_error); try w.writeIntField("timestamp", m.timestamp); },
+    }
+    try w.endObject();
+}
+
+fn parseMessage(allocator: std.mem.Allocator, value: std.json.Value) !ai_types.Message {
+    const obj = switch (value) { .object => |o| o, else => return error.InvalidMessage };
+    const role = stringField(obj, "role") orelse return error.InvalidMessage;
+    if (std.mem.eql(u8, role, "user")) return .{ .user = .{ .content = .{ .text = try allocator.dupe(u8, stringField(obj, "text") orelse "") }, .timestamp = intField(obj, "timestamp") orelse 0 } };
+    if (std.mem.eql(u8, role, "assistant")) return .{ .assistant = try assistantTextMessage(allocator, stringField(obj, "text") orelse "", parseStopReason(stringField(obj, "stop_reason") orelse "stop")) };
+    if (std.mem.eql(u8, role, "tool_result")) {
+        const parts = try allocator.alloc(ai_types.UserContentPart, 1);
+        errdefer allocator.free(parts);
+        parts[0] = .{ .text = .{ .text = try allocator.dupe(u8, stringField(obj, "text") orelse "") } };
+        return .{ .tool_result = .{
+            .tool_call_id = try allocator.dupe(u8, stringField(obj, "tool_call_id") orelse ""),
+            .tool_name = try allocator.dupe(u8, stringField(obj, "tool_name") orelse ""),
+            .content = parts,
+            .details_json = OwnedSlice(u8).initOwned(try allocator.dupe(u8, stringField(obj, "details_json") orelse "")),
+            .is_error = boolField(obj, "is_error", false),
+            .timestamp = intField(obj, "timestamp") orelse 0,
+        } };
+    }
+    return error.InvalidMessage;
+}
+
+fn assistantText(content: []const ai_types.AssistantContent) []const u8 {
+    for (content) |block| switch (block) { .text => |t| return t.text, else => {} };
+    return "";
+}
+
+fn userPartsText(parts: []const ai_types.UserContentPart) []const u8 {
+    for (parts) |part| switch (part) { .text => |t| return t.text, else => {} };
+    return "";
+}
+
+fn stringField(obj: std.json.ObjectMap, key: []const u8) ?[]const u8 {
+    const value = obj.get(key) orelse return null;
+    return switch (value) { .string => |s| s, else => null };
+}
+
+fn boolField(obj: std.json.ObjectMap, key: []const u8, default: bool) bool {
+    const value = obj.get(key) orelse return default;
+    return switch (value) { .bool => |b| b, else => default };
+}
+
+fn intField(obj: std.json.ObjectMap, key: []const u8) ?i64 {
+    const value = obj.get(key) orelse return null;
+    return switch (value) { .integer => |i| @intCast(i), else => null };
+}
+
+fn uintField(obj: std.json.ObjectMap, key: []const u8) ?usize {
+    const value = obj.get(key) orelse return null;
+    return switch (value) { .integer => |i| if (i >= 0) @intCast(i) else null, else => null };
+}
+
+fn parseRole(value: []const u8) tui_session.TuiEvent.MessageRole {
+    if (std.mem.eql(u8, value, "user")) return .user;
+    if (std.mem.eql(u8, value, "tool_result")) return .tool_result;
+    return .assistant;
+}
+
+fn parseStopReason(value: []const u8) ai_types.StopReason {
+    if (std.mem.eql(u8, value, "length")) return .length;
+    if (std.mem.eql(u8, value, "tool_use")) return .tool_use;
+    if (std.mem.eql(u8, value, "content_filter")) return .content_filter;
+    if (std.mem.eql(u8, value, "error")) return .@"error";
+    if (std.mem.eql(u8, value, "aborted")) return .aborted;
+    return .stop;
+}
+
+fn parseEndReason(value: []const u8) tui_session.TuiEndReason {
+    if (std.mem.eql(u8, value, "cancelled")) return .cancelled;
+    if (std.mem.eql(u8, value, "error")) return .@"error";
+    return .completed;
+}
+
+test "save 10 events load replays in order" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const base = try tmpBase(std.testing.allocator, &tmp);
+    defer std.testing.allocator.free(base);
+    var store = try Store.init(std.testing.allocator, base);
+    defer store.deinit();
+    var meta = try defaultMetadata(std.testing.allocator, "s1");
+    defer meta.deinit(std.testing.allocator);
+    try replaceString(std.testing.allocator, &meta.model, "model-a");
+    try replaceString(std.testing.allocator, &meta.provider, "test");
+    try replaceString(std.testing.allocator, &meta.working_dir, base);
+    meta.created_at = 1;
+    var i: usize = 0;
+    while (i < 10) : (i += 1) {
+        meta.last_active = @intCast(i + 1);
+        meta.turn_count = i + 1;
+        const delta = try std.fmt.allocPrint(std.testing.allocator, "d{d}", .{i});
+        defer std.testing.allocator.free(delta);
+        var event = tui_session.TuiEvent{ .text_delta = .{ .content_index = i, .delta = try owned(std.testing.allocator, delta) } };
+        defer event.deinit(std.testing.allocator);
+        try store.save(meta, event);
+    }
+    var loaded = try store.load("s1");
+    defer loaded.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 10), loaded.events.items.len);
+    for (loaded.events.items, 0..) |event, idx| try std.testing.expectEqual(idx, event.text_delta.content_index);
+}
+
+test "corrupted JSONL line is skipped" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const base = try tmpBase(std.testing.allocator, &tmp);
+    defer std.testing.allocator.free(base);
+    var store = try Store.init(std.testing.allocator, base);
+    defer store.deinit();
+    var meta = try defaultMetadata(std.testing.allocator, "s2");
+    defer meta.deinit(std.testing.allocator);
+    try store.save(meta, .turn_start);
+    const path = try sessionPath(std.testing.allocator, base, "s2");
+    defer std.testing.allocator.free(path);
+    try appendFile(path, "{bad json}\n");
+    try store.save(meta, .{ .agent_end = .{ .reason = .completed } });
+    var loaded = try store.load("s2");
+    defer loaded.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 2), loaded.events.items.len);
+    try std.testing.expect(loaded.events.items[0] == .turn_start);
+    try std.testing.expect(loaded.events.items[1] == .agent_end);
+}
+
+test "session metadata updates from last valid line" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const base = try tmpBase(std.testing.allocator, &tmp);
+    defer std.testing.allocator.free(base);
+    var store = try Store.init(std.testing.allocator, base);
+    defer store.deinit();
+    var meta = try defaultMetadata(std.testing.allocator, "s3");
+    defer meta.deinit(std.testing.allocator);
+    try replaceString(std.testing.allocator, &meta.model, "m1");
+    try replaceString(std.testing.allocator, &meta.provider, "p1");
+    meta.created_at = 10;
+    meta.last_active = 20;
+    meta.turn_count = 1;
+    try store.save(meta, tui_session.TuiEvent.turn_start);
+    meta.last_active = 30;
+    meta.turn_count = 2;
+    try store.save(meta, tui_session.TuiEvent.turn_start);
+    var list = try store.list();
+    defer {
+        for (list.items) |*item| item.deinit(std.testing.allocator);
+        list.deinit(std.testing.allocator);
+    }
+    try std.testing.expectEqual(@as(usize, 1), list.items.len);
+    try std.testing.expectEqual(@as(i64, 30), list.items[0].last_active);
+    try std.testing.expectEqual(@as(usize, 2), list.items[0].turn_count);
+}

--- a/zig/src/tui/session_store.zig
+++ b/zig/src/tui/session_store.zig
@@ -46,6 +46,18 @@ pub const SessionMetadata = struct {
     }
 };
 
+const ReplayState = struct {
+    current_role: ?tui_session.TuiEvent.MessageRole = null,
+    assistant_text: std.ArrayList(u8) = .empty,
+    tool_call_json: std.ArrayList(u8) = .empty,
+
+    fn deinit(self: *ReplayState, allocator: std.mem.Allocator) void {
+        self.assistant_text.deinit(allocator);
+        self.tool_call_json.deinit(allocator);
+        self.* = undefined;
+    }
+};
+
 pub const LoadedSession = struct {
     metadata: SessionMetadata,
     events: std.ArrayList(tui_session.TuiEvent) = .empty,
@@ -101,11 +113,13 @@ pub const Store = struct {
         defer self.allocator.free(data);
         var loaded = LoadedSession{ .metadata = try defaultMetadata(self.allocator, session_id) };
         errdefer loaded.deinit(self.allocator);
+        var replay = ReplayState{};
+        defer replay.deinit(self.allocator);
         var it = std.mem.splitScalar(u8, data, '\n');
         while (it.next()) |line| {
             const trimmed = std.mem.trim(u8, line, " \t\r");
             if (trimmed.len == 0) continue;
-            applyLine(self.allocator, &loaded, trimmed) catch continue;
+            applyLine(self.allocator, &loaded, &replay, trimmed) catch continue;
         }
         return loaded;
     }
@@ -125,11 +139,36 @@ pub const Store = struct {
         while (try iter.next(defaultIo())) |entry| {
             if (entry.kind != .file or !std.mem.endsWith(u8, entry.name, ".jsonl")) continue;
             const session_id = entry.name[0 .. entry.name.len - ".jsonl".len];
-            var loaded = self.load(session_id) catch continue;
-            defer loaded.deinit(self.allocator);
-            try result.append(self.allocator, try cloneMetadata(self.allocator, loaded.metadata));
+            var metadata = self.loadMetadata(session_id) catch continue;
+            errdefer metadata.deinit(self.allocator);
+            try result.append(self.allocator, metadata);
         }
         return result;
+    }
+
+    fn loadMetadata(self: Store, session_id: []const u8) !SessionMetadata {
+        const path = try sessionPath(self.allocator, self.base_dir, session_id);
+        defer self.allocator.free(path);
+        const data = try compat.fs.readFileAlloc(self.allocator, compat.fs.getCwd(), path, 16 * 1024 * 1024);
+        defer self.allocator.free(data);
+        var meta = try defaultMetadata(self.allocator, session_id);
+        errdefer meta.deinit(self.allocator);
+        var last: []const u8 = "";
+        var it = std.mem.splitScalar(u8, data, '\n');
+        while (it.next()) |line| {
+            const trimmed = std.mem.trim(u8, line, " \t\r");
+            if (trimmed.len > 0) last = trimmed;
+        }
+        if (last.len > 0) {
+            var parsed = try std.json.parseFromSlice(std.json.Value, self.allocator, last, .{});
+            defer parsed.deinit();
+            const obj = switch (parsed.value) { .object => |o| o, else => return meta };
+            if (obj.get("metadata")) |value| switch (value) {
+                .object => |meta_obj| try updateMetadata(self.allocator, &meta, meta_obj),
+                else => {},
+            };
+        }
+        return meta;
     }
 
     pub fn resumeSession(self: Store, session_id: []const u8, runtime: *tui_runtime.TuiRuntime) !LoadedSession {
@@ -142,9 +181,17 @@ pub const Store = struct {
 };
 
 fn sessionPath(allocator: std.mem.Allocator, base_dir: []const u8, session_id: []const u8) ![]u8 {
+    try validateSessionId(session_id);
     const file_name = try std.fmt.allocPrint(allocator, "{s}.jsonl", .{session_id});
     defer allocator.free(file_name);
     return std.fs.path.join(allocator, &.{ base_dir, file_name });
+}
+
+fn validateSessionId(session_id: []const u8) !void {
+    if (session_id.len == 0) return error.InvalidSessionId;
+    if (std.mem.indexOfScalar(u8, session_id, '/') != null) return error.InvalidSessionId;
+    if (std.mem.indexOfScalar(u8, session_id, '\\') != null) return error.InvalidSessionId;
+    if (std.mem.indexOf(u8, session_id, "..") != null) return error.InvalidSessionId;
 }
 
 fn defaultMetadata(allocator: std.mem.Allocator, session_id: []const u8) !SessionMetadata {
@@ -171,7 +218,7 @@ fn cloneMetadata(allocator: std.mem.Allocator, meta: SessionMetadata) !SessionMe
     };
 }
 
-fn applyLine(allocator: std.mem.Allocator, loaded: *LoadedSession, line: []const u8) !void {
+fn applyLine(allocator: std.mem.Allocator, loaded: *LoadedSession, replay: *ReplayState, line: []const u8) !void {
     var parsed = try std.json.parseFromSlice(std.json.Value, allocator, line, .{});
     defer parsed.deinit();
     const obj = switch (parsed.value) {
@@ -188,6 +235,7 @@ fn applyLine(allocator: std.mem.Allocator, loaded: *LoadedSession, line: []const
             var ev = event;
             ev.deinit(allocator);
         }
+        try replayEvent(allocator, &loaded.messages, replay, loaded.metadata, event);
         try loaded.events.append(allocator, event);
     }
     if (obj.get("message")) |message_value| {
@@ -197,6 +245,48 @@ fn applyLine(allocator: std.mem.Allocator, loaded: *LoadedSession, line: []const
             msg.deinit(allocator);
         }
         try loaded.messages.append(allocator, message);
+    }
+}
+
+fn replayEvent(allocator: std.mem.Allocator, messages: *std.ArrayList(ai_types.Message), replay: *ReplayState, meta: SessionMetadata, event: tui_session.TuiEvent) !void {
+    switch (event) {
+        .message_start => |payload| {
+            replay.current_role = payload.role;
+            replay.assistant_text.clearRetainingCapacity();
+            replay.tool_call_json.clearRetainingCapacity();
+        },
+        .text_delta => |payload| if (replay.current_role == .assistant) {
+            try replay.assistant_text.appendSlice(allocator, payload.delta.slice());
+        },
+        .tool_call_delta => |payload| if (replay.current_role == .assistant) {
+            try replay.tool_call_json.appendSlice(allocator, payload.delta.slice());
+        },
+        .message_end => |payload| {
+            defer {
+                replay.current_role = null;
+                replay.assistant_text.clearRetainingCapacity();
+                replay.tool_call_json.clearRetainingCapacity();
+            }
+            switch (payload.role) {
+                .user => if (payload.text.slice().len > 0) try messages.append(allocator, try userMessage(allocator, payload.text.slice())),
+                .assistant => {
+                    if (payload.tool_call_id.slice().len > 0) {
+                        try messages.append(allocator, .{ .assistant = try assistantToolCallMessage(allocator, meta, payload.tool_call_id.slice(), payload.tool_name.slice(), payload.args_json.slice()) });
+                    } else if (payload.text.slice().len > 0) {
+                        try messages.append(allocator, .{ .assistant = try assistantTextMessageWithMeta(allocator, meta, payload.text.slice(), .stop) });
+                    } else if (replay.assistant_text.items.len > 0) {
+                        try messages.append(allocator, .{ .assistant = try assistantTextMessageWithMeta(allocator, meta, replay.assistant_text.items, .stop) });
+                    } else if (replay.tool_call_json.items.len > 0) {
+                        try messages.append(allocator, .{ .assistant = try assistantToolCallMessage(allocator, meta, "", "", replay.tool_call_json.items) });
+                    }
+                },
+                .tool_result => if (payload.tool_call_id.slice().len > 0) {
+                    try messages.append(allocator, .{ .tool_result = try toolResultFromFields(allocator, payload.tool_call_id.slice(), payload.tool_name.slice(), payload.text.slice(), false) });
+                },
+            }
+        },
+        .tool_execution_end => |payload| try messages.append(allocator, .{ .tool_result = try toolResultMessage(allocator, payload) }),
+        else => {},
     }
 }
 
@@ -223,12 +313,6 @@ fn serializeEventRecord(allocator: std.mem.Allocator, metadata: SessionMetadata,
     try writeMetadata(&w, metadata);
     try w.writeKey("event");
     try writeEvent(&w, event);
-    if (messageFromEvent(allocator, event)) |message| {
-        var msg = message;
-        defer msg.deinit(allocator);
-        try w.writeKey("message");
-        try writeMessage(&w, msg);
-    } else |_| {}
     try w.endObject();
     try buf.append(allocator, '\n');
     return buf.toOwnedSlice(allocator);
@@ -256,7 +340,7 @@ fn writeEvent(w: *json_writer.JsonWriter, event: tui_session.TuiEvent) !void {
         .text_delta => |p| { try w.writeStringField("type", "text_delta"); try w.writeIntField("content_index", p.content_index); try w.writeStringField("delta", p.delta.slice()); },
         .thinking_delta => |p| { try w.writeStringField("type", "thinking_delta"); try w.writeIntField("content_index", p.content_index); try w.writeStringField("delta", p.delta.slice()); },
         .tool_call_delta => |p| { try w.writeStringField("type", "tool_call_delta"); try w.writeIntField("content_index", p.content_index); try w.writeStringField("delta", p.delta.slice()); },
-        .message_end => |p| { try w.writeStringField("type", "message_end"); try w.writeStringField("role", @tagName(p.role)); },
+        .message_end => |p| { try w.writeStringField("type", "message_end"); try w.writeStringField("role", @tagName(p.role)); try w.writeStringField("text", p.text.slice()); try w.writeStringField("tool_call_id", p.tool_call_id.slice()); try w.writeStringField("tool_name", p.tool_name.slice()); try w.writeStringField("args_json", p.args_json.slice()); },
         .tool_approval_requested => |p| { try w.writeStringField("type", "tool_approval_requested"); try writeToolFields(w, p.tool_call_id.slice(), p.tool_name.slice(), p.args_json.slice()); },
         .tool_execution_start => |p| { try w.writeStringField("type", "tool_execution_start"); try writeToolFields(w, p.tool_call_id.slice(), p.tool_name.slice(), p.args_json.slice()); },
         .tool_execution_update => |p| { try w.writeStringField("type", "tool_execution_update"); try writeToolFields(w, p.tool_call_id.slice(), p.tool_name.slice(), p.args_json.slice()); try w.writeStringField("partial_result_json", p.partial_result_json.slice()); },
@@ -283,7 +367,13 @@ fn parseEvent(allocator: std.mem.Allocator, value: std.json.Value) !tui_session.
     if (std.mem.eql(u8, kind, "text_delta")) return .{ .text_delta = .{ .content_index = uintField(obj, "content_index") orelse 0, .delta = try owned(allocator, stringField(obj, "delta") orelse "") } };
     if (std.mem.eql(u8, kind, "thinking_delta")) return .{ .thinking_delta = .{ .content_index = uintField(obj, "content_index") orelse 0, .delta = try owned(allocator, stringField(obj, "delta") orelse "") } };
     if (std.mem.eql(u8, kind, "tool_call_delta")) return .{ .tool_call_delta = .{ .content_index = uintField(obj, "content_index") orelse 0, .delta = try owned(allocator, stringField(obj, "delta") orelse "") } };
-    if (std.mem.eql(u8, kind, "message_end")) return .{ .message_end = .{ .role = parseRole(stringField(obj, "role") orelse "assistant") } };
+    if (std.mem.eql(u8, kind, "message_end")) return .{ .message_end = .{
+        .role = parseRole(stringField(obj, "role") orelse "assistant"),
+        .text = try owned(allocator, stringField(obj, "text") orelse ""),
+        .tool_call_id = try owned(allocator, stringField(obj, "tool_call_id") orelse ""),
+        .tool_name = try owned(allocator, stringField(obj, "tool_name") orelse ""),
+        .args_json = try owned(allocator, stringField(obj, "args_json") orelse ""),
+    } };
     if (std.mem.eql(u8, kind, "tool_approval_requested")) return .{ .tool_approval_requested = .{ .tool_call_id = try owned(allocator, stringField(obj, "tool_call_id") orelse ""), .tool_name = try owned(allocator, stringField(obj, "tool_name") orelse ""), .args_json = try owned(allocator, stringField(obj, "args_json") orelse "") } };
     if (std.mem.eql(u8, kind, "tool_execution_start")) return .{ .tool_execution_start = .{ .tool_call_id = try owned(allocator, stringField(obj, "tool_call_id") orelse ""), .tool_name = try owned(allocator, stringField(obj, "tool_name") orelse ""), .args_json = try owned(allocator, stringField(obj, "args_json") orelse "") } };
     if (std.mem.eql(u8, kind, "tool_execution_update")) return .{ .tool_execution_update = .{ .tool_call_id = try owned(allocator, stringField(obj, "tool_call_id") orelse ""), .tool_name = try owned(allocator, stringField(obj, "tool_name") orelse ""), .args_json = try owned(allocator, stringField(obj, "args_json") orelse ""), .partial_result_json = try owned(allocator, stringField(obj, "partial_result_json") orelse "") } };
@@ -298,26 +388,47 @@ fn owned(allocator: std.mem.Allocator, value: []const u8) !OwnedSlice(u8) {
     return OwnedSlice(u8).initOwned(try allocator.dupe(u8, value));
 }
 
-fn messageFromEvent(allocator: std.mem.Allocator, event: tui_session.TuiEvent) !ai_types.Message {
-    return switch (event) {
-        .message_start => |p| switch (p.role) {
-            else => error.NoMessage,
-        },
-        .text_delta => |p| .{ .user = .{ .content = .{ .text = try allocator.dupe(u8, p.delta.slice()) }, .timestamp = compat.time.nowMillis() } },
-        .tool_execution_end => |p| .{ .tool_result = try toolResultMessage(allocator, p) },
-        else => error.NoMessage,
-    };
+fn userMessage(allocator: std.mem.Allocator, text: []const u8) !ai_types.Message {
+    return .{ .user = .{ .content = .{ .text = try allocator.dupe(u8, text) }, .timestamp = compat.time.nowMillis() } };
 }
 
 fn assistantTextMessage(allocator: std.mem.Allocator, text: []const u8, stop_reason: ai_types.StopReason) !ai_types.AssistantMessage {
+    const meta = SessionMetadata{
+        .session_id = @constCast(""),
+        .model = @constCast(""),
+        .provider = @constCast(""),
+        .created_at = 0,
+        .last_active = 0,
+        .turn_count = 0,
+        .working_dir = @constCast(""),
+    };
+    return assistantTextMessageWithMeta(allocator, meta, text, stop_reason);
+}
+
+fn assistantTextMessageWithMeta(allocator: std.mem.Allocator, meta: SessionMetadata, text: []const u8, stop_reason: ai_types.StopReason) !ai_types.AssistantMessage {
     const content = try allocator.alloc(ai_types.AssistantContent, 1);
     errdefer allocator.free(content);
     content[0] = .{ .text = .{ .text = try allocator.dupe(u8, text) } };
+    return assistantMessage(allocator, meta, content, stop_reason);
+}
+
+fn assistantToolCallMessage(allocator: std.mem.Allocator, meta: SessionMetadata, id: []const u8, name: []const u8, args_json: []const u8) !ai_types.AssistantMessage {
+    const content = try allocator.alloc(ai_types.AssistantContent, 1);
+    errdefer allocator.free(content);
+    content[0] = .{ .tool_call = .{
+        .id = try allocator.dupe(u8, id),
+        .name = try allocator.dupe(u8, name),
+        .arguments_json = try allocator.dupe(u8, args_json),
+    } };
+    return assistantMessage(allocator, meta, content, .tool_use);
+}
+
+fn assistantMessage(allocator: std.mem.Allocator, meta: SessionMetadata, content: []const ai_types.AssistantContent, stop_reason: ai_types.StopReason) !ai_types.AssistantMessage {
     const api = try allocator.dupe(u8, "");
     errdefer allocator.free(api);
-    const provider = try allocator.dupe(u8, "");
+    const provider = try allocator.dupe(u8, meta.provider);
     errdefer allocator.free(provider);
-    const model = try allocator.dupe(u8, "");
+    const model = try allocator.dupe(u8, meta.model);
     errdefer allocator.free(model);
     return .{
         .content = content,
@@ -332,15 +443,19 @@ fn assistantTextMessage(allocator: std.mem.Allocator, text: []const u8, stop_rea
 }
 
 fn toolResultMessage(allocator: std.mem.Allocator, p: anytype) !ai_types.ToolResultMessage {
+    return toolResultFromFields(allocator, p.tool_call_id.slice(), p.tool_name.slice(), p.result_json.slice(), p.is_error);
+}
+
+fn toolResultFromFields(allocator: std.mem.Allocator, tool_call_id: []const u8, tool_name: []const u8, result: []const u8, is_error: bool) !ai_types.ToolResultMessage {
     const parts = try allocator.alloc(ai_types.UserContentPart, 1);
     errdefer allocator.free(parts);
-    parts[0] = .{ .text = .{ .text = try allocator.dupe(u8, p.result_json.slice()) } };
+    parts[0] = .{ .text = .{ .text = try allocator.dupe(u8, result) } };
     return .{
-        .tool_call_id = try allocator.dupe(u8, p.tool_call_id.slice()),
-        .tool_name = try allocator.dupe(u8, p.tool_name.slice()),
+        .tool_call_id = try allocator.dupe(u8, tool_call_id),
+        .tool_name = try allocator.dupe(u8, tool_name),
         .content = parts,
-        .details_json = OwnedSlice(u8).initOwned(try allocator.dupe(u8, p.result_json.slice())),
-        .is_error = p.is_error,
+        .details_json = OwnedSlice(u8).initOwned(try allocator.dupe(u8, result)),
+        .is_error = is_error,
         .timestamp = compat.time.nowMillis(),
     };
 }
@@ -475,6 +590,13 @@ test "corrupted JSONL line is skipped" {
     try std.testing.expectEqual(@as(usize, 2), loaded.events.items.len);
     try std.testing.expect(loaded.events.items[0] == .turn_start);
     try std.testing.expect(loaded.events.items[1] == .agent_end);
+}
+
+test "invalid session id is rejected" {
+    try std.testing.expectError(error.InvalidSessionId, validateSessionId("../escape"));
+    try std.testing.expectError(error.InvalidSessionId, validateSessionId("foo/bar"));
+    try std.testing.expectError(error.InvalidSessionId, validateSessionId("foo\\bar"));
+    try validateSessionId("session-123");
 }
 
 test "session metadata updates from last valid line" {

--- a/zig/src/tui/tests/scenario_tests.zig
+++ b/zig/src/tui/tests/scenario_tests.zig
@@ -5,6 +5,7 @@ const tui_session = @import("tui_session");
 const session_store = @import("tui_session_store");
 const mock_provider = @import("tui_tests_mock_provider");
 const fixtures = @import("tui_tests_fixtures");
+const ai_types = @import("ai_types");
 
 const TuiRuntime = tui_runtime.TuiRuntime;
 const TuiSession = tui_runtime.TuiSession;
@@ -310,6 +311,19 @@ fn ownedText(text: []const u8) !@import("owned_slice").OwnedSlice(u8) {
     return @import("owned_slice").OwnedSlice(u8).initOwned(try std.testing.allocator.dupe(u8, text));
 }
 
+const alternate_model = ai_types.Model{
+    .id = "alternate-tui-model",
+    .name = "Alternate TUI Model",
+    .api = "tui-fixture-api",
+    .provider = "tui-fixture-provider",
+    .base_url = "https://example.invalid",
+    .reasoning = false,
+    .input = &.{"text"},
+    .cost = .{ .input = 0, .output = 0, .cache_read = 0, .cache_write = 0 },
+    .context_window = 8192,
+    .max_tokens = 1024,
+};
+
 test "runtime persistence full save and resume cycle" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -345,10 +359,11 @@ test "runtime persistence full save and resume cycle" {
 
     const steps = [_]mock_provider.ResponseStep{.{ .text = fixtures.expected_text }};
     var provider = mock_provider.MockProvider.init(.{ .steps = &steps });
-    const models = [_]@TypeOf(mock_provider.test_model){mock_provider.test_model};
+    const models = [_]ai_types.Model{ alternate_model, mock_provider.test_model };
     var runtime = try TuiRuntime.init(std.testing.allocator, .{
         .protocol = provider.protocolClient(),
         .models = &models,
+        .initial_model_id = alternate_model.id,
         .run_async = false,
     });
     defer runtime.deinit();
@@ -361,6 +376,7 @@ test "runtime persistence full save and resume cycle" {
     try std.testing.expect(loaded.messages.items[1] == .assistant);
     try std.testing.expectEqualStrings("hello", loaded.messages.items[1].assistant.content[0].text.text);
     try std.testing.expectEqualStrings(mock_provider.test_model.id, loaded.messages.items[1].assistant.model);
+    try std.testing.expectEqualStrings(mock_provider.test_model.id, runtime.currentModel().?.id);
 
     var session = runtime.createSession();
     try session.submitTurn("again");

--- a/zig/src/tui/tests/scenario_tests.zig
+++ b/zig/src/tui/tests/scenario_tests.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const compat = @import("compat");
 const tui_runtime = @import("tui_runtime");
 const tui_session = @import("tui_session");
+const session_store = @import("tui_session_store");
 const mock_provider = @import("tui_tests_mock_provider");
 const fixtures = @import("tui_tests_fixtures");
 
@@ -296,6 +297,64 @@ test "tool approval approve runs tool and reject skips executor" {
     try std.testing.expect(reject_requested);
     try std.testing.expect(reject_tool_error);
     try std.testing.expectEqual(@as(usize, 1), reject_state.calls);
+}
+
+fn tmpSessionBase(allocator: std.mem.Allocator, tmp: *std.testing.TmpDir) ![]u8 {
+    const base = try std.fs.path.join(allocator, &.{ ".zig-cache", "tmp", &tmp.sub_path, "sessions" });
+    errdefer allocator.free(base);
+    try compat.fs.createDir(compat.fs.getCwd(), base);
+    return base;
+}
+
+fn ownedText(text: []const u8) !@import("owned_slice").OwnedSlice(u8) {
+    return @import("owned_slice").OwnedSlice(u8).initOwned(try std.testing.allocator.dupe(u8, text));
+}
+
+test "runtime persistence full save and resume cycle" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const base = try tmpSessionBase(std.testing.allocator, &tmp);
+    defer std.testing.allocator.free(base);
+
+    var store = try session_store.Store.init(std.testing.allocator, base);
+    defer store.deinit();
+
+    var meta = session_store.SessionMetadata{
+        .session_id = try std.testing.allocator.dupe(u8, "resume-cycle"),
+        .model = try std.testing.allocator.dupe(u8, mock_provider.test_model.id),
+        .provider = try std.testing.allocator.dupe(u8, mock_provider.test_model.provider),
+        .created_at = 1,
+        .last_active = 1,
+        .turn_count = 1,
+        .working_dir = try std.testing.allocator.dupe(u8, "."),
+    };
+    defer meta.deinit(std.testing.allocator);
+
+    try store.save(meta, .{ .message_start = .{ .role = .user } });
+    var user_delta = tui_session.TuiEvent{ .text_delta = .{ .content_index = 0, .delta = try ownedText("hello") } };
+    defer user_delta.deinit(std.testing.allocator);
+    try store.save(meta, user_delta);
+
+    const steps = [_]mock_provider.ResponseStep{.{ .text = fixtures.expected_text }};
+    var provider = mock_provider.MockProvider.init(.{ .steps = &steps });
+    const models = [_]@TypeOf(mock_provider.test_model){mock_provider.test_model};
+    var runtime = try TuiRuntime.init(std.testing.allocator, .{
+        .protocol = provider.protocolClient(),
+        .models = &models,
+        .run_async = false,
+    });
+    defer runtime.deinit();
+
+    var loaded = try store.resumeSession("resume-cycle", &runtime);
+    defer loaded.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 1), loaded.messages.items.len);
+
+    var session = runtime.createSession();
+    try session.submitTurn("again");
+    var summary = EventSummary{};
+    try drainUntilAgentEnd(&session, &summary);
+    try std.testing.expect(summary.agent_end);
+    try std.testing.expectEqual(@as(usize, 2), provider.last_message_count);
 }
 
 test {

--- a/zig/src/tui/tests/scenario_tests.zig
+++ b/zig/src/tui/tests/scenario_tests.zig
@@ -331,9 +331,17 @@ test "runtime persistence full save and resume cycle" {
     defer meta.deinit(std.testing.allocator);
 
     try store.save(meta, .{ .message_start = .{ .role = .user } });
-    var user_delta = tui_session.TuiEvent{ .text_delta = .{ .content_index = 0, .delta = try ownedText("hello") } };
-    defer user_delta.deinit(std.testing.allocator);
-    try store.save(meta, user_delta);
+    var user_end = tui_session.TuiEvent{ .message_end = .{ .role = .user, .text = try ownedText("hello") } };
+    defer user_end.deinit(std.testing.allocator);
+    try store.save(meta, user_end);
+    try store.save(meta, .{ .message_start = .{ .role = .assistant } });
+    var assistant_a = tui_session.TuiEvent{ .text_delta = .{ .content_index = 0, .delta = try ownedText("hel") } };
+    defer assistant_a.deinit(std.testing.allocator);
+    try store.save(meta, assistant_a);
+    var assistant_b = tui_session.TuiEvent{ .text_delta = .{ .content_index = 0, .delta = try ownedText("lo") } };
+    defer assistant_b.deinit(std.testing.allocator);
+    try store.save(meta, assistant_b);
+    try store.save(meta, .{ .message_end = .{ .role = .assistant } });
 
     const steps = [_]mock_provider.ResponseStep{.{ .text = fixtures.expected_text }};
     var provider = mock_provider.MockProvider.init(.{ .steps = &steps });
@@ -347,14 +355,65 @@ test "runtime persistence full save and resume cycle" {
 
     var loaded = try store.resumeSession("resume-cycle", &runtime);
     defer loaded.deinit(std.testing.allocator);
-    try std.testing.expectEqual(@as(usize, 1), loaded.messages.items.len);
+    try std.testing.expectEqual(@as(usize, 2), loaded.messages.items.len);
+    try std.testing.expect(loaded.messages.items[0] == .user);
+    try std.testing.expectEqualStrings("hello", loaded.messages.items[0].user.content.text);
+    try std.testing.expect(loaded.messages.items[1] == .assistant);
+    try std.testing.expectEqualStrings("hello", loaded.messages.items[1].assistant.content[0].text.text);
+    try std.testing.expectEqualStrings(mock_provider.test_model.id, loaded.messages.items[1].assistant.model);
 
     var session = runtime.createSession();
     try session.submitTurn("again");
     var summary = EventSummary{};
     try drainUntilAgentEnd(&session, &summary);
     try std.testing.expect(summary.agent_end);
-    try std.testing.expectEqual(@as(usize, 2), provider.last_message_count);
+    try std.testing.expectEqual(@as(usize, 3), provider.last_message_count);
+}
+
+test "session persistence reconstructs tool call before tool result" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const base = try tmpSessionBase(std.testing.allocator, &tmp);
+    defer std.testing.allocator.free(base);
+    var store = try session_store.Store.init(std.testing.allocator, base);
+    defer store.deinit();
+    var meta = session_store.SessionMetadata{
+        .session_id = try std.testing.allocator.dupe(u8, "tool-cycle"),
+        .model = try std.testing.allocator.dupe(u8, mock_provider.test_model.id),
+        .provider = try std.testing.allocator.dupe(u8, mock_provider.test_model.provider),
+        .created_at = 1,
+        .last_active = 1,
+        .turn_count = 1,
+        .working_dir = try std.testing.allocator.dupe(u8, "."),
+    };
+    defer meta.deinit(std.testing.allocator);
+
+    try store.save(meta, .{ .message_start = .{ .role = .assistant } });
+    var assistant_tool = tui_session.TuiEvent{ .message_end = .{
+        .role = .assistant,
+        .tool_call_id = try ownedText("call-1"),
+        .tool_name = try ownedText("demo_tool"),
+        .args_json = try ownedText("{\"x\":1}"),
+    } };
+    defer assistant_tool.deinit(std.testing.allocator);
+    try store.save(meta, assistant_tool);
+    var tool_result = tui_session.TuiEvent{ .tool_execution_end = .{
+        .tool_call_id = try ownedText("call-1"),
+        .tool_name = try ownedText("demo_tool"),
+        .result_json = try ownedText("{\"ok\":true}"),
+        .is_error = false,
+    } };
+    defer tool_result.deinit(std.testing.allocator);
+    try store.save(meta, tool_result);
+
+    var loaded = try store.load("tool-cycle");
+    defer loaded.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 2), loaded.messages.items.len);
+    try std.testing.expect(loaded.messages.items[0] == .assistant);
+    try std.testing.expect(loaded.messages.items[0].assistant.content[0] == .tool_call);
+    try std.testing.expectEqualStrings("call-1", loaded.messages.items[0].assistant.content[0].tool_call.id);
+    try std.testing.expect(loaded.messages.items[1] == .tool_result);
+    try std.testing.expectEqualStrings("call-1", loaded.messages.items[1].tool_result.tool_call_id);
 }
 
 test {


### PR DESCRIPTION
## Summary
- Add `tui/config.zig` for `~/.makai/config.json` load/save with defaults, model/provider, permissions, workspace, mode, and UI settings.
- Add `tui/session_store.zig` for append-only JSONL session events, metadata listing, corrupted-line recovery, and runtime resume.
- Expose runtime message replacement for resume and add persistence unit/integration coverage.

## Test plan
- [x] `scripts/check-zig-patterns.sh`
- [x] `cd zig && zig build test-unit-tui`
- [x] `cd zig && zig build test`