### PR TITLE
Show registered tools in TUI panel

### DIFF
--- a/zig/build.zig
+++ b/zig/build.zig
@@ -926,6 +926,8 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
         .imports = &.{
+            .{ .name = "agent", .module = agent_mod },
+            .{ .name = "ai_types", .module = ai_types_mod },
             .{ .name = "tui_runtime", .module = tui_runtime_mod },
             .{ .name = "owned_slice", .module = owned_slice_mod },
         },
@@ -945,7 +947,7 @@ pub fn build(b: *std.Build) void {
     const tui_view_transcript_mod = b.createModule(.{ .root_source_file = b.path("src/tui/views/transcript.zig"), .target = target, .optimize = optimize, .imports = &.{ .{ .name = "tui_state", .module = tui_state_mod } } });
     const tui_view_composer_mod = b.createModule(.{ .root_source_file = b.path("src/tui/views/composer.zig"), .target = target, .optimize = optimize, .imports = &.{ .{ .name = "tui_state", .module = tui_state_mod } } });
     const tui_view_status_bar_mod = b.createModule(.{ .root_source_file = b.path("src/tui/views/status_bar.zig"), .target = target, .optimize = optimize, .imports = &.{ .{ .name = "tui_state", .module = tui_state_mod } } });
-    const tui_view_tool_panel_mod = b.createModule(.{ .root_source_file = b.path("src/tui/views/tool_panel.zig"), .target = target, .optimize = optimize, .imports = &.{ .{ .name = "tui_state", .module = tui_state_mod } } });
+    const tui_view_tool_panel_mod = b.createModule(.{ .root_source_file = b.path("src/tui/views/tool_panel.zig"), .target = target, .optimize = optimize, .imports = &.{ .{ .name = "ai_types", .module = ai_types_mod }, .{ .name = "agent", .module = agent_mod }, .{ .name = "tui_state", .module = tui_state_mod } } });
     const tui_view_telemetry_mod = b.createModule(.{ .root_source_file = b.path("src/tui/views/telemetry.zig"), .target = target, .optimize = optimize, .imports = &.{ .{ .name = "tui_state", .module = tui_state_mod } } });
     const tui_view_approval_mod = b.createModule(.{ .root_source_file = b.path("src/tui/views/approval.zig"), .target = target, .optimize = optimize, .imports = &.{ .{ .name = "tui_state", .module = tui_state_mod } } });
     const tui_view_preview_mod = b.createModule(.{ .root_source_file = b.path("src/tui/views/preview.zig"), .target = target, .optimize = optimize, .imports = &.{ .{ .name = "tui_state", .module = tui_state_mod } } });

--- a/zig/src/tui/app.zig
+++ b/zig/src/tui/app.zig
@@ -97,6 +97,7 @@ pub const App = struct {
         };
         errdefer app.deinit();
         app.session = app.runtime.?.createSession();
+        try app.state.setRegisteredTools(app.runtime.?.availableTools());
         if (app.runtime.?.currentModel()) |model| {
             try app.state.status.setModelWithContext(allocator, model.id, model.provider, model.context_window);
             app.state.telemetry.context_window = model.context_window;
@@ -408,6 +409,17 @@ pub fn run(allocator: std.mem.Allocator, io: std.Io) !void {
     program.model = .{ .options = production.options() };
     defer program.deinit();
     try program.run();
+}
+
+test "App init seeds registered tools from runtime" {
+    var production = try ProductionRuntime.init(std.testing.allocator);
+    defer production.deinit();
+    var app = try App.init(std.testing.allocator, production.options());
+    defer app.deinit();
+
+    try std.testing.expect(app.state.registered_tools.items.len >= 12);
+    try std.testing.expectEqual(app.runtime.?.availableTools().len, app.state.registered_tools.items.len);
+    try std.testing.expectEqualStrings("shell_execute", app.state.registered_tools.items[0].name);
 }
 
 test "App submit appends user transcript without runtime" {

--- a/zig/src/tui/state.zig
+++ b/zig/src/tui/state.zig
@@ -1,4 +1,6 @@
 const std = @import("std");
+const agent = @import("agent");
+const ai_types = @import("ai_types");
 const tui_runtime = @import("tui_runtime");
 
 pub const AppMode = enum {
@@ -49,6 +51,33 @@ pub const TranscriptEntry = struct {
 
     pub fn deinit(self: *TranscriptEntry, allocator: std.mem.Allocator) void {
         self.text.deinit(allocator);
+        self.* = undefined;
+    }
+};
+
+pub const RegisteredToolEntry = struct {
+    name: []u8,
+    label: []u8,
+    short_description: []u8,
+
+    pub fn init(allocator: std.mem.Allocator, tool: agent.AgentTool) !RegisteredToolEntry {
+        const name = try allocator.dupe(u8, tool.name);
+        errdefer allocator.free(name);
+        const label = try allocator.dupe(u8, tool.label);
+        errdefer allocator.free(label);
+        const short_description = try allocator.dupe(u8, tool.short_description orelse "");
+        errdefer allocator.free(short_description);
+        return .{
+            .name = name,
+            .label = label,
+            .short_description = short_description,
+        };
+    }
+
+    pub fn deinit(self: *RegisteredToolEntry, allocator: std.mem.Allocator) void {
+        allocator.free(self.name);
+        allocator.free(self.label);
+        allocator.free(self.short_description);
         self.* = undefined;
     }
 };
@@ -244,6 +273,7 @@ pub const AppState = struct {
     allocator: std.mem.Allocator,
     mode: AppMode = .normal,
     transcript: std.ArrayList(TranscriptEntry) = .empty,
+    registered_tools: std.ArrayList(RegisteredToolEntry) = .empty,
     tools: std.ArrayList(ToolEntry) = .empty,
     sessions: std.ArrayList(SessionEntry) = .empty,
     composer: ComposerState = .{},
@@ -264,6 +294,8 @@ pub const AppState = struct {
     pub fn deinit(self: *AppState) void {
         for (self.transcript.items) |*entry| entry.deinit(self.allocator);
         self.transcript.deinit(self.allocator);
+        for (self.registered_tools.items) |*tool| tool.deinit(self.allocator);
+        self.registered_tools.deinit(self.allocator);
         for (self.tools.items) |*tool| tool.deinit(self.allocator);
         self.tools.deinit(self.allocator);
         for (self.sessions.items) |*session| session.deinit(self.allocator);
@@ -277,6 +309,13 @@ pub const AppState = struct {
 
     pub fn appendTranscript(self: *AppState, kind: TranscriptKind, text: []const u8) !void {
         try self.transcript.append(self.allocator, try TranscriptEntry.init(self.allocator, kind, text));
+    }
+
+    pub fn setRegisteredTools(self: *AppState, tools: []const agent.AgentTool) !void {
+        for (self.registered_tools.items) |*tool| tool.deinit(self.allocator);
+        self.registered_tools.clearRetainingCapacity();
+        try self.registered_tools.ensureTotalCapacity(self.allocator, tools.len);
+        for (tools) |tool| self.registered_tools.appendAssumeCapacity(try RegisteredToolEntry.init(self.allocator, tool));
     }
 
     pub fn clearTranscript(self: *AppState) void {
@@ -642,6 +681,23 @@ fn ownedText(text: []const u8) !@import("owned_slice").OwnedSlice(u8) {
     return @import("owned_slice").OwnedSlice(u8).initOwned(try std.testing.allocator.dupe(u8, text));
 }
 
+fn noopTool(
+    tool_call_id: []const u8,
+    args_json: []const u8,
+    cancel_token: ?ai_types.CancelToken,
+    on_update_ctx: ?*anyopaque,
+    on_update: ?agent.ToolUpdateCallback,
+    allocator: std.mem.Allocator,
+) anyerror!agent.AgentToolResult {
+    _ = tool_call_id;
+    _ = args_json;
+    _ = cancel_token;
+    _ = on_update_ctx;
+    _ = on_update;
+    _ = allocator;
+    return error.NotImplemented;
+}
+
 test "AppState applies transcript and tool events" {
     var state = AppState.init(std.testing.allocator);
     defer state.deinit();
@@ -874,6 +930,47 @@ test "AppState clears stale active assistant before next inline message_end" {
     try std.testing.expectEqual(@as(usize, 2), state.transcript.items.len);
     try std.testing.expectEqualStrings("interrupted", state.transcript.items[0].text.items);
     try std.testing.expectEqualStrings("next response", state.transcript.items[1].text.items);
+}
+
+test "AppState clones registered tool metadata" {
+    const tools = [_]agent.AgentTool{
+        .{
+            .label = "Shell Execute",
+            .name = "shell_execute",
+            .description = "Run command",
+            .short_description = "Run shell commands",
+            .parameters_schema_json = "{}",
+            .execute = noopTool,
+        },
+        .{
+            .label = "Workspace Info",
+            .name = "workspace_info",
+            .description = "Show workspace",
+            .parameters_schema_json = "{}",
+            .execute = noopTool,
+        },
+    };
+    var state = AppState.init(std.testing.allocator);
+    defer state.deinit();
+
+    try state.setRegisteredTools(&tools);
+    try std.testing.expectEqual(@as(usize, 2), state.registered_tools.items.len);
+    try std.testing.expectEqualStrings("shell_execute", state.registered_tools.items[0].name);
+    try std.testing.expectEqualStrings("Shell Execute", state.registered_tools.items[0].label);
+    try std.testing.expectEqualStrings("Run shell commands", state.registered_tools.items[0].short_description);
+    try std.testing.expectEqualStrings("", state.registered_tools.items[1].short_description);
+
+    const replacement = [_]agent.AgentTool{.{
+        .label = "File Read",
+        .name = "file_read",
+        .description = "Read file",
+        .short_description = "Read files",
+        .parameters_schema_json = "{}",
+        .execute = noopTool,
+    }};
+    try state.setRegisteredTools(&replacement);
+    try std.testing.expectEqual(@as(usize, 1), state.registered_tools.items.len);
+    try std.testing.expectEqualStrings("file_read", state.registered_tools.items[0].name);
 }
 
 test "AppState tool_result message_end updates active tool entry only" {

--- a/zig/src/tui/state.zig
+++ b/zig/src/tui/state.zig
@@ -681,7 +681,7 @@ fn ownedText(text: []const u8) !@import("owned_slice").OwnedSlice(u8) {
     return @import("owned_slice").OwnedSlice(u8).initOwned(try std.testing.allocator.dupe(u8, text));
 }
 
-fn noopTool(
+pub fn noopToolForTest(
     tool_call_id: []const u8,
     args_json: []const u8,
     cancel_token: ?ai_types.CancelToken,
@@ -940,14 +940,14 @@ test "AppState clones registered tool metadata" {
             .description = "Run command",
             .short_description = "Run shell commands",
             .parameters_schema_json = "{}",
-            .execute = noopTool,
+            .execute = noopToolForTest,
         },
         .{
             .label = "Workspace Info",
             .name = "workspace_info",
             .description = "Show workspace",
             .parameters_schema_json = "{}",
-            .execute = noopTool,
+            .execute = noopToolForTest,
         },
     };
     var state = AppState.init(std.testing.allocator);
@@ -966,7 +966,7 @@ test "AppState clones registered tool metadata" {
         .description = "Read file",
         .short_description = "Read files",
         .parameters_schema_json = "{}",
-        .execute = noopTool,
+        .execute = noopToolForTest,
     }};
     try state.setRegisteredTools(&replacement);
     try std.testing.expectEqual(@as(usize, 1), state.registered_tools.items.len);

--- a/zig/src/tui/views/tool_panel.zig
+++ b/zig/src/tui/views/tool_panel.zig
@@ -9,9 +9,22 @@ pub const Options = struct {
 pub fn render(allocator: std.mem.Allocator, state: *const tui_state.AppState, options: Options) ![]u8 {
     var out: std.Io.Writer.Allocating = .init(allocator);
     const writer = &out.writer;
-    try writer.writeAll("Tools");
+    try writer.print("Tools ({d} registered)", .{state.registered_tools.items.len});
     if (state.tools.items.len == 0) {
-        try writer.writeAll("\n  none");
+        if (state.registered_tools.items.len == 0) {
+            try writer.writeAll("\n  none");
+            return out.toOwnedSlice();
+        }
+        var rows: usize = 1;
+        for (state.registered_tools.items) |tool| {
+            if (rows >= options.height) break;
+            try writer.print("\n  {s}", .{tool.name});
+            if (tool.short_description.len > 0) {
+                try writer.writeAll(" - ");
+                try writeOneLine(writer, tool.short_description, options.width -| tool.name.len -| 5);
+            }
+            rows += 1;
+        }
         return out.toOwnedSlice();
     }
 
@@ -51,6 +64,44 @@ fn writeOneLine(writer: *std.Io.Writer, text: []const u8, width: usize) !void {
     const line = text[0..nl];
     try writer.writeAll(line[0..@min(width, line.len)]);
     if (line.len > width or nl < text.len) try writer.writeAll("…");
+}
+
+fn noopTool(
+    tool_call_id: []const u8,
+    args_json: []const u8,
+    cancel_token: ?@import("ai_types").CancelToken,
+    on_update_ctx: ?*anyopaque,
+    on_update: ?@import("agent").ToolUpdateCallback,
+    allocator: std.mem.Allocator,
+) anyerror!@import("agent").AgentToolResult {
+    _ = tool_call_id;
+    _ = args_json;
+    _ = cancel_token;
+    _ = on_update_ctx;
+    _ = on_update;
+    _ = allocator;
+    return error.NotImplemented;
+}
+
+test "tool panel renders registered tools when idle" {
+    var state = tui_state.AppState.init(std.testing.allocator);
+    defer state.deinit();
+    const tools = [_]@import("agent").AgentTool{.{
+        .label = "Shell Execute",
+        .name = "shell_execute",
+        .description = "Run shell commands",
+        .short_description = "Run shell commands",
+        .parameters_schema_json = "{}",
+        .execute = noopTool,
+    }};
+    try state.setRegisteredTools(&tools);
+
+    const text = try render(std.testing.allocator, &state, .{ .width = 80, .height = 4 });
+    defer std.testing.allocator.free(text);
+
+    try std.testing.expect(std.mem.indexOf(u8, text, "Tools (1 registered)") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "shell_execute - Run shell commands") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "none") == null);
 }
 
 test "tool panel renders tool status and output" {

--- a/zig/src/tui/views/tool_panel.zig
+++ b/zig/src/tui/views/tool_panel.zig
@@ -66,23 +66,6 @@ fn writeOneLine(writer: *std.Io.Writer, text: []const u8, width: usize) !void {
     if (line.len > width or nl < text.len) try writer.writeAll("…");
 }
 
-fn noopTool(
-    tool_call_id: []const u8,
-    args_json: []const u8,
-    cancel_token: ?@import("ai_types").CancelToken,
-    on_update_ctx: ?*anyopaque,
-    on_update: ?@import("agent").ToolUpdateCallback,
-    allocator: std.mem.Allocator,
-) anyerror!@import("agent").AgentToolResult {
-    _ = tool_call_id;
-    _ = args_json;
-    _ = cancel_token;
-    _ = on_update_ctx;
-    _ = on_update;
-    _ = allocator;
-    return error.NotImplemented;
-}
-
 test "tool panel renders registered tools when idle" {
     var state = tui_state.AppState.init(std.testing.allocator);
     defer state.deinit();
@@ -92,7 +75,7 @@ test "tool panel renders registered tools when idle" {
         .description = "Run shell commands",
         .short_description = "Run shell commands",
         .parameters_schema_json = "{}",
-        .execute = noopTool,
+        .execute = tui_state.noopToolForTest,
     }};
     try state.setRegisteredTools(&tools);
 


### PR DESCRIPTION
## Summary
- Seed TUI app state with registered runtime tool metadata.
- Render registered tools in the tool panel before execution events exist.
- Cover registered tool cloning, app seeding, and idle panel rendering with tests.

## Test plan
- [x] zig build -Doptimize=Debug test-unit-tui --build-file /Users/lsm/.neokai/projects/makai-c058549f/worktrees/goal-check-in-tui-overhaul-production-coding-agent-terminal/zig/build.zig
- [x] zig build test --build-file /Users/lsm/.neokai/projects/makai-c058549f/worktrees/goal-check-in-tui-overhaul-production-coding-agent-terminal/zig/build.zig