### PR TITLE
Improve TUI transcript composer status

### DIFF
--- a/zig/src/tui/app.zig
+++ b/zig/src/tui/app.zig
@@ -290,7 +290,11 @@ const TuiModel = struct {
         switch (msg) {
             .key => |key| {
                 if (key.modifiers.ctrl) switch (key.key) {
-                    .char => |c| if (c == 'c') return .quit,
+                    .char => |c| switch (c) {
+                        'c' => return .quit,
+                        'r' => app.state.toggleThinking(),
+                        else => {},
+                    },
                     else => {},
                 };
                 if (app.state.mode == .approval) {
@@ -327,8 +331,14 @@ const TuiModel = struct {
                     .backspace => deleteLastCodepoint(app),
                     .char => |c| appendChar(app, c) catch {},
                     .space => app.state.composer.buffer.append(app.allocator, ' ') catch {},
-                    .up, .page_up => app.state.transcript_scroll += 1,
-                    .down, .page_down => app.state.transcript_scroll -|= 1,
+                    .up => {
+                        if (!(app.state.composerHistoryPrev() catch false)) app.state.transcript_scroll += 1;
+                    },
+                    .down => {
+                        if (!(app.state.composerHistoryNext() catch false)) app.state.transcript_scroll -|= 1;
+                    },
+                    .page_up => app.state.transcript_scroll += 1,
+                    .page_down => app.state.transcript_scroll -|= 1,
                     .escape => app.state.mode = .normal,
                     else => {},
                 }

--- a/zig/src/tui/app.zig
+++ b/zig/src/tui/app.zig
@@ -292,8 +292,11 @@ const TuiModel = struct {
                 if (key.modifiers.ctrl) switch (key.key) {
                     .char => |c| switch (c) {
                         'c' => return .quit,
-                        'r' => app.state.toggleThinking(),
-                        else => {},
+                        'r' => {
+                            app.state.toggleThinking();
+                            return .none;
+                        },
+                        else => return .none,
                     },
                     else => {},
                 };
@@ -317,6 +320,7 @@ const TuiModel = struct {
                             return .none;
                         }
                         const text = app.state.composer.text();
+                        app.state.recordComposerHistory(text) catch |err| app.recordError(@errorName(err)) catch {};
                         app.submit(text) catch |err| {
                             if (err == error.QuitRequested) return .quit;
                             app.state.status.setError(app.allocator, @errorName(err)) catch {};

--- a/zig/src/tui/state.zig
+++ b/zig/src/tui/state.zig
@@ -281,6 +281,7 @@ pub const AppState = struct {
     status: StatusState = .{},
     telemetry: TelemetryState = .{},
     preview: PreviewState = .{},
+    show_thinking: bool = true,
     transcript_scroll: usize = 0,
     tool_scroll: usize = 0,
     session_index: usize = 0,
@@ -342,6 +343,39 @@ pub const AppState = struct {
         return submitted;
     }
 
+    pub fn replaceComposerBuffer(self: *AppState, text: []const u8) !void {
+        self.composer.buffer.clearRetainingCapacity();
+        try self.composer.buffer.appendSlice(self.allocator, text);
+    }
+
+    pub fn composerHistoryPrev(self: *AppState) !bool {
+        if (self.composer.history.items.len == 0) return false;
+        const next_index = if (self.composer.history_index) |index|
+            index -| 1
+        else
+            self.composer.history.items.len - 1;
+        self.composer.history_index = next_index;
+        try self.replaceComposerBuffer(self.composer.history.items[next_index]);
+        return true;
+    }
+
+    pub fn composerHistoryNext(self: *AppState) !bool {
+        const current = self.composer.history_index orelse return false;
+        if (current + 1 >= self.composer.history.items.len) {
+            self.composer.history_index = null;
+            self.composer.buffer.clearRetainingCapacity();
+            return true;
+        }
+        const next_index = current + 1;
+        self.composer.history_index = next_index;
+        try self.replaceComposerBuffer(self.composer.history.items[next_index]);
+        return true;
+    }
+
+    pub fn toggleThinking(self: *AppState) void {
+        self.show_thinking = !self.show_thinking;
+    }
+
     pub fn applyEvent(self: *AppState, event: tui_runtime.TuiEvent) !void {
         switch (event) {
             .agent_start => {
@@ -375,7 +409,9 @@ pub const AppState = struct {
             .tool_execution_start => |payload| {
                 const tool = try self.upsertTool(payload.tool_call_id.slice(), payload.tool_name.slice(), payload.args_json.slice(), .running);
                 tool.expanded = true;
-                try self.appendTranscript(.tool, payload.tool_name.slice());
+                const summary = try toolSummary(self.allocator, payload.tool_name.slice(), payload.args_json.slice());
+                defer self.allocator.free(summary);
+                try self.appendTranscript(.tool, summary);
             },
             .tool_execution_update => |payload| {
                 const tool = try self.upsertTool(payload.tool_call_id.slice(), payload.tool_name.slice(), payload.args_json.slice(), .running);
@@ -677,6 +713,55 @@ fn jsonUsize(obj: std.json.ObjectMap, key: []const u8) ?usize {
     };
 }
 
+fn toolSummary(allocator: std.mem.Allocator, name: []const u8, args_json: []const u8) ![]u8 {
+    const primary = primaryToolArg(allocator, args_json) catch null;
+    defer if (primary) |value| allocator.free(value);
+    if (primary) |value| {
+        const clipped = try clipSummaryArg(allocator, value);
+        defer allocator.free(clipped);
+        return std.fmt.allocPrint(allocator, "◈ {s} \"{s}\"", .{ name, clipped });
+    }
+    return std.fmt.allocPrint(allocator, "◈ {s}", .{name});
+}
+
+fn primaryToolArg(allocator: std.mem.Allocator, args_json: []const u8) !?[]u8 {
+    if (args_json.len == 0) return null;
+    var parsed = std.json.parseFromSlice(std.json.Value, allocator, args_json, .{}) catch return null;
+    defer parsed.deinit();
+    if (parsed.value != .object) return null;
+    const keys = [_][]const u8{ "command", "path", "query", "pattern", "file", "operation" };
+    for (keys) |key| {
+        if (jsonString(parsed.value.object, key)) |value| {
+            if (value.len > 0) return try allocator.dupe(u8, value);
+        }
+    }
+    return null;
+}
+
+fn clipSummaryArg(allocator: std.mem.Allocator, value: []const u8) ![]u8 {
+    var out: std.Io.Writer.Allocating = .init(allocator);
+    errdefer out.deinit();
+    const writer = &out.writer;
+    var width: usize = 0;
+    var i: usize = 0;
+    while (i < value.len and width < 48) {
+        const c = value[i];
+        if (c == '\n' or c == '\r' or c == '\t') {
+            try writer.writeByte(' ');
+            width += 1;
+            i += 1;
+            continue;
+        }
+        const len = std.unicode.utf8ByteSequenceLength(c) catch 1;
+        if (i + len > value.len) break;
+        try writer.writeAll(value[i .. i + len]);
+        width += 1;
+        i += len;
+    }
+    if (i < value.len) try writer.writeAll("…");
+    return out.toOwnedSlice();
+}
+
 fn ownedText(text: []const u8) !@import("owned_slice").OwnedSlice(u8) {
     return @import("owned_slice").OwnedSlice(u8).initOwned(try std.testing.allocator.dupe(u8, text));
 }
@@ -738,6 +823,7 @@ test "AppState applies transcript and tool events" {
     try std.testing.expectEqual(@as(usize, 1), state.tools.items.len);
     try std.testing.expectEqual(ToolStatus.done, state.tools.items[0].status);
     try std.testing.expect(std.mem.indexOf(u8, state.tools.items[0].output.items, "ok") != null);
+    try std.testing.expect(std.mem.indexOf(u8, state.transcript.items[1].text.items, "◈ shell_command \"pwd\"") != null);
 }
 
 test "AppState finalizes transcript from message_end text" {
@@ -1083,6 +1169,31 @@ test "Composer submission stores history and user transcript" {
     try std.testing.expectEqual(@as(usize, 1), state.transcript.items.len);
     try std.testing.expectEqual(TranscriptKind.user, state.transcript.items[0].kind);
     try std.testing.expectEqualStrings("hello makai", state.transcript.items[0].text.items);
+}
+
+test "Composer history navigation recalls entries and clears at end" {
+    var state = AppState.init(std.testing.allocator);
+    defer state.deinit();
+
+    try state.composer.history.append(std.testing.allocator, try std.testing.allocator.dupe(u8, "first"));
+    try state.composer.history.append(std.testing.allocator, try std.testing.allocator.dupe(u8, "second"));
+
+    try std.testing.expect(try state.composerHistoryPrev());
+    try std.testing.expectEqualStrings("second", state.composer.text());
+    try std.testing.expect(try state.composerHistoryPrev());
+    try std.testing.expectEqualStrings("first", state.composer.text());
+    try std.testing.expect(try state.composerHistoryNext());
+    try std.testing.expectEqualStrings("second", state.composer.text());
+    try std.testing.expect(try state.composerHistoryNext());
+    try std.testing.expectEqualStrings("", state.composer.text());
+}
+
+test "AppState toggles thinking visibility" {
+    var state = AppState.init(std.testing.allocator);
+    defer state.deinit();
+    try std.testing.expect(state.show_thinking);
+    state.toggleThinking();
+    try std.testing.expect(!state.show_thinking);
 }
 
 test "AppState applies thinking tool call and lifecycle events" {

--- a/zig/src/tui/state.zig
+++ b/zig/src/tui/state.zig
@@ -770,9 +770,25 @@ fn clipSummaryArg(allocator: std.mem.Allocator, value: []const u8) ![]u8 {
             i += 1;
             continue;
         }
+        if (c < 0x20 or c == 0x7f) {
+            i += 1;
+            continue;
+        }
         const len = std.unicode.utf8ByteSequenceLength(c) catch 1;
         if (i + len > value.len) break;
-        try writer.writeAll(value[i .. i + len]);
+        if (len == 1) {
+            try writer.writeByte(c);
+        } else {
+            const codepoint = std.unicode.utf8Decode(value[i .. i + len]) catch {
+                i += 1;
+                continue;
+            };
+            if (codepoint < 0x20 or codepoint == 0x7f) {
+                i += len;
+                continue;
+            }
+            try writer.writeAll(value[i .. i + len]);
+        }
         width += 1;
         i += len;
     }
@@ -842,6 +858,23 @@ test "AppState applies transcript and tool events" {
     try std.testing.expectEqual(ToolStatus.done, state.tools.items[0].status);
     try std.testing.expect(std.mem.indexOf(u8, state.tools.items[0].output.items, "ok") != null);
     try std.testing.expect(std.mem.indexOf(u8, state.transcript.items[1].text.items, "◈ shell_command \"pwd\"") != null);
+}
+
+test "AppState strips control bytes from tool summaries" {
+    var state = AppState.init(std.testing.allocator);
+    defer state.deinit();
+
+    var start_event = tui_runtime.TuiEvent{ .tool_execution_start = .{
+        .tool_call_id = try ownedText("call-1"),
+        .tool_name = try ownedText("shell_command"),
+        .args_json = try ownedText("{\"command\":\"before\\u001b[2Jafter\\u0007\"}"),
+    } };
+    defer start_event.deinit(std.testing.allocator);
+    try state.applyEvent(start_event);
+
+    try std.testing.expect(std.mem.indexOfScalar(u8, state.transcript.items[0].text.items, 0x1b) == null);
+    try std.testing.expect(std.mem.indexOfScalar(u8, state.transcript.items[0].text.items, 0x07) == null);
+    try std.testing.expect(std.mem.indexOf(u8, state.transcript.items[0].text.items, "before[2Jafter") != null);
 }
 
 test "AppState finalizes transcript from message_end text" {

--- a/zig/src/tui/state.zig
+++ b/zig/src/tui/state.zig
@@ -248,17 +248,20 @@ pub const ComposerState = struct {
     buffer: std.ArrayList(u8) = .empty,
     history: std.ArrayList([]u8) = .empty,
     history_index: ?usize = null,
+    history_draft: std.ArrayList(u8) = .empty,
 
     pub fn deinit(self: *ComposerState, allocator: std.mem.Allocator) void {
         self.buffer.deinit(allocator);
         for (self.history.items) |item| allocator.free(item);
         self.history.deinit(allocator);
+        self.history_draft.deinit(allocator);
         self.* = undefined;
     }
 
     pub fn clear(self: *ComposerState) void {
         self.buffer.clearRetainingCapacity();
         self.history_index = null;
+        self.history_draft.clearRetainingCapacity();
     }
 
     pub fn text(self: ComposerState) []const u8 {
@@ -337,10 +340,18 @@ pub const AppState = struct {
         }
         const submitted = try self.allocator.dupe(u8, raw);
         errdefer self.allocator.free(submitted);
-        try self.composer.history.append(self.allocator, try self.allocator.dupe(u8, submitted));
+        try self.recordComposerHistory(submitted);
         self.composer.clear();
         try self.appendUserMessage(submitted);
         return submitted;
+    }
+
+    pub fn recordComposerHistory(self: *AppState, text: []const u8) !void {
+        const raw = std.mem.trim(u8, text, " \t\r\n");
+        if (raw.len == 0) return;
+        try self.composer.history.append(self.allocator, try self.allocator.dupe(u8, raw));
+        self.composer.history_index = null;
+        self.composer.history_draft.clearRetainingCapacity();
     }
 
     pub fn replaceComposerBuffer(self: *AppState, text: []const u8) !void {
@@ -350,10 +361,16 @@ pub const AppState = struct {
 
     pub fn composerHistoryPrev(self: *AppState) !bool {
         if (self.composer.history.items.len == 0) return false;
-        const next_index = if (self.composer.history_index) |index|
-            index -| 1
-        else
-            self.composer.history.items.len - 1;
+        if (self.composer.history_index) |index| {
+            if (index == 0) return false;
+            const next_index = index - 1;
+            self.composer.history_index = next_index;
+            try self.replaceComposerBuffer(self.composer.history.items[next_index]);
+            return true;
+        }
+        self.composer.history_draft.clearRetainingCapacity();
+        try self.composer.history_draft.appendSlice(self.allocator, self.composer.buffer.items);
+        const next_index = self.composer.history.items.len - 1;
         self.composer.history_index = next_index;
         try self.replaceComposerBuffer(self.composer.history.items[next_index]);
         return true;
@@ -363,7 +380,8 @@ pub const AppState = struct {
         const current = self.composer.history_index orelse return false;
         if (current + 1 >= self.composer.history.items.len) {
             self.composer.history_index = null;
-            self.composer.buffer.clearRetainingCapacity();
+            try self.replaceComposerBuffer(self.composer.history_draft.items);
+            self.composer.history_draft.clearRetainingCapacity();
             return true;
         }
         const next_index = current + 1;
@@ -1171,21 +1189,24 @@ test "Composer submission stores history and user transcript" {
     try std.testing.expectEqualStrings("hello makai", state.transcript.items[0].text.items);
 }
 
-test "Composer history navigation recalls entries and clears at end" {
+test "Composer history navigation recalls entries and restores draft" {
     var state = AppState.init(std.testing.allocator);
     defer state.deinit();
 
     try state.composer.history.append(std.testing.allocator, try std.testing.allocator.dupe(u8, "first"));
     try state.composer.history.append(std.testing.allocator, try std.testing.allocator.dupe(u8, "second"));
+    try state.composer.buffer.appendSlice(std.testing.allocator, "draft");
 
     try std.testing.expect(try state.composerHistoryPrev());
     try std.testing.expectEqualStrings("second", state.composer.text());
     try std.testing.expect(try state.composerHistoryPrev());
     try std.testing.expectEqualStrings("first", state.composer.text());
+    try std.testing.expect(!try state.composerHistoryPrev());
+    try std.testing.expectEqualStrings("first", state.composer.text());
     try std.testing.expect(try state.composerHistoryNext());
     try std.testing.expectEqualStrings("second", state.composer.text());
     try std.testing.expect(try state.composerHistoryNext());
-    try std.testing.expectEqualStrings("", state.composer.text());
+    try std.testing.expectEqualStrings("draft", state.composer.text());
 }
 
 test "AppState toggles thinking visibility" {

--- a/zig/src/tui/text.zig
+++ b/zig/src/tui/text.zig
@@ -16,6 +16,12 @@ pub fn lineCount(text: []const u8) usize {
     return count;
 }
 
+pub fn compactNumber(allocator: std.mem.Allocator, value: u64) ![]u8 {
+    if (value >= 1_000_000) return std.fmt.allocPrint(allocator, "{d}M", .{value / 1_000_000});
+    if (value >= 1_000) return std.fmt.allocPrint(allocator, "{d}k", .{value / 1_000});
+    return std.fmt.allocPrint(allocator, "{d}", .{value});
+}
+
 pub fn truncateToWidth(allocator: std.mem.Allocator, text: []const u8, max_width: usize) ![]u8 {
     return truncateLineToWidth(allocator, text, max_width);
 }
@@ -240,6 +246,18 @@ fn copyAnsiSequence(writer: *std.Io.Writer, text: []const u8, index: *usize) !vo
 
 fn isSgrSequence(seq: []const u8) bool {
     return seq.len >= 3 and seq[0] == 0x1b and seq[1] == '[' and seq[seq.len - 1] == 'm';
+}
+
+test "compactNumber formats suffixes" {
+    const small = try compactNumber(std.testing.allocator, 42);
+    defer std.testing.allocator.free(small);
+    try std.testing.expectEqualStrings("42", small);
+    const thousands = try compactNumber(std.testing.allocator, 12_345);
+    defer std.testing.allocator.free(thousands);
+    try std.testing.expectEqualStrings("12k", thousands);
+    const millions = try compactNumber(std.testing.allocator, 2_000_000);
+    defer std.testing.allocator.free(millions);
+    try std.testing.expectEqualStrings("2M", millions);
 }
 
 test "visibleWidth ignores ANSI" {

--- a/zig/src/tui/views/composer.zig
+++ b/zig/src/tui/views/composer.zig
@@ -13,24 +13,65 @@ pub fn render(allocator: std.mem.Allocator, state: *const tui_state.AppState, op
     const inner_width = options.width -| 4;
     const input = try renderInput(allocator, state, inner_width);
     defer allocator.free(input);
-    const help = try tui_theme.muted().render(allocator, "Enter submit • Shift+Enter newline • Ctrl+C quit • /quit quit");
-    defer allocator.free(help);
-    const body = try tui_render.joinVertical(allocator, &.{ input, help });
+    const hint = try renderHint(allocator, state);
+    defer allocator.free(hint);
+    const body = try tui_render.joinVertical(allocator, &.{ input, hint });
     defer allocator.free(body);
     return tui_theme.panel().width(@intCast(@min(options.width, std.math.maxInt(u16)))).render(allocator, body);
 }
 
 fn renderInput(allocator: std.mem.Allocator, state: *const tui_state.AppState, width: usize) ![]u8 {
-    const text = state.composer.text();
-    const prompt = try tui_theme.composerPrompt().render(allocator, "> ");
+    const prompt = try tui_theme.composerPrompt().render(allocator, promptFor(state));
     defer allocator.free(prompt);
-    const remaining = width -| tui_text.visibleWidth(prompt);
-    const content = if (text.len == 0)
-        try tui_theme.composerPlaceholder().render(allocator, "Ask Makai…")
-    else
-        try tui_text.truncateLinesToWidth(allocator, text, remaining, 3);
+    if (state.composer.text().len == 0) {
+        var area = zz.TextArea.init(allocator);
+        defer area.deinit();
+        area.placeholder = "Ask Makai…";
+        area.placeholder_style = tui_theme.composerPlaceholder();
+        area.setSize(@intCast(@min(width, std.math.maxInt(u16))), 1);
+        const content = try tui_theme.composerPlaceholder().render(allocator, "Ask Makai…");
+        defer allocator.free(content);
+        return prefixFirstLine(allocator, prompt, content);
+    }
+    const content = try tui_text.truncateLinesToWidth(allocator, state.composer.text(), width, 4);
     defer allocator.free(content);
-    return std.fmt.allocPrint(allocator, "{s}{s}", .{ prompt, content });
+    return prefixFirstLine(allocator, prompt, content);
+}
+
+fn renderHint(allocator: std.mem.Allocator, state: *const tui_state.AppState) ![]const u8 {
+    const text = state.composer.text();
+    if (std.mem.startsWith(u8, text, "!"))
+        return tui_theme.muted().render(allocator, "shell mode • Enter runs command through agent");
+    if (std.mem.startsWith(u8, text, "@"))
+        return tui_theme.muted().render(allocator, "file picker • type path or query");
+    if (state.composer.history.items.len > 0) {
+        const hint = try std.fmt.allocPrint(allocator, "↑/↓ history • {d} saved • Shift+Enter newline • Ctrl+R thinking", .{state.composer.history.items.len});
+        defer allocator.free(hint);
+        return tui_theme.muted().render(allocator, hint);
+    }
+    return tui_theme.muted().render(allocator, "Enter submit • Shift+Enter newline • Ctrl+R thinking • Ctrl+C quit");
+}
+
+fn promptFor(state: *const tui_state.AppState) []const u8 {
+    const text = state.composer.text();
+    if (std.mem.startsWith(u8, text, "!")) return "! ";
+    if (std.mem.startsWith(u8, text, "@")) return "@ ";
+    return "> ";
+}
+
+fn prefixFirstLine(allocator: std.mem.Allocator, prompt: []const u8, content: []const u8) ![]u8 {
+    var out: std.Io.Writer.Allocating = .init(allocator);
+    errdefer out.deinit();
+    const writer = &out.writer;
+    try writer.writeAll(prompt);
+    var lines = std.mem.splitScalar(u8, content, '\n');
+    if (lines.next()) |first| try writer.writeAll(first);
+    while (lines.next()) |line| {
+        try writer.writeByte('\n');
+        try writer.writeAll("  ");
+        try writer.writeAll(line);
+    }
+    return out.toOwnedSlice();
 }
 
 test "composer renders placeholder and text" {
@@ -59,4 +100,19 @@ test "composer renders multiline draft content" {
 
     try std.testing.expect(std.mem.indexOf(u8, text, "first line") != null);
     try std.testing.expect(std.mem.indexOf(u8, text, "second line") != null);
+}
+
+test "composer renders shell and file hints" {
+    var state = tui_state.AppState.init(std.testing.allocator);
+    defer state.deinit();
+    try state.composer.buffer.appendSlice(std.testing.allocator, "!ls");
+    const shell = try render(std.testing.allocator, &state, .{ .width = 50 });
+    defer std.testing.allocator.free(shell);
+    try std.testing.expect(std.mem.indexOf(u8, shell, "shell mode") != null);
+
+    state.composer.buffer.clearRetainingCapacity();
+    try state.composer.buffer.appendSlice(std.testing.allocator, "@src");
+    const file = try render(std.testing.allocator, &state, .{ .width = 50 });
+    defer std.testing.allocator.free(file);
+    try std.testing.expect(std.mem.indexOf(u8, file, "file picker") != null);
 }

--- a/zig/src/tui/views/composer.zig
+++ b/zig/src/tui/views/composer.zig
@@ -22,12 +22,15 @@ pub fn render(allocator: std.mem.Allocator, state: *const tui_state.AppState, op
 fn renderInput(allocator: std.mem.Allocator, state: *const tui_state.AppState, width: usize) ![]u8 {
     const prompt = try tui_theme.composerPrompt().render(allocator, promptFor(state));
     defer allocator.free(prompt);
+    const content_width = width -| tui_text.visibleWidth(promptFor(state));
     if (state.composer.text().len == 0) {
-        const content = try tui_theme.composerPlaceholder().render(allocator, "Ask Makai…");
+        const placeholder = try tui_text.truncateLineToWidth(allocator, "Ask Makai…", content_width);
+        defer allocator.free(placeholder);
+        const content = try tui_theme.composerPlaceholder().render(allocator, placeholder);
         defer allocator.free(content);
         return prefixFirstLine(allocator, prompt, content);
     }
-    const content = try tui_text.truncateLinesToWidth(allocator, state.composer.text(), width, 4);
+    const content = try tui_text.truncateLinesToWidth(allocator, state.composer.text(), content_width, 4);
     defer allocator.free(content);
     return prefixFirstLine(allocator, prompt, content);
 }
@@ -109,4 +112,18 @@ test "composer renders shell and file hints" {
     const file = try render(std.testing.allocator, &state, .{ .width = 50 });
     defer std.testing.allocator.free(file);
     try std.testing.expect(std.mem.indexOf(u8, file, "file picker") != null);
+}
+
+test "composer accounts for prompt width when truncating text" {
+    var state = tui_state.AppState.init(std.testing.allocator);
+    defer state.deinit();
+    try state.composer.buffer.appendSlice(std.testing.allocator, "1234567890");
+
+    const input = try renderInput(std.testing.allocator, &state, 8);
+    defer std.testing.allocator.free(input);
+
+    var lines = std.mem.splitScalar(u8, input, '\n');
+    while (lines.next()) |line| {
+        try std.testing.expect(tui_text.visibleWidth(line) <= 8);
+    }
 }

--- a/zig/src/tui/views/composer.zig
+++ b/zig/src/tui/views/composer.zig
@@ -1,5 +1,4 @@
 const std = @import("std");
-const zz = @import("zigzag");
 const tui_state = @import("tui_state");
 const tui_theme = @import("tui_theme");
 const tui_text = @import("tui_text");
@@ -24,11 +23,6 @@ fn renderInput(allocator: std.mem.Allocator, state: *const tui_state.AppState, w
     const prompt = try tui_theme.composerPrompt().render(allocator, promptFor(state));
     defer allocator.free(prompt);
     if (state.composer.text().len == 0) {
-        var area = zz.TextArea.init(allocator);
-        defer area.deinit();
-        area.placeholder = "Ask Makai…";
-        area.placeholder_style = tui_theme.composerPlaceholder();
-        area.setSize(@intCast(@min(width, std.math.maxInt(u16))), 1);
         const content = try tui_theme.composerPlaceholder().render(allocator, "Ask Makai…");
         defer allocator.free(content);
         return prefixFirstLine(allocator, prompt, content);

--- a/zig/src/tui/views/status_bar.zig
+++ b/zig/src/tui/views/status_bar.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const zz = @import("zigzag");
 const tui_state = @import("tui_state");
 const tui_theme = @import("tui_theme");
 const tui_text = @import("tui_text");
@@ -7,41 +8,38 @@ pub const Options = struct {
     width: usize = 80,
 };
 
+const gauge_thresholds = [_]zz.Gauge.Threshold{
+    .{ .value = 70, .color = tui_theme.palette.warning },
+    .{ .value = 90, .color = tui_theme.palette.danger },
+};
+
 pub fn render(allocator: std.mem.Allocator, state: *const tui_state.AppState, options: Options) ![]const u8 {
     var out: std.Io.Writer.Allocating = .init(allocator);
+    errdefer out.deinit();
     const writer = &out.writer;
     const model = if (state.status.model.len > 0) state.status.model else "no-model";
-    const provider = if (state.status.provider.len > 0) state.status.provider else "no-provider";
-    const session = if (state.status.session_id.len > 0) state.status.session_id else "local";
+    const provider = if (state.status.provider.len > 0) state.status.provider else "local";
     const stream = if (state.status.streaming) "streaming" else "idle";
+    const perm = if (state.mode == .approval) "pending" else "ask";
 
     try writeOwnedSegment(writer, allocator, "model", try std.fmt.allocPrint(allocator, "{s}/{s}", .{ provider, model }));
     try writer.writeAll(" • ");
-    try writeSegment(writer, allocator, "session", session);
+    try writeContext(writer, allocator, state);
+    try writer.writeAll(" • ");
+    try writeOwnedSegment(writer, allocator, "cost", try estimatedCost(allocator, state));
+    try writer.writeAll(" • ");
+    try writeStyledValue(writer, allocator, "state", stream, if (state.status.streaming) tui_theme.successText() else tui_theme.muted());
+    try writer.writeAll(" • ");
+    try writeSegment(writer, allocator, "perm", perm);
     try writer.writeAll(" • ");
     try writeOwnedSegment(writer, allocator, "turns", try std.fmt.allocPrint(allocator, "{d}", .{state.status.turn_count}));
-    try writer.writeAll(" • ");
-    const stream_style = if (state.status.streaming) tui_theme.successText() else tui_theme.muted();
-    const styled_stream = try stream_style.render(allocator, stream);
-    defer allocator.free(styled_stream);
-    try writer.writeAll(styled_stream);
-
-    if (state.status.context_limit > 0) {
-        const pct = (state.status.context_used * 100) / state.status.context_limit;
-        try writer.writeAll(" • ");
-        const ctx = try std.fmt.allocPrint(allocator, "{d}% {d}/{d}", .{ pct, state.status.context_used, state.status.context_limit });
-        try writeOwnedSegment(writer, allocator, "ctx", ctx);
-    } else if (state.status.context_used > 0) {
-        try writer.writeAll(" • ");
-        const ctx = try std.fmt.allocPrint(allocator, "{d}tok", .{state.status.context_used});
-        try writeOwnedSegment(writer, allocator, "ctx", ctx);
-    }
     if (state.status.last_error.len > 0) {
         try writer.writeAll(" • ");
         const err = try tui_theme.errorText().render(allocator, state.status.last_error);
         defer allocator.free(err);
         try writer.writeAll(err);
     }
+
     const items = out.written();
     if (tui_text.visibleWidth(items) > options.width) {
         const clipped = try tui_text.truncateToWidth(allocator, items, options.width);
@@ -51,10 +49,55 @@ pub fn render(allocator: std.mem.Allocator, state: *const tui_state.AppState, op
     return out.toOwnedSlice();
 }
 
+fn writeContext(writer: *std.Io.Writer, allocator: std.mem.Allocator, state: *const tui_state.AppState) !void {
+    const used: u64 = if (state.telemetry.estimated_tokens > 0) state.telemetry.estimated_tokens else state.status.context_used;
+    const limit: u64 = if (state.telemetry.context_window > 0) state.telemetry.context_window else state.status.context_limit;
+    const pct: u64 = if (limit > 0) (used * 100) / limit else 0;
+    var gauge = zz.Gauge{
+        .value = @floatFromInt(pct),
+        .min = 0,
+        .max = 100,
+        .width = 8,
+        .show_value = false,
+        .show_percent = false,
+        .thresholds = &gauge_thresholds,
+        .base_color = tui_theme.palette.success,
+        .empty_color = tui_theme.palette.dim,
+    };
+    var gauge_arena = std.heap.ArenaAllocator.init(allocator);
+    defer gauge_arena.deinit();
+    const gauge_text = gauge.view(gauge_arena.allocator());
+    const used_text = try compactNumber(allocator, used);
+    defer allocator.free(used_text);
+    if (limit > 0) {
+        const limit_text = try compactNumber(allocator, limit);
+        defer allocator.free(limit_text);
+        try writeOwnedSegment(writer, allocator, "ctx", try std.fmt.allocPrint(allocator, "{s} {d}% {s}/{s}", .{ gauge_text, pct, used_text, limit_text }));
+    } else {
+        try writeOwnedSegment(writer, allocator, "ctx", try std.fmt.allocPrint(allocator, "{s} {s}", .{ gauge_text, used_text }));
+    }
+}
+
+fn estimatedCost(allocator: std.mem.Allocator, state: *const tui_state.AppState) ![]u8 {
+    const tokens: f64 = @floatFromInt(if (state.telemetry.estimated_tokens > 0) state.telemetry.estimated_tokens else state.status.context_used);
+    const dollars = (tokens / 1_000_000.0) * 3.0;
+    return std.fmt.allocPrint(allocator, "${d:.4}", .{dollars});
+}
+
+fn compactNumber(allocator: std.mem.Allocator, value: u64) ![]u8 {
+    if (value >= 1_000_000) return std.fmt.allocPrint(allocator, "{d}M", .{value / 1_000_000});
+    if (value >= 1_000) return std.fmt.allocPrint(allocator, "{d}k", .{value / 1_000});
+    return std.fmt.allocPrint(allocator, "{d}", .{value});
+}
+
 fn writeSegment(writer: *std.Io.Writer, allocator: std.mem.Allocator, key: []const u8, value: []const u8) !void {
+    try writeStyledValue(writer, allocator, key, value, tui_theme.statusSegment());
+}
+
+fn writeStyledValue(writer: *std.Io.Writer, allocator: std.mem.Allocator, key: []const u8, value: []const u8, value_style: zz.Style) !void {
     const styled_key = try tui_theme.statusKey().render(allocator, key);
     defer allocator.free(styled_key);
-    const styled_value = try tui_theme.statusSegment().render(allocator, value);
+    const styled_value = try value_style.render(allocator, value);
     defer allocator.free(styled_value);
     try writer.print("{s}:{s}", .{ styled_key, styled_value });
 }
@@ -75,4 +118,19 @@ test "status bar renders model and clips width" {
 
     try std.testing.expect(tui_text.visibleWidth(text) <= 24);
     try std.testing.expect(std.mem.indexOf(u8, text, "anthropic") != null);
+}
+
+test "status bar renders context gauge cost and permission" {
+    var state = tui_state.AppState.init(std.testing.allocator);
+    defer state.deinit();
+    try state.status.setModelWithContext(std.testing.allocator, "claude", "anthropic", 200_000);
+    state.telemetry.estimated_tokens = 10_000;
+    state.telemetry.context_window = 200_000;
+
+    const text = try render(std.testing.allocator, &state, .{ .width = 160 });
+    defer std.testing.allocator.free(text);
+
+    try std.testing.expect(std.mem.indexOf(u8, text, "ctx") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "cost") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "perm") != null);
 }

--- a/zig/src/tui/views/status_bar.zig
+++ b/zig/src/tui/views/status_bar.zig
@@ -67,10 +67,10 @@ fn writeContext(writer: *std.Io.Writer, allocator: std.mem.Allocator, state: *co
     var gauge_arena = std.heap.ArenaAllocator.init(allocator);
     defer gauge_arena.deinit();
     const gauge_text = gauge.view(gauge_arena.allocator());
-    const used_text = try compactNumber(allocator, used);
+    const used_text = try tui_text.compactNumber(allocator, used);
     defer allocator.free(used_text);
     if (limit > 0) {
-        const limit_text = try compactNumber(allocator, limit);
+        const limit_text = try tui_text.compactNumber(allocator, limit);
         defer allocator.free(limit_text);
         try writeOwnedSegment(writer, allocator, "ctx", try std.fmt.allocPrint(allocator, "{s} {d}% {s}/{s}", .{ gauge_text, pct, used_text, limit_text }));
     } else {
@@ -82,12 +82,6 @@ fn estimatedCost(allocator: std.mem.Allocator, state: *const tui_state.AppState)
     const tokens: f64 = @floatFromInt(if (state.telemetry.estimated_tokens > 0) state.telemetry.estimated_tokens else state.status.context_used);
     const dollars = (tokens / 1_000_000.0) * 3.0;
     return std.fmt.allocPrint(allocator, "${d:.4}", .{dollars});
-}
-
-fn compactNumber(allocator: std.mem.Allocator, value: u64) ![]u8 {
-    if (value >= 1_000_000) return std.fmt.allocPrint(allocator, "{d}M", .{value / 1_000_000});
-    if (value >= 1_000) return std.fmt.allocPrint(allocator, "{d}k", .{value / 1_000});
-    return std.fmt.allocPrint(allocator, "{d}", .{value});
 }
 
 fn writeSegment(writer: *std.Io.Writer, allocator: std.mem.Allocator, key: []const u8, value: []const u8) !void {

--- a/zig/src/tui/views/telemetry.zig
+++ b/zig/src/tui/views/telemetry.zig
@@ -37,16 +37,16 @@ pub fn render(allocator: std.mem.Allocator, state: *const tui_state.AppState, op
     defer gauge_arena.deinit();
     const gauge_text = gauge.view(gauge_arena.allocator());
     try writer.writeAll(gauge_text);
-    const used_text = try compactNumber(allocator, telemetry.estimated_tokens);
+    const used_text = try tui_text.compactNumber(allocator, telemetry.estimated_tokens);
     defer allocator.free(used_text);
     if (limit > 0) {
-        const limit_text = try compactNumber(allocator, limit);
+        const limit_text = try tui_text.compactNumber(allocator, limit);
         defer allocator.free(limit_text);
         try writer.print(" {s}/{s} tok", .{ used_text, limit_text });
     } else {
         try writer.print(" {s} tok", .{used_text});
     }
-    const bytes_text = try compactNumber(allocator, telemetry.total_bytes);
+    const bytes_text = try tui_text.compactNumber(allocator, telemetry.total_bytes);
     defer allocator.free(bytes_text);
     try writer.print(" ({s} bytes)", .{bytes_text});
 
@@ -61,9 +61,9 @@ pub fn render(allocator: std.mem.Allocator, state: *const tui_state.AppState, op
     try writeSegment(writer, allocator, "tools", telemetry.tool_definitions);
 
     if (findLatestTruncatedTool(state)) |tool| {
-        const raw_text = try compactNumber(allocator, tool.raw_total_bytes);
+        const raw_text = try tui_text.compactNumber(allocator, tool.raw_total_bytes);
         defer allocator.free(raw_text);
-        const returned_text = try compactNumber(allocator, tool.returned_total_bytes);
+        const returned_text = try tui_text.compactNumber(allocator, tool.returned_total_bytes);
         defer allocator.free(returned_text);
         try writer.print("\nTool output truncated {s}->{s} bytes", .{ raw_text, returned_text });
         if (tool.artifact_refs.len > 0) try writer.print(" • artifact {s}", .{tool.artifact_refs});
@@ -78,12 +78,6 @@ pub fn render(allocator: std.mem.Allocator, state: *const tui_state.AppState, op
     return out.toOwnedSlice();
 }
 
-fn compactNumber(allocator: std.mem.Allocator, value: u64) ![]u8 {
-    if (value >= 1_000_000) return std.fmt.allocPrint(allocator, "{d}M", .{value / 1_000_000});
-    if (value >= 1_000) return std.fmt.allocPrint(allocator, "{d}k", .{value / 1_000});
-    return std.fmt.allocPrint(allocator, "{d}", .{value});
-}
-
 fn writeSegment(writer: *std.Io.Writer, allocator: std.mem.Allocator, name: []const u8, segment: tui_state.PromptSegmentState) !void {
     const styled_name = try tui_theme.statusKey().render(allocator, name);
     defer allocator.free(styled_name);
@@ -95,9 +89,9 @@ fn writeSegment(writer: *std.Io.Writer, allocator: std.mem.Allocator, name: []co
         .stable => "stable/cacheable",
         .dynamic => "dynamic",
     };
-    const bytes = try compactNumber(allocator, segment.bytes);
+    const bytes = try tui_text.compactNumber(allocator, segment.bytes);
     defer allocator.free(bytes);
-    const tokens = try compactNumber(allocator, segment.estimated_tokens);
+    const tokens = try tui_text.compactNumber(allocator, segment.estimated_tokens);
     defer allocator.free(tokens);
     try writer.print("{s}:{s}b/{s}t {s}", .{ styled_name, bytes, tokens, role });
 }

--- a/zig/src/tui/views/telemetry.zig
+++ b/zig/src/tui/views/telemetry.zig
@@ -54,9 +54,9 @@ pub fn render(allocator: std.mem.Allocator, state: *const tui_state.AppState, op
     const segments = try tui_theme.statusKey().render(allocator, "Segments");
     defer allocator.free(segments);
     try writer.print("{s} ", .{segments});
-    try writeSegment(writer, allocator, "system_prompt", telemetry.system_prompt);
+    try writeSegment(writer, allocator, "sys", telemetry.system_prompt);
     try writer.writeAll(" • ");
-    try writeSegment(writer, allocator, "messages", telemetry.messages);
+    try writeSegment(writer, allocator, "msg", telemetry.messages);
     try writer.writeAll(" • ");
     try writeSegment(writer, allocator, "tools", telemetry.tool_definitions);
 
@@ -125,8 +125,8 @@ test "telemetry view renders context and segments" {
     defer std.testing.allocator.free(text);
 
     try std.testing.expect(std.mem.indexOf(u8, text, "100/200 tok") != null);
-    try std.testing.expect(std.mem.indexOf(u8, text, "system_prompt") != null);
-    try std.testing.expect(std.mem.indexOf(u8, text, "messages") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "sys") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "msg") != null);
 }
 
 test "telemetry overflow preserves segment line" {

--- a/zig/src/tui/views/transcript.zig
+++ b/zig/src/tui/views/transcript.zig
@@ -14,6 +14,8 @@ pub const Options = struct {
 };
 
 pub fn render(allocator: std.mem.Allocator, state: *const AppState, options: Options) ![]const u8 {
+    if (options.height == 0) return allocator.dupe(u8, "");
+
     var visible_entries = std.ArrayList(*const TranscriptEntry).empty;
     defer visible_entries.deinit(allocator);
     for (state.transcript.items) |*entry| {
@@ -21,28 +23,23 @@ pub fn render(allocator: std.mem.Allocator, state: *const AppState, options: Opt
         try visible_entries.append(allocator, entry);
     }
 
-    const total = visible_entries.items.len;
-    if (total == 0) {
+    if (visible_entries.items.len == 0) {
         var ready_text: []const u8 = "Makai ready. Type message, /quit exits.";
         if (state.transcript.items.len > 0 and !state.show_thinking) ready_text = "Thinking hidden. Ctrl+R shows reasoning.";
         return tui_theme.muted().render(allocator, ready_text);
     }
 
-    const visible = @min(options.height, total);
-    const max_start = total - visible;
-    const start = max_start -| state.transcript_scroll;
-
-    var out: std.Io.Writer.Allocating = .init(allocator);
-    errdefer out.deinit();
-    const writer = &out.writer;
-    for (visible_entries.items[start..], 0..) |entry, i| {
-        if (i >= visible) break;
-        if (i > 0) try writer.writeByte('\n');
+    var all_rows: std.Io.Writer.Allocating = .init(allocator);
+    defer all_rows.deinit();
+    const all_writer = &all_rows.writer;
+    for (visible_entries.items, 0..) |entry, i| {
+        if (i > 0) try all_writer.writeByte('\n');
         const row = try renderEntry(allocator, entry, options.width);
         defer allocator.free(row);
-        try writer.writeAll(row);
+        try all_writer.writeAll(row);
     }
-    return out.toOwnedSlice();
+
+    return lineWindow(allocator, all_rows.written(), options.height, state.transcript_scroll);
 }
 
 fn renderEntry(allocator: std.mem.Allocator, entry: *const TranscriptEntry, width: usize) ![]u8 {
@@ -69,7 +66,7 @@ fn renderEntryText(allocator: std.mem.Allocator, kind: TranscriptKind, text: []c
         else => try allocator.dupe(u8, text),
     };
     defer allocator.free(styled);
-    return tui_text.wrapTextWithAnsi(allocator, styled, @max(width, 1));
+    return tui_text.truncateLinesToWidth(allocator, styled, @max(width, 1), std.math.maxInt(usize));
 }
 
 fn indentBody(allocator: std.mem.Allocator, styled_label: []const u8, label_width: usize, body: []const u8) ![]u8 {
@@ -88,6 +85,28 @@ fn indentBody(allocator: std.mem.Allocator, styled_label: []const u8, label_widt
         }
         first = false;
         try writer.writeAll(line);
+    }
+    return out.toOwnedSlice();
+}
+
+fn lineWindow(allocator: std.mem.Allocator, text: []const u8, height: usize, scroll: usize) ![]u8 {
+    const total = tui_text.lineCount(text);
+    if (total <= height and scroll == 0) return allocator.dupe(u8, text);
+    const visible = @min(height, total);
+    const max_start = total - visible;
+    const start_line = max_start -| scroll;
+    var out: std.Io.Writer.Allocating = .init(allocator);
+    errdefer out.deinit();
+    const writer = &out.writer;
+    var lines = std.mem.splitScalar(u8, text, '\n');
+    var line_index: usize = 0;
+    var written: usize = 0;
+    while (lines.next()) |line| : (line_index += 1) {
+        if (line_index < start_line) continue;
+        if (written >= visible) break;
+        if (written > 0) try writer.writeByte('\n');
+        try writer.writeAll(line);
+        written += 1;
     }
     return out.toOwnedSlice();
 }
@@ -170,4 +189,29 @@ test "transcript keeps assistant code indentation" {
     defer std.testing.allocator.free(text);
 
     try std.testing.expect(std.mem.indexOf(u8, text, "    const x") != null);
+}
+
+test "transcript caps rendered lines to height" {
+    var state = AppState.init(std.testing.allocator);
+    defer state.deinit();
+    try state.appendTranscript(.assistant, "one\ntwo\nthree\nfour");
+
+    const text = try render(std.testing.allocator, &state, .{ .width = 80, .height = 2 });
+    defer std.testing.allocator.free(text);
+
+    try std.testing.expectEqual(@as(usize, 2), tui_text.lineCount(text));
+    try std.testing.expect(std.mem.indexOf(u8, text, "three") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "four") != null);
+}
+
+test "transcript preserves non-assistant whitespace" {
+    var state = AppState.init(std.testing.allocator);
+    defer state.deinit();
+    try state.appendTranscript(.tool, "  alpha   beta\n    gamma");
+
+    const text = try render(std.testing.allocator, &state, .{ .width = 80, .height = 10 });
+    defer std.testing.allocator.free(text);
+
+    try std.testing.expect(std.mem.indexOf(u8, text, "  alpha   beta") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "    gamma") != null);
 }

--- a/zig/src/tui/views/transcript.zig
+++ b/zig/src/tui/views/transcript.zig
@@ -1,10 +1,12 @@
 const std = @import("std");
+const zz = @import("zigzag");
 const tui_state = @import("tui_state");
 const tui_theme = @import("tui_theme");
 const tui_text = @import("tui_text");
 
 const AppState = tui_state.AppState;
 const TranscriptKind = tui_state.TranscriptKind;
+const TranscriptEntry = tui_state.TranscriptEntry;
 
 pub const Options = struct {
     width: usize = 80,
@@ -12,49 +14,86 @@ pub const Options = struct {
 };
 
 pub fn render(allocator: std.mem.Allocator, state: *const AppState, options: Options) ![]const u8 {
-    var out: std.Io.Writer.Allocating = .init(allocator);
-    const writer = &out.writer;
+    var visible_entries = std.ArrayList(*const TranscriptEntry).empty;
+    defer visible_entries.deinit(allocator);
+    for (state.transcript.items) |*entry| {
+        if (entry.kind == .thinking and !state.show_thinking) continue;
+        try visible_entries.append(allocator, entry);
+    }
 
-    const total = state.transcript.items.len;
+    const total = visible_entries.items.len;
+    if (total == 0) {
+        var ready_text: []const u8 = "Makai ready. Type message, /quit exits.";
+        if (state.transcript.items.len > 0 and !state.show_thinking) ready_text = "Thinking hidden. Ctrl+R shows reasoning.";
+        return tui_theme.muted().render(allocator, ready_text);
+    }
+
     const visible = @min(options.height, total);
     const max_start = total - visible;
     const start = max_start -| state.transcript_scroll;
 
-    if (total == 0) {
-        const ready = try tui_theme.muted().render(allocator, "Makai ready. Type message, /quit exits.");
-        defer allocator.free(ready);
-        try writer.writeAll(ready);
-        return out.toOwnedSlice();
-    }
-
-    for (state.transcript.items[start..], 0..) |entry, i| {
+    var out: std.Io.Writer.Allocating = .init(allocator);
+    errdefer out.deinit();
+    const writer = &out.writer;
+    for (visible_entries.items[start..], 0..) |entry, i| {
         if (i >= visible) break;
         if (i > 0) try writer.writeByte('\n');
-        const raw_label = label(entry.kind);
-        const styled_label = try tui_theme.role(entry.kind).render(allocator, raw_label);
-        defer allocator.free(styled_label);
-        try writer.writeAll(styled_label);
-        try writer.writeByte(' ');
-        const max_text_width = options.width -| tui_text.visibleWidth(raw_label) -| 1;
-        const rendered = try renderEntryText(allocator, entry.kind, entry.text.items, max_text_width);
-        defer allocator.free(rendered);
-        try writer.writeAll(rendered);
+        const row = try renderEntry(allocator, entry, options.width);
+        defer allocator.free(row);
+        try writer.writeAll(row);
     }
-
     return out.toOwnedSlice();
 }
 
+fn renderEntry(allocator: std.mem.Allocator, entry: *const TranscriptEntry, width: usize) ![]u8 {
+    const raw_label = label(entry.kind);
+    const styled_label = try tui_theme.role(entry.kind).render(allocator, raw_label);
+    defer allocator.free(styled_label);
+    const label_width = tui_text.visibleWidth(raw_label);
+    const body_width = width -| label_width -| 1;
+    const rendered_body = try renderEntryText(allocator, entry.kind, entry.text.items, @max(body_width, 8));
+    defer allocator.free(rendered_body);
+    return indentBody(allocator, styled_label, label_width, rendered_body);
+}
+
 fn renderEntryText(allocator: std.mem.Allocator, kind: TranscriptKind, text: []const u8, width: usize) ![]const u8 {
-    const flattened = try tui_text.flattenNewlines(allocator, text, " / ");
-    defer allocator.free(flattened);
-    const clipped = try tui_text.truncateToWidth(allocator, flattened, width);
-    errdefer allocator.free(clipped);
-    if (kind == .@"error") {
-        const styled = try tui_theme.errorText().render(allocator, clipped);
-        allocator.free(clipped);
-        return styled;
+    const styled = switch (kind) {
+        .assistant => blk: {
+            var markdown = zz.Markdown.init();
+            markdown.width = @intCast(@min(width, std.math.maxInt(u16)));
+            break :blk try markdown.render(allocator, text);
+        },
+        .@"error" => try tui_theme.errorText().render(allocator, text),
+        .thinking => try tui_theme.role(.thinking).render(allocator, text),
+        .system => try tui_theme.muted().render(allocator, text),
+        else => try allocator.dupe(u8, text),
+    };
+    defer allocator.free(styled);
+    return tui_text.wrapTextWithAnsi(allocator, styled, @max(width, 1));
+}
+
+fn indentBody(allocator: std.mem.Allocator, styled_label: []const u8, label_width: usize, body: []const u8) ![]u8 {
+    var out: std.Io.Writer.Allocating = .init(allocator);
+    errdefer out.deinit();
+    const writer = &out.writer;
+    try writer.writeAll(styled_label);
+    try writer.writeByte(' ');
+    const indent_width = label_width + 1;
+    var lines = std.mem.splitScalar(u8, body, '\n');
+    var first = true;
+    while (lines.next()) |line| {
+        if (!first) {
+            try writer.writeByte('\n');
+            try writeSpaces(writer, indent_width);
+        }
+        first = false;
+        try writer.writeAll(line);
     }
-    return clipped;
+    return out.toOwnedSlice();
+}
+
+fn writeSpaces(writer: *std.Io.Writer, count: usize) !void {
+    for (0..count) |_| try writer.writeByte(' ');
 }
 
 fn label(kind: TranscriptKind) []const u8 {
@@ -83,7 +122,7 @@ test "transcript renders labels" {
     try std.testing.expect(std.mem.indexOf(u8, text, "world") != null);
 }
 
-test "transcript flattens multiline entries into one rendered row" {
+test "transcript preserves multiline entries" {
     var state = AppState.init(std.testing.allocator);
     defer state.deinit();
     try state.appendTranscript(.assistant, "alpha\nbeta");
@@ -91,5 +130,33 @@ test "transcript flattens multiline entries into one rendered row" {
     const text = try render(std.testing.allocator, &state, .{ .width = 80, .height = 10 });
     defer std.testing.allocator.free(text);
 
-    try std.testing.expect(std.mem.indexOf(u8, text, "alpha / beta") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "alpha\n") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "beta") != null);
+}
+
+test "transcript hides thinking when toggled off" {
+    var state = AppState.init(std.testing.allocator);
+    defer state.deinit();
+    try state.appendTranscript(.thinking, "secret plan");
+    try state.appendTranscript(.assistant, "visible answer");
+    state.show_thinking = false;
+
+    const text = try render(std.testing.allocator, &state, .{ .width = 80, .height = 10 });
+    defer std.testing.allocator.free(text);
+
+    try std.testing.expect(std.mem.indexOf(u8, text, "secret plan") == null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "visible answer") != null);
+}
+
+test "transcript renders markdown syntax" {
+    var state = AppState.init(std.testing.allocator);
+    defer state.deinit();
+    try state.appendTranscript(.assistant, "# Heading\n- item");
+
+    const text = try render(std.testing.allocator, &state, .{ .width = 80, .height = 10 });
+    defer std.testing.allocator.free(text);
+
+    try std.testing.expect(std.mem.indexOf(u8, text, "Heading") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "item") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "# Heading") == null);
 }

--- a/zig/src/tui/views/transcript.zig
+++ b/zig/src/tui/views/transcript.zig
@@ -57,12 +57,12 @@ fn renderEntry(allocator: std.mem.Allocator, entry: *const TranscriptEntry, widt
 }
 
 fn renderEntryText(allocator: std.mem.Allocator, kind: TranscriptKind, text: []const u8, width: usize) ![]const u8 {
+    if (kind == .assistant) {
+        var markdown = zz.Markdown.init();
+        markdown.width = @intCast(@min(width, std.math.maxInt(u16)));
+        return markdown.render(allocator, text);
+    }
     const styled = switch (kind) {
-        .assistant => blk: {
-            var markdown = zz.Markdown.init();
-            markdown.width = @intCast(@min(width, std.math.maxInt(u16)));
-            break :blk try markdown.render(allocator, text);
-        },
         .@"error" => try tui_theme.errorText().render(allocator, text),
         .thinking => try tui_theme.role(.thinking).render(allocator, text),
         .system => try tui_theme.muted().render(allocator, text),
@@ -159,4 +159,15 @@ test "transcript renders markdown syntax" {
     try std.testing.expect(std.mem.indexOf(u8, text, "Heading") != null);
     try std.testing.expect(std.mem.indexOf(u8, text, "item") != null);
     try std.testing.expect(std.mem.indexOf(u8, text, "# Heading") == null);
+}
+
+test "transcript keeps assistant code indentation" {
+    var state = AppState.init(std.testing.allocator);
+    defer state.deinit();
+    try state.appendTranscript(.assistant, "```zig\n    const x = 1;\n```\n");
+
+    const text = try render(std.testing.allocator, &state, .{ .width = 80, .height = 10 });
+    defer std.testing.allocator.free(text);
+
+    try std.testing.expect(std.mem.indexOf(u8, text, "    const x") != null);
 }


### PR DESCRIPTION
## Summary
- Render transcript entries as wrapped role rows with assistant markdown, hidden-thinking toggle, and tool call summaries.
- Refresh composer with bordered multiline input display, shell/file mode hints, and history navigation.
- Compact status/telemetry with inline context gauge, cost estimate, permission state, and shorter segment labels.

## Test plan
- [x] cd zig && zig build test-unit-makai-cli
- [x] cd zig && zig build test
- [x] cd zig && perl -e 'alarm 3; exec @ARGV' zig build run-tui (smoke launch timed out via alarm after startup)