### PR TITLE
Add ZigZag TUI styling foundation

### DIFF
--- a/zig/build.zig
+++ b/zig/build.zig
@@ -944,14 +944,18 @@ pub fn build(b: *std.Build) void {
         },
     });
 
-    const tui_view_transcript_mod = b.createModule(.{ .root_source_file = b.path("src/tui/views/transcript.zig"), .target = target, .optimize = optimize, .imports = &.{ .{ .name = "tui_state", .module = tui_state_mod } } });
-    const tui_view_composer_mod = b.createModule(.{ .root_source_file = b.path("src/tui/views/composer.zig"), .target = target, .optimize = optimize, .imports = &.{ .{ .name = "tui_state", .module = tui_state_mod } } });
-    const tui_view_status_bar_mod = b.createModule(.{ .root_source_file = b.path("src/tui/views/status_bar.zig"), .target = target, .optimize = optimize, .imports = &.{ .{ .name = "tui_state", .module = tui_state_mod } } });
-    const tui_view_tool_panel_mod = b.createModule(.{ .root_source_file = b.path("src/tui/views/tool_panel.zig"), .target = target, .optimize = optimize, .imports = &.{ .{ .name = "ai_types", .module = ai_types_mod }, .{ .name = "agent", .module = agent_mod }, .{ .name = "tui_state", .module = tui_state_mod } } });
-    const tui_view_telemetry_mod = b.createModule(.{ .root_source_file = b.path("src/tui/views/telemetry.zig"), .target = target, .optimize = optimize, .imports = &.{ .{ .name = "tui_state", .module = tui_state_mod } } });
-    const tui_view_approval_mod = b.createModule(.{ .root_source_file = b.path("src/tui/views/approval.zig"), .target = target, .optimize = optimize, .imports = &.{ .{ .name = "tui_state", .module = tui_state_mod } } });
-    const tui_view_preview_mod = b.createModule(.{ .root_source_file = b.path("src/tui/views/preview.zig"), .target = target, .optimize = optimize, .imports = &.{ .{ .name = "tui_state", .module = tui_state_mod } } });
-    const tui_view_session_picker_mod = b.createModule(.{ .root_source_file = b.path("src/tui/views/session_picker.zig"), .target = target, .optimize = optimize, .imports = &.{ .{ .name = "tui_state", .module = tui_state_mod } } });
+    const tui_theme_mod = b.createModule(.{ .root_source_file = b.path("src/tui/theme.zig"), .target = target, .optimize = optimize, .imports = &.{ .{ .name = "zigzag", .module = zigzag_mod }, .{ .name = "tui_state", .module = tui_state_mod } } });
+    const tui_text_mod = b.createModule(.{ .root_source_file = b.path("src/tui/text.zig"), .target = target, .optimize = optimize, .imports = &.{ .{ .name = "zigzag", .module = zigzag_mod } } });
+    const tui_render_mod = b.createModule(.{ .root_source_file = b.path("src/tui/render.zig"), .target = target, .optimize = optimize, .imports = &.{ .{ .name = "zigzag", .module = zigzag_mod } } });
+
+    const tui_view_transcript_mod = b.createModule(.{ .root_source_file = b.path("src/tui/views/transcript.zig"), .target = target, .optimize = optimize, .imports = &.{ .{ .name = "zigzag", .module = zigzag_mod }, .{ .name = "tui_state", .module = tui_state_mod }, .{ .name = "tui_theme", .module = tui_theme_mod }, .{ .name = "tui_text", .module = tui_text_mod }, .{ .name = "tui_render", .module = tui_render_mod } } });
+    const tui_view_composer_mod = b.createModule(.{ .root_source_file = b.path("src/tui/views/composer.zig"), .target = target, .optimize = optimize, .imports = &.{ .{ .name = "zigzag", .module = zigzag_mod }, .{ .name = "tui_state", .module = tui_state_mod }, .{ .name = "tui_theme", .module = tui_theme_mod }, .{ .name = "tui_text", .module = tui_text_mod }, .{ .name = "tui_render", .module = tui_render_mod } } });
+    const tui_view_status_bar_mod = b.createModule(.{ .root_source_file = b.path("src/tui/views/status_bar.zig"), .target = target, .optimize = optimize, .imports = &.{ .{ .name = "zigzag", .module = zigzag_mod }, .{ .name = "tui_state", .module = tui_state_mod }, .{ .name = "tui_theme", .module = tui_theme_mod }, .{ .name = "tui_text", .module = tui_text_mod }, .{ .name = "tui_render", .module = tui_render_mod } } });
+    const tui_view_tool_panel_mod = b.createModule(.{ .root_source_file = b.path("src/tui/views/tool_panel.zig"), .target = target, .optimize = optimize, .imports = &.{ .{ .name = "zigzag", .module = zigzag_mod }, .{ .name = "ai_types", .module = ai_types_mod }, .{ .name = "agent", .module = agent_mod }, .{ .name = "tui_state", .module = tui_state_mod }, .{ .name = "tui_theme", .module = tui_theme_mod }, .{ .name = "tui_text", .module = tui_text_mod }, .{ .name = "tui_render", .module = tui_render_mod } } });
+    const tui_view_telemetry_mod = b.createModule(.{ .root_source_file = b.path("src/tui/views/telemetry.zig"), .target = target, .optimize = optimize, .imports = &.{ .{ .name = "zigzag", .module = zigzag_mod }, .{ .name = "tui_state", .module = tui_state_mod }, .{ .name = "tui_theme", .module = tui_theme_mod }, .{ .name = "tui_text", .module = tui_text_mod }, .{ .name = "tui_render", .module = tui_render_mod } } });
+    const tui_view_approval_mod = b.createModule(.{ .root_source_file = b.path("src/tui/views/approval.zig"), .target = target, .optimize = optimize, .imports = &.{ .{ .name = "zigzag", .module = zigzag_mod }, .{ .name = "tui_state", .module = tui_state_mod }, .{ .name = "tui_theme", .module = tui_theme_mod }, .{ .name = "tui_text", .module = tui_text_mod }, .{ .name = "tui_render", .module = tui_render_mod } } });
+    const tui_view_preview_mod = b.createModule(.{ .root_source_file = b.path("src/tui/views/preview.zig"), .target = target, .optimize = optimize, .imports = &.{ .{ .name = "zigzag", .module = zigzag_mod }, .{ .name = "tui_state", .module = tui_state_mod }, .{ .name = "tui_theme", .module = tui_theme_mod }, .{ .name = "tui_text", .module = tui_text_mod }, .{ .name = "tui_render", .module = tui_render_mod } } });
+    const tui_view_session_picker_mod = b.createModule(.{ .root_source_file = b.path("src/tui/views/session_picker.zig"), .target = target, .optimize = optimize, .imports = &.{ .{ .name = "zigzag", .module = zigzag_mod }, .{ .name = "tui_state", .module = tui_state_mod }, .{ .name = "tui_theme", .module = tui_theme_mod }, .{ .name = "tui_text", .module = tui_text_mod }, .{ .name = "tui_render", .module = tui_render_mod } } });
 
     const tui_app_mod = b.createModule(.{
         .root_source_file = b.path("src/tui/app.zig"),
@@ -967,6 +971,7 @@ pub fn build(b: *std.Build) void {
             .{ .name = "tui_runtime", .module = tui_runtime_mod },
             .{ .name = "tui_state", .module = tui_state_mod },
             .{ .name = "tui_commands", .module = tui_commands_mod },
+            .{ .name = "tui_render", .module = tui_render_mod },
             .{ .name = "tui_view_transcript", .module = tui_view_transcript_mod },
             .{ .name = "tui_view_composer", .module = tui_view_composer_mod },
             .{ .name = "tui_view_status_bar", .module = tui_view_status_bar_mod },
@@ -1367,6 +1372,9 @@ pub fn build(b: *std.Build) void {
     const tui_state_test = b.addTest(.{ .root_module = tui_state_mod });
     const tui_commands_test = b.addTest(.{ .root_module = tui_commands_mod });
     const tui_app_test = b.addTest(.{ .root_module = tui_app_mod });
+    const tui_theme_test = b.addTest(.{ .root_module = tui_theme_mod });
+    const tui_text_test = b.addTest(.{ .root_module = tui_text_mod });
+    const tui_render_test = b.addTest(.{ .root_module = tui_render_mod });
     const tui_view_transcript_test = b.addTest(.{ .root_module = tui_view_transcript_mod });
     const tui_view_composer_test = b.addTest(.{ .root_module = tui_view_composer_mod });
     const tui_view_status_bar_test = b.addTest(.{ .root_module = tui_view_status_bar_mod });
@@ -1574,6 +1582,9 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(&b.addRunArtifact(tui_state_test).step);
     test_step.dependOn(&b.addRunArtifact(tui_commands_test).step);
     test_step.dependOn(&b.addRunArtifact(tui_app_test).step);
+    test_step.dependOn(&b.addRunArtifact(tui_theme_test).step);
+    test_step.dependOn(&b.addRunArtifact(tui_text_test).step);
+    test_step.dependOn(&b.addRunArtifact(tui_render_test).step);
     test_step.dependOn(&b.addRunArtifact(tui_view_transcript_test).step);
     test_step.dependOn(&b.addRunArtifact(tui_view_composer_test).step);
     test_step.dependOn(&b.addRunArtifact(tui_view_status_bar_test).step);
@@ -1738,6 +1749,9 @@ pub fn build(b: *std.Build) void {
     test_unit_tui_step.dependOn(&b.addRunArtifact(tui_state_test).step);
     test_unit_tui_step.dependOn(&b.addRunArtifact(tui_commands_test).step);
     test_unit_tui_step.dependOn(&b.addRunArtifact(tui_app_test).step);
+    test_unit_tui_step.dependOn(&b.addRunArtifact(tui_theme_test).step);
+    test_unit_tui_step.dependOn(&b.addRunArtifact(tui_text_test).step);
+    test_unit_tui_step.dependOn(&b.addRunArtifact(tui_render_test).step);
     test_unit_tui_step.dependOn(&b.addRunArtifact(tui_view_transcript_test).step);
     test_unit_tui_step.dependOn(&b.addRunArtifact(tui_view_composer_test).step);
     test_unit_tui_step.dependOn(&b.addRunArtifact(tui_view_status_bar_test).step);

--- a/zig/src/tui/app.zig
+++ b/zig/src/tui/app.zig
@@ -16,6 +16,7 @@ const telemetry_view = @import("tui_view_telemetry");
 const approval_view = @import("tui_view_approval");
 const preview_view = @import("tui_view_preview");
 const session_picker_view = @import("tui_view_session_picker");
+const tui_render = @import("tui_render");
 
 pub const ApprovalWaiter = struct {
     allocator: std.mem.Allocator,
@@ -356,7 +357,8 @@ const TuiModel = struct {
         const fixed = countLines(status) + countLines(composer) + countLines(tools) + countLines(telemetry) + countLines(extra) + 5;
         const transcript_height = if (height > fixed) height - fixed else 3;
         const transcript = transcript_view.render(ctx.allocator, &app.state, .{ .width = width, .height = transcript_height }) catch "";
-        return std.fmt.allocPrint(ctx.allocator, "{s}\n{s}\n{s}\n{s}\n{s}\n{s}", .{ transcript, tools, telemetry, extra, composer, status }) catch "";
+        const frame = tui_render.joinVertical(ctx.allocator, &.{ transcript, tools, telemetry, extra, composer, status }) catch "";
+        return tui_render.withSynchronizedOutput(ctx.allocator, frame) catch frame;
     }
 
     fn appendChar(app: *App, c: u21) !void {

--- a/zig/src/tui/render.zig
+++ b/zig/src/tui/render.zig
@@ -1,0 +1,24 @@
+const std = @import("std");
+const zz = @import("zigzag");
+
+pub fn joinVertical(allocator: std.mem.Allocator, parts: []const []const u8) ![]const u8 {
+    return zz.joinVertical(allocator, parts);
+}
+
+pub fn withSynchronizedOutput(allocator: std.mem.Allocator, body: []const u8) ![]const u8 {
+    return std.fmt.allocPrint(allocator, "{s}{s}{s}", .{ zz.ansi.sync_start, body, zz.ansi.sync_end });
+}
+
+test "joinVertical stacks blocks" {
+    const text = try joinVertical(std.testing.allocator, &.{ "A", "B" });
+    defer std.testing.allocator.free(text);
+    try std.testing.expectEqualStrings("A\nB", text);
+}
+
+test "withSynchronizedOutput wraps CSI 2026 markers" {
+    const text = try withSynchronizedOutput(std.testing.allocator, "body");
+    defer std.testing.allocator.free(text);
+    try std.testing.expect(std.mem.startsWith(u8, text, zz.ansi.sync_start));
+    try std.testing.expect(std.mem.endsWith(u8, text, zz.ansi.sync_end));
+    try std.testing.expect(std.mem.indexOf(u8, text, "body") != null);
+}

--- a/zig/src/tui/text.zig
+++ b/zig/src/tui/text.zig
@@ -1,0 +1,180 @@
+const std = @import("std");
+const zz = @import("zigzag");
+
+const ellipsis = "…";
+
+pub fn visibleWidth(text: []const u8) usize {
+    return zz.width(text);
+}
+
+pub fn lineCount(text: []const u8) usize {
+    if (text.len == 0) return 0;
+    var count: usize = 1;
+    for (text) |c| {
+        if (c == '\n') count += 1;
+    }
+    return count;
+}
+
+pub fn truncateToWidth(allocator: std.mem.Allocator, text: []const u8, max_width: usize) ![]u8 {
+    if (max_width == 0) return allocator.dupe(u8, "");
+    if (visibleWidth(text) <= max_width) return allocator.dupe(u8, text);
+    if (max_width <= 1) return allocator.dupe(u8, ellipsis);
+
+    var out: std.Io.Writer.Allocating = .init(allocator);
+    errdefer out.deinit();
+    const writer = &out.writer;
+    const target = max_width - 1;
+    var width: usize = 0;
+    var i: usize = 0;
+    var open_sgr = false;
+
+    while (i < text.len and width < target) {
+        if (text[i] == 0x1b) {
+            const start = i;
+            try copyAnsiSequence(writer, text, &i);
+            if (i > start and isSgrSequence(text[start..i])) open_sgr = true;
+            continue;
+        }
+        if (text[i] == '\n') break;
+
+        const len = std.unicode.utf8ByteSequenceLength(text[i]) catch 1;
+        if (i + len > text.len) break;
+        const codepoint = std.unicode.utf8Decode(text[i .. i + len]) catch text[i];
+        const cw = zz.measure.charWidth(@intCast(codepoint));
+        if (width + cw > target) break;
+        try writer.writeAll(text[i .. i + len]);
+        width += cw;
+        i += len;
+    }
+
+    try writer.writeAll(ellipsis);
+    if (open_sgr) try writer.writeAll(zz.ansi.reset);
+    return out.toOwnedSlice();
+}
+
+pub fn wrapTextWithAnsi(allocator: std.mem.Allocator, text: []const u8, max_width: usize) ![]u8 {
+    if (max_width == 0 or text.len == 0) return allocator.dupe(u8, text);
+
+    var out: std.Io.Writer.Allocating = .init(allocator);
+    errdefer out.deinit();
+    const writer = &out.writer;
+    var line_width: usize = 0;
+    var word = std.ArrayList(u8).empty;
+    defer word.deinit(allocator);
+    var word_width: usize = 0;
+    var pending_space = false;
+
+    var i: usize = 0;
+    while (i < text.len) {
+        if (text[i] == 0x1b) {
+            const start = i;
+            var sink: std.Io.Writer.Allocating = .init(allocator);
+            defer sink.deinit();
+            try copyAnsiSequence(&sink.writer, text, &i);
+            try word.appendSlice(allocator, sink.written());
+            _ = start;
+            continue;
+        }
+
+        const c = text[i];
+        if (c == '\n') {
+            try flushWord(writer, &word, word_width, &line_width, max_width, pending_space);
+            word_width = 0;
+            pending_space = false;
+            try writer.writeByte('\n');
+            line_width = 0;
+            i += 1;
+            continue;
+        }
+        if (c == ' ' or c == '\t' or c == '\r') {
+            try flushWord(writer, &word, word_width, &line_width, max_width, pending_space);
+            word_width = 0;
+            pending_space = line_width > 0;
+            i += 1;
+            continue;
+        }
+
+        const len = std.unicode.utf8ByteSequenceLength(c) catch 1;
+        if (i + len > text.len) break;
+        const codepoint = std.unicode.utf8Decode(text[i .. i + len]) catch c;
+        const cw = zz.measure.charWidth(@intCast(codepoint));
+        try word.appendSlice(allocator, text[i .. i + len]);
+        word_width += cw;
+        i += len;
+    }
+
+    try flushWord(writer, &word, word_width, &line_width, max_width, pending_space);
+    return out.toOwnedSlice();
+}
+
+fn flushWord(writer: *std.Io.Writer, word: *std.ArrayList(u8), word_width: usize, line_width: *usize, max_width: usize, pending_space: bool) !void {
+    if (word.items.len == 0) return;
+    const sep: usize = if (pending_space and line_width.* > 0) 1 else 0;
+    if (line_width.* > 0 and line_width.* + sep + word_width > max_width) {
+        try writer.writeByte('\n');
+        line_width.* = 0;
+    } else if (sep == 1) {
+        try writer.writeByte(' ');
+        line_width.* += 1;
+    }
+    try writer.writeAll(word.items);
+    line_width.* += word_width;
+    word.clearRetainingCapacity();
+}
+
+fn copyAnsiSequence(writer: *std.Io.Writer, text: []const u8, index: *usize) !void {
+    const start = index.*;
+    try writer.writeByte(text[index.*]);
+    index.* += 1;
+    if (index.* >= text.len) return;
+    try writer.writeByte(text[index.*]);
+    const second = text[index.*];
+    index.* += 1;
+
+    if (second == '[') {
+        while (index.* < text.len) {
+            const c = text[index.*];
+            try writer.writeByte(c);
+            index.* += 1;
+            if ((c >= 'A' and c <= 'Z') or (c >= 'a' and c <= 'z')) return;
+        }
+        return;
+    }
+    if (second == ']') {
+        while (index.* < text.len) {
+            const c = text[index.*];
+            try writer.writeByte(c);
+            index.* += 1;
+            if (c == 0x07) return;
+            if (c == 0x1b and index.* < text.len and text[index.*] == '\\') {
+                try writer.writeByte(text[index.*]);
+                index.* += 1;
+                return;
+            }
+        }
+        return;
+    }
+    _ = start;
+}
+
+fn isSgrSequence(seq: []const u8) bool {
+    return seq.len >= 3 and seq[0] == 0x1b and seq[1] == '[' and seq[seq.len - 1] == 'm';
+}
+
+test "visibleWidth ignores ANSI" {
+    try std.testing.expectEqual(@as(usize, 5), visibleWidth("\x1b[31mhello\x1b[0m"));
+}
+
+test "truncateToWidth preserves ANSI and width" {
+    const text = try truncateToWidth(std.testing.allocator, "\x1b[31mhello world\x1b[0m", 6);
+    defer std.testing.allocator.free(text);
+    try std.testing.expect(visibleWidth(text) <= 6);
+    try std.testing.expect(std.mem.indexOf(u8, text, ellipsis) != null);
+}
+
+test "wrapTextWithAnsi wraps words" {
+    const text = try wrapTextWithAnsi(std.testing.allocator, "alpha beta gamma", 10);
+    defer std.testing.allocator.free(text);
+    try std.testing.expectEqualStrings("alpha beta\ngamma", text);
+}

--- a/zig/src/tui/text.zig
+++ b/zig/src/tui/text.zig
@@ -120,17 +120,15 @@ pub fn truncateLinesToWidth(allocator: std.mem.Allocator, text: []const u8, line
     const writer = &out.writer;
     var lines = std.mem.splitScalar(u8, text, '\n');
     var row: usize = 0;
-    while (lines.next()) |line| {
-        if (row >= max_lines) {
-            if (row > 0) try writer.writeByte('\n');
-            try writer.writeAll(ellipsis);
-            break;
-        }
+    while (row < max_lines) : (row += 1) {
+        const line = lines.next() orelse break;
         if (row > 0) try writer.writeByte('\n');
-        const clipped = try truncateLineToWidth(allocator, line, line_width);
+        const has_more_lines = row + 1 == max_lines and lines.peek() != null;
+        const width = if (has_more_lines) line_width -| 1 else line_width;
+        const clipped = try truncateLineToWidth(allocator, line, width);
         defer allocator.free(clipped);
         try writer.writeAll(clipped);
-        row += 1;
+        if (has_more_lines) try writer.writeAll(ellipsis);
     }
     return out.toOwnedSlice();
 }
@@ -265,6 +263,14 @@ test "truncateMultilineToBudget preserves newline before clipping" {
     const text = try truncateMultilineToBudget(std.testing.allocator, "alpha\nbeta gamma", 10);
     defer std.testing.allocator.free(text);
     try std.testing.expect(std.mem.indexOfScalar(u8, text, '\n') != null);
+}
+
+test "truncateLinesToWidth caps output to max lines" {
+    const text = try truncateLinesToWidth(std.testing.allocator, "one\ntwo\nthree\nfour", 10, 3);
+    defer std.testing.allocator.free(text);
+    try std.testing.expectEqual(@as(usize, 3), lineCount(text));
+    try std.testing.expect(std.mem.indexOf(u8, text, "three") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, ellipsis) != null);
 }
 
 test "truncateToWidth accepts CSI tilde terminator" {

--- a/zig/src/tui/text.zig
+++ b/zig/src/tui/text.zig
@@ -17,8 +17,12 @@ pub fn lineCount(text: []const u8) usize {
 }
 
 pub fn truncateToWidth(allocator: std.mem.Allocator, text: []const u8, max_width: usize) ![]u8 {
+    return truncateLineToWidth(allocator, text, max_width);
+}
+
+pub fn truncateLineToWidth(allocator: std.mem.Allocator, text: []const u8, max_width: usize) ![]u8 {
     if (max_width == 0) return allocator.dupe(u8, "");
-    if (visibleWidth(text) <= max_width) return allocator.dupe(u8, text);
+    if (visibleWidth(text) <= max_width and std.mem.indexOfScalar(u8, text, '\n') == null) return allocator.dupe(u8, text);
     if (max_width <= 1) return allocator.dupe(u8, ellipsis);
 
     var out: std.Io.Writer.Allocating = .init(allocator);
@@ -28,6 +32,7 @@ pub fn truncateToWidth(allocator: std.mem.Allocator, text: []const u8, max_width
     var width: usize = 0;
     var i: usize = 0;
     var open_sgr = false;
+    var truncated = false;
 
     while (i < text.len and width < target) {
         if (text[i] == 0x1b) {
@@ -36,20 +41,97 @@ pub fn truncateToWidth(allocator: std.mem.Allocator, text: []const u8, max_width
             if (i > start and isSgrSequence(text[start..i])) open_sgr = true;
             continue;
         }
-        if (text[i] == '\n') break;
+        if (text[i] == '\n') {
+            truncated = true;
+            break;
+        }
 
         const len = std.unicode.utf8ByteSequenceLength(text[i]) catch 1;
         if (i + len > text.len) break;
         const codepoint = std.unicode.utf8Decode(text[i .. i + len]) catch text[i];
         const cw = zz.measure.charWidth(@intCast(codepoint));
-        if (width + cw > target) break;
+        if (width + cw > target) {
+            truncated = true;
+            break;
+        }
         try writer.writeAll(text[i .. i + len]);
         width += cw;
         i += len;
     }
 
-    try writer.writeAll(ellipsis);
+    if (i < text.len or truncated) try writer.writeAll(ellipsis);
     if (open_sgr) try writer.writeAll(zz.ansi.reset);
+    return out.toOwnedSlice();
+}
+
+pub fn flattenNewlines(allocator: std.mem.Allocator, text: []const u8, separator: []const u8) ![]u8 {
+    var out: std.Io.Writer.Allocating = .init(allocator);
+    errdefer out.deinit();
+    const writer = &out.writer;
+    var lines = std.mem.splitScalar(u8, text, '\n');
+    var first = true;
+    while (lines.next()) |line| {
+        if (!first) try writer.writeAll(separator);
+        first = false;
+        try writer.writeAll(line);
+    }
+    return out.toOwnedSlice();
+}
+
+pub fn truncateMultilineToBudget(allocator: std.mem.Allocator, text: []const u8, max_width: usize) ![]u8 {
+    if (max_width == 0) return allocator.dupe(u8, "");
+    if (visibleWidth(text) <= max_width) return allocator.dupe(u8, text);
+    if (max_width <= 1) return allocator.dupe(u8, ellipsis);
+
+    var out: std.Io.Writer.Allocating = .init(allocator);
+    errdefer out.deinit();
+    const writer = &out.writer;
+    var remaining = max_width;
+    var lines = std.mem.splitScalar(u8, text, '\n');
+    var first = true;
+    var source_has_more = false;
+    while (lines.next()) |line| {
+        if (!first) try writer.writeByte('\n');
+        first = false;
+        if (remaining <= 1) {
+            source_has_more = true;
+            break;
+        }
+        const line_width = visibleWidth(line);
+        const budget = @min(remaining, line_width + 1);
+        const clipped = try truncateLineToWidth(allocator, line, budget);
+        defer allocator.free(clipped);
+        try writer.writeAll(clipped);
+        const consumed = @min(remaining, visibleWidth(clipped));
+        remaining -|= consumed;
+        if (line_width > budget or remaining == 0) {
+            source_has_more = true;
+            break;
+        }
+    }
+    if (source_has_more and remaining > 0) try writer.writeAll(ellipsis);
+    return out.toOwnedSlice();
+}
+
+pub fn truncateLinesToWidth(allocator: std.mem.Allocator, text: []const u8, line_width: usize, max_lines: usize) ![]u8 {
+    if (line_width == 0 or max_lines == 0) return allocator.dupe(u8, "");
+    var out: std.Io.Writer.Allocating = .init(allocator);
+    errdefer out.deinit();
+    const writer = &out.writer;
+    var lines = std.mem.splitScalar(u8, text, '\n');
+    var row: usize = 0;
+    while (lines.next()) |line| {
+        if (row >= max_lines) {
+            if (row > 0) try writer.writeByte('\n');
+            try writer.writeAll(ellipsis);
+            break;
+        }
+        if (row > 0) try writer.writeByte('\n');
+        const clipped = try truncateLineToWidth(allocator, line, line_width);
+        defer allocator.free(clipped);
+        try writer.writeAll(clipped);
+        row += 1;
+    }
     return out.toOwnedSlice();
 }
 
@@ -137,7 +219,7 @@ fn copyAnsiSequence(writer: *std.Io.Writer, text: []const u8, index: *usize) !vo
             const c = text[index.*];
             try writer.writeByte(c);
             index.* += 1;
-            if ((c >= 'A' and c <= 'Z') or (c >= 'a' and c <= 'z')) return;
+            if (c >= 0x40 and c <= 0x7e) return;
         }
         return;
     }
@@ -171,6 +253,31 @@ test "truncateToWidth preserves ANSI and width" {
     defer std.testing.allocator.free(text);
     try std.testing.expect(visibleWidth(text) <= 6);
     try std.testing.expect(std.mem.indexOf(u8, text, ellipsis) != null);
+}
+
+test "flattenNewlines joins rows for single-line transcript entries" {
+    const text = try flattenNewlines(std.testing.allocator, "alpha\nbeta", " / ");
+    defer std.testing.allocator.free(text);
+    try std.testing.expectEqualStrings("alpha / beta", text);
+}
+
+test "truncateMultilineToBudget preserves newline before clipping" {
+    const text = try truncateMultilineToBudget(std.testing.allocator, "alpha\nbeta gamma", 10);
+    defer std.testing.allocator.free(text);
+    try std.testing.expect(std.mem.indexOfScalar(u8, text, '\n') != null);
+}
+
+test "truncateToWidth accepts CSI tilde terminator" {
+    const text = try truncateToWidth(std.testing.allocator, "\x1b[1~hello", 5);
+    defer std.testing.allocator.free(text);
+    try std.testing.expect(std.mem.indexOf(u8, text, "hello") != null);
+}
+
+test "wrapTextWithAnsi accepts CSI tilde terminator" {
+    const text = try wrapTextWithAnsi(std.testing.allocator, "\x1b[1~alpha beta", 20);
+    defer std.testing.allocator.free(text);
+    try std.testing.expect(std.mem.indexOf(u8, text, "alpha") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "beta") != null);
 }
 
 test "wrapTextWithAnsi wraps words" {

--- a/zig/src/tui/theme.zig
+++ b/zig/src/tui/theme.zig
@@ -1,0 +1,111 @@
+const std = @import("std");
+const zz = @import("zigzag");
+const tui_state = @import("tui_state");
+
+pub const palette = struct {
+    pub const text = zz.Color.brightWhite;
+    pub const muted = zz.Color.gray(12);
+    pub const dim = zz.Color.gray(9);
+    pub const border = zz.Color.gray(8);
+    pub const panel_border = zz.Color.gray(10);
+    pub const panel_title = zz.Color.brightCyan;
+    pub const user = zz.Color.brightBlue;
+    pub const assistant = zz.Color.brightCyan;
+    pub const thinking = zz.Color.brightMagenta;
+    pub const tool = zz.Color.brightYellow;
+    pub const system = zz.Color.gray(13);
+    pub const danger = zz.Color.brightRed;
+    pub const success = zz.Color.brightGreen;
+    pub const warning = zz.Color.brightYellow;
+    pub const running = zz.Color.brightCyan;
+    pub const accent = zz.Color.fromRgb(122, 162, 247);
+    pub const surface = zz.Color.fromRgb(22, 22, 30);
+    pub const surface_alt = zz.Color.fromRgb(31, 31, 42);
+};
+
+pub fn base() zz.Style {
+    return (zz.Style{}).fg(palette.text).inline_style(true);
+}
+
+pub fn muted() zz.Style {
+    return (zz.Style{}).fg(palette.muted).dim(true).inline_style(true);
+}
+
+pub fn dim() zz.Style {
+    return (zz.Style{}).fg(palette.dim).dim(true).inline_style(true);
+}
+
+pub fn strong() zz.Style {
+    return (zz.Style{}).fg(palette.text).bold(true).inline_style(true);
+}
+
+pub fn panel() zz.Style {
+    return (zz.Style{})
+        .borderAll(zz.Border.rounded)
+        .borderForeground(palette.panel_border)
+        .padding(.{ .top = 0, .right = 1, .bottom = 0, .left = 1 });
+}
+
+pub fn panelTitle() zz.Style {
+    return (zz.Style{}).fg(palette.panel_title).bold(true).inline_style(true);
+}
+
+pub fn role(kind: tui_state.TranscriptKind) zz.Style {
+    return switch (kind) {
+        .user => (zz.Style{}).fg(palette.user).bold(true).inline_style(true),
+        .assistant => (zz.Style{}).fg(palette.assistant).bold(true).inline_style(true),
+        .thinking => (zz.Style{}).fg(palette.thinking).dim(true).inline_style(true),
+        .tool => (zz.Style{}).fg(palette.tool).bold(true).inline_style(true),
+        .system => (zz.Style{}).fg(palette.system).dim(true).inline_style(true),
+        .@"error" => (zz.Style{}).fg(palette.danger).bold(true).inline_style(true),
+    };
+}
+
+pub fn toolStatus(status: tui_state.ToolStatus) zz.Style {
+    return switch (status) {
+        .pending => (zz.Style{}).fg(palette.warning).bold(true).inline_style(true),
+        .running => (zz.Style{}).fg(palette.running).bold(true).inline_style(true),
+        .done => (zz.Style{}).fg(palette.success).bold(true).inline_style(true),
+        .@"error" => (zz.Style{}).fg(palette.danger).bold(true).inline_style(true),
+    };
+}
+
+pub fn errorText() zz.Style {
+    return (zz.Style{}).fg(palette.danger).bold(true).inline_style(true);
+}
+
+pub fn successText() zz.Style {
+    return (zz.Style{}).fg(palette.success).inline_style(true);
+}
+
+pub fn composerPrompt() zz.Style {
+    return (zz.Style{}).fg(palette.accent).bold(true).inline_style(true);
+}
+
+pub fn composerPlaceholder() zz.Style {
+    return muted();
+}
+
+pub fn statusSegment() zz.Style {
+    return (zz.Style{}).fg(palette.text).inline_style(true);
+}
+
+pub fn statusKey() zz.Style {
+    return (zz.Style{}).fg(palette.muted).dim(true).inline_style(true);
+}
+
+pub fn diffLine(line: []const u8) zz.Style {
+    if (std.mem.startsWith(u8, line, "+")) return (zz.Style{}).fg(palette.success).inline_style(true);
+    if (std.mem.startsWith(u8, line, "-")) return (zz.Style{}).fg(palette.danger).inline_style(true);
+    return base();
+}
+
+test "theme exposes role and panel styles" {
+    const styled = try role(.assistant).render(std.testing.allocator, "AI:");
+    defer std.testing.allocator.free(styled);
+    try std.testing.expect(std.mem.indexOf(u8, styled, "AI:") != null);
+
+    const panel_text = try panel().render(std.testing.allocator, "body");
+    defer std.testing.allocator.free(panel_text);
+    try std.testing.expect(std.mem.indexOf(u8, panel_text, "body") != null);
+}

--- a/zig/src/tui/views/approval.zig
+++ b/zig/src/tui/views/approval.zig
@@ -1,30 +1,40 @@
 const std = @import("std");
 const tui_state = @import("tui_state");
+const tui_theme = @import("tui_theme");
+const tui_text = @import("tui_text");
+const tui_render = @import("tui_render");
 
 pub const Options = struct {
     width: usize = 80,
 };
 
-pub fn render(allocator: std.mem.Allocator, state: *const tui_state.AppState, options: Options) ![]u8 {
-    var out: std.Io.Writer.Allocating = .init(allocator);
-    const writer = &out.writer;
-    if (state.approval.status != .pending) return out.toOwnedSlice();
-    try writer.writeAll("Approval required\n");
-    try writer.print("Tool: {s}\n", .{state.approval.tool_name});
-    try writer.print("Args: {s}\n", .{state.approval.args_json});
+pub fn render(allocator: std.mem.Allocator, state: *const tui_state.AppState, options: Options) ![]const u8 {
+    if (state.approval.status != .pending) return allocator.dupe(u8, "");
+    var parts = std.ArrayList([]const u8).empty;
+    defer parts.deinit(allocator);
+    defer for (parts.items) |part| allocator.free(part);
+
+    try parts.append(allocator, try tui_theme.errorText().render(allocator, "Approval required"));
+    try parts.append(allocator, try std.fmt.allocPrint(allocator, "Tool: {s}", .{state.approval.tool_name}));
+    const args = try tui_text.truncateToWidth(allocator, state.approval.args_json, options.width -| 8);
+    defer allocator.free(args);
+    try parts.append(allocator, try std.fmt.allocPrint(allocator, "Args: {s}", .{args}));
     if (std.mem.eql(u8, state.approval.tool_name, "hashline_edit") and state.preview.content.len > 0) {
-        try writer.writeAll("\nPreview:\n");
-        var rows: usize = 4;
+        try parts.append(allocator, try tui_theme.panelTitle().render(allocator, "Preview:"));
+        var rows: usize = 0;
         var lines = std.mem.splitScalar(u8, state.preview.content, '\n');
         while (lines.next()) |line| {
-            if (rows >= 12) break;
-            try writer.writeAll(line[0..@min(options.width, line.len)]);
-            try writer.writeByte('\n');
+            if (rows >= 8) break;
+            const clipped = try tui_text.truncateToWidth(allocator, line, options.width -| 4);
+            defer allocator.free(clipped);
+            try parts.append(allocator, try tui_theme.diffLine(line).render(allocator, clipped));
             rows += 1;
         }
     }
-    try writer.writeAll("[a] allow  [d] deny  [A] always allow");
-    return out.toOwnedSlice();
+    try parts.append(allocator, try tui_theme.muted().render(allocator, "(a) allow once  (A) allow always  (d) deny  Esc abort"));
+    const body = try tui_render.joinVertical(allocator, parts.items);
+    defer allocator.free(body);
+    return tui_theme.panel().borderForeground(tui_theme.palette.warning).width(@intCast(@min(options.width, std.math.maxInt(u16)))).render(allocator, body);
 }
 
 test "approval renders pending request" {
@@ -37,7 +47,7 @@ test "approval renders pending request" {
 
     try std.testing.expect(std.mem.indexOf(u8, text, "Approval required") != null);
     try std.testing.expect(std.mem.indexOf(u8, text, "edit_file") != null);
-    try std.testing.expect(std.mem.indexOf(u8, text, "always allow") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "allow always") != null);
 }
 
 test "approval renders hashline preview" {

--- a/zig/src/tui/views/composer.zig
+++ b/zig/src/tui/views/composer.zig
@@ -1,36 +1,50 @@
 const std = @import("std");
+const zz = @import("zigzag");
 const tui_state = @import("tui_state");
+const tui_theme = @import("tui_theme");
+const tui_text = @import("tui_text");
+const tui_render = @import("tui_render");
 
 pub const Options = struct {
     width: usize = 80,
 };
 
-pub fn render(allocator: std.mem.Allocator, state: *const tui_state.AppState, options: Options) ![]u8 {
-    var out: std.Io.Writer.Allocating = .init(allocator);
-    const writer = &out.writer;
+pub fn render(allocator: std.mem.Allocator, state: *const tui_state.AppState, options: Options) ![]const u8 {
+    const inner_width = options.width -| 4;
+    const input = try renderInput(allocator, state, inner_width);
+    defer allocator.free(input);
+    const help = try tui_theme.muted().render(allocator, "Enter submit • Shift+Enter newline • Ctrl+C quit • /quit quit");
+    defer allocator.free(help);
+    const body = try tui_render.joinVertical(allocator, &.{ input, help });
+    defer allocator.free(body);
+    return tui_theme.panel().width(@intCast(@min(options.width, std.math.maxInt(u16)))).render(allocator, body);
+}
+
+fn renderInput(allocator: std.mem.Allocator, state: *const tui_state.AppState, width: usize) ![]u8 {
     const text = state.composer.text();
-    try writer.writeAll("> ");
-    if (text.len == 0) {
-        try writer.writeAll("Ask Makai…");
-    } else {
-        const max = options.width -| 2;
-        try writer.writeAll(text[0..@min(max, text.len)]);
-        if (text.len > max) try writer.writeAll("…");
-    }
-    try writer.writeAll("\nEnter submit • Shift+Enter newline • Ctrl+C quit • /quit quit");
-    return out.toOwnedSlice();
+    const prompt = try tui_theme.composerPrompt().render(allocator, "> ");
+    defer allocator.free(prompt);
+    const remaining = width -| tui_text.visibleWidth(prompt);
+    const content = if (text.len == 0)
+        try tui_theme.composerPlaceholder().render(allocator, "Ask Makai…")
+    else
+        try tui_text.truncateToWidth(allocator, text, remaining);
+    defer allocator.free(content);
+    return std.fmt.allocPrint(allocator, "{s}{s}", .{ prompt, content });
 }
 
 test "composer renders placeholder and text" {
     var state = tui_state.AppState.init(std.testing.allocator);
     defer state.deinit();
 
-    const placeholder = try render(std.testing.allocator, &state, .{ .width = 20 });
+    const placeholder = try render(std.testing.allocator, &state, .{ .width = 30 });
     defer std.testing.allocator.free(placeholder);
     try std.testing.expect(std.mem.indexOf(u8, placeholder, "Ask Makai") != null);
+    try std.testing.expect(std.mem.indexOf(u8, placeholder, "╭") != null);
 
     try state.composer.buffer.appendSlice(std.testing.allocator, "hello world");
-    const text = try render(std.testing.allocator, &state, .{ .width = 20 });
+    const text = try render(std.testing.allocator, &state, .{ .width = 30 });
     defer std.testing.allocator.free(text);
-    try std.testing.expect(std.mem.indexOf(u8, text, "> hello world") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, ">") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "hello world") != null);
 }

--- a/zig/src/tui/views/composer.zig
+++ b/zig/src/tui/views/composer.zig
@@ -28,7 +28,7 @@ fn renderInput(allocator: std.mem.Allocator, state: *const tui_state.AppState, w
     const content = if (text.len == 0)
         try tui_theme.composerPlaceholder().render(allocator, "Ask Makai…")
     else
-        try tui_text.truncateToWidth(allocator, text, remaining);
+        try tui_text.truncateLinesToWidth(allocator, text, remaining, 3);
     defer allocator.free(content);
     return std.fmt.allocPrint(allocator, "{s}{s}", .{ prompt, content });
 }
@@ -47,4 +47,16 @@ test "composer renders placeholder and text" {
     defer std.testing.allocator.free(text);
     try std.testing.expect(std.mem.indexOf(u8, text, ">") != null);
     try std.testing.expect(std.mem.indexOf(u8, text, "hello world") != null);
+}
+
+test "composer renders multiline draft content" {
+    var state = tui_state.AppState.init(std.testing.allocator);
+    defer state.deinit();
+    try state.composer.buffer.appendSlice(std.testing.allocator, "first line\nsecond line");
+
+    const text = try render(std.testing.allocator, &state, .{ .width = 40 });
+    defer std.testing.allocator.free(text);
+
+    try std.testing.expect(std.mem.indexOf(u8, text, "first line") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "second line") != null);
 }

--- a/zig/src/tui/views/preview.zig
+++ b/zig/src/tui/views/preview.zig
@@ -1,19 +1,29 @@
 const std = @import("std");
 const tui_state = @import("tui_state");
+const tui_theme = @import("tui_theme");
+const tui_text = @import("tui_text");
 
 pub const Options = struct {
     width: usize = 80,
     height: usize = 20,
 };
 
-pub fn render(allocator: std.mem.Allocator, state: *const tui_state.AppState, options: Options) ![]u8 {
+pub fn render(allocator: std.mem.Allocator, state: *const tui_state.AppState, options: Options) ![]const u8 {
     var out: std.Io.Writer.Allocating = .init(allocator);
     const writer = &out.writer;
     if (state.preview.content.len == 0) {
-        try writer.writeAll("No preview");
-        return out.toOwnedSlice();
+        const empty = try tui_theme.muted().render(allocator, "No preview");
+        defer allocator.free(empty);
+        try writer.writeAll(empty);
+        const body = try out.toOwnedSlice();
+        defer allocator.free(body);
+        return tui_theme.panel().width(@intCast(@min(options.width, std.math.maxInt(u16)))).render(allocator, body);
     }
-    try writer.print("{s}: {s}\n", .{ kindText(state.preview.kind), state.preview.title });
+    const title = try std.fmt.allocPrint(allocator, "{s}: {s}", .{ kindText(state.preview.kind), state.preview.title });
+    defer allocator.free(title);
+    const styled_title = try tui_theme.panelTitle().render(allocator, title);
+    defer allocator.free(styled_title);
+    try writer.writeAll(styled_title);
     var row: usize = 1;
     var skipped: usize = 0;
     var lines = std.mem.splitScalar(u8, state.preview.content, '\n');
@@ -23,11 +33,17 @@ pub fn render(allocator: std.mem.Allocator, state: *const tui_state.AppState, op
             continue;
         }
         if (row >= options.height) break;
-        if (row > 1) try writer.writeByte('\n');
-        try writer.writeAll(line[0..@min(options.width, line.len)]);
+        try writer.writeByte('\n');
+        const clipped = try tui_text.truncateToWidth(allocator, line, options.width -| 4);
+        defer allocator.free(clipped);
+        const styled = try tui_theme.diffLine(line).render(allocator, clipped);
+        defer allocator.free(styled);
+        try writer.writeAll(styled);
         row += 1;
     }
-    return out.toOwnedSlice();
+    const body = try out.toOwnedSlice();
+    defer allocator.free(body);
+    return tui_theme.panel().width(@intCast(@min(options.width, std.math.maxInt(u16)))).render(allocator, body);
 }
 
 fn kindText(kind: tui_state.PreviewKind) []const u8 {

--- a/zig/src/tui/views/session_picker.zig
+++ b/zig/src/tui/views/session_picker.zig
@@ -1,24 +1,40 @@
 const std = @import("std");
 const tui_state = @import("tui_state");
+const tui_theme = @import("tui_theme");
+const tui_text = @import("tui_text");
 
 pub const Options = struct {
     height: usize = 12,
 };
 
-pub fn render(allocator: std.mem.Allocator, state: *const tui_state.AppState, options: Options) ![]u8 {
+pub fn render(allocator: std.mem.Allocator, state: *const tui_state.AppState, options: Options) ![]const u8 {
     var out: std.Io.Writer.Allocating = .init(allocator);
     const writer = &out.writer;
-    try writer.writeAll("Sessions\n");
+    const title = try tui_theme.panelTitle().render(allocator, "Sessions");
+    defer allocator.free(title);
+    try writer.writeAll(title);
     if (state.sessions.items.len == 0) {
-        try writer.writeAll("  no saved sessions");
-        return out.toOwnedSlice();
+        const none = try tui_theme.muted().render(allocator, "  no saved sessions");
+        defer allocator.free(none);
+        try writer.writeByte('\n');
+        try writer.writeAll(none);
+        const body = try out.toOwnedSlice();
+        defer allocator.free(body);
+        return tui_theme.panel().render(allocator, body);
     }
     for (state.sessions.items, 0..) |session, i| {
         if (i >= options.height) break;
-        try writer.print("{s} {s} ({s})", .{ if (i == state.session_index) ">" else " ", session.label, session.id });
-        if (i + 1 < state.sessions.items.len and i + 1 < options.height) try writer.writeByte('\n');
+        try writer.writeByte('\n');
+        const marker = if (i == state.session_index) ">" else " ";
+        const row = try std.fmt.allocPrint(allocator, "{s} {s} ({s})", .{ marker, session.label, session.id });
+        defer allocator.free(row);
+        const styled = if (i == state.session_index) try tui_theme.successText().render(allocator, row) else try tui_theme.muted().render(allocator, row);
+        defer allocator.free(styled);
+        try writer.writeAll(styled);
     }
-    return out.toOwnedSlice();
+    const body = try out.toOwnedSlice();
+    defer allocator.free(body);
+    return tui_theme.panel().render(allocator, body);
 }
 
 test "session picker renders selected session" {
@@ -33,4 +49,5 @@ test "session picker renders selected session" {
 
     try std.testing.expect(std.mem.indexOf(u8, text, "First (s1)") != null);
     try std.testing.expect(std.mem.indexOf(u8, text, "> Second (s2)") != null);
+    try std.testing.expect(tui_text.visibleWidth(text) > 0);
 }

--- a/zig/src/tui/views/status_bar.zig
+++ b/zig/src/tui/views/status_bar.zig
@@ -1,34 +1,67 @@
 const std = @import("std");
 const tui_state = @import("tui_state");
+const tui_theme = @import("tui_theme");
+const tui_text = @import("tui_text");
 
 pub const Options = struct {
     width: usize = 80,
 };
 
-pub fn render(allocator: std.mem.Allocator, state: *const tui_state.AppState, options: Options) ![]u8 {
+pub fn render(allocator: std.mem.Allocator, state: *const tui_state.AppState, options: Options) ![]const u8 {
     var out: std.Io.Writer.Allocating = .init(allocator);
     const writer = &out.writer;
     const model = if (state.status.model.len > 0) state.status.model else "no-model";
     const provider = if (state.status.provider.len > 0) state.status.provider else "no-provider";
     const session = if (state.status.session_id.len > 0) state.status.session_id else "local";
     const stream = if (state.status.streaming) "streaming" else "idle";
-    try writer.print(" {s}/{s} • session:{s} • turns:{d} • {s}", .{ provider, model, session, state.status.turn_count, stream });
+
+    try writeOwnedSegment(writer, allocator, "model", try std.fmt.allocPrint(allocator, "{s}/{s}", .{ provider, model }));
+    try writer.writeAll(" • ");
+    try writeSegment(writer, allocator, "session", session);
+    try writer.writeAll(" • ");
+    try writeOwnedSegment(writer, allocator, "turns", try std.fmt.allocPrint(allocator, "{d}", .{state.status.turn_count}));
+    try writer.writeAll(" • ");
+    const stream_style = if (state.status.streaming) tui_theme.successText() else tui_theme.muted();
+    const styled_stream = try stream_style.render(allocator, stream);
+    defer allocator.free(styled_stream);
+    try writer.writeAll(styled_stream);
+
     if (state.status.context_limit > 0) {
         const pct = (state.status.context_used * 100) / state.status.context_limit;
-        try writer.print(" • ctx:{d}% {d}/{d}", .{ pct, state.status.context_used, state.status.context_limit });
+        try writer.writeAll(" • ");
+        const ctx = try std.fmt.allocPrint(allocator, "{d}% {d}/{d}", .{ pct, state.status.context_used, state.status.context_limit });
+        try writeOwnedSegment(writer, allocator, "ctx", ctx);
     } else if (state.status.context_used > 0) {
-        try writer.print(" • ctx:{d}tok", .{state.status.context_used});
+        try writer.writeAll(" • ");
+        const ctx = try std.fmt.allocPrint(allocator, "{d}tok", .{state.status.context_used});
+        try writeOwnedSegment(writer, allocator, "ctx", ctx);
     }
     if (state.status.last_error.len > 0) {
-        try writer.print(" • error:{s}", .{state.status.last_error});
+        try writer.writeAll(" • ");
+        const err = try tui_theme.errorText().render(allocator, state.status.last_error);
+        defer allocator.free(err);
+        try writer.writeAll(err);
     }
     const items = out.written();
-    if (items.len > options.width) {
-        const clipped = try allocator.dupe(u8, items[0..options.width]);
+    if (tui_text.visibleWidth(items) > options.width) {
+        const clipped = try tui_text.truncateToWidth(allocator, items, options.width);
         out.deinit();
         return clipped;
     }
     return out.toOwnedSlice();
+}
+
+fn writeSegment(writer: *std.Io.Writer, allocator: std.mem.Allocator, key: []const u8, value: []const u8) !void {
+    const styled_key = try tui_theme.statusKey().render(allocator, key);
+    defer allocator.free(styled_key);
+    const styled_value = try tui_theme.statusSegment().render(allocator, value);
+    defer allocator.free(styled_value);
+    try writer.print("{s}:{s}", .{ styled_key, styled_value });
+}
+
+fn writeOwnedSegment(writer: *std.Io.Writer, allocator: std.mem.Allocator, key: []const u8, value: []u8) !void {
+    defer allocator.free(value);
+    try writeSegment(writer, allocator, key, value);
 }
 
 test "status bar renders model and clips width" {
@@ -40,6 +73,6 @@ test "status bar renders model and clips width" {
     const text = try render(std.testing.allocator, &state, .{ .width = 24 });
     defer std.testing.allocator.free(text);
 
-    try std.testing.expectEqual(@as(usize, 24), text.len);
+    try std.testing.expect(tui_text.visibleWidth(text) <= 24);
     try std.testing.expect(std.mem.indexOf(u8, text, "anthropic") != null);
 }

--- a/zig/src/tui/views/telemetry.zig
+++ b/zig/src/tui/views/telemetry.zig
@@ -1,63 +1,105 @@
 const std = @import("std");
+const zz = @import("zigzag");
 const tui_state = @import("tui_state");
+const tui_theme = @import("tui_theme");
+const tui_text = @import("tui_text");
 
 pub const Options = struct {
     width: usize = 80,
 };
 
-pub fn render(allocator: std.mem.Allocator, state: *const tui_state.AppState, options: Options) ![]u8 {
+const gauge_thresholds = [_]zz.Gauge.Threshold{
+    .{ .value = 70, .color = tui_theme.palette.warning },
+    .{ .value = 90, .color = tui_theme.palette.danger },
+};
+
+pub fn render(allocator: std.mem.Allocator, state: *const tui_state.AppState, options: Options) ![]const u8 {
     var out: std.Io.Writer.Allocating = .init(allocator);
     const writer = &out.writer;
     const telemetry = state.telemetry;
     const limit = if (telemetry.context_window > 0) telemetry.context_window else state.status.context_limit;
 
-    try writer.writeAll("Context ");
-    try writeContextBar(writer, telemetry.estimated_tokens, limit, 20);
+    const context_label = try tui_theme.statusKey().render(allocator, "Context");
+    defer allocator.free(context_label);
+    try writer.print("{s} ", .{context_label});
+    var gauge = zz.Gauge{
+        .value = @floatFromInt(telemetry.estimated_tokens),
+        .min = 0,
+        .max = if (limit > 0) @floatFromInt(limit) else 100,
+        .width = 20,
+        .show_value = false,
+        .show_percent = false,
+        .thresholds = &gauge_thresholds,
+        .base_color = tui_theme.palette.success,
+        .empty_color = tui_theme.palette.dim,
+    };
+    var gauge_arena = std.heap.ArenaAllocator.init(allocator);
+    defer gauge_arena.deinit();
+    const gauge_text = gauge.view(gauge_arena.allocator());
+    try writer.writeAll(gauge_text);
+    const used_text = try compactNumber(allocator, telemetry.estimated_tokens);
+    defer allocator.free(used_text);
     if (limit > 0) {
-        try writer.print(" {d}/{d} tok", .{ telemetry.estimated_tokens, limit });
+        const limit_text = try compactNumber(allocator, limit);
+        defer allocator.free(limit_text);
+        try writer.print(" {s}/{s} tok", .{ used_text, limit_text });
     } else {
-        try writer.print(" {d} tok", .{telemetry.estimated_tokens});
+        try writer.print(" {s} tok", .{used_text});
     }
-    try writer.print(" ({d} bytes)", .{telemetry.total_bytes});
+    const bytes_text = try compactNumber(allocator, telemetry.total_bytes);
+    defer allocator.free(bytes_text);
+    try writer.print(" ({s} bytes)", .{bytes_text});
 
-    try writer.writeAll("\nSegments ");
-    try writeSegment(writer, "system_prompt", telemetry.system_prompt);
+    try writer.writeAll("\n");
+    const segments = try tui_theme.statusKey().render(allocator, "Segments");
+    defer allocator.free(segments);
+    try writer.print("{s} ", .{segments});
+    try writeSegment(writer, allocator, "system_prompt", telemetry.system_prompt);
     try writer.writeAll(" • ");
-    try writeSegment(writer, "messages", telemetry.messages);
+    try writeSegment(writer, allocator, "messages", telemetry.messages);
     try writer.writeAll(" • ");
-    try writeSegment(writer, "tools", telemetry.tool_definitions);
+    try writeSegment(writer, allocator, "tools", telemetry.tool_definitions);
 
     if (findLatestTruncatedTool(state)) |tool| {
-        try writer.print("\nTool output truncated {d}->{d} bytes", .{ tool.raw_total_bytes, tool.returned_total_bytes });
+        const raw_text = try compactNumber(allocator, tool.raw_total_bytes);
+        defer allocator.free(raw_text);
+        const returned_text = try compactNumber(allocator, tool.returned_total_bytes);
+        defer allocator.free(returned_text);
+        try writer.print("\nTool output truncated {s}->{s} bytes", .{ raw_text, returned_text });
         if (tool.artifact_refs.len > 0) try writer.print(" • artifact {s}", .{tool.artifact_refs});
     }
 
     const items = out.written();
-    if (items.len > options.width * 3) {
-        const clipped = try allocator.dupe(u8, items[0 .. options.width * 3]);
+    if (tui_text.visibleWidth(items) > options.width * 3) {
+        const clipped = try tui_text.truncateToWidth(allocator, items, options.width * 3);
         out.deinit();
         return clipped;
     }
     return out.toOwnedSlice();
 }
 
-fn writeContextBar(writer: *std.Io.Writer, used: u64, limit: u64, width: usize) !void {
-    try writer.writeByte('[');
-    const filled = if (limit > 0) @min(width, @as(usize, @intCast((used * width) / limit))) else 0;
-    for (0..width) |i| try writer.writeByte(if (i < filled) '#' else '-');
-    try writer.writeByte(']');
+fn compactNumber(allocator: std.mem.Allocator, value: u64) ![]u8 {
+    if (value >= 1_000_000) return std.fmt.allocPrint(allocator, "{d}M", .{value / 1_000_000});
+    if (value >= 1_000) return std.fmt.allocPrint(allocator, "{d}k", .{value / 1_000});
+    return std.fmt.allocPrint(allocator, "{d}", .{value});
 }
 
-fn writeSegment(writer: *std.Io.Writer, name: []const u8, segment: tui_state.PromptSegmentState) !void {
+fn writeSegment(writer: *std.Io.Writer, allocator: std.mem.Allocator, name: []const u8, segment: tui_state.PromptSegmentState) !void {
+    const styled_name = try tui_theme.statusKey().render(allocator, name);
+    defer allocator.free(styled_name);
     if (!segment.seen) {
-        try writer.print("{s}:n/a", .{name});
+        try writer.print("{s}:n/a", .{styled_name});
         return;
     }
     const role: []const u8 = switch (segment.cache_role) {
         .stable => "stable/cacheable",
         .dynamic => "dynamic",
     };
-    try writer.print("{s}:{d}b/{d}t {s}", .{ name, segment.bytes, segment.estimated_tokens, role });
+    const bytes = try compactNumber(allocator, segment.bytes);
+    defer allocator.free(bytes);
+    const tokens = try compactNumber(allocator, segment.estimated_tokens);
+    defer allocator.free(tokens);
+    try writer.print("{s}:{s}b/{s}t {s}", .{ styled_name, bytes, tokens, role });
 }
 
 fn findLatestTruncatedTool(state: *const tui_state.AppState) ?*const tui_state.ToolEntry {
@@ -83,6 +125,6 @@ test "telemetry view renders context and segments" {
     defer std.testing.allocator.free(text);
 
     try std.testing.expect(std.mem.indexOf(u8, text, "100/200 tok") != null);
-    try std.testing.expect(std.mem.indexOf(u8, text, "system_prompt:40b/10t stable/cacheable") != null);
-    try std.testing.expect(std.mem.indexOf(u8, text, "messages:200b/50t dynamic") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "system_prompt") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "messages") != null);
 }

--- a/zig/src/tui/views/telemetry.zig
+++ b/zig/src/tui/views/telemetry.zig
@@ -71,7 +71,7 @@ pub fn render(allocator: std.mem.Allocator, state: *const tui_state.AppState, op
 
     const items = out.written();
     if (tui_text.visibleWidth(items) > options.width * 3) {
-        const clipped = try tui_text.truncateToWidth(allocator, items, options.width * 3);
+        const clipped = try tui_text.truncateLinesToWidth(allocator, items, options.width, 3);
         out.deinit();
         return clipped;
     }
@@ -127,4 +127,20 @@ test "telemetry view renders context and segments" {
     try std.testing.expect(std.mem.indexOf(u8, text, "100/200 tok") != null);
     try std.testing.expect(std.mem.indexOf(u8, text, "system_prompt") != null);
     try std.testing.expect(std.mem.indexOf(u8, text, "messages") != null);
+}
+
+test "telemetry overflow preserves segment line" {
+    var state = tui_state.AppState.init(std.testing.allocator);
+    defer state.deinit();
+    state.telemetry.estimated_tokens = 100;
+    state.telemetry.context_window = 200;
+    state.telemetry.total_bytes = 400;
+    state.telemetry.system_prompt = .{ .bytes = 40, .estimated_tokens = 10, .item_count = 1, .cache_role = .stable, .seen = true };
+    state.telemetry.messages = .{ .bytes = 200, .estimated_tokens = 50, .item_count = 4, .cache_role = .dynamic, .seen = true };
+    state.telemetry.tool_definitions = .{ .bytes = 160, .estimated_tokens = 40, .item_count = 2, .cache_role = .stable, .seen = true };
+
+    const text = try render(std.testing.allocator, &state, .{ .width = 12 });
+    defer std.testing.allocator.free(text);
+
+    try std.testing.expect(std.mem.indexOf(u8, text, "Segments") != null);
 }

--- a/zig/src/tui/views/tool_panel.zig
+++ b/zig/src/tui/views/tool_panel.zig
@@ -1,37 +1,59 @@
 const std = @import("std");
 const tui_state = @import("tui_state");
+const tui_theme = @import("tui_theme");
+const tui_text = @import("tui_text");
 
 pub const Options = struct {
     width: usize = 80,
     height: usize = 8,
 };
 
-pub fn render(allocator: std.mem.Allocator, state: *const tui_state.AppState, options: Options) ![]u8 {
+pub fn render(allocator: std.mem.Allocator, state: *const tui_state.AppState, options: Options) ![]const u8 {
     var out: std.Io.Writer.Allocating = .init(allocator);
     const writer = &out.writer;
-    try writer.print("Tools ({d} registered)", .{state.registered_tools.items.len});
+    const title = try std.fmt.allocPrint(allocator, "Tools ({d} registered)", .{state.registered_tools.items.len});
+    defer allocator.free(title);
+    const styled_title = try tui_theme.panelTitle().render(allocator, title);
+    defer allocator.free(styled_title);
+    try writer.writeAll(styled_title);
     if (state.tools.items.len == 0) {
         if (state.registered_tools.items.len == 0) {
-            try writer.writeAll("\n  none");
-            return out.toOwnedSlice();
+            const none = try tui_theme.muted().render(allocator, "  none");
+            defer allocator.free(none);
+            try writer.writeByte('\n');
+            try writer.writeAll(none);
+            const body = try out.toOwnedSlice();
+            defer allocator.free(body);
+            return tui_theme.panel().width(@intCast(@min(options.width, std.math.maxInt(u16)))).render(allocator, body);
         }
         var rows: usize = 1;
         for (state.registered_tools.items) |tool| {
             if (rows >= options.height) break;
-            try writer.print("\n  {s}", .{tool.name});
+            try writer.writeByte('\n');
+            try writer.print("  {s}", .{tool.name});
             if (tool.short_description.len > 0) {
-                try writer.writeAll(" - ");
-                try writeOneLine(writer, tool.short_description, options.width -| tool.name.len -| 5);
+                try writer.writeAll(" ");
+                const desc = try tui_text.truncateToWidth(allocator, tool.short_description, options.width -| tool.name.len -| 6);
+                defer allocator.free(desc);
+                const styled_desc = try tui_theme.muted().render(allocator, desc);
+                defer allocator.free(styled_desc);
+                try writer.writeAll(styled_desc);
             }
             rows += 1;
         }
-        return out.toOwnedSlice();
+        const body = try out.toOwnedSlice();
+        defer allocator.free(body);
+        return tui_theme.panel().width(@intCast(@min(options.width, std.math.maxInt(u16)))).render(allocator, body);
     }
 
     var rows: usize = 1;
     for (state.tools.items) |tool| {
         if (rows >= options.height) break;
-        try writer.print("\n  [{s}] {s}", .{ statusText(tool.status), tool.name });
+        try writer.writeByte('\n');
+        try writer.writeAll("  ");
+        const status = try tui_theme.toolStatus(tool.status).render(allocator, statusText(tool.status));
+        defer allocator.free(status);
+        try writer.print("[{s}] {s}", .{ status, tool.name });
         if (tool.raw_total_bytes > 0 or tool.returned_total_bytes > 0) {
             try writer.print(" ({d}->{d} bytes", .{ tool.raw_total_bytes, tool.returned_total_bytes });
             if (tool.estimated_returned_tokens > 0) try writer.print(", ~{d} tok", .{tool.estimated_returned_tokens});
@@ -41,12 +63,19 @@ pub fn render(allocator: std.mem.Allocator, state: *const tui_state.AppState, op
         if (tool.artifact_refs.len > 0) try writer.print(" artifact:{s}", .{tool.artifact_refs});
         rows += 1;
         if (tool.expanded and rows < options.height) {
-            try writer.writeAll(" ");
-            try writeOneLine(writer, if (tool.output.items.len > 0) tool.output.items else tool.args_json, options.width -| 4);
+            try writer.writeByte('\n');
+            try writer.writeAll("    ");
+            const one = try oneLine(allocator, if (tool.output.items.len > 0) tool.output.items else tool.args_json, options.width -| 6);
+            defer allocator.free(one);
+            const styled = try tui_theme.muted().render(allocator, one);
+            defer allocator.free(styled);
+            try writer.writeAll(styled);
             rows += 1;
         }
     }
-    return out.toOwnedSlice();
+    const body = try out.toOwnedSlice();
+    defer allocator.free(body);
+    return tui_theme.panel().width(@intCast(@min(options.width, std.math.maxInt(u16)))).render(allocator, body);
 }
 
 fn statusText(status: tui_state.ToolStatus) []const u8 {
@@ -58,12 +87,16 @@ fn statusText(status: tui_state.ToolStatus) []const u8 {
     };
 }
 
-fn writeOneLine(writer: *std.Io.Writer, text: []const u8, width: usize) !void {
-    if (width == 0) return;
+fn oneLine(allocator: std.mem.Allocator, text: []const u8, width: usize) ![]u8 {
     const nl = std.mem.indexOfScalar(u8, text, '\n') orelse text.len;
     const line = text[0..nl];
-    try writer.writeAll(line[0..@min(width, line.len)]);
-    if (line.len > width or nl < text.len) try writer.writeAll("…");
+    const clipped = try tui_text.truncateToWidth(allocator, line, width);
+    if (nl < text.len and tui_text.visibleWidth(clipped) < width) {
+        const with_ellipsis = try std.fmt.allocPrint(allocator, "{s}…", .{clipped});
+        allocator.free(clipped);
+        return with_ellipsis;
+    }
+    return clipped;
 }
 
 test "tool panel renders registered tools when idle" {
@@ -83,7 +116,8 @@ test "tool panel renders registered tools when idle" {
     defer std.testing.allocator.free(text);
 
     try std.testing.expect(std.mem.indexOf(u8, text, "Tools (1 registered)") != null);
-    try std.testing.expect(std.mem.indexOf(u8, text, "shell_execute - Run shell commands") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "shell_execute") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "Run shell commands") != null);
     try std.testing.expect(std.mem.indexOf(u8, text, "none") == null);
 }
 
@@ -97,6 +131,7 @@ test "tool panel renders tool status and output" {
     const text = try render(std.testing.allocator, &state, .{ .width = 80, .height = 4 });
     defer std.testing.allocator.free(text);
 
-    try std.testing.expect(std.mem.indexOf(u8, text, "[running] shell_command") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "running") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "shell_command") != null);
     try std.testing.expect(std.mem.indexOf(u8, text, "ok") != null);
 }

--- a/zig/src/tui/views/transcript.zig
+++ b/zig/src/tui/views/transcript.zig
@@ -45,7 +45,9 @@ pub fn render(allocator: std.mem.Allocator, state: *const AppState, options: Opt
 }
 
 fn renderEntryText(allocator: std.mem.Allocator, kind: TranscriptKind, text: []const u8, width: usize) ![]const u8 {
-    const clipped = try tui_text.truncateToWidth(allocator, text, width);
+    const flattened = try tui_text.flattenNewlines(allocator, text, " / ");
+    defer allocator.free(flattened);
+    const clipped = try tui_text.truncateToWidth(allocator, flattened, width);
     errdefer allocator.free(clipped);
     if (kind == .@"error") {
         const styled = try tui_theme.errorText().render(allocator, clipped);
@@ -79,4 +81,15 @@ test "transcript renders labels" {
     try std.testing.expect(std.mem.indexOf(u8, text, "hello") != null);
     try std.testing.expect(std.mem.indexOf(u8, text, "AI:") != null);
     try std.testing.expect(std.mem.indexOf(u8, text, "world") != null);
+}
+
+test "transcript flattens multiline entries into one rendered row" {
+    var state = AppState.init(std.testing.allocator);
+    defer state.deinit();
+    try state.appendTranscript(.assistant, "alpha\nbeta");
+
+    const text = try render(std.testing.allocator, &state, .{ .width = 80, .height = 10 });
+    defer std.testing.allocator.free(text);
+
+    try std.testing.expect(std.mem.indexOf(u8, text, "alpha / beta") != null);
 }

--- a/zig/src/tui/views/transcript.zig
+++ b/zig/src/tui/views/transcript.zig
@@ -1,5 +1,7 @@
 const std = @import("std");
 const tui_state = @import("tui_state");
+const tui_theme = @import("tui_theme");
+const tui_text = @import("tui_text");
 
 const AppState = tui_state.AppState;
 const TranscriptKind = tui_state.TranscriptKind;
@@ -9,7 +11,7 @@ pub const Options = struct {
     height: usize = 20,
 };
 
-pub fn render(allocator: std.mem.Allocator, state: *const AppState, options: Options) ![]u8 {
+pub fn render(allocator: std.mem.Allocator, state: *const AppState, options: Options) ![]const u8 {
     var out: std.Io.Writer.Allocating = .init(allocator);
     const writer = &out.writer;
 
@@ -19,18 +21,38 @@ pub fn render(allocator: std.mem.Allocator, state: *const AppState, options: Opt
     const start = max_start -| state.transcript_scroll;
 
     if (total == 0) {
-        try writer.writeAll("Makai ready. Type message, /quit exits.");
+        const ready = try tui_theme.muted().render(allocator, "Makai ready. Type message, /quit exits.");
+        defer allocator.free(ready);
+        try writer.writeAll(ready);
         return out.toOwnedSlice();
     }
 
     for (state.transcript.items[start..], 0..) |entry, i| {
         if (i >= visible) break;
         if (i > 0) try writer.writeByte('\n');
-        try writer.print("{s} ", .{label(entry.kind)});
-        try writeClipped(writer, entry.text.items, options.width -| label(entry.kind).len -| 1);
+        const raw_label = label(entry.kind);
+        const styled_label = try tui_theme.role(entry.kind).render(allocator, raw_label);
+        defer allocator.free(styled_label);
+        try writer.writeAll(styled_label);
+        try writer.writeByte(' ');
+        const max_text_width = options.width -| tui_text.visibleWidth(raw_label) -| 1;
+        const rendered = try renderEntryText(allocator, entry.kind, entry.text.items, max_text_width);
+        defer allocator.free(rendered);
+        try writer.writeAll(rendered);
     }
 
     return out.toOwnedSlice();
+}
+
+fn renderEntryText(allocator: std.mem.Allocator, kind: TranscriptKind, text: []const u8, width: usize) ![]const u8 {
+    const clipped = try tui_text.truncateToWidth(allocator, text, width);
+    errdefer allocator.free(clipped);
+    if (kind == .@"error") {
+        const styled = try tui_theme.errorText().render(allocator, clipped);
+        allocator.free(clipped);
+        return styled;
+    }
+    return clipped;
 }
 
 fn label(kind: TranscriptKind) []const u8 {
@@ -44,22 +66,6 @@ fn label(kind: TranscriptKind) []const u8 {
     };
 }
 
-fn writeClipped(writer: *std.Io.Writer, text: []const u8, width: usize) !void {
-    if (width == 0) return;
-    var line_len: usize = 0;
-    var iter = std.mem.splitScalar(u8, text, '\n');
-    while (iter.next()) |line| {
-        if (line_len > 0) try writer.writeAll(" / ");
-        const take = @min(width, line.len);
-        try writer.writeAll(line[0..take]);
-        line_len += take;
-        if (take < line.len) {
-            try writer.writeAll("…");
-            break;
-        }
-    }
-}
-
 test "transcript renders labels" {
     var state = AppState.init(std.testing.allocator);
     defer state.deinit();
@@ -69,6 +75,8 @@ test "transcript renders labels" {
     const text = try render(std.testing.allocator, &state, .{ .width = 80, .height = 10 });
     defer std.testing.allocator.free(text);
 
-    try std.testing.expect(std.mem.indexOf(u8, text, "You: hello") != null);
-    try std.testing.expect(std.mem.indexOf(u8, text, "AI: world") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "You:") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "hello") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "AI:") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "world") != null);
 }


### PR DESCRIPTION
## Summary
- Add shared TUI theme, ANSI-aware text helpers, and synchronized output wrapper.
- Apply ZigZag styles, bordered panels, colored roles/statuses, ANSI-aware truncation, and Gauge telemetry across current TUI views.
- Replace top-level manual newline layout with ZigZag vertical joins and CSI 2026 synchronized frame rendering.

## Test plan
- [x] `zig build test-unit-tui`
- [x] `zig build test`
- [x] `zig build run-tui` launched briefly with a 3s alarm; terminated by alarm as expected.