### PR TITLE
Harden TUI transcript finalization

### DIFF
--- a/zig/src/tui/state.zig
+++ b/zig/src/tui/state.zig
@@ -254,6 +254,8 @@ pub const AppState = struct {
     transcript_scroll: usize = 0,
     tool_scroll: usize = 0,
     session_index: usize = 0,
+    active_assistant_entry: ?usize = null,
+    active_tool_result_entry: ?usize = null,
 
     pub fn init(allocator: std.mem.Allocator) AppState {
         return .{ .allocator = allocator };
@@ -312,17 +314,17 @@ pub const AppState = struct {
                 self.status.turn_count += 1;
             },
             .message_start => |payload| switch (payload.role) {
-                .assistant => try self.ensureTrailingEntry(.assistant),
-                .user => try self.ensureTrailingEntry(.user),
-                .tool_result => try self.ensureTrailingEntry(.tool),
+                .assistant => self.active_assistant_entry = try self.ensureTrailingEntry(.assistant),
+                .user => _ = try self.ensureTrailingEntry(.user),
+                .tool_result => self.active_tool_result_entry = try self.appendEmptyTranscript(.tool),
             },
             .text_delta => |payload| try self.appendDelta(.assistant, payload.delta.slice()),
             .thinking_delta => |payload| try self.appendDelta(.thinking, payload.delta.slice()),
             .tool_call_delta => |payload| try self.appendDelta(.tool, payload.delta.slice()),
             .message_end => |payload| switch (payload.role) {
-                .assistant => try self.finishTranscriptEntry(.assistant, payload.text.slice()),
-                .user => try self.finishTranscriptEntry(.user, payload.text.slice()),
-                .tool_result => try self.finishTranscriptEntry(.tool, payload.text.slice()),
+                .assistant => try self.finishTranscriptEntry(.assistant, payload.text.slice(), &self.active_assistant_entry),
+                .user => try self.finishTranscriptEntry(.user, payload.text.slice(), null),
+                .tool_result => try self.finishTranscriptEntry(.tool, payload.text.slice(), &self.active_tool_result_entry),
             },
             .tool_approval_requested => |payload| {
                 try self.approval.setPending(self.allocator, payload.tool_call_id.slice(), payload.tool_name.slice(), payload.args_json.slice());
@@ -426,26 +428,54 @@ pub const AppState = struct {
         try self.preview.set(self.allocator, .diff, path, out.items);
     }
 
-    fn ensureTrailingEntry(self: *AppState, kind: TranscriptKind) !void {
-        if (self.transcript.items.len > 0 and self.transcript.items[self.transcript.items.len - 1].kind == kind) return;
+    fn ensureTrailingEntry(self: *AppState, kind: TranscriptKind) !usize {
+        if (self.transcript.items.len == 0 or self.transcript.items[self.transcript.items.len - 1].kind != kind) {
+            return try self.appendEmptyTranscript(kind);
+        }
+        return self.transcript.items.len - 1;
+    }
+
+    fn appendEmptyTranscript(self: *AppState, kind: TranscriptKind) !usize {
         try self.appendTranscript(kind, "");
+        return self.transcript.items.len - 1;
     }
 
     fn appendDelta(self: *AppState, kind: TranscriptKind, delta: []const u8) !void {
-        try self.ensureTrailingEntry(kind);
-        try self.transcript.items[self.transcript.items.len - 1].text.appendSlice(self.allocator, delta);
+        const index = try self.ensureTrailingEntry(kind);
+        switch (kind) {
+            .assistant => self.active_assistant_entry = index,
+            .tool => self.active_tool_result_entry = index,
+            else => {},
+        }
+        try self.transcript.items[index].text.appendSlice(self.allocator, delta);
     }
 
-    fn finishTranscriptEntry(self: *AppState, kind: TranscriptKind, text: []const u8) !void {
-        if (text.len == 0) return;
-        if (self.transcript.items.len > 0 and self.transcript.items[self.transcript.items.len - 1].kind == kind) {
-            const entry = &self.transcript.items[self.transcript.items.len - 1];
-            if (std.mem.eql(u8, entry.text.items, text)) return;
-            entry.text.clearRetainingCapacity();
-            try entry.text.appendSlice(self.allocator, text);
+    fn finishTranscriptEntry(self: *AppState, kind: TranscriptKind, text: []const u8, active_entry: ?*?usize) !void {
+        if (text.len == 0) {
+            if (active_entry) |entry| entry.* = null;
             return;
         }
+
+        if (active_entry) |entry| {
+            if (entry.*) |index| {
+                if (index < self.transcript.items.len and self.transcript.items[index].kind == kind) {
+                    try self.replaceEntryText(index, text);
+                    entry.* = null;
+                    return;
+                }
+            }
+            entry.* = null;
+        }
+
+        if (self.transcript.items.len > 0 and self.transcript.items[self.transcript.items.len - 1].kind == kind and std.mem.eql(u8, self.transcript.items[self.transcript.items.len - 1].text.items, text)) return;
         try self.appendTranscript(kind, text);
+    }
+
+    fn replaceEntryText(self: *AppState, index: usize, text: []const u8) !void {
+        const entry = &self.transcript.items[index];
+        if (std.mem.eql(u8, entry.text.items, text)) return;
+        entry.text.clearRetainingCapacity();
+        try entry.text.appendSlice(self.allocator, text);
     }
 
     fn applyContextUsage(self: *AppState, payload: anytype) void {
@@ -640,6 +670,67 @@ test "AppState message_end user text avoids duplicate submitted message" {
     try std.testing.expectEqual(@as(usize, 1), state.transcript.items.len);
     try std.testing.expectEqual(TranscriptKind.user, state.transcript.items[0].kind);
     try std.testing.expectEqualStrings("hello", state.transcript.items[0].text.items);
+}
+
+test "AppState message_end updates active assistant before trailing tool" {
+    var state = AppState.init(std.testing.allocator);
+    defer state.deinit();
+
+    try state.applyEvent(.{ .message_start = .{ .role = .assistant } });
+    var text_delta = tui_runtime.TuiEvent{ .text_delta = .{ .content_index = 0, .delta = try ownedText("partial") } };
+    defer text_delta.deinit(std.testing.allocator);
+    try state.applyEvent(text_delta);
+
+    var tool_delta = tui_runtime.TuiEvent{ .tool_call_delta = .{ .content_index = 1, .delta = try ownedText("{\"name\":\"shell\"}") } };
+    defer tool_delta.deinit(std.testing.allocator);
+    try state.applyEvent(tool_delta);
+
+    var assistant_end = tui_runtime.TuiEvent{ .message_end = .{ .role = .assistant, .text = try ownedText("final assistant") } };
+    defer assistant_end.deinit(std.testing.allocator);
+    try state.applyEvent(assistant_end);
+
+    try std.testing.expectEqual(@as(usize, 2), state.transcript.items.len);
+    try std.testing.expectEqual(TranscriptKind.assistant, state.transcript.items[0].kind);
+    try std.testing.expectEqualStrings("final assistant", state.transcript.items[0].text.items);
+    try std.testing.expectEqual(TranscriptKind.tool, state.transcript.items[1].kind);
+    try std.testing.expect(std.mem.indexOf(u8, state.transcript.items[1].text.items, "shell") != null);
+}
+
+test "AppState message_end-only assistant appends after prior assistant" {
+    var state = AppState.init(std.testing.allocator);
+    defer state.deinit();
+
+    try state.appendTranscript(.assistant, "previous response");
+    var assistant_end = tui_runtime.TuiEvent{ .message_end = .{ .role = .assistant, .text = try ownedText("next response") } };
+    defer assistant_end.deinit(std.testing.allocator);
+    try state.applyEvent(assistant_end);
+
+    try std.testing.expectEqual(@as(usize, 2), state.transcript.items.len);
+    try std.testing.expectEqualStrings("previous response", state.transcript.items[0].text.items);
+    try std.testing.expectEqualStrings("next response", state.transcript.items[1].text.items);
+}
+
+test "AppState tool_result message_end updates active tool entry only" {
+    var state = AppState.init(std.testing.allocator);
+    defer state.deinit();
+
+    try state.appendTranscript(.tool, "shell_execute");
+    try state.applyEvent(.{ .message_start = .{ .role = .tool_result } });
+    var tool_result_a = tui_runtime.TuiEvent{ .message_end = .{ .role = .tool_result, .text = try ownedText("first result") } };
+    defer tool_result_a.deinit(std.testing.allocator);
+    try state.applyEvent(tool_result_a);
+
+    try state.appendTranscript(.tool, "file_read");
+    try state.applyEvent(.{ .message_start = .{ .role = .tool_result } });
+    var tool_result_b = tui_runtime.TuiEvent{ .message_end = .{ .role = .tool_result, .text = try ownedText("second result") } };
+    defer tool_result_b.deinit(std.testing.allocator);
+    try state.applyEvent(tool_result_b);
+
+    try std.testing.expectEqual(@as(usize, 4), state.transcript.items.len);
+    try std.testing.expectEqualStrings("shell_execute", state.transcript.items[0].text.items);
+    try std.testing.expectEqualStrings("first result", state.transcript.items[1].text.items);
+    try std.testing.expectEqualStrings("file_read", state.transcript.items[2].text.items);
+    try std.testing.expectEqualStrings("second result", state.transcript.items[3].text.items);
 }
 
 test "AppState approval flow transitions pending to approved and rejected" {

--- a/zig/src/tui/state.zig
+++ b/zig/src/tui/state.zig
@@ -312,9 +312,10 @@ pub const AppState = struct {
             .turn_start => {
                 self.status.streaming = true;
                 self.status.turn_count += 1;
+                self.clearActiveTranscriptEntries();
             },
             .message_start => |payload| switch (payload.role) {
-                .assistant => self.active_assistant_entry = try self.ensureTrailingEntry(.assistant),
+                .assistant => self.active_assistant_entry = try self.appendEmptyTranscript(.assistant),
                 .user => _ = try self.ensureTrailingEntry(.user),
                 .tool_result => self.active_tool_result_entry = try self.appendEmptyTranscript(.tool),
             },
@@ -323,7 +324,7 @@ pub const AppState = struct {
             .tool_call_delta => |payload| try self.appendDelta(.tool, payload.delta.slice()),
             .message_end => |payload| switch (payload.role) {
                 .assistant => try self.finishTranscriptEntry(.assistant, payload.text.slice(), &self.active_assistant_entry),
-                .user => try self.finishTranscriptEntry(.user, payload.text.slice(), null),
+                .user => try self.finishTranscriptEntryWithOptions(.user, payload.text.slice(), null, true),
                 .tool_result => try self.finishTranscriptEntry(.tool, payload.text.slice(), &self.active_tool_result_entry),
             },
             .tool_approval_requested => |payload| {
@@ -352,9 +353,13 @@ pub const AppState = struct {
             },
             .context_usage => |payload| self.applyContextUsage(payload),
             .prompt_segment_usage => |payload| self.applyPromptSegmentUsage(payload),
-            .turn_end => self.status.streaming = false,
+            .turn_end => {
+                self.status.streaming = false;
+                self.clearActiveTranscriptEntries();
+            },
             .agent_end => |payload| {
                 self.status.streaming = false;
+                self.clearActiveTranscriptEntries();
                 switch (payload.reason) {
                     .completed => {},
                     .cancelled => try self.appendTranscript(.system, "agent cancelled"),
@@ -362,6 +367,7 @@ pub const AppState = struct {
                 }
             },
             .@"error" => |payload| {
+                self.clearActiveTranscriptEntries();
                 try self.status.setError(self.allocator, payload.message.slice());
                 try self.appendTranscript(.@"error", payload.message.slice());
             },
@@ -451,6 +457,10 @@ pub const AppState = struct {
     }
 
     fn finishTranscriptEntry(self: *AppState, kind: TranscriptKind, text: []const u8, active_entry: ?*?usize) !void {
+        return self.finishTranscriptEntryWithOptions(kind, text, active_entry, false);
+    }
+
+    fn finishTranscriptEntryWithOptions(self: *AppState, kind: TranscriptKind, text: []const u8, active_entry: ?*?usize, dedupe_trailing: bool) !void {
         if (text.len == 0) {
             if (active_entry) |entry| entry.* = null;
             return;
@@ -467,8 +477,13 @@ pub const AppState = struct {
             entry.* = null;
         }
 
-        if (self.transcript.items.len > 0 and self.transcript.items[self.transcript.items.len - 1].kind == kind and std.mem.eql(u8, self.transcript.items[self.transcript.items.len - 1].text.items, text)) return;
+        if (dedupe_trailing and self.transcript.items.len > 0 and self.transcript.items[self.transcript.items.len - 1].kind == kind and std.mem.eql(u8, self.transcript.items[self.transcript.items.len - 1].text.items, text)) return;
         try self.appendTranscript(kind, text);
+    }
+
+    fn clearActiveTranscriptEntries(self: *AppState) void {
+        self.active_assistant_entry = null;
+        self.active_tool_result_entry = null;
     }
 
     fn replaceEntryText(self: *AppState, index: usize, text: []const u8) !void {
@@ -707,6 +722,56 @@ test "AppState message_end-only assistant appends after prior assistant" {
 
     try std.testing.expectEqual(@as(usize, 2), state.transcript.items.len);
     try std.testing.expectEqualStrings("previous response", state.transcript.items[0].text.items);
+    try std.testing.expectEqualStrings("next response", state.transcript.items[1].text.items);
+}
+
+test "AppState message_start opens fresh assistant row after prior assistant" {
+    var state = AppState.init(std.testing.allocator);
+    defer state.deinit();
+
+    try state.appendTranscript(.assistant, "previous response");
+    try state.applyEvent(.{ .message_start = .{ .role = .assistant } });
+    var assistant_end = tui_runtime.TuiEvent{ .message_end = .{ .role = .assistant, .text = try ownedText("next response") } };
+    defer assistant_end.deinit(std.testing.allocator);
+    try state.applyEvent(assistant_end);
+
+    try std.testing.expectEqual(@as(usize, 2), state.transcript.items.len);
+    try std.testing.expectEqualStrings("previous response", state.transcript.items[0].text.items);
+    try std.testing.expectEqualStrings("next response", state.transcript.items[1].text.items);
+}
+
+test "AppState keeps identical inline assistant message_end turns" {
+    var state = AppState.init(std.testing.allocator);
+    defer state.deinit();
+
+    var first_end = tui_runtime.TuiEvent{ .message_end = .{ .role = .assistant, .text = try ownedText("Done") } };
+    defer first_end.deinit(std.testing.allocator);
+    try state.applyEvent(first_end);
+    var second_end = tui_runtime.TuiEvent{ .message_end = .{ .role = .assistant, .text = try ownedText("Done") } };
+    defer second_end.deinit(std.testing.allocator);
+    try state.applyEvent(second_end);
+
+    try std.testing.expectEqual(@as(usize, 2), state.transcript.items.len);
+    try std.testing.expectEqualStrings("Done", state.transcript.items[0].text.items);
+    try std.testing.expectEqualStrings("Done", state.transcript.items[1].text.items);
+}
+
+test "AppState clears stale active assistant before next inline message_end" {
+    var state = AppState.init(std.testing.allocator);
+    defer state.deinit();
+
+    try state.applyEvent(.{ .message_start = .{ .role = .assistant } });
+    var partial = tui_runtime.TuiEvent{ .text_delta = .{ .content_index = 0, .delta = try ownedText("interrupted") } };
+    defer partial.deinit(std.testing.allocator);
+    try state.applyEvent(partial);
+    try state.applyEvent(.{ .agent_end = .{ .reason = .@"error" } });
+
+    var assistant_end = tui_runtime.TuiEvent{ .message_end = .{ .role = .assistant, .text = try ownedText("next response") } };
+    defer assistant_end.deinit(std.testing.allocator);
+    try state.applyEvent(assistant_end);
+
+    try std.testing.expectEqual(@as(usize, 2), state.transcript.items.len);
+    try std.testing.expectEqualStrings("interrupted", state.transcript.items[0].text.items);
     try std.testing.expectEqualStrings("next response", state.transcript.items[1].text.items);
 }
 

--- a/zig/src/tui/state.zig
+++ b/zig/src/tui/state.zig
@@ -319,7 +319,11 @@ pub const AppState = struct {
             .text_delta => |payload| try self.appendDelta(.assistant, payload.delta.slice()),
             .thinking_delta => |payload| try self.appendDelta(.thinking, payload.delta.slice()),
             .tool_call_delta => |payload| try self.appendDelta(.tool, payload.delta.slice()),
-            .message_end => {},
+            .message_end => |payload| switch (payload.role) {
+                .assistant => try self.finishTranscriptEntry(.assistant, payload.text.slice()),
+                .user => try self.finishTranscriptEntry(.user, payload.text.slice()),
+                .tool_result => try self.finishTranscriptEntry(.tool, payload.text.slice()),
+            },
             .tool_approval_requested => |payload| {
                 try self.approval.setPending(self.allocator, payload.tool_call_id.slice(), payload.tool_name.slice(), payload.args_json.slice());
                 if (std.mem.eql(u8, payload.tool_name.slice(), "hashline_edit")) try self.setHashlinePreview(payload.args_json.slice());
@@ -430,6 +434,18 @@ pub const AppState = struct {
     fn appendDelta(self: *AppState, kind: TranscriptKind, delta: []const u8) !void {
         try self.ensureTrailingEntry(kind);
         try self.transcript.items[self.transcript.items.len - 1].text.appendSlice(self.allocator, delta);
+    }
+
+    fn finishTranscriptEntry(self: *AppState, kind: TranscriptKind, text: []const u8) !void {
+        if (text.len == 0) return;
+        if (self.transcript.items.len > 0 and self.transcript.items[self.transcript.items.len - 1].kind == kind) {
+            const entry = &self.transcript.items[self.transcript.items.len - 1];
+            if (std.mem.eql(u8, entry.text.items, text)) return;
+            entry.text.clearRetainingCapacity();
+            try entry.text.appendSlice(self.allocator, text);
+            return;
+        }
+        try self.appendTranscript(kind, text);
     }
 
     fn applyContextUsage(self: *AppState, payload: anytype) void {
@@ -549,6 +565,14 @@ test "AppState applies transcript and tool events" {
     try std.testing.expectEqual(TranscriptKind.assistant, state.transcript.items[0].kind);
     try std.testing.expectEqualStrings("hello", state.transcript.items[0].text.items);
 
+    var final_text_event = tui_runtime.TuiEvent{ .message_end = .{ .role = .assistant, .text = try ownedText("hello world") } };
+    defer final_text_event.deinit(std.testing.allocator);
+    try state.applyEvent(final_text_event);
+
+    try std.testing.expectEqual(@as(usize, 1), state.transcript.items.len);
+    try std.testing.expectEqual(TranscriptKind.assistant, state.transcript.items[0].kind);
+    try std.testing.expectEqualStrings("hello world", state.transcript.items[0].text.items);
+
     var start_event = tui_runtime.TuiEvent{ .tool_execution_start = .{
         .tool_call_id = try ownedText("call-1"),
         .tool_name = try ownedText("shell_command"),
@@ -569,6 +593,53 @@ test "AppState applies transcript and tool events" {
     try std.testing.expectEqual(@as(usize, 1), state.tools.items.len);
     try std.testing.expectEqual(ToolStatus.done, state.tools.items[0].status);
     try std.testing.expect(std.mem.indexOf(u8, state.tools.items[0].output.items, "ok") != null);
+}
+
+test "AppState finalizes transcript from message_end text" {
+    var state = AppState.init(std.testing.allocator);
+    defer state.deinit();
+
+    var assistant_end = tui_runtime.TuiEvent{ .message_end = .{ .role = .assistant, .text = try ownedText("final response") } };
+    defer assistant_end.deinit(std.testing.allocator);
+    try state.applyEvent(assistant_end);
+
+    try std.testing.expectEqual(@as(usize, 1), state.transcript.items.len);
+    try std.testing.expectEqual(TranscriptKind.assistant, state.transcript.items[0].kind);
+    try std.testing.expectEqualStrings("final response", state.transcript.items[0].text.items);
+}
+
+test "AppState message_end does not duplicate streamed transcript" {
+    var state = AppState.init(std.testing.allocator);
+    defer state.deinit();
+
+    var delta_a = tui_runtime.TuiEvent{ .text_delta = .{ .content_index = 0, .delta = try ownedText("hel") } };
+    defer delta_a.deinit(std.testing.allocator);
+    try state.applyEvent(delta_a);
+
+    var delta_b = tui_runtime.TuiEvent{ .text_delta = .{ .content_index = 0, .delta = try ownedText("lo") } };
+    defer delta_b.deinit(std.testing.allocator);
+    try state.applyEvent(delta_b);
+
+    var assistant_end = tui_runtime.TuiEvent{ .message_end = .{ .role = .assistant, .text = try ownedText("hello") } };
+    defer assistant_end.deinit(std.testing.allocator);
+    try state.applyEvent(assistant_end);
+
+    try std.testing.expectEqual(@as(usize, 1), state.transcript.items.len);
+    try std.testing.expectEqualStrings("hello", state.transcript.items[0].text.items);
+}
+
+test "AppState message_end user text avoids duplicate submitted message" {
+    var state = AppState.init(std.testing.allocator);
+    defer state.deinit();
+
+    try state.appendUserMessage("hello");
+    var user_end = tui_runtime.TuiEvent{ .message_end = .{ .role = .user, .text = try ownedText("hello") } };
+    defer user_end.deinit(std.testing.allocator);
+    try state.applyEvent(user_end);
+
+    try std.testing.expectEqual(@as(usize, 1), state.transcript.items.len);
+    try std.testing.expectEqual(TranscriptKind.user, state.transcript.items[0].kind);
+    try std.testing.expectEqualStrings("hello", state.transcript.items[0].text.items);
 }
 
 test "AppState approval flow transitions pending to approved and rejected" {


### PR DESCRIPTION
## Summary
- Open fresh assistant transcript rows on `message_start` so final-only turns do not replace previous assistant output
- Clear active transcript entry pointers at turn/error boundaries so interrupted turns cannot be rewritten by later inline completions
- Preserve identical consecutive inline assistant `message_end` responses as distinct transcript rows

## Test plan
- [x] `zig build -Doptimize=Debug --build-file zig/build.zig test-unit-tui`
- [x] `zig build -Doptimize=Debug --build-file zig/build.zig test`