### PR TITLE
Add TUI telemetry panel

### DIFF
--- a/zig/build.zig
+++ b/zig/build.zig
@@ -874,6 +874,7 @@ pub fn build(b: *std.Build) void {
     const tui_view_composer_mod = b.createModule(.{ .root_source_file = b.path("src/tui/views/composer.zig"), .target = target, .optimize = optimize, .imports = &.{ .{ .name = "tui_state", .module = tui_state_mod } } });
     const tui_view_status_bar_mod = b.createModule(.{ .root_source_file = b.path("src/tui/views/status_bar.zig"), .target = target, .optimize = optimize, .imports = &.{ .{ .name = "tui_state", .module = tui_state_mod } } });
     const tui_view_tool_panel_mod = b.createModule(.{ .root_source_file = b.path("src/tui/views/tool_panel.zig"), .target = target, .optimize = optimize, .imports = &.{ .{ .name = "tui_state", .module = tui_state_mod } } });
+    const tui_view_telemetry_mod = b.createModule(.{ .root_source_file = b.path("src/tui/views/telemetry.zig"), .target = target, .optimize = optimize, .imports = &.{ .{ .name = "tui_state", .module = tui_state_mod } } });
     const tui_view_approval_mod = b.createModule(.{ .root_source_file = b.path("src/tui/views/approval.zig"), .target = target, .optimize = optimize, .imports = &.{ .{ .name = "tui_state", .module = tui_state_mod } } });
     const tui_view_preview_mod = b.createModule(.{ .root_source_file = b.path("src/tui/views/preview.zig"), .target = target, .optimize = optimize, .imports = &.{ .{ .name = "tui_state", .module = tui_state_mod } } });
     const tui_view_session_picker_mod = b.createModule(.{ .root_source_file = b.path("src/tui/views/session_picker.zig"), .target = target, .optimize = optimize, .imports = &.{ .{ .name = "tui_state", .module = tui_state_mod } } });
@@ -895,6 +896,7 @@ pub fn build(b: *std.Build) void {
             .{ .name = "tui_view_composer", .module = tui_view_composer_mod },
             .{ .name = "tui_view_status_bar", .module = tui_view_status_bar_mod },
             .{ .name = "tui_view_tool_panel", .module = tui_view_tool_panel_mod },
+            .{ .name = "tui_view_telemetry", .module = tui_view_telemetry_mod },
             .{ .name = "tui_view_approval", .module = tui_view_approval_mod },
             .{ .name = "tui_view_preview", .module = tui_view_preview_mod },
             .{ .name = "tui_view_session_picker", .module = tui_view_session_picker_mod },
@@ -1286,6 +1288,7 @@ pub fn build(b: *std.Build) void {
     const tui_view_composer_test = b.addTest(.{ .root_module = tui_view_composer_mod });
     const tui_view_status_bar_test = b.addTest(.{ .root_module = tui_view_status_bar_mod });
     const tui_view_tool_panel_test = b.addTest(.{ .root_module = tui_view_tool_panel_mod });
+    const tui_view_telemetry_test = b.addTest(.{ .root_module = tui_view_telemetry_mod });
     const tui_view_approval_test = b.addTest(.{ .root_module = tui_view_approval_mod });
     const tui_view_preview_test = b.addTest(.{ .root_module = tui_view_preview_mod });
     const tui_view_session_picker_test = b.addTest(.{ .root_module = tui_view_session_picker_mod });
@@ -1485,6 +1488,7 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(&b.addRunArtifact(tui_view_composer_test).step);
     test_step.dependOn(&b.addRunArtifact(tui_view_status_bar_test).step);
     test_step.dependOn(&b.addRunArtifact(tui_view_tool_panel_test).step);
+    test_step.dependOn(&b.addRunArtifact(tui_view_telemetry_test).step);
     test_step.dependOn(&b.addRunArtifact(tui_view_approval_test).step);
     test_step.dependOn(&b.addRunArtifact(tui_view_preview_test).step);
     test_step.dependOn(&b.addRunArtifact(tui_view_session_picker_test).step);
@@ -1637,6 +1641,7 @@ pub fn build(b: *std.Build) void {
     test_unit_tui_step.dependOn(&b.addRunArtifact(tui_view_composer_test).step);
     test_unit_tui_step.dependOn(&b.addRunArtifact(tui_view_status_bar_test).step);
     test_unit_tui_step.dependOn(&b.addRunArtifact(tui_view_tool_panel_test).step);
+    test_unit_tui_step.dependOn(&b.addRunArtifact(tui_view_telemetry_test).step);
     test_unit_tui_step.dependOn(&b.addRunArtifact(tui_view_approval_test).step);
     test_unit_tui_step.dependOn(&b.addRunArtifact(tui_view_preview_test).step);
     test_unit_tui_step.dependOn(&b.addRunArtifact(tui_view_session_picker_test).step);

--- a/zig/src/tui/app.zig
+++ b/zig/src/tui/app.zig
@@ -11,6 +11,7 @@ const transcript_view = @import("tui_view_transcript");
 const composer_view = @import("tui_view_composer");
 const status_bar_view = @import("tui_view_status_bar");
 const tool_panel_view = @import("tui_view_tool_panel");
+const telemetry_view = @import("tui_view_telemetry");
 const approval_view = @import("tui_view_approval");
 const preview_view = @import("tui_view_preview");
 const session_picker_view = @import("tui_view_session_picker");
@@ -86,7 +87,10 @@ pub const App = struct {
         };
         errdefer app.deinit();
         app.session = app.runtime.?.createSession();
-        if (app.runtime.?.currentModel()) |model| try app.state.status.setModel(allocator, model.id, model.provider);
+        if (app.runtime.?.currentModel()) |model| {
+            try app.state.status.setModelWithContext(allocator, model.id, model.provider, model.context_window);
+            app.state.telemetry.context_window = model.context_window;
+        }
         return app;
     }
 
@@ -285,16 +289,17 @@ const TuiModel = struct {
         const composer = composer_view.render(ctx.allocator, &app.state, .{ .width = width }) catch "";
         const tool_height: usize = if (app.state.tools.items.len > 0) @min(@as(usize, 8), height / 4) else 2;
         const tools = tool_panel_view.render(ctx.allocator, &app.state, .{ .width = width, .height = tool_height }) catch "";
+        const telemetry = telemetry_view.render(ctx.allocator, &app.state, .{ .width = width }) catch "";
         const extra = switch (app.state.mode) {
             .approval => approval_view.render(ctx.allocator, &app.state, .{ .width = width }) catch "",
             .preview => preview_view.render(ctx.allocator, &app.state, .{ .width = width, .height = height / 2 }) catch "",
             .session_picker => session_picker_view.render(ctx.allocator, &app.state, .{ .height = height / 2 }) catch "",
             .normal => "",
         };
-        const fixed = countLines(status) + countLines(composer) + countLines(tools) + countLines(extra) + 4;
+        const fixed = countLines(status) + countLines(composer) + countLines(tools) + countLines(telemetry) + countLines(extra) + 5;
         const transcript_height = if (height > fixed) height - fixed else 3;
         const transcript = transcript_view.render(ctx.allocator, &app.state, .{ .width = width, .height = transcript_height }) catch "";
-        return std.fmt.allocPrint(ctx.allocator, "{s}\n{s}\n{s}\n{s}\n{s}", .{ transcript, tools, extra, composer, status }) catch "";
+        return std.fmt.allocPrint(ctx.allocator, "{s}\n{s}\n{s}\n{s}\n{s}\n{s}", .{ transcript, tools, telemetry, extra, composer, status }) catch "";
     }
 
     fn appendChar(app: *App, c: u21) !void {

--- a/zig/src/tui/app.zig
+++ b/zig/src/tui/app.zig
@@ -11,6 +11,7 @@ const transcript_view = @import("tui_view_transcript");
 const composer_view = @import("tui_view_composer");
 const status_bar_view = @import("tui_view_status_bar");
 const tool_panel_view = @import("tui_view_tool_panel");
+const telemetry_view = @import("tui_view_telemetry");
 const approval_view = @import("tui_view_approval");
 const preview_view = @import("tui_view_preview");
 const session_picker_view = @import("tui_view_session_picker");
@@ -95,7 +96,10 @@ pub const App = struct {
         };
         errdefer app.deinit();
         app.session = app.runtime.?.createSession();
-        if (app.runtime.?.currentModel()) |model| try app.state.status.setModel(allocator, model.id, model.provider);
+        if (app.runtime.?.currentModel()) |model| {
+            try app.state.status.setModelWithContext(allocator, model.id, model.provider, model.context_window);
+            app.state.telemetry.context_window = model.context_window;
+        }
         return app;
     }
 
@@ -301,16 +305,17 @@ const TuiModel = struct {
         const composer = composer_view.render(ctx.allocator, &app.state, .{ .width = width }) catch "";
         const tool_height: usize = if (app.state.tools.items.len > 0) @min(@as(usize, 8), height / 4) else 2;
         const tools = tool_panel_view.render(ctx.allocator, &app.state, .{ .width = width, .height = tool_height }) catch "";
+        const telemetry = telemetry_view.render(ctx.allocator, &app.state, .{ .width = width }) catch "";
         const extra = switch (app.state.mode) {
             .approval => approval_view.render(ctx.allocator, &app.state, .{ .width = width }) catch "",
             .preview => preview_view.render(ctx.allocator, &app.state, .{ .width = width, .height = height / 2 }) catch "",
             .session_picker => session_picker_view.render(ctx.allocator, &app.state, .{ .height = height / 2 }) catch "",
             .normal => "",
         };
-        const fixed = countLines(status) + countLines(composer) + countLines(tools) + countLines(extra) + 4;
+        const fixed = countLines(status) + countLines(composer) + countLines(tools) + countLines(telemetry) + countLines(extra) + 5;
         const transcript_height = if (height > fixed) height - fixed else 3;
         const transcript = transcript_view.render(ctx.allocator, &app.state, .{ .width = width, .height = transcript_height }) catch "";
-        return std.fmt.allocPrint(ctx.allocator, "{s}\n{s}\n{s}\n{s}\n{s}", .{ transcript, tools, extra, composer, status }) catch "";
+        return std.fmt.allocPrint(ctx.allocator, "{s}\n{s}\n{s}\n{s}\n{s}\n{s}", .{ transcript, tools, telemetry, extra, composer, status }) catch "";
     }
 
     fn appendChar(app: *App, c: u21) !void {

--- a/zig/src/tui/runtime.zig
+++ b/zig/src/tui/runtime.zig
@@ -414,6 +414,11 @@ pub const TuiRuntime = struct {
                 .tool_name = try self.dupeOwned(payload.tool_name),
                 .result_json = try self.dupeOwned(payload.result_json),
                 .is_error = payload.is_error,
+                .raw_total_bytes = payload.raw_total_bytes,
+                .returned_total_bytes = payload.returned_total_bytes,
+                .estimated_returned_tokens = payload.estimated_returned_tokens,
+                .artifact_count = payload.artifact_count,
+                .artifact_refs = try self.formatArtifactRefs(payload.artifacts),
             } }),
             .turn_end => |payload| {
                 self.last_turn_stop_reason = payload.message.stop_reason;
@@ -426,8 +431,45 @@ pub const TuiRuntime = struct {
                 self.event_stream.complete(.{ .reason = reason });
                 self.stream_active = false;
             },
-            .context_usage, .prompt_segment_usage => {},
+            .context_usage => |payload| self.push(.{ .context_usage = .{
+                .system_prompt_bytes = payload.system_prompt_bytes,
+                .message_bytes = payload.message_bytes,
+                .tool_definition_bytes = payload.tool_definition_bytes,
+                .total_bytes = payload.total_bytes,
+                .estimated_tokens = payload.estimated_tokens,
+                .message_count = payload.message_count,
+                .tool_count = payload.tool_count,
+            } }),
+            .prompt_segment_usage => |payload| self.push(.{ .prompt_segment_usage = .{
+                .segment = switch (payload.segment) {
+                    .system_prompt => .system_prompt,
+                    .message_history => .message_history,
+                    .tool_definitions => .tool_definitions,
+                },
+                .cache_role = switch (payload.cache_role) {
+                    .stable => .stable,
+                    .dynamic => .dynamic,
+                },
+                .bytes = payload.bytes,
+                .estimated_tokens = payload.estimated_tokens,
+                .item_count = payload.item_count,
+            } }),
         }
+    }
+
+    fn formatArtifactRefs(self: *TuiRuntime, artifacts: []const ai_types.ArtifactReference) !OwnedSlice(u8) {
+        var out: std.Io.Writer.Allocating = .init(self.allocator);
+        defer out.deinit();
+        const writer = &out.writer;
+        for (artifacts, 0..) |artifact, i| {
+            if (i > 0) try writer.writeAll(", ");
+            if (artifact.getUri()) |uri| {
+                try writer.writeAll(uri);
+            } else {
+                try writer.writeAll(artifact.artifact_id);
+            }
+        }
+        return OwnedSlice(u8).initOwned(try out.toOwnedSlice());
     }
 
     fn pushMessageUpdate(self: *TuiRuntime, event: ai_types.AssistantMessageEvent) !void {

--- a/zig/src/tui/runtime.zig
+++ b/zig/src/tui/runtime.zig
@@ -408,6 +408,11 @@ pub const TuiRuntime = struct {
                 .tool_name = try self.dupeOwned(payload.tool_name),
                 .result_json = try self.dupeOwned(payload.result_json),
                 .is_error = payload.is_error,
+                .raw_total_bytes = payload.raw_total_bytes,
+                .returned_total_bytes = payload.returned_total_bytes,
+                .estimated_returned_tokens = payload.estimated_returned_tokens,
+                .artifact_count = payload.artifact_count,
+                .artifact_refs = try self.formatArtifactRefs(payload.artifacts),
             } }),
             .turn_end => |payload| {
                 self.last_turn_stop_reason = payload.message.stop_reason;
@@ -420,8 +425,45 @@ pub const TuiRuntime = struct {
                 self.event_stream.complete(.{ .reason = reason });
                 self.stream_active = false;
             },
-            .context_usage, .prompt_segment_usage => {},
+            .context_usage => |payload| self.push(.{ .context_usage = .{
+                .system_prompt_bytes = payload.system_prompt_bytes,
+                .message_bytes = payload.message_bytes,
+                .tool_definition_bytes = payload.tool_definition_bytes,
+                .total_bytes = payload.total_bytes,
+                .estimated_tokens = payload.estimated_tokens,
+                .message_count = payload.message_count,
+                .tool_count = payload.tool_count,
+            } }),
+            .prompt_segment_usage => |payload| self.push(.{ .prompt_segment_usage = .{
+                .segment = switch (payload.segment) {
+                    .system_prompt => .system_prompt,
+                    .message_history => .message_history,
+                    .tool_definitions => .tool_definitions,
+                },
+                .cache_role = switch (payload.cache_role) {
+                    .stable => .stable,
+                    .dynamic => .dynamic,
+                },
+                .bytes = payload.bytes,
+                .estimated_tokens = payload.estimated_tokens,
+                .item_count = payload.item_count,
+            } }),
         }
+    }
+
+    fn formatArtifactRefs(self: *TuiRuntime, artifacts: []const ai_types.ArtifactReference) !OwnedSlice(u8) {
+        var out: std.Io.Writer.Allocating = .init(self.allocator);
+        defer out.deinit();
+        const writer = &out.writer;
+        for (artifacts, 0..) |artifact, i| {
+            if (i > 0) try writer.writeAll(", ");
+            if (artifact.getUri()) |uri| {
+                try writer.writeAll(uri);
+            } else {
+                try writer.writeAll(artifact.artifact_id);
+            }
+        }
+        return OwnedSlice(u8).initOwned(try out.toOwnedSlice());
     }
 
     fn pushMessageUpdate(self: *TuiRuntime, event: ai_types.AssistantMessageEvent) !void {

--- a/zig/src/tui/session.zig
+++ b/zig/src/tui/session.zig
@@ -54,6 +54,27 @@ pub const TuiEvent = union(enum) {
         tool_name: OwnedSlice(u8),
         result_json: OwnedSlice(u8),
         is_error: bool,
+        raw_total_bytes: u64 = 0,
+        returned_total_bytes: u64 = 0,
+        estimated_returned_tokens: u64 = 0,
+        artifact_count: u32 = 0,
+        artifact_refs: OwnedSlice(u8) = OwnedSlice(u8).initBorrowed(""),
+    },
+    context_usage: struct {
+        system_prompt_bytes: u64 = 0,
+        message_bytes: u64 = 0,
+        tool_definition_bytes: u64 = 0,
+        total_bytes: u64 = 0,
+        estimated_tokens: u64 = 0,
+        message_count: u32 = 0,
+        tool_count: u32 = 0,
+    },
+    prompt_segment_usage: struct {
+        segment: PromptSegmentKind,
+        cache_role: PromptSegmentCacheRole,
+        bytes: u64 = 0,
+        estimated_tokens: u64 = 0,
+        item_count: u32 = 0,
     },
     turn_end: struct { stop_reason: ai_types.StopReason },
     agent_end: struct { reason: TuiEndReason },
@@ -63,6 +84,17 @@ pub const TuiEvent = union(enum) {
         user,
         assistant,
         tool_result,
+    };
+
+    pub const PromptSegmentKind = enum {
+        system_prompt,
+        message_history,
+        tool_definitions,
+    };
+
+    pub const PromptSegmentCacheRole = enum {
+        stable,
+        dynamic,
     };
 
     pub fn deinit(self: *TuiEvent, allocator: std.mem.Allocator) void {
@@ -90,6 +122,7 @@ pub const TuiEvent = union(enum) {
                 p.tool_call_id.deinit(allocator);
                 p.tool_name.deinit(allocator);
                 p.result_json.deinit(allocator);
+                p.artifact_refs.deinit(allocator);
             },
             .@"error" => |*p| p.message.deinit(allocator),
             else => {},

--- a/zig/src/tui/session.zig
+++ b/zig/src/tui/session.zig
@@ -56,6 +56,27 @@ pub const TuiEvent = union(enum) {
         tool_name: OwnedSlice(u8),
         result_json: OwnedSlice(u8),
         is_error: bool,
+        raw_total_bytes: u64 = 0,
+        returned_total_bytes: u64 = 0,
+        estimated_returned_tokens: u64 = 0,
+        artifact_count: u32 = 0,
+        artifact_refs: OwnedSlice(u8) = OwnedSlice(u8).initBorrowed(""),
+    },
+    context_usage: struct {
+        system_prompt_bytes: u64 = 0,
+        message_bytes: u64 = 0,
+        tool_definition_bytes: u64 = 0,
+        total_bytes: u64 = 0,
+        estimated_tokens: u64 = 0,
+        message_count: u32 = 0,
+        tool_count: u32 = 0,
+    },
+    prompt_segment_usage: struct {
+        segment: PromptSegmentKind,
+        cache_role: PromptSegmentCacheRole,
+        bytes: u64 = 0,
+        estimated_tokens: u64 = 0,
+        item_count: u32 = 0,
     },
     turn_end: struct { stop_reason: ai_types.StopReason },
     agent_end: struct { reason: TuiEndReason },
@@ -65,6 +86,17 @@ pub const TuiEvent = union(enum) {
         user,
         assistant,
         tool_result,
+    };
+
+    pub const PromptSegmentKind = enum {
+        system_prompt,
+        message_history,
+        tool_definitions,
+    };
+
+    pub const PromptSegmentCacheRole = enum {
+        stable,
+        dynamic,
     };
 
     pub fn deinit(self: *TuiEvent, allocator: std.mem.Allocator) void {
@@ -92,6 +124,7 @@ pub const TuiEvent = union(enum) {
                 p.tool_call_id.deinit(allocator);
                 p.tool_name.deinit(allocator);
                 p.result_json.deinit(allocator);
+                p.artifact_refs.deinit(allocator);
             },
             .@"error" => |*p| p.message.deinit(allocator),
             else => {},

--- a/zig/src/tui/state.zig
+++ b/zig/src/tui/state.zig
@@ -60,6 +60,12 @@ pub const ToolEntry = struct {
     output: std.ArrayList(u8) = .empty,
     status: ToolStatus = .pending,
     expanded: bool = false,
+    raw_total_bytes: u64 = 0,
+    returned_total_bytes: u64 = 0,
+    estimated_returned_tokens: u64 = 0,
+    artifact_count: u32 = 0,
+    artifact_refs: []u8 = &.{},
+    truncated: bool = false,
 
     pub fn init(allocator: std.mem.Allocator, id: []const u8, name: []const u8, args_json: []const u8, status: ToolStatus) !ToolEntry {
         return .{
@@ -75,6 +81,7 @@ pub const ToolEntry = struct {
         allocator.free(self.name);
         allocator.free(self.args_json);
         self.output.deinit(allocator);
+        if (self.artifact_refs.len > 0) allocator.free(self.artifact_refs);
         self.* = undefined;
     }
 };
@@ -104,6 +111,36 @@ pub const ApprovalState = struct {
     }
 };
 
+pub const PromptSegmentState = struct {
+    bytes: u64 = 0,
+    estimated_tokens: u64 = 0,
+    item_count: u32 = 0,
+    cache_role: tui_runtime.TuiEvent.PromptSegmentCacheRole = .dynamic,
+    seen: bool = false,
+};
+
+pub const TelemetryState = struct {
+    system_prompt_bytes: u64 = 0,
+    message_bytes: u64 = 0,
+    tool_definition_bytes: u64 = 0,
+    total_bytes: u64 = 0,
+    estimated_tokens: u64 = 0,
+    context_window: u64 = 0,
+    message_count: u32 = 0,
+    tool_count: u32 = 0,
+    system_prompt: PromptSegmentState = .{},
+    messages: PromptSegmentState = .{},
+    tool_definitions: PromptSegmentState = .{},
+
+    pub fn segment(self: *TelemetryState, kind: tui_runtime.TuiEvent.PromptSegmentKind) *PromptSegmentState {
+        return switch (kind) {
+            .system_prompt => &self.system_prompt,
+            .message_history => &self.messages,
+            .tool_definitions => &self.tool_definitions,
+        };
+    }
+};
+
 pub const StatusState = struct {
     model: []u8 = &.{},
     provider: []u8 = &.{},
@@ -123,10 +160,15 @@ pub const StatusState = struct {
     }
 
     pub fn setModel(self: *StatusState, allocator: std.mem.Allocator, model: []const u8, provider: []const u8) !void {
+        try self.setModelWithContext(allocator, model, provider, 0);
+    }
+
+    pub fn setModelWithContext(self: *StatusState, allocator: std.mem.Allocator, model: []const u8, provider: []const u8, context_limit: usize) !void {
         if (self.model.len > 0) allocator.free(self.model);
         if (self.provider.len > 0) allocator.free(self.provider);
         self.model = try allocator.dupe(u8, model);
         self.provider = try allocator.dupe(u8, provider);
+        self.context_limit = context_limit;
     }
 
     pub fn setError(self: *StatusState, allocator: std.mem.Allocator, message: []const u8) !void {
@@ -204,6 +246,7 @@ pub const AppState = struct {
     composer: ComposerState = .{},
     approval: ApprovalState = .{},
     status: StatusState = .{},
+    telemetry: TelemetryState = .{},
     preview: PreviewState = .{},
     transcript_scroll: usize = 0,
     tool_scroll: usize = 0,
@@ -288,8 +331,11 @@ pub const AppState = struct {
                 const tool = try self.upsertTool(payload.tool_call_id.slice(), payload.tool_name.slice(), "", status);
                 if (tool.output.items.len > 0) try tool.output.append(self.allocator, '\n');
                 try tool.output.appendSlice(self.allocator, payload.result_json.slice());
+                try self.applyToolTelemetry(tool, payload.raw_total_bytes, payload.returned_total_bytes, payload.estimated_returned_tokens, payload.artifact_count, payload.artifact_refs.slice());
                 if (payload.is_error) try self.status.setError(self.allocator, payload.result_json.slice());
             },
+            .context_usage => |payload| self.applyContextUsage(payload),
+            .prompt_segment_usage => |payload| self.applyPromptSegmentUsage(payload),
             .turn_end => self.status.streaming = false,
             .agent_end => |payload| {
                 self.status.streaming = false;
@@ -334,6 +380,50 @@ pub const AppState = struct {
     fn appendDelta(self: *AppState, kind: TranscriptKind, delta: []const u8) !void {
         try self.ensureTrailingEntry(kind);
         try self.transcript.items[self.transcript.items.len - 1].text.appendSlice(self.allocator, delta);
+    }
+
+    fn applyContextUsage(self: *AppState, payload: anytype) void {
+        self.telemetry.system_prompt_bytes = payload.system_prompt_bytes;
+        self.telemetry.message_bytes = payload.message_bytes;
+        self.telemetry.tool_definition_bytes = payload.tool_definition_bytes;
+        self.telemetry.total_bytes = payload.total_bytes;
+        self.telemetry.estimated_tokens = payload.estimated_tokens;
+        self.telemetry.message_count = payload.message_count;
+        self.telemetry.tool_count = payload.tool_count;
+        self.telemetry.context_window = self.status.context_limit;
+        self.status.context_used = @intCast(payload.estimated_tokens);
+    }
+
+    fn applyPromptSegmentUsage(self: *AppState, payload: anytype) void {
+        const segment = self.telemetry.segment(payload.segment);
+        segment.* = .{
+            .bytes = payload.bytes,
+            .estimated_tokens = payload.estimated_tokens,
+            .item_count = payload.item_count,
+            .cache_role = payload.cache_role,
+            .seen = true,
+        };
+    }
+
+    fn applyToolTelemetry(self: *AppState, tool: *ToolEntry, raw_total_bytes: u64, returned_total_bytes: u64, estimated_returned_tokens: u64, artifact_count: u32, artifact_refs: []const u8) !void {
+        tool.raw_total_bytes = raw_total_bytes;
+        tool.returned_total_bytes = returned_total_bytes;
+        tool.estimated_returned_tokens = estimated_returned_tokens;
+        tool.artifact_count = artifact_count;
+        tool.truncated = raw_total_bytes > returned_total_bytes or artifact_count > 0;
+        if (tool.artifact_refs.len > 0) self.allocator.free(tool.artifact_refs);
+        tool.artifact_refs = try self.allocator.dupe(u8, artifact_refs);
+        if (tool.truncated) {
+            var out: std.Io.Writer.Allocating = .init(self.allocator);
+            defer out.deinit();
+            const writer = &out.writer;
+            try writer.print("{s} [truncated {d}->{d} bytes; show full", .{ tool.name, returned_total_bytes, raw_total_bytes });
+            if (artifact_refs.len > 0) try writer.print(": {s}", .{artifact_refs});
+            try writer.writeByte(']');
+            const indicator = try out.toOwnedSlice();
+            defer self.allocator.free(indicator);
+            try self.appendTranscript(.tool, indicator);
+        }
     }
 
     fn findTool(self: *AppState, id: []const u8) ?*ToolEntry {
@@ -478,4 +568,78 @@ test "AppState appends tool execution updates" {
     try std.testing.expectEqual(@as(usize, 1), state.tools.items.len);
     try std.testing.expectEqual(ToolStatus.running, state.tools.items[0].status);
     try std.testing.expectEqualStrings("{\"match\":1}", state.tools.items[0].output.items);
+}
+
+test "AppState token counters update from context usage events" {
+    var state = AppState.init(std.testing.allocator);
+    defer state.deinit();
+    state.status.context_limit = 2000;
+
+    try state.applyEvent(.{ .context_usage = .{
+        .system_prompt_bytes = 100,
+        .message_bytes = 300,
+        .tool_definition_bytes = 200,
+        .total_bytes = 600,
+        .estimated_tokens = 150,
+        .message_count = 4,
+        .tool_count = 2,
+    } });
+
+    try std.testing.expectEqual(@as(usize, 150), state.status.context_used);
+    try std.testing.expectEqual(@as(u64, 150), state.telemetry.estimated_tokens);
+    try std.testing.expectEqual(@as(u64, 600), state.telemetry.total_bytes);
+    try std.testing.expectEqual(@as(u64, 2000), state.telemetry.context_window);
+    try std.testing.expectEqual(@as(u32, 4), state.telemetry.message_count);
+}
+
+test "AppState parses prompt segment usage events" {
+    var state = AppState.init(std.testing.allocator);
+    defer state.deinit();
+
+    try state.applyEvent(.{ .prompt_segment_usage = .{
+        .segment = .system_prompt,
+        .cache_role = .stable,
+        .bytes = 80,
+        .estimated_tokens = 20,
+        .item_count = 1,
+    } });
+    try state.applyEvent(.{ .prompt_segment_usage = .{
+        .segment = .message_history,
+        .cache_role = .dynamic,
+        .bytes = 240,
+        .estimated_tokens = 60,
+        .item_count = 3,
+    } });
+
+    try std.testing.expect(state.telemetry.system_prompt.seen);
+    try std.testing.expectEqual(@as(u64, 80), state.telemetry.system_prompt.bytes);
+    try std.testing.expectEqual(tui_runtime.TuiEvent.PromptSegmentCacheRole.stable, state.telemetry.system_prompt.cache_role);
+    try std.testing.expect(state.telemetry.messages.seen);
+    try std.testing.expectEqual(@as(u64, 60), state.telemetry.messages.estimated_tokens);
+    try std.testing.expectEqual(tui_runtime.TuiEvent.PromptSegmentCacheRole.dynamic, state.telemetry.messages.cache_role);
+}
+
+test "AppState detects truncated tool execution end events" {
+    var state = AppState.init(std.testing.allocator);
+    defer state.deinit();
+
+    var end_event = tui_runtime.TuiEvent{ .tool_execution_end = .{
+        .tool_call_id = try ownedText("call-trunc"),
+        .tool_name = try ownedText("shell_command"),
+        .result_json = try ownedText("{\"summary\":true}"),
+        .is_error = false,
+        .raw_total_bytes = 4096,
+        .returned_total_bytes = 512,
+        .estimated_returned_tokens = 128,
+        .artifact_count = 1,
+        .artifact_refs = try ownedText("artifact://tool-output/1"),
+    } };
+    defer end_event.deinit(std.testing.allocator);
+    try state.applyEvent(end_event);
+
+    try std.testing.expectEqual(@as(usize, 1), state.tools.items.len);
+    try std.testing.expect(state.tools.items[0].truncated);
+    try std.testing.expectEqual(@as(u64, 4096), state.tools.items[0].raw_total_bytes);
+    try std.testing.expectEqualStrings("artifact://tool-output/1", state.tools.items[0].artifact_refs);
+    try std.testing.expect(std.mem.indexOf(u8, state.transcript.items[state.transcript.items.len - 1].text.items, "show full") != null);
 }

--- a/zig/src/tui/state.zig
+++ b/zig/src/tui/state.zig
@@ -417,7 +417,7 @@ pub const AppState = struct {
             var out: std.Io.Writer.Allocating = .init(self.allocator);
             defer out.deinit();
             const writer = &out.writer;
-            try writer.print("{s} [truncated {d}->{d} bytes; show full", .{ tool.name, returned_total_bytes, raw_total_bytes });
+            try writer.print("{s} [truncated {d}->{d} bytes; show full", .{ tool.name, raw_total_bytes, returned_total_bytes });
             if (artifact_refs.len > 0) try writer.print(": {s}", .{artifact_refs});
             try writer.writeByte(']');
             const indicator = try out.toOwnedSlice();

--- a/zig/src/tui/views/status_bar.zig
+++ b/zig/src/tui/views/status_bar.zig
@@ -14,7 +14,10 @@ pub fn render(allocator: std.mem.Allocator, state: *const tui_state.AppState, op
     const stream = if (state.status.streaming) "streaming" else "idle";
     try writer.print(" {s}/{s} • session:{s} • turns:{d} • {s}", .{ provider, model, session, state.status.turn_count, stream });
     if (state.status.context_limit > 0) {
-        try writer.print(" • ctx:{d}/{d}", .{ state.status.context_used, state.status.context_limit });
+        const pct = (state.status.context_used * 100) / state.status.context_limit;
+        try writer.print(" • ctx:{d}% {d}/{d}", .{ pct, state.status.context_used, state.status.context_limit });
+    } else if (state.status.context_used > 0) {
+        try writer.print(" • ctx:{d}tok", .{state.status.context_used});
     }
     if (state.status.last_error.len > 0) {
         try writer.print(" • error:{s}", .{state.status.last_error});

--- a/zig/src/tui/views/telemetry.zig
+++ b/zig/src/tui/views/telemetry.zig
@@ -1,0 +1,88 @@
+const std = @import("std");
+const tui_state = @import("tui_state");
+
+pub const Options = struct {
+    width: usize = 80,
+};
+
+pub fn render(allocator: std.mem.Allocator, state: *const tui_state.AppState, options: Options) ![]u8 {
+    var out: std.Io.Writer.Allocating = .init(allocator);
+    const writer = &out.writer;
+    const telemetry = state.telemetry;
+    const limit = if (telemetry.context_window > 0) telemetry.context_window else state.status.context_limit;
+
+    try writer.writeAll("Context ");
+    try writeContextBar(writer, telemetry.estimated_tokens, limit, 20);
+    if (limit > 0) {
+        try writer.print(" {d}/{d} tok", .{ telemetry.estimated_tokens, limit });
+    } else {
+        try writer.print(" {d} tok", .{telemetry.estimated_tokens});
+    }
+    try writer.print(" ({d} bytes)", .{telemetry.total_bytes});
+
+    try writer.writeAll("\nSegments ");
+    try writeSegment(writer, "system_prompt", telemetry.system_prompt);
+    try writer.writeAll(" • ");
+    try writeSegment(writer, "messages", telemetry.messages);
+    try writer.writeAll(" • ");
+    try writeSegment(writer, "tools", telemetry.tool_definitions);
+
+    if (findLatestTruncatedTool(state)) |tool| {
+        try writer.print("\nTool output truncated {d}->{d} bytes", .{ tool.returned_total_bytes, tool.raw_total_bytes });
+        if (tool.artifact_refs.len > 0) try writer.print(" • artifact {s}", .{tool.artifact_refs});
+    }
+
+    const items = out.written();
+    if (items.len > options.width * 3) {
+        const clipped = try allocator.dupe(u8, items[0 .. options.width * 3]);
+        out.deinit();
+        return clipped;
+    }
+    return out.toOwnedSlice();
+}
+
+fn writeContextBar(writer: *std.Io.Writer, used: u64, limit: u64, width: usize) !void {
+    try writer.writeByte('[');
+    const filled = if (limit > 0) @min(width, @as(usize, @intCast((used * width) / limit))) else 0;
+    for (0..width) |i| try writer.writeByte(if (i < filled) '#' else '-');
+    try writer.writeByte(']');
+}
+
+fn writeSegment(writer: *std.Io.Writer, name: []const u8, segment: tui_state.PromptSegmentState) !void {
+    if (!segment.seen) {
+        try writer.print("{s}:n/a", .{name});
+        return;
+    }
+    const role: []const u8 = switch (segment.cache_role) {
+        .stable => "stable/cacheable",
+        .dynamic => "dynamic",
+    };
+    try writer.print("{s}:{d}b/{d}t {s}", .{ name, segment.bytes, segment.estimated_tokens, role });
+}
+
+fn findLatestTruncatedTool(state: *const tui_state.AppState) ?*const tui_state.ToolEntry {
+    var i = state.tools.items.len;
+    while (i > 0) {
+        i -= 1;
+        if (state.tools.items[i].truncated) return &state.tools.items[i];
+    }
+    return null;
+}
+
+test "telemetry view renders context and segments" {
+    var state = tui_state.AppState.init(std.testing.allocator);
+    defer state.deinit();
+    state.telemetry.estimated_tokens = 100;
+    state.telemetry.context_window = 200;
+    state.telemetry.total_bytes = 400;
+    state.telemetry.system_prompt = .{ .bytes = 40, .estimated_tokens = 10, .item_count = 1, .cache_role = .stable, .seen = true };
+    state.telemetry.messages = .{ .bytes = 200, .estimated_tokens = 50, .item_count = 4, .cache_role = .dynamic, .seen = true };
+    state.telemetry.tool_definitions = .{ .bytes = 160, .estimated_tokens = 40, .item_count = 2, .cache_role = .stable, .seen = true };
+
+    const text = try render(std.testing.allocator, &state, .{ .width = 120 });
+    defer std.testing.allocator.free(text);
+
+    try std.testing.expect(std.mem.indexOf(u8, text, "100/200 tok") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "system_prompt:40b/10t stable/cacheable") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "messages:200b/50t dynamic") != null);
+}

--- a/zig/src/tui/views/telemetry.zig
+++ b/zig/src/tui/views/telemetry.zig
@@ -28,7 +28,7 @@ pub fn render(allocator: std.mem.Allocator, state: *const tui_state.AppState, op
     try writeSegment(writer, "tools", telemetry.tool_definitions);
 
     if (findLatestTruncatedTool(state)) |tool| {
-        try writer.print("\nTool output truncated {d}->{d} bytes", .{ tool.returned_total_bytes, tool.raw_total_bytes });
+        try writer.print("\nTool output truncated {d}->{d} bytes", .{ tool.raw_total_bytes, tool.returned_total_bytes });
         if (tool.artifact_refs.len > 0) try writer.print(" • artifact {s}", .{tool.artifact_refs});
     }
 

--- a/zig/src/tui/views/tool_panel.zig
+++ b/zig/src/tui/views/tool_panel.zig
@@ -19,6 +19,13 @@ pub fn render(allocator: std.mem.Allocator, state: *const tui_state.AppState, op
     for (state.tools.items) |tool| {
         if (rows >= options.height) break;
         try writer.print("\n  [{s}] {s}", .{ statusText(tool.status), tool.name });
+        if (tool.raw_total_bytes > 0 or tool.returned_total_bytes > 0) {
+            try writer.print(" ({d}->{d} bytes", .{ tool.raw_total_bytes, tool.returned_total_bytes });
+            if (tool.estimated_returned_tokens > 0) try writer.print(", ~{d} tok", .{tool.estimated_returned_tokens});
+            try writer.writeByte(')');
+        }
+        if (tool.truncated) try writer.writeAll(" truncated/show full");
+        if (tool.artifact_refs.len > 0) try writer.print(" artifact:{s}", .{tool.artifact_refs});
         rows += 1;
         if (tool.expanded and rows < options.height) {
             try writer.writeAll(" ");

--- a/zig/src/tui/views/transcript.zig
+++ b/zig/src/tui/views/transcript.zig
@@ -28,7 +28,6 @@ pub fn render(allocator: std.mem.Allocator, state: *const AppState, options: Opt
         if (i > 0) try writer.writeByte('\n');
         try writer.print("{s} ", .{label(entry.kind)});
         try writeClipped(writer, entry.text.items, options.width -| label(entry.kind).len -| 1);
-        if (entry.kind == .tool and std.mem.indexOf(u8, entry.text.items, "[truncated") != null) try writer.writeAll(" (show full)");
     }
 
     return out.toOwnedSlice();

--- a/zig/src/tui/views/transcript.zig
+++ b/zig/src/tui/views/transcript.zig
@@ -28,6 +28,7 @@ pub fn render(allocator: std.mem.Allocator, state: *const AppState, options: Opt
         if (i > 0) try writer.writeByte('\n');
         try writer.print("{s} ", .{label(entry.kind)});
         try writeClipped(writer, entry.text.items, options.width -| label(entry.kind).len -| 1);
+        if (entry.kind == .tool and std.mem.indexOf(u8, entry.text.items, "[truncated") != null) try writer.writeAll(" (show full)");
     }
 
     return out.toOwnedSlice();


### PR DESCRIPTION
## Summary
- Surface context usage and prompt segment telemetry in the TUI with a lightweight telemetry view.
- Wire cache-role indicators, status bar context usage, and tool truncation/artifact metadata through runtime and state.
- Show truncated tool output markers in transcript/tool panel with raw vs returned byte counts.

## Test plan
- [x] zig build --build-file /Users/lsm/.neokai/projects/makai-c058549f/worktrees/t10-token-efficiency-ui/zig/build.zig test-unit-tui
- [x] /Users/lsm/.neokai/projects/makai-c058549f/worktrees/t10-token-efficiency-ui/scripts/check-zig-patterns.sh
- [x] zig build --build-file /Users/lsm/.neokai/projects/makai-c058549f/worktrees/t10-token-efficiency-ui/zig/build.zig test