### PR TITLE
Unify tool dispatch through tool protocol

### DIFF
--- a/zig/build.zig
+++ b/zig/build.zig
@@ -774,6 +774,23 @@ pub fn build(b: *std.Build) void {
         },
     });
 
+    const protocol_tool_local_runtime_mod = b.createModule(.{
+        .root_source_file = b.path("src/protocol/tool/local_runtime.zig"),
+        .target = target,
+        .optimize = optimize,
+        .imports = &.{
+            .{ .name = "compat", .module = compat_mod },
+            .{ .name = "ai_types", .module = ai_types_mod },
+            .{ .name = "agent_types", .module = agent_types_mod },
+            .{ .name = "tool_types", .module = protocol_tool_types_mod },
+            .{ .name = "tool_envelope", .module = protocol_tool_envelope_mod },
+            .{ .name = "tool_runtime", .module = protocol_tool_runtime_mod },
+            .{ .name = "transports/in_process", .module = in_process_transport_mod },
+            .{ .name = "json_writer", .module = json_writer_mod },
+            .{ .name = "owned_slice", .module = owned_slice_mod },
+        },
+    });
+
     const agent_loop_mod = b.createModule(.{
         .root_source_file = b.path("src/agent/agent_loop.zig"),
         .target = target,
@@ -803,6 +820,7 @@ pub fn build(b: *std.Build) void {
             .{ .name = "protocol_server", .module = protocol_server_mod },
             .{ .name = "protocol_client", .module = protocol_client_mod },
             .{ .name = "protocol_runtime", .module = protocol_runtime_mod },
+            .{ .name = "tool_local_runtime", .module = protocol_tool_local_runtime_mod },
             .{ .name = "transports/in_process", .module = in_process_transport_mod },
         },
     });
@@ -866,6 +884,7 @@ pub fn build(b: *std.Build) void {
             .{ .name = "ai_types", .module = ai_types_mod },
             .{ .name = "event_stream", .module = event_stream_mod },
             .{ .name = "agent", .module = agent_mod },
+            .{ .name = "agent_types", .module = agent_types_mod },
             .{ .name = "permission", .module = permission_mod },
             .{ .name = "agent_protocol_client", .module = protocol_agent_client_mod },
             .{ .name = "agent_protocol_server", .module = protocol_agent_server_mod },
@@ -879,6 +898,7 @@ pub fn build(b: *std.Build) void {
             .{ .name = "model_ref", .module = protocol_model_ref_mod },
             .{ .name = "tui_session", .module = tui_session_mod },
             .{ .name = "tools/registry", .module = tools_registry_mod },
+            .{ .name = "tool_local_runtime", .module = protocol_tool_local_runtime_mod },
             .{ .name = "json/writer", .module = json_writer_mod },
             .{ .name = "json_writer", .module = json_writer_mod },
             .{ .name = "owned_slice", .module = owned_slice_mod },
@@ -1326,6 +1346,7 @@ pub fn build(b: *std.Build) void {
     const protocol_tool_types_test = b.addTest(.{ .root_module = protocol_tool_types_mod });
     const protocol_tool_envelope_test = b.addTest(.{ .root_module = protocol_tool_envelope_mod });
     const protocol_tool_runtime_test = b.addTest(.{ .root_module = protocol_tool_runtime_mod });
+    const protocol_tool_local_runtime_test = b.addTest(.{ .root_module = protocol_tool_local_runtime_mod });
 
     // Agent tests
     const permission_test = b.addTest(.{ .root_module = permission_mod });
@@ -1575,6 +1596,7 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(&b.addRunArtifact(protocol_tool_types_test).step);
     test_step.dependOn(&b.addRunArtifact(protocol_tool_envelope_test).step);
     test_step.dependOn(&b.addRunArtifact(protocol_tool_runtime_test).step);
+    test_step.dependOn(&b.addRunArtifact(protocol_tool_local_runtime_test).step);
     test_step.dependOn(&auth_cli_test_run.step);
     test_step.dependOn(&makai_cli_test_run.step);
 
@@ -1621,6 +1643,7 @@ pub fn build(b: *std.Build) void {
     test_unit_protocol_step.dependOn(&b.addRunArtifact(protocol_tool_types_test).step);
     test_unit_protocol_step.dependOn(&b.addRunArtifact(protocol_tool_envelope_test).step);
     test_unit_protocol_step.dependOn(&b.addRunArtifact(protocol_tool_runtime_test).step);
+    test_unit_protocol_step.dependOn(&b.addRunArtifact(protocol_tool_local_runtime_test).step);
 
     const test_unit_providers_step = b.step("test-unit-providers", "Run provider unit tests");
     test_unit_providers_step.dependOn(&b.addRunArtifact(api_registry_test).step);

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -1267,6 +1267,7 @@ pub fn build(b: *std.Build) void {
                 .{ .name = "tool_types", .module = protocol_tool_types_mod },
                 .{ .name = "tool_envelope", .module = protocol_tool_envelope_mod },
                 .{ .name = "tool_runtime", .module = protocol_tool_runtime_mod },
+                .{ .name = "tool_local_runtime", .module = protocol_tool_local_runtime_mod },
                 .{ .name = "transports/in_process", .module = in_process_transport_mod },
             },
         }),

--- a/zig/src/agent/agent.zig
+++ b/zig/src/agent/agent.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const compat = @import("compat");
 const ai_types = @import("ai_types");
+const tool_local_runtime = @import("tool_local_runtime");
 const event_stream_mod = @import("event_stream");
 const types = @import("agent_types");
 const agent_loop = @import("agent_loop");
@@ -52,6 +53,8 @@ pub const AgentOptions = struct {
 
     // Provider options
     session_id: ?[]const u8 = null,
+    execute_tool_via_protocol_fn: ?types.ToolProtocolExecuteFn = null,
+    execute_tool_via_protocol_ctx: ?*anyopaque = null,
     get_api_key_fn: ?GetApiKeyFn = null,
     get_api_key_ctx: ?*anyopaque = null,
     thinking_budgets: ?ai_types.ThinkingBudgets = null,
@@ -98,6 +101,8 @@ pub const Agent = struct {
     _transform_context_fn: ?TransformContextFn,
     _transform_context_ctx: ?*anyopaque,
     _session_id: ?[]const u8,
+    _execute_tool_via_protocol_fn: ?types.ToolProtocolExecuteFn,
+    _execute_tool_via_protocol_ctx: ?*anyopaque,
     _get_api_key_fn: ?GetApiKeyFn,
     _get_api_key_ctx: ?*anyopaque,
     _thinking_budgets: ?ai_types.ThinkingBudgets,
@@ -137,6 +142,8 @@ pub const Agent = struct {
             ._transform_context_fn = options.transform_context_fn,
             ._transform_context_ctx = options.transform_context_ctx,
             ._session_id = options.session_id,
+            ._execute_tool_via_protocol_fn = options.execute_tool_via_protocol_fn,
+            ._execute_tool_via_protocol_ctx = options.execute_tool_via_protocol_ctx,
             ._get_api_key_fn = options.get_api_key_fn,
             ._get_api_key_ctx = options.get_api_key_ctx,
             ._thinking_budgets = options.thinking_budgets,
@@ -895,11 +902,16 @@ pub const Agent = struct {
             try context.appendMessage(try self.cloneMessage(msg));
         }
 
+        var local_tools = try tool_local_runtime.LocalToolProtocol.init(self._allocator, self._state.tools);
+        defer local_tools.deinit();
+
         // Build config. Agent remains auth-agnostic; provider layer owns credentials.
         const config = agent_loop.AgentLoopConfig{
             .model = model,
             .protocol = self._protocol,
             .tools = self._state.tools,
+            .execute_tool_via_protocol_fn = self._execute_tool_via_protocol_fn orelse tool_local_runtime.LocalToolProtocol.executeFn,
+            .execute_tool_via_protocol_ctx = self._execute_tool_via_protocol_ctx orelse &local_tools,
             .temperature = null,
             .max_tokens = null,
             .api_key = null,

--- a/zig/src/agent/agent.zig
+++ b/zig/src/agent/agent.zig
@@ -103,6 +103,7 @@ pub const Agent = struct {
     _session_id: ?[]const u8,
     _execute_tool_via_protocol_fn: ?types.ToolProtocolExecuteFn,
     _execute_tool_via_protocol_ctx: ?*anyopaque,
+    _local_tool_protocol: ?*tool_local_runtime.LocalToolProtocol,
     _get_api_key_fn: ?GetApiKeyFn,
     _get_api_key_ctx: ?*anyopaque,
     _thinking_budgets: ?ai_types.ThinkingBudgets,
@@ -144,6 +145,7 @@ pub const Agent = struct {
             ._session_id = options.session_id,
             ._execute_tool_via_protocol_fn = options.execute_tool_via_protocol_fn,
             ._execute_tool_via_protocol_ctx = options.execute_tool_via_protocol_ctx,
+            ._local_tool_protocol = null,
             ._get_api_key_fn = options.get_api_key_fn,
             ._get_api_key_ctx = options.get_api_key_ctx,
             ._thinking_budgets = options.thinking_budgets,
@@ -162,6 +164,12 @@ pub const Agent = struct {
         // Wait for any running thread to complete
         if (self._thread != null) {
             self.waitForIdle();
+        }
+
+        if (self._local_tool_protocol) |local| {
+            local.deinit();
+            self._allocator.destroy(local);
+            self._local_tool_protocol = null;
         }
 
         // Clear queues
@@ -902,8 +910,17 @@ pub const Agent = struct {
             try context.appendMessage(try self.cloneMessage(msg));
         }
 
-        var local_tools = try tool_local_runtime.LocalToolProtocol.init(self._allocator, self._state.tools);
-        defer local_tools.deinit();
+        if (self._execute_tool_via_protocol_fn == null) {
+            if (self._local_tool_protocol == null) {
+                const local = try self._allocator.create(tool_local_runtime.LocalToolProtocol);
+                errdefer self._allocator.destroy(local);
+                local.* = try tool_local_runtime.LocalToolProtocol.init(self._allocator, self._state.tools);
+                self._local_tool_protocol = local;
+            } else {
+                self._local_tool_protocol.?.server.tools.clearRetainingCapacity();
+                try self._local_tool_protocol.?.server.registerTools(self._state.tools);
+            }
+        }
 
         // Build config. Agent remains auth-agnostic; provider layer owns credentials.
         const config = agent_loop.AgentLoopConfig{
@@ -911,7 +928,7 @@ pub const Agent = struct {
             .protocol = self._protocol,
             .tools = self._state.tools,
             .execute_tool_via_protocol_fn = self._execute_tool_via_protocol_fn orelse tool_local_runtime.LocalToolProtocol.executeFn,
-            .execute_tool_via_protocol_ctx = self._execute_tool_via_protocol_ctx orelse &local_tools,
+            .execute_tool_via_protocol_ctx = self._execute_tool_via_protocol_ctx orelse self._local_tool_protocol,
             .temperature = null,
             .max_tokens = null,
             .api_key = null,

--- a/zig/src/agent/agent_loop.zig
+++ b/zig/src/agent/agent_loop.zig
@@ -635,52 +635,19 @@ fn executeToolCalls(
                 .args_json = execution_args,
             };
 
-            result = blk: {
-                if (config.execute_tool_via_protocol_fn) |exec_remote| {
-                    break :blk exec_remote(
-                        config.execute_tool_via_protocol_ctx,
-                        tool_call.id,
-                        tool_call.name,
-                        execution_args,
-                        config.cancel_token,
-                        &update_ctx,
-                        onToolUpdate,
-                        allocator,
-                    ) catch |err| {
-                        result = try createErrorResult(allocator, err);
-                        is_error = true;
-                        break :blk result;
-                    };
-                }
-
-                if (t.execute_with_context) |exec_with_context| {
-                    break :blk exec_with_context(
-                        t.execute_ctx,
-                        tool_call.id,
-                        execution_args,
-                        config.cancel_token,
-                        &update_ctx,
-                        onToolUpdate,
-                        allocator,
-                    ) catch |err| {
-                        result = try createErrorResult(allocator, err);
-                        is_error = true;
-                        break :blk result;
-                    };
-                }
-
-                break :blk t.execute(
-                    tool_call.id,
-                    execution_args,
-                    config.cancel_token,
-                    &update_ctx,
-                    onToolUpdate,
-                    allocator,
-                ) catch |err| {
-                    result = try createErrorResult(allocator, err);
-                    is_error = true;
-                    break :blk result;
-                };
+            result = config.execute_tool_via_protocol_fn(
+                config.execute_tool_via_protocol_ctx,
+                tool_call.id,
+                tool_call.name,
+                execution_args,
+                config.cancel_token,
+                &update_ctx,
+                onToolUpdate,
+                allocator,
+            ) catch |err| blk: {
+                result = try createErrorResult(allocator, err);
+                is_error = true;
+                break :blk result;
             };
         } else {
             result = try createErrorResult(allocator, error.ToolNotFound);

--- a/zig/src/agent/types.zig
+++ b/zig/src/agent/types.zig
@@ -169,7 +169,7 @@ pub const ToolUpdateCallback = *const fn (
     partial_result_json: []const u8,
 ) void;
 
-/// Tool execution function signature
+/// Tool execution function signature used by local tool runtimes behind ToolProtocolServer.
 pub const ToolExecuteFn = *const fn (
     tool_call_id: []const u8,
     args_json: []const u8,
@@ -179,17 +179,7 @@ pub const ToolExecuteFn = *const fn (
     allocator: std.mem.Allocator,
 ) anyerror!AgentToolResult;
 
-pub const ToolExecuteWithContextFn = *const fn (
-    ctx: ?*anyopaque,
-    tool_call_id: []const u8,
-    args_json: []const u8,
-    cancel_token: ?ai_types.CancelToken,
-    on_update_ctx: ?*anyopaque,
-    on_update: ?ToolUpdateCallback,
-    allocator: std.mem.Allocator,
-) anyerror!AgentToolResult;
-
-/// Tool execution via remote protocol path
+/// Single tool protocol dispatch path used by the agent loop.
 pub const ToolProtocolExecuteFn = *const fn (
     ctx: ?*anyopaque,
     tool_call_id: []const u8,
@@ -200,6 +190,27 @@ pub const ToolProtocolExecuteFn = *const fn (
     on_update: ?ToolUpdateCallback,
     allocator: std.mem.Allocator,
 ) anyerror!AgentToolResult;
+
+fn defaultToolProtocolExecute(
+    ctx: ?*anyopaque,
+    tool_call_id: []const u8,
+    tool_name: []const u8,
+    args_json: []const u8,
+    cancel_token: ?ai_types.CancelToken,
+    on_update_ctx: ?*anyopaque,
+    on_update: ?ToolUpdateCallback,
+    allocator: std.mem.Allocator,
+) anyerror!AgentToolResult {
+    _ = ctx;
+    _ = tool_call_id;
+    _ = tool_name;
+    _ = args_json;
+    _ = cancel_token;
+    _ = on_update_ctx;
+    _ = on_update;
+    _ = allocator;
+    return error.ToolProtocolNotConfigured;
+}
 
 pub const ToolOutputMiddlewareInput = struct {
     tool_call_id: []const u8,
@@ -252,8 +263,6 @@ pub const AgentTool = struct {
     short_description: ?[]const u8 = null,
     parameters_schema_json: []const u8,
     execute: ToolExecuteFn,
-    execute_ctx: ?*anyopaque = null,
-    execute_with_context: ?ToolExecuteWithContextFn = null,
     approval_ctx: ?*anyopaque = null,
     approval_fn: ?ToolApprovalFn = null,
     approval_ui_ctx: ?*anyopaque = null,
@@ -380,7 +389,7 @@ pub const AgentLoopConfig = struct {
 
     // Tools (optional)
     tools: ?[]const AgentTool = null,
-    execute_tool_via_protocol_fn: ?ToolProtocolExecuteFn = null,
+    execute_tool_via_protocol_fn: ToolProtocolExecuteFn = defaultToolProtocolExecute,
     execute_tool_via_protocol_ctx: ?*anyopaque = null,
     tool_output_middleware_fn: ?ToolOutputMiddlewareFn = null,
     tool_output_middleware_ctx: ?*anyopaque = null,
@@ -676,7 +685,7 @@ test "AgentTool.toTool conversion" {
         .description = "A test tool",
         .short_description = "Test compact",
         .parameters_schema_json = "{}",
-        .execute = undefined, // Would be a real function in practice
+        .execute = undefined, // Runtime registration callback only; agent loop never calls directly.
     };
 
     const converted = try tool.toTool(std.testing.allocator);

--- a/zig/src/agent/types.zig
+++ b/zig/src/agent/types.zig
@@ -179,6 +179,17 @@ pub const ToolExecuteFn = *const fn (
     allocator: std.mem.Allocator,
 ) anyerror!AgentToolResult;
 
+/// Context-aware runtime function used only inside ToolProtocolServer.
+pub const ToolRuntimeExecuteFn = *const fn (
+    ctx: ?*anyopaque,
+    tool_call_id: []const u8,
+    args_json: []const u8,
+    cancel_token: ?ai_types.CancelToken,
+    on_update_ctx: ?*anyopaque,
+    on_update: ?ToolUpdateCallback,
+    allocator: std.mem.Allocator,
+) anyerror!AgentToolResult;
+
 /// Single tool protocol dispatch path used by the agent loop.
 pub const ToolProtocolExecuteFn = *const fn (
     ctx: ?*anyopaque,
@@ -263,6 +274,8 @@ pub const AgentTool = struct {
     short_description: ?[]const u8 = null,
     parameters_schema_json: []const u8,
     execute: ToolExecuteFn,
+    runtime_ctx: ?*anyopaque = null,
+    runtime_execute: ?ToolRuntimeExecuteFn = null,
     approval_ctx: ?*anyopaque = null,
     approval_fn: ?ToolApprovalFn = null,
     approval_ui_ctx: ?*anyopaque = null,

--- a/zig/src/protocol/tool/local_runtime.zig
+++ b/zig/src/protocol/tool/local_runtime.zig
@@ -1,0 +1,641 @@
+const std = @import("std");
+const compat = @import("compat");
+const ai_types = @import("ai_types");
+const agent_types = @import("agent_types");
+const tool_envelope = @import("tool_envelope");
+const tool_types = @import("tool_types");
+const in_process = @import("transports/in_process");
+const json_writer = @import("json_writer");
+const OwnedSlice = @import("owned_slice").OwnedSlice;
+
+const PipeTransport = in_process.SerializedPipe;
+
+const ExecutionUpdateContext = struct {
+    threadlocal var current: ExecutionUpdateContext = .{};
+
+    ctx: ?*anyopaque = null,
+    callback: ?agent_types.ToolUpdateCallback = null,
+
+    fn set(ctx: ?*anyopaque, callback: ?agent_types.ToolUpdateCallback) void {
+        current = .{ .ctx = ctx, .callback = callback };
+    }
+
+    fn clear() void {
+        current = .{};
+    }
+
+    fn consume() ExecutionUpdateContext {
+        const value = current;
+        current = .{};
+        return value;
+    }
+};
+
+pub const ToolProtocolServer = struct {
+    allocator: std.mem.Allocator,
+    tools: std.ArrayList(agent_types.AgentTool) = .empty,
+    server_id: tool_types.Ulid,
+    sequence: u64 = 0,
+
+    pub fn init(allocator: std.mem.Allocator) ToolProtocolServer {
+        return .{ .allocator = allocator, .server_id = tool_types.generateUlid() };
+    }
+
+    pub fn deinit(self: *ToolProtocolServer) void {
+        self.tools.deinit(self.allocator);
+        self.* = undefined;
+    }
+
+    pub fn registerTool(self: *ToolProtocolServer, tool: agent_types.AgentTool) !void {
+        if (self.resolve(tool.name) != null) return error.DuplicateTool;
+        try self.tools.append(self.allocator, tool);
+    }
+
+    pub fn replaceOrRegisterTool(self: *ToolProtocolServer, tool: agent_types.AgentTool) !void {
+        for (self.tools.items) |*existing| {
+            if (std.mem.eql(u8, existing.name, tool.name)) {
+                existing.* = tool;
+                return;
+            }
+        }
+        try self.tools.append(self.allocator, tool);
+    }
+
+    pub fn registerTools(self: *ToolProtocolServer, tools: []const agent_types.AgentTool) !void {
+        for (tools) |tool| try self.replaceOrRegisterTool(tool);
+    }
+
+    pub fn resolve(self: *const ToolProtocolServer, name: []const u8) ?agent_types.AgentTool {
+        for (self.tools.items) |tool| if (std.mem.eql(u8, tool.name, name)) return tool;
+        return null;
+    }
+
+    pub fn list(self: *const ToolProtocolServer) []const agent_types.AgentTool {
+        return self.tools.items;
+    }
+
+    fn nextEnvelope(self: *ToolProtocolServer, in_reply_to: ?tool_types.Ulid, payload: tool_types.Payload) tool_types.Envelope {
+        self.sequence += 1;
+        return .{
+            .server_id = self.server_id,
+            .message_id = tool_types.generateUlid(),
+            .sequence = self.sequence,
+            .in_reply_to = in_reply_to,
+            .timestamp = compat.time.nowMillis(),
+            .payload = payload,
+        };
+    }
+
+    pub fn handleClientEnvelope(ctx: ?*anyopaque, env: tool_types.Envelope, allocator: std.mem.Allocator) !?tool_types.Envelope {
+        const self: *ToolProtocolServer = @ptrCast(@alignCast(ctx.?));
+        switch (env.payload) {
+            .tool_execute => |req| {
+                const update_ctx = ExecutionUpdateContext.consume();
+                const tool = self.resolve(req.tool_name) orelse {
+                    return self.nextEnvelope(env.message_id, .{ .tool_error = .{
+                        .execution_id = req.execution_id,
+                        .code = .tool_not_found,
+                        .message = try allocator.dupe(u8, "unknown tool"),
+                    } });
+                };
+
+                const start_ms = compat.time.nowMillis();
+                var result = tool.execute(req.tool_call_id, req.args_json, null, update_ctx.ctx, update_ctx.callback, allocator) catch |err| {
+                    return self.nextEnvelope(env.message_id, .{ .tool_error = .{
+                        .execution_id = req.execution_id,
+                        .code = .tool_execution_error,
+                        .message = try allocator.dupe(u8, @errorName(err)),
+                    } });
+                };
+                defer result.deinit(allocator);
+
+                const result_json = try serializeUserContentParts(allocator, result.content.slice());
+                errdefer allocator.free(result_json);
+                const details_json = if (result.getDetailsJson()) |details|
+                    OwnedSlice(u8).initOwned(try allocator.dupe(u8, details))
+                else
+                    OwnedSlice(u8).initBorrowed("");
+                errdefer {
+                    var mutable = details_json;
+                    mutable.deinit(allocator);
+                }
+                const artifacts = OwnedSlice(tool_types.ArtifactReference).initOwned(try cloneArtifactsToTool(allocator, result.artifacts.slice()));
+                errdefer {
+                    var mutable = artifacts;
+                    mutable.deinit(allocator);
+                }
+
+                return self.nextEnvelope(env.message_id, .{ .tool_result = .{
+                    .execution_id = req.execution_id,
+                    .tool_call_id = try allocator.dupe(u8, req.tool_call_id),
+                    .result_json = result_json,
+                    .details_json = details_json,
+                    .artifacts = artifacts,
+                    .duration_ms = @intCast(@max(compat.time.nowMillis() - start_ms, 0)),
+                } });
+            },
+            .tool_list => |req| {
+                const prefix = req.getPrefix();
+                var metas = std.ArrayList(tool_types.ToolMetadata).empty;
+                errdefer {
+                    for (metas.items) |*meta| deinitToolMetadata(meta, allocator);
+                    metas.deinit(allocator);
+                }
+                for (self.tools.items) |tool| {
+                    if (prefix) |p| {
+                        if (!std.mem.startsWith(u8, tool.name, p)) continue;
+                    }
+                    try metas.append(allocator, try toolMetadataFromAgentTool(allocator, tool));
+                }
+                return self.nextEnvelope(env.message_id, .{ .tool_list_response = .{ .tools = try metas.toOwnedSlice(allocator) } });
+            },
+            else => return null,
+        }
+    }
+};
+
+pub const ToolProtocolClient = struct {
+    pipe: *PipeTransport,
+    server_id: tool_types.Ulid,
+    sequence: u64 = 0,
+
+    pub fn init(pipe: *PipeTransport) ToolProtocolClient {
+        return .{ .pipe = pipe, .server_id = tool_types.generateUlid() };
+    }
+
+    pub fn execute(
+        self: *ToolProtocolClient,
+        tool_call_id: []const u8,
+        tool_name: []const u8,
+        args_json: []const u8,
+        allocator: std.mem.Allocator,
+    ) !agent_types.AgentToolResult {
+        const execution_id = tool_types.generateUlid();
+        self.sequence += 1;
+        var env = tool_types.Envelope{
+            .server_id = self.server_id,
+            .message_id = tool_types.generateUlid(),
+            .sequence = self.sequence,
+            .timestamp = compat.time.nowMillis(),
+            .payload = .{ .tool_execute = .{
+                .execution_id = execution_id,
+                .tool_call_id = try allocator.dupe(u8, tool_call_id),
+                .tool_name = try allocator.dupe(u8, tool_name),
+                .args_json = try allocator.dupe(u8, args_json),
+            } },
+        };
+        defer env.deinit(allocator);
+
+        const json = try tool_envelope.serializeEnvelope(env, allocator);
+        defer allocator.free(json);
+
+        var sender = self.pipe.clientSender();
+        try sender.write(json);
+        try sender.flush();
+
+        var recv = self.pipe.clientReceiver();
+        while (try recv.readLine(allocator)) |line| {
+            defer allocator.free(line);
+            var response = try tool_envelope.deserializeEnvelope(line, allocator);
+            defer response.deinit(allocator);
+            switch (response.payload) {
+                .tool_result => |res| return try agentToolResultFromProtocol(allocator, res),
+                .tool_error => |err| return toolErrorToError(err.code),
+                else => {},
+            }
+        }
+
+        return error.ToolProtocolNoResponse;
+    }
+
+    pub fn executeFn(
+        ctx: ?*anyopaque,
+        tool_call_id: []const u8,
+        tool_name: []const u8,
+        args_json: []const u8,
+        cancel_token: ?ai_types.CancelToken,
+        on_update_ctx: ?*anyopaque,
+        on_update: ?agent_types.ToolUpdateCallback,
+        allocator: std.mem.Allocator,
+    ) anyerror!agent_types.AgentToolResult {
+        _ = cancel_token;
+        _ = on_update_ctx;
+        _ = on_update;
+        const self: *ToolProtocolClient = @ptrCast(@alignCast(ctx.?));
+        return self.execute(tool_call_id, tool_name, args_json, allocator);
+    }
+};
+
+pub const LocalToolProtocol = struct {
+    allocator: std.mem.Allocator,
+    pipe: PipeTransport,
+    server: ToolProtocolServer,
+    client: ToolProtocolClient,
+
+    pub fn init(allocator: std.mem.Allocator, tools: []const agent_types.AgentTool) !LocalToolProtocol {
+        var pipe = PipeTransport.init(allocator);
+        errdefer pipe.deinit();
+        var server = ToolProtocolServer.init(allocator);
+        errdefer server.deinit();
+        try server.registerTools(tools);
+        const client = ToolProtocolClient.init(&pipe);
+        return .{
+            .allocator = allocator,
+            .pipe = pipe,
+            .server = server,
+            .client = client,
+        };
+    }
+
+    pub fn deinit(self: *LocalToolProtocol) void {
+        self.server.deinit();
+        self.pipe.deinit();
+        self.* = undefined;
+    }
+
+    pub fn execute(
+        self: *LocalToolProtocol,
+        tool_call_id: []const u8,
+        tool_name: []const u8,
+        args_json: []const u8,
+        cancel_token: ?ai_types.CancelToken,
+        on_update_ctx: ?*anyopaque,
+        on_update: ?agent_types.ToolUpdateCallback,
+        allocator: std.mem.Allocator,
+    ) !agent_types.AgentToolResult {
+        return self.executeWithOverride(tool_call_id, tool_name, args_json, cancel_token, on_update_ctx, on_update, null, null, allocator);
+    }
+
+    pub fn executeWithOverride(
+        self: *LocalToolProtocol,
+        tool_call_id: []const u8,
+        tool_name: []const u8,
+        args_json: []const u8,
+        cancel_token: ?ai_types.CancelToken,
+        on_update_ctx: ?*anyopaque,
+        on_update: ?agent_types.ToolUpdateCallback,
+        override_ctx: ?*anyopaque,
+        override_fn: ?agent_types.ToolProtocolExecuteFn,
+        allocator: std.mem.Allocator,
+    ) !agent_types.AgentToolResult {
+        if (override_fn) |exec| return exec(override_ctx, tool_call_id, tool_name, args_json, cancel_token, on_update_ctx, on_update, allocator);
+        const execution_id = tool_types.generateUlid();
+        self.client.sequence += 1;
+        var env = tool_types.Envelope{
+            .server_id = self.client.server_id,
+            .message_id = tool_types.generateUlid(),
+            .sequence = self.client.sequence,
+            .timestamp = compat.time.nowMillis(),
+            .payload = .{ .tool_execute = .{
+                .execution_id = execution_id,
+                .tool_call_id = try allocator.dupe(u8, tool_call_id),
+                .tool_name = try allocator.dupe(u8, tool_name),
+                .args_json = try allocator.dupe(u8, args_json),
+            } },
+        };
+        defer env.deinit(allocator);
+
+        const json = try tool_envelope.serializeEnvelope(env, allocator);
+        defer allocator.free(json);
+
+        var sender = self.pipe.clientSender();
+        try sender.write(json);
+        try sender.flush();
+        ExecutionUpdateContext.set(on_update_ctx, on_update);
+        defer ExecutionUpdateContext.clear();
+        try self.pumpClientMessages();
+
+        var recv = self.pipe.clientReceiver();
+        while (try recv.readLine(allocator)) |line| {
+            defer allocator.free(line);
+            var response = try tool_envelope.deserializeEnvelope(line, allocator);
+            defer response.deinit(allocator);
+            switch (response.payload) {
+                .tool_result => |res| return try agentToolResultFromProtocol(allocator, res),
+                .tool_error => |err| return toolErrorToError(err.code),
+                else => {},
+            }
+        }
+
+        return error.ToolProtocolNoResponse;
+    }
+
+    pub fn executeFn(
+        ctx: ?*anyopaque,
+        tool_call_id: []const u8,
+        tool_name: []const u8,
+        args_json: []const u8,
+        cancel_token: ?ai_types.CancelToken,
+        on_update_ctx: ?*anyopaque,
+        on_update: ?agent_types.ToolUpdateCallback,
+        allocator: std.mem.Allocator,
+    ) anyerror!agent_types.AgentToolResult {
+        const self: *LocalToolProtocol = @ptrCast(@alignCast(ctx.?));
+        return self.execute(tool_call_id, tool_name, args_json, cancel_token, on_update_ctx, on_update, allocator);
+    }
+
+    fn pumpClientMessages(self: *LocalToolProtocol) !void {
+        var recv = self.pipe.serverReceiver();
+        while (try recv.readLine(self.allocator)) |line| {
+            defer self.allocator.free(line);
+            var env = tool_envelope.deserializeEnvelope(line, self.allocator) catch continue;
+            defer env.deinit(self.allocator);
+            if (try ToolProtocolServer.handleClientEnvelope(&self.server, env, self.allocator)) |response| {
+                var out = response;
+                defer out.deinit(self.allocator);
+                const out_json = try tool_envelope.serializeEnvelope(out, self.allocator);
+                defer self.allocator.free(out_json);
+                var sender = self.pipe.serverSender();
+                try sender.write(out_json);
+                try sender.flush();
+            }
+        }
+    }
+};
+
+fn serializeUserContentParts(allocator: std.mem.Allocator, parts: []const ai_types.UserContentPart) ![]u8 {
+    var buffer = std.ArrayList(u8).empty;
+    errdefer buffer.deinit(allocator);
+    var w = json_writer.JsonWriter.init(&buffer, allocator);
+    try w.beginArray();
+    for (parts) |part| {
+        try w.beginObject();
+        switch (part) {
+            .text => |text| {
+                try w.writeStringField("type", "text");
+                try w.writeStringField("text", text.text);
+                if (text.text_signature) |sig| try w.writeStringField("text_signature", sig);
+            },
+            .image => |image| {
+                try w.writeStringField("type", "image");
+                try w.writeStringField("data", image.data);
+                try w.writeStringField("mime_type", image.mime_type);
+            },
+        }
+        try w.endObject();
+    }
+    try w.endArray();
+    return buffer.toOwnedSlice(allocator);
+}
+
+fn parseUserContentParts(allocator: std.mem.Allocator, json: []const u8) ![]ai_types.UserContentPart {
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, json, .{});
+    defer parsed.deinit();
+    const arr = switch (parsed.value) {
+        .array => |a| a,
+        else => return error.InvalidToolResultJson,
+    };
+    const parts = try allocator.alloc(ai_types.UserContentPart, arr.items.len);
+    var initialized: usize = 0;
+    errdefer {
+        for (parts[0..initialized]) |*part| part.deinit(allocator);
+        allocator.free(parts);
+    }
+    for (arr.items, 0..) |item, i| {
+        const obj = switch (item) {
+            .object => |o| o,
+            else => return error.InvalidToolResultJson,
+        };
+        const kind = try jsonStringField(obj, "type");
+        if (std.mem.eql(u8, kind, "text")) {
+            const text = try allocator.dupe(u8, try jsonStringField(obj, "text"));
+            errdefer allocator.free(text);
+            const sig = if (obj.get("text_signature")) |value| try allocator.dupe(u8, try jsonStringValue(value)) else null;
+            errdefer if (sig) |s| allocator.free(s);
+            parts[i] = .{ .text = .{ .text = text, .text_signature = sig } };
+        } else if (std.mem.eql(u8, kind, "image")) {
+            const data = try allocator.dupe(u8, try jsonStringField(obj, "data"));
+            errdefer allocator.free(data);
+            const mime_type = try allocator.dupe(u8, try jsonStringField(obj, "mime_type"));
+            errdefer allocator.free(mime_type);
+            parts[i] = .{ .image = .{ .data = data, .mime_type = mime_type } };
+        } else return error.InvalidToolResultJson;
+        initialized += 1;
+    }
+    return parts;
+}
+
+fn jsonStringField(obj: std.json.ObjectMap, key: []const u8) ![]const u8 {
+    return jsonStringValue(obj.get(key) orelse return error.InvalidToolResultJson);
+}
+
+fn jsonStringValue(value: std.json.Value) ![]const u8 {
+    return switch (value) {
+        .string => |s| s,
+        else => error.InvalidToolResultJson,
+    };
+}
+
+fn agentToolResultFromProtocol(allocator: std.mem.Allocator, res: tool_types.ToolExecuteResult) !agent_types.AgentToolResult {
+    const content = try parseUserContentParts(allocator, res.result_json);
+    errdefer {
+        for (content) |*part| part.deinit(allocator);
+        allocator.free(content);
+    }
+    const details = if (res.getDetailsJson()) |details_json|
+        OwnedSlice(u8).initOwned(try allocator.dupe(u8, details_json))
+    else
+        OwnedSlice(u8).initBorrowed("");
+    errdefer {
+        var mutable = details;
+        mutable.deinit(allocator);
+    }
+    const artifacts = OwnedSlice(ai_types.ArtifactReference).initOwned(try cloneArtifactsToAgent(allocator, res.artifacts.slice()));
+    errdefer {
+        var mutable = artifacts;
+        mutable.deinit(allocator);
+    }
+    return .{
+        .content = OwnedSlice(ai_types.UserContentPart).initOwned(content),
+        .details_json = details,
+        .artifacts = artifacts,
+    };
+}
+
+fn cloneArtifactsToTool(allocator: std.mem.Allocator, artifacts: []const ai_types.ArtifactReference) ![]tool_types.ArtifactReference {
+    const cloned = try allocator.alloc(tool_types.ArtifactReference, artifacts.len);
+    var initialized: usize = 0;
+    errdefer {
+        for (cloned[0..initialized]) |*artifact| artifact.deinit(allocator);
+        allocator.free(cloned);
+    }
+    for (artifacts, 0..) |artifact, i| {
+        cloned[i] = .{
+            .artifact_id = try allocator.dupe(u8, artifact.artifact_id),
+            .uri = if (artifact.getUri()) |v| OwnedSlice(u8).initOwned(try allocator.dupe(u8, v)) else OwnedSlice(u8).initBorrowed(""),
+            .mime_type = if (artifact.getMimeType()) |v| OwnedSlice(u8).initOwned(try allocator.dupe(u8, v)) else OwnedSlice(u8).initBorrowed(""),
+            .byte_size = artifact.byte_size,
+            .sha256 = if (artifact.getSha256()) |v| OwnedSlice(u8).initOwned(try allocator.dupe(u8, v)) else OwnedSlice(u8).initBorrowed(""),
+            .description = if (artifact.getDescription()) |v| OwnedSlice(u8).initOwned(try allocator.dupe(u8, v)) else OwnedSlice(u8).initBorrowed(""),
+        };
+        initialized += 1;
+    }
+    return cloned;
+}
+
+fn cloneArtifactsToAgent(allocator: std.mem.Allocator, artifacts: []const tool_types.ArtifactReference) ![]ai_types.ArtifactReference {
+    const cloned = try allocator.alloc(ai_types.ArtifactReference, artifacts.len);
+    var initialized: usize = 0;
+    errdefer {
+        for (cloned[0..initialized]) |*artifact| artifact.deinit(allocator);
+        allocator.free(cloned);
+    }
+    for (artifacts, 0..) |artifact, i| {
+        cloned[i] = .{
+            .artifact_id = try allocator.dupe(u8, artifact.artifact_id),
+            .uri = if (artifact.getUri()) |v| OwnedSlice(u8).initOwned(try allocator.dupe(u8, v)) else OwnedSlice(u8).initBorrowed(""),
+            .mime_type = if (artifact.getMimeType()) |v| OwnedSlice(u8).initOwned(try allocator.dupe(u8, v)) else OwnedSlice(u8).initBorrowed(""),
+            .byte_size = artifact.byte_size,
+            .sha256 = if (artifact.getSha256()) |v| OwnedSlice(u8).initOwned(try allocator.dupe(u8, v)) else OwnedSlice(u8).initBorrowed(""),
+            .description = if (artifact.getDescription()) |v| OwnedSlice(u8).initOwned(try allocator.dupe(u8, v)) else OwnedSlice(u8).initBorrowed(""),
+        };
+        initialized += 1;
+    }
+    return cloned;
+}
+
+fn toolMetadataFromAgentTool(allocator: std.mem.Allocator, tool: agent_types.AgentTool) !tool_types.ToolMetadata {
+    return .{
+        .name = try allocator.dupe(u8, tool.name),
+        .description = try allocator.dupe(u8, tool.description),
+        .parameters_schema_json = try allocator.dupe(u8, tool.parameters_schema_json),
+        .version = try allocator.dupe(u8, "1.0.0"),
+    };
+}
+
+fn deinitToolMetadata(meta: *tool_types.ToolMetadata, allocator: std.mem.Allocator) void {
+    allocator.free(meta.name);
+    allocator.free(meta.description);
+    allocator.free(meta.parameters_schema_json);
+    allocator.free(meta.version);
+    if (meta.required_permissions) |perms| {
+        for (perms) |perm| allocator.free(perm);
+        allocator.free(perms);
+    }
+}
+
+fn toolErrorToError(code: tool_types.ToolErrorCode) anyerror {
+    return switch (code) {
+        .tool_not_found => error.ToolNotFound,
+        .tool_timeout => error.ToolTimeout,
+        .invalid_arguments => error.InvalidToolArguments,
+        .tool_unavailable => error.ToolUnavailable,
+        .artifact_not_found => error.ArtifactNotFound,
+        .hashline_disabled => error.HashlineDisabled,
+        .stale_anchor => error.StaleAnchor,
+        else => error.ToolExecutionFailed,
+    };
+}
+
+test "tool protocol server wraps shell_execute and returns correct result" {
+    const allocator = std.testing.allocator;
+    const callbacks = struct {
+        fn execute(
+            tool_call_id: []const u8,
+            args_json: []const u8,
+            cancel_token: ?ai_types.CancelToken,
+            on_update_ctx: ?*anyopaque,
+            on_update: ?agent_types.ToolUpdateCallback,
+            test_allocator: std.mem.Allocator,
+        ) anyerror!agent_types.AgentToolResult {
+            _ = tool_call_id;
+            _ = args_json;
+            _ = cancel_token;
+            _ = on_update_ctx;
+            _ = on_update;
+            const parts = try test_allocator.alloc(ai_types.UserContentPart, 1);
+            parts[0] = .{ .text = .{ .text = try test_allocator.dupe(u8, "shell ok") } };
+            return .{ .content = OwnedSlice(ai_types.UserContentPart).initOwned(parts) };
+        }
+    };
+    const tool = agent_types.AgentTool{ .label = "Shell Execute", .name = "shell_execute", .description = "Run shell command", .parameters_schema_json = "{}", .execute = callbacks.execute };
+    var local = try LocalToolProtocol.init(allocator, &.{tool});
+    defer local.deinit();
+
+    var result = try local.execute("call_1", "shell_execute", "{}", null, null, null, allocator);
+    defer result.deinit(allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), result.content.slice().len);
+    try std.testing.expect(result.content.slice()[0] == .text);
+    try std.testing.expectEqualStrings("shell ok", result.content.slice()[0].text.text);
+}
+
+test "tool protocol server wraps MCP bridge-style tool and returns correct result" {
+    const allocator = std.testing.allocator;
+    const callbacks = struct {
+        fn execute(
+            tool_call_id: []const u8,
+            args_json: []const u8,
+            cancel_token: ?ai_types.CancelToken,
+            on_update_ctx: ?*anyopaque,
+            on_update: ?agent_types.ToolUpdateCallback,
+            test_allocator: std.mem.Allocator,
+        ) anyerror!agent_types.AgentToolResult {
+            _ = tool_call_id;
+            _ = args_json;
+            _ = cancel_token;
+            _ = on_update_ctx;
+            _ = on_update;
+            const parts = try test_allocator.alloc(ai_types.UserContentPart, 1);
+            parts[0] = .{ .text = .{ .text = try test_allocator.dupe(u8, "mcp ok") } };
+            return .{
+                .content = OwnedSlice(ai_types.UserContentPart).initOwned(parts),
+                .details_json = OwnedSlice(u8).initOwned(try test_allocator.dupe(u8, "{\"bridge\":true}")),
+            };
+        }
+    };
+    const tool = agent_types.AgentTool{
+        .label = "MCP Echo",
+        .name = "mcp_echo",
+        .description = "MCP bridge echo tool",
+        .parameters_schema_json = "{}",
+        .execute = callbacks.execute,
+    };
+    var local = try LocalToolProtocol.init(allocator, &.{tool});
+    defer local.deinit();
+
+    var result = try local.execute("call_1", "mcp_echo", "{}", null, null, null, allocator);
+    defer result.deinit(allocator);
+
+    try std.testing.expectEqualStrings("mcp ok", result.content.slice()[0].text.text);
+    try std.testing.expectEqualStrings("{\"bridge\":true}", result.getDetailsJson().?);
+}
+
+test "in-process tool protocol round-trip stays near direct call" {
+    const allocator = std.testing.allocator;
+    const callbacks = struct {
+        fn execute(
+            tool_call_id: []const u8,
+            args_json: []const u8,
+            cancel_token: ?ai_types.CancelToken,
+            on_update_ctx: ?*anyopaque,
+            on_update: ?agent_types.ToolUpdateCallback,
+            test_allocator: std.mem.Allocator,
+        ) anyerror!agent_types.AgentToolResult {
+            _ = tool_call_id;
+            _ = args_json;
+            _ = cancel_token;
+            _ = on_update_ctx;
+            _ = on_update;
+            const parts = try test_allocator.alloc(ai_types.UserContentPart, 1);
+            parts[0] = .{ .text = .{ .text = try test_allocator.dupe(u8, "ok") } };
+            return .{ .content = OwnedSlice(ai_types.UserContentPart).initOwned(parts) };
+        }
+    };
+    const tool = agent_types.AgentTool{ .label = "Bench", .name = "bench", .description = "Bench", .parameters_schema_json = "{}", .execute = callbacks.execute };
+    var local = try LocalToolProtocol.init(allocator, &.{tool});
+    defer local.deinit();
+
+    const direct_start = compat.time.nowMillis();
+    var direct = try callbacks.execute("call", "{}", null, null, null, allocator);
+    direct.deinit(allocator);
+    const direct_ms = compat.time.nowMillis() - direct_start;
+
+    const proto_start = compat.time.nowMillis();
+    var proto = try local.execute("call", "bench", "{}", null, null, null, allocator);
+    proto.deinit(allocator);
+    const proto_ms = compat.time.nowMillis() - proto_start;
+
+    _ = direct_ms;
+    try std.testing.expect(proto_ms <= 1);
+}

--- a/zig/src/protocol/tool/local_runtime.zig
+++ b/zig/src/protocol/tool/local_runtime.zig
@@ -10,21 +10,22 @@ const OwnedSlice = @import("owned_slice").OwnedSlice;
 
 const PipeTransport = in_process.SerializedPipe;
 
-const ExecutionUpdateContext = struct {
-    threadlocal var current: ExecutionUpdateContext = .{};
+const ExecutionContext = struct {
+    threadlocal var current: ExecutionContext = .{};
 
-    ctx: ?*anyopaque = null,
-    callback: ?agent_types.ToolUpdateCallback = null,
+    cancel_token: ?ai_types.CancelToken = null,
+    update_ctx: ?*anyopaque = null,
+    update_callback: ?agent_types.ToolUpdateCallback = null,
 
-    fn set(ctx: ?*anyopaque, callback: ?agent_types.ToolUpdateCallback) void {
-        current = .{ .ctx = ctx, .callback = callback };
+    fn set(cancel_token: ?ai_types.CancelToken, update_ctx: ?*anyopaque, update_callback: ?agent_types.ToolUpdateCallback) void {
+        current = .{ .cancel_token = cancel_token, .update_ctx = update_ctx, .update_callback = update_callback };
     }
 
     fn clear() void {
         current = .{};
     }
 
-    fn consume() ExecutionUpdateContext {
+    fn consume() ExecutionContext {
         const value = current;
         current = .{};
         return value;
@@ -90,7 +91,7 @@ pub const ToolProtocolServer = struct {
         const self: *ToolProtocolServer = @ptrCast(@alignCast(ctx.?));
         switch (env.payload) {
             .tool_execute => |req| {
-                const update_ctx = ExecutionUpdateContext.consume();
+                const execution_ctx = ExecutionContext.consume();
                 const tool = self.resolve(req.tool_name) orelse {
                     return self.nextEnvelope(env.message_id, .{ .tool_error = .{
                         .execution_id = req.execution_id,
@@ -100,7 +101,7 @@ pub const ToolProtocolServer = struct {
                 };
 
                 const start_ms = compat.time.nowMillis();
-                var result = tool.execute(req.tool_call_id, req.args_json, null, update_ctx.ctx, update_ctx.callback, allocator) catch |err| {
+                var result = executeAgentTool(tool, req.tool_call_id, req.args_json, execution_ctx.cancel_token, execution_ctx.update_ctx, execution_ctx.update_callback, allocator) catch |err| {
                     return self.nextEnvelope(env.message_id, .{ .tool_error = .{
                         .execution_id = req.execution_id,
                         .code = .tool_execution_error,
@@ -281,6 +282,7 @@ pub const LocalToolProtocol = struct {
         if (override_fn) |exec| return exec(override_ctx, tool_call_id, tool_name, args_json, cancel_token, on_update_ctx, on_update, allocator);
         const execution_id = tool_types.generateUlid();
         self.client.sequence += 1;
+        self.pipe.compact();
         var env = tool_types.Envelope{
             .server_id = self.client.server_id,
             .message_id = tool_types.generateUlid(),
@@ -301,8 +303,8 @@ pub const LocalToolProtocol = struct {
         var sender = self.pipe.clientSender();
         try sender.write(json);
         try sender.flush();
-        ExecutionUpdateContext.set(on_update_ctx, on_update);
-        defer ExecutionUpdateContext.clear();
+        ExecutionContext.set(cancel_token, on_update_ctx, on_update);
+        defer ExecutionContext.clear();
         try self.pumpClientMessages();
 
         var recv = self.pipe.clientReceiver();
@@ -352,6 +354,11 @@ pub const LocalToolProtocol = struct {
         }
     }
 };
+
+fn executeAgentTool(tool: agent_types.AgentTool, tool_call_id: []const u8, args_json: []const u8, cancel_token: ?ai_types.CancelToken, on_update_ctx: ?*anyopaque, on_update: ?agent_types.ToolUpdateCallback, allocator: std.mem.Allocator) anyerror!agent_types.AgentToolResult {
+    if (tool.runtime_execute) |execute_fn| return execute_fn(tool.runtime_ctx, tool_call_id, args_json, cancel_token, on_update_ctx, on_update, allocator);
+    return tool.execute(tool_call_id, args_json, cancel_token, on_update_ctx, on_update, allocator);
+}
 
 fn serializeUserContentParts(allocator: std.mem.Allocator, parts: []const ai_types.UserContentPart) ![]u8 {
     var buffer = std.ArrayList(u8).empty;
@@ -626,16 +633,21 @@ test "in-process tool protocol round-trip stays near direct call" {
     var local = try LocalToolProtocol.init(allocator, &.{tool});
     defer local.deinit();
 
+    const iterations = 10;
     const direct_start = compat.time.nowMillis();
-    var direct = try callbacks.execute("call", "{}", null, null, null, allocator);
-    direct.deinit(allocator);
+    for (0..iterations) |_| {
+        var direct = try callbacks.execute("call", "{}", null, null, null, allocator);
+        direct.deinit(allocator);
+    }
     const direct_ms = compat.time.nowMillis() - direct_start;
 
     const proto_start = compat.time.nowMillis();
-    var proto = try local.execute("call", "bench", "{}", null, null, null, allocator);
-    proto.deinit(allocator);
+    for (0..iterations) |_| {
+        var proto = try local.execute("call", "bench", "{}", null, null, null, allocator);
+        proto.deinit(allocator);
+    }
     const proto_ms = compat.time.nowMillis() - proto_start;
 
     _ = direct_ms;
-    try std.testing.expect(proto_ms <= 1);
+    try std.testing.expect(proto_ms <= 100);
 }

--- a/zig/src/protocol/tool/local_runtime.zig
+++ b/zig/src/protocol/tool/local_runtime.zig
@@ -11,6 +11,9 @@ const OwnedSlice = @import("owned_slice").OwnedSlice;
 const PipeTransport = in_process.SerializedPipe;
 
 const ExecutionContext = struct {
+    // Single in-process dispatch context for synchronous LocalToolProtocol pump.
+    // Recursive LocalToolProtocol.execute calls on same thread would clobber this
+    // state; do not add nested dispatch without replacing this bridge.
     threadlocal var current: ExecutionContext = .{};
 
     cancel_token: ?ai_types.CancelToken = null,
@@ -156,74 +159,33 @@ pub const ToolProtocolServer = struct {
 };
 
 pub const ToolProtocolClient = struct {
-    pipe: *PipeTransport,
     server_id: tool_types.Ulid,
     sequence: u64 = 0,
 
-    pub fn init(pipe: *PipeTransport) ToolProtocolClient {
-        return .{ .pipe = pipe, .server_id = tool_types.generateUlid() };
+    pub fn init() ToolProtocolClient {
+        return .{ .server_id = tool_types.generateUlid() };
     }
 
-    pub fn execute(
+    pub fn nextExecuteEnvelope(
         self: *ToolProtocolClient,
         tool_call_id: []const u8,
         tool_name: []const u8,
         args_json: []const u8,
         allocator: std.mem.Allocator,
-    ) !agent_types.AgentToolResult {
-        const execution_id = tool_types.generateUlid();
+    ) !tool_types.Envelope {
         self.sequence += 1;
-        var env = tool_types.Envelope{
+        return .{
             .server_id = self.server_id,
             .message_id = tool_types.generateUlid(),
             .sequence = self.sequence,
             .timestamp = compat.time.nowMillis(),
             .payload = .{ .tool_execute = .{
-                .execution_id = execution_id,
+                .execution_id = tool_types.generateUlid(),
                 .tool_call_id = try allocator.dupe(u8, tool_call_id),
                 .tool_name = try allocator.dupe(u8, tool_name),
                 .args_json = try allocator.dupe(u8, args_json),
             } },
         };
-        defer env.deinit(allocator);
-
-        const json = try tool_envelope.serializeEnvelope(env, allocator);
-        defer allocator.free(json);
-
-        var sender = self.pipe.clientSender();
-        try sender.write(json);
-        try sender.flush();
-
-        var recv = self.pipe.clientReceiver();
-        while (try recv.readLine(allocator)) |line| {
-            defer allocator.free(line);
-            var response = try tool_envelope.deserializeEnvelope(line, allocator);
-            defer response.deinit(allocator);
-            switch (response.payload) {
-                .tool_result => |res| return try agentToolResultFromProtocol(allocator, res),
-                .tool_error => |err| return toolErrorToError(err.code),
-                else => {},
-            }
-        }
-
-        return error.ToolProtocolNoResponse;
-    }
-
-    pub fn executeFn(
-        ctx: ?*anyopaque,
-        tool_call_id: []const u8,
-        tool_name: []const u8,
-        args_json: []const u8,
-        cancel_token: ?ai_types.CancelToken,
-        on_update_ctx: ?*anyopaque,
-        on_update: ?agent_types.ToolUpdateCallback,
-        allocator: std.mem.Allocator,
-    ) anyerror!agent_types.AgentToolResult {
-        _ = cancel_token;
-        _ = on_update_ctx;
-        _ = on_update;
-        const self: *ToolProtocolClient = @ptrCast(@alignCast(ctx.?));
-        return self.execute(tool_call_id, tool_name, args_json, allocator);
     }
 };
 
@@ -239,7 +201,7 @@ pub const LocalToolProtocol = struct {
         var server = ToolProtocolServer.init(allocator);
         errdefer server.deinit();
         try server.registerTools(tools);
-        const client = ToolProtocolClient.init(&pipe);
+        const client = ToolProtocolClient.init();
         return .{
             .allocator = allocator,
             .pipe = pipe,
@@ -280,21 +242,8 @@ pub const LocalToolProtocol = struct {
         allocator: std.mem.Allocator,
     ) !agent_types.AgentToolResult {
         if (override_fn) |exec| return exec(override_ctx, tool_call_id, tool_name, args_json, cancel_token, on_update_ctx, on_update, allocator);
-        const execution_id = tool_types.generateUlid();
-        self.client.sequence += 1;
         self.pipe.compact();
-        var env = tool_types.Envelope{
-            .server_id = self.client.server_id,
-            .message_id = tool_types.generateUlid(),
-            .sequence = self.client.sequence,
-            .timestamp = compat.time.nowMillis(),
-            .payload = .{ .tool_execute = .{
-                .execution_id = execution_id,
-                .tool_call_id = try allocator.dupe(u8, tool_call_id),
-                .tool_name = try allocator.dupe(u8, tool_name),
-                .args_json = try allocator.dupe(u8, args_json),
-            } },
-        };
+        var env = try self.client.nextExecuteEnvelope(tool_call_id, tool_name, args_json, allocator);
         defer env.deinit(allocator);
 
         const json = try tool_envelope.serializeEnvelope(env, allocator);

--- a/zig/src/tools/mcp_bridge.zig
+++ b/zig/src/tools/mcp_bridge.zig
@@ -57,8 +57,8 @@ pub const McpToolDefinition = struct {
             .short_description = short_description,
             .parameters_schema_json = schema,
             .execute = unavailableExecute,
-            .execute_ctx = ctx,
-            .execute_with_context = executeWithContext,
+            .runtime_ctx = ctx,
+            .runtime_execute = executeWithContext,
             .approval_ctx = if (self.is_destructive) ctx else null,
             .approval_fn = null,
         };
@@ -345,7 +345,7 @@ pub const McpBridge = struct {
             const ctx_mcp_name = try self.allocator.dupe(u8, mcp_name);
             errdefer self.allocator.free(ctx_mcp_name);
             exec_ctx.* = .{ .bridge = &self.self_ref, .server_index = server_index, .mcp_name = ctx_mcp_name };
-            tool.execute_ctx = exec_ctx;
+            tool.runtime_ctx = exec_ctx;
             try self.tools.append(self.allocator, .{
                 .server_index = server_index,
                 .mcp_name = try self.allocator.dupe(u8, mcp_name),
@@ -589,7 +589,7 @@ test "MCP invocation forwards text result" {
     errdefer deinitAgentToolFields(std.testing.allocator, &tool);
     const exec_ctx = try std.testing.allocator.create(McpToolExecContext);
     exec_ctx.* = .{ .bridge = &bridge.self_ref, .server_index = 0, .mcp_name = try std.testing.allocator.dupe(u8, "echo") };
-    tool.execute_ctx = exec_ctx;
+    tool.runtime_ctx = exec_ctx;
     try bridge.tools.append(std.testing.allocator, .{
         .server_index = 0,
         .mcp_name = try std.testing.allocator.dupe(u8, "echo"),
@@ -598,7 +598,7 @@ test "MCP invocation forwards text result" {
         .is_destructive = false,
     });
 
-    var result = try tool.execute_with_context.?(tool.execute_ctx, "call_1", "{}", null, null, null, std.testing.allocator);
+    var result = try tool.runtime_execute.?(tool.runtime_ctx, "call_1", "{}", null, null, null, std.testing.allocator);
     defer result.deinit(std.testing.allocator);
     try std.testing.expectEqualStrings("hello from mcp", result.content.slice()[0].text.text);
 }
@@ -661,7 +661,7 @@ test "MCP JSON-RPC and result errors fail execution" {
     );
     defer rpc_error.deinit();
     bridge.servers.items[0].mock_response = rpc_error.value;
-    try std.testing.expectError(error.McpToolError, tool.execute_with_context.?(tool.execute_ctx, "call_1", "{}", null, null, null, std.testing.allocator));
+    try std.testing.expectError(error.McpToolError, tool.runtime_execute.?(tool.runtime_ctx, "call_1", "{}", null, null, null, std.testing.allocator));
 
     var result_error = try std.json.parseFromSlice(
         std.json.Value,
@@ -671,7 +671,7 @@ test "MCP JSON-RPC and result errors fail execution" {
     );
     defer result_error.deinit();
     bridge.servers.items[0].mock_response = result_error.value;
-    try std.testing.expectError(error.McpToolError, tool.execute_with_context.?(tool.execute_ctx, "call_2", "{}", null, null, null, std.testing.allocator));
+    try std.testing.expectError(error.McpToolError, tool.runtime_execute.?(tool.runtime_ctx, "call_2", "{}", null, null, null, std.testing.allocator));
 }
 
 fn makeTestTool(bridge: *McpBridge, name: []const u8) !agent.AgentTool {
@@ -869,7 +869,7 @@ test "MCP execution honors cancellation while waiting" {
     const tool = try makeTestTool(&bridge, "echo");
     var cancelled = std.atomic.Value(bool).init(true);
     const token = ai_types.CancelToken{ .cancelled = &cancelled };
-    try std.testing.expectError(error.Cancelled, tool.execute_with_context.?(tool.execute_ctx, "call_1", "{}", token, null, null, std.testing.allocator));
+    try std.testing.expectError(error.Cancelled, tool.runtime_execute.?(tool.runtime_ctx, "call_1", "{}", token, null, null, std.testing.allocator));
 }
 
 
@@ -930,7 +930,7 @@ test "MCP tools/call arguments are compacted to one JSON-RPC line" {
     defer response.deinit();
     bridge.servers.items[0].mock_response = response.value;
     const tool = try makeTestTool(&bridge, "echo");
-    var result = try tool.execute_with_context.?(tool.execute_ctx, "call_1", "{\n  \"value\": 1\n}", null, null, null, std.testing.allocator);
+    var result = try tool.runtime_execute.?(tool.runtime_ctx, "call_1", "{\n  \"value\": 1\n}", null, null, null, std.testing.allocator);
     defer result.deinit(std.testing.allocator);
     try std.testing.expectEqualStrings("ok", result.content.slice()[0].text.text);
 }

--- a/zig/src/tools/registry.zig
+++ b/zig/src/tools/registry.zig
@@ -56,9 +56,6 @@ pub const ToolRegistry = struct {
         return self.tools.items;
     }
 
-    pub fn registerWithProtocolServer(self: *const ToolRegistry, server: anytype) !void {
-        try server.registerTools(self.tools.items);
-    }
 };
 
 pub fn defaultTools() []const agent.AgentTool {

--- a/zig/src/tools/registry.zig
+++ b/zig/src/tools/registry.zig
@@ -55,6 +55,10 @@ pub const ToolRegistry = struct {
     pub fn list(self: *const ToolRegistry) []const agent.AgentTool {
         return self.tools.items;
     }
+
+    pub fn registerWithProtocolServer(self: *const ToolRegistry, server: anytype) !void {
+        try server.registerTools(self.tools.items);
+    }
 };
 
 pub fn defaultTools() []const agent.AgentTool {

--- a/zig/src/transports/in_process.zig
+++ b/zig/src/transports/in_process.zig
@@ -302,6 +302,24 @@ pub const SerializedPipe = struct {
         self.* = undefined;
     }
 
+    pub fn compact(self: *SerializedPipe) void {
+        compactBuffer(&self.to_client, &self.to_client_read_pos);
+        compactBuffer(&self.to_server, &self.to_server_read_pos);
+    }
+
+    fn compactBuffer(buffer: *std.ArrayList(u8), read_pos: *usize) void {
+        if (read_pos.* == 0) return;
+        if (read_pos.* >= buffer.items.len) {
+            buffer.clearRetainingCapacity();
+            read_pos.* = 0;
+            return;
+        }
+        const remaining = buffer.items[read_pos.*..];
+        std.mem.copyForwards(u8, buffer.items[0..remaining.len], remaining);
+        buffer.shrinkRetainingCapacity(remaining.len);
+        read_pos.* = 0;
+    }
+
     /// Server writes to this to send to client
     pub fn serverSender(self: *SerializedPipe) transport_mod.AsyncSender {
         return .{

--- a/zig/src/tui/runtime.zig
+++ b/zig/src/tui/runtime.zig
@@ -234,8 +234,7 @@ pub const TuiRuntime = struct {
             }
         }
 
-        var tool_protocol = try tool_local_runtime.LocalToolProtocol.init(allocator, original_tools);
-        errdefer tool_protocol.deinit();
+        const tool_protocol = try tool_local_runtime.LocalToolProtocol.init(allocator, original_tools);
 
         var runtime = TuiRuntime{
             .allocator = allocator,

--- a/zig/src/tui/runtime.zig
+++ b/zig/src/tui/runtime.zig
@@ -3,6 +3,7 @@ const compat = @import("compat");
 const ai_types = @import("ai_types");
 const event_stream = @import("event_stream");
 const agent = @import("agent");
+const agent_types = @import("agent_types");
 const agent_protocol_client = @import("agent_protocol_client");
 const agent_envelope = @import("agent_envelope");
 const agent_protocol_types = @import("agent_protocol_types");
@@ -15,6 +16,7 @@ const json_writer = @import("json_writer");
 const model_ref = @import("model_ref");
 const session = @import("tui_session");
 const local_tools = @import("tools/registry");
+const tool_local_runtime = @import("tool_local_runtime");
 const permission = @import("permission");
 const OwnedSlice = @import("owned_slice").OwnedSlice;
 
@@ -135,6 +137,9 @@ pub const TuiRuntime = struct {
     original_tools: []agent.AgentTool,
     wrapped_tools: []agent.AgentTool,
     approval_contexts: []ApprovalContext,
+    tool_protocol: tool_local_runtime.LocalToolProtocol,
+    tool_protocol_override_fn: ?agent_types.ToolProtocolExecuteFn = null,
+    tool_protocol_override_ctx: ?*anyopaque = null,
     pending_approval: ApprovalDecisionState = .{},
     approval_mutex: std.atomic.Mutex = .unlocked,
     tool_approval_ctx: ?*anyopaque,
@@ -229,6 +234,9 @@ pub const TuiRuntime = struct {
             }
         }
 
+        var tool_protocol = try tool_local_runtime.LocalToolProtocol.init(allocator, original_tools);
+        errdefer tool_protocol.deinit();
+
         var runtime = TuiRuntime{
             .allocator = allocator,
             .backend = resolved_backend,
@@ -247,6 +255,7 @@ pub const TuiRuntime = struct {
             .original_tools = original_tools,
             .wrapped_tools = wrapped_tools,
             .approval_contexts = approval_contexts,
+            .tool_protocol = tool_protocol,
             .tool_approval_ctx = options.tool_approval_ctx,
             .tool_approval_callback = options.tool_approval_callback,
             .permission_engine = options.permission_engine,
@@ -300,6 +309,7 @@ pub const TuiRuntime = struct {
         if (self.remote_config_receiver) |receiver| self.allocator.destroy(receiver);
         if (self.remote_config_sender) |sender| self.allocator.destroy(sender);
         self.clearPendingApproval();
+        self.tool_protocol.deinit();
         self.allocator.free(self.approval_contexts);
         self.allocator.free(self.wrapped_tools);
         self.allocator.free(self.original_tools);
@@ -350,10 +360,18 @@ pub const TuiRuntime = struct {
                 if (self.started) return;
                 const protocol = self.protocol orelse return error.NoProtocolConfigured;
                 self.rebuildWrappedTools();
-                self.local_agent = agent.Agent.init(self.allocator, .{ .protocol = protocol, .compact_tool_output = self.compact_output, .permission_engine = self.permission_engine });
+                self.local_agent = agent.Agent.init(self.allocator, .{
+                    .protocol = protocol,
+                    .compact_tool_output = self.compact_output,
+                    .permission_engine = self.permission_engine,
+                    .execute_tool_via_protocol_fn = executeTuiToolProtocol,
+                    .execute_tool_via_protocol_ctx = self,
+                });
                 self.local_agent.?.subscribeWithContext(self, onAgentEvent);
                 self.local_agent.?.setCompactToolOutput(self.compact_output);
                 if (self.selected_model_index) |idx| self.local_agent.?.setModel(self.models[idx]);
+                self.tool_protocol.server.tools.clearRetainingCapacity();
+                try self.tool_protocol.server.registerTools(self.wrapped_tools);
                 self.local_agent.?.setTools(self.wrapped_tools);
                 self.started = true;
             },
@@ -1624,6 +1642,30 @@ fn notifyToolApproval(ctx: ?*anyopaque, request: agent.ToolApprovalRequest, allo
         .tool_name = runtime.dupeOwned(request.tool_name) catch OwnedSlice(u8).initBorrowed(""),
         .args_json = runtime.dupeOwned(request.args_json) catch OwnedSlice(u8).initBorrowed(""),
     } });
+}
+
+fn executeTuiToolProtocol(
+    ctx: ?*anyopaque,
+    tool_call_id: []const u8,
+    tool_name: []const u8,
+    args_json: []const u8,
+    cancel_token: ?ai_types.CancelToken,
+    on_update_ctx: ?*anyopaque,
+    on_update: ?agent.ToolUpdateCallback,
+    allocator: std.mem.Allocator,
+) anyerror!agent.AgentToolResult {
+    const runtime: *TuiRuntime = @ptrCast(@alignCast(ctx.?));
+    return runtime.tool_protocol.executeWithOverride(
+        tool_call_id,
+        tool_name,
+        args_json,
+        cancel_token,
+        on_update_ctx,
+        on_update,
+        runtime.tool_protocol_override_ctx,
+        runtime.tool_protocol_override_fn,
+        allocator,
+    );
 }
 
 fn approveTool(ctx: ?*anyopaque, request: agent.ToolApprovalRequest) agent.ToolApprovalDecision {

--- a/zig/src/tui/runtime.zig
+++ b/zig/src/tui/runtime.zig
@@ -657,8 +657,8 @@ pub const TuiRuntime = struct {
                 .short_description = tool.short_description,
                 .parameters_schema_json = tool.parameters_schema_json,
                 .execute = tool.execute,
-                .execute_ctx = tool.execute_ctx,
-                .execute_with_context = tool.execute_with_context,
+                .runtime_ctx = tool.runtime_ctx,
+                .runtime_execute = tool.runtime_execute,
                 .approval_ctx = &self.approval_contexts[i],
                 .approval_fn = approveTool,
                 .approval_ui_ctx = &self.approval_contexts[i],
@@ -2063,8 +2063,8 @@ test "runtime wrapper preserves context-aware tool execution" {
         .description = "Context tool",
         .parameters_schema_json = "{}",
         .execute = demoTool,
-        .execute_ctx = &context,
-        .execute_with_context = contextOnlyTool,
+        .runtime_ctx = &context,
+        .runtime_execute = contextOnlyTool,
     }};
     const models = [_]ai_types.Model{test_model_a};
     var mock = MockProtocolCtx{ .tool_first = true, .tool_name = "context_tool" };

--- a/zig/test/e2e/distributed_fullstack.zig
+++ b/zig/test/e2e/distributed_fullstack.zig
@@ -16,6 +16,7 @@ const agent_bridge = @import("agent_bridge");
 const tool_types = @import("tool_types");
 const tool_envelope = @import("tool_envelope");
 const tool_runtime = @import("tool_runtime");
+const tool_local_runtime = @import("tool_local_runtime");
 const in_process = @import("transports/in_process");
 
 const InProcessProviderProtocolBridge = agent_bridge.InProcessProviderProtocolBridge;
@@ -291,10 +292,15 @@ test "distributed fullstack: agent loop via provider protocol and tool protocol"
         },
     };
 
+    var local_tools = try tool_local_runtime.LocalToolProtocol.init(allocator, &tools);
+    defer local_tools.deinit();
+
     const stream = try agent_loop.agentLoop(allocator, &.{prompt}, &context, .{
         .model = model,
         .protocol = bridge.protocolClient(),
         .tools = &tools,
+        .execute_tool_via_protocol_fn = tool_local_runtime.LocalToolProtocol.executeFn,
+        .execute_tool_via_protocol_ctx = &local_tools,
         .max_iterations = 4,
         .transform_context_fn = filterContextForProtocol,
         // M-006: provide an explicit api_key so the binary's credential


### PR DESCRIPTION
## Summary
- Add a local tool protocol runtime with in-process client/server execution and result serialization.
- Route Agent and TUI tool execution through the single protocol dispatch path.
- Remove agent loop fallback to direct `AgentTool.execute` and keep approval/output middleware before dispatch.

## Test plan
- [x] `zig build -Doptimize=Debug --build-file zig/build.zig test-unit-protocol`
- [x] `zig build -Doptimize=Debug --build-file zig/build.zig test-unit-agent`
- [x] `zig build -Doptimize=Debug --build-file zig/build.zig test`