### PR TITLE
Improve TUI tool output rendering

### DIFF
--- a/zig/src/tui/views/preview.zig
+++ b/zig/src/tui/views/preview.zig
@@ -78,3 +78,16 @@ test "preview renders hashline diff anchors" {
     try std.testing.expect(std.mem.indexOf(u8, text, "2:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa") != null);
     try std.testing.expect(std.mem.indexOf(u8, text, "+ 2|new") != null);
 }
+
+test "preview preserves adjacent diff pair text with styling" {
+    var state = tui_state.AppState.init(std.testing.allocator);
+    defer state.deinit();
+    try state.setPreview(.diff, "patch.diff", "- value = old\n+ value = new");
+
+    const text = try render(std.testing.allocator, &state, .{ .width = 80, .height = 4 });
+    defer std.testing.allocator.free(text);
+
+    try std.testing.expect(std.mem.indexOf(u8, text, "- value = old") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "+ value = new") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "\x1b[") != null);
+}

--- a/zig/src/tui/views/tool_panel.zig
+++ b/zig/src/tui/views/tool_panel.zig
@@ -59,18 +59,12 @@ pub fn render(allocator: std.mem.Allocator, state: *const tui_state.AppState, op
             if (tool.estimated_returned_tokens > 0) try writer.print(", ~{d} tok", .{tool.estimated_returned_tokens});
             try writer.writeByte(')');
         }
-        if (tool.truncated) try writer.writeAll(" truncated/show full");
-        if (tool.artifact_refs.len > 0) try writer.print(" artifact:{s}", .{tool.artifact_refs});
+        if (tool.truncated) try writer.writeAll(" truncated · show full");
+        if (tool.artifact_refs.len > 0) try writer.print(" · artifact:{s}", .{tool.artifact_refs});
+        if (tool.expanded) try writer.writeAll(" · expanded");
         rows += 1;
         if (tool.expanded and rows < options.height) {
-            try writer.writeByte('\n');
-            try writer.writeAll("    ");
-            const one = try oneLine(allocator, if (tool.output.items.len > 0) tool.output.items else tool.args_json, options.width -| 6);
-            defer allocator.free(one);
-            const styled = try tui_theme.muted().render(allocator, one);
-            defer allocator.free(styled);
-            try writer.writeAll(styled);
-            rows += 1;
+            rows = try renderExpandedOutput(allocator, writer, tool, options.width, options.height, rows);
         }
     }
     const body = try out.toOwnedSlice();
@@ -87,16 +81,41 @@ fn statusText(status: tui_state.ToolStatus) []const u8 {
     };
 }
 
-fn oneLine(allocator: std.mem.Allocator, text: []const u8, width: usize) ![]u8 {
-    const nl = std.mem.indexOfScalar(u8, text, '\n') orelse text.len;
-    const line = text[0..nl];
-    const clipped = try tui_text.truncateToWidth(allocator, line, width);
-    if (nl < text.len and tui_text.visibleWidth(clipped) < width) {
-        const with_ellipsis = try std.fmt.allocPrint(allocator, "{s}…", .{clipped});
-        allocator.free(clipped);
-        return with_ellipsis;
+fn renderExpandedOutput(allocator: std.mem.Allocator, writer: *std.Io.Writer, tool: tui_state.ToolEntry, width: usize, height: usize, rows: usize) !usize {
+    const source = if (tool.output.items.len > 0) tool.output.items else tool.args_json;
+    if (source.len == 0) return rows;
+    const available_lines = height - rows;
+    if (available_lines == 0) return rows;
+    const content_width = width -| 8;
+    if (content_width == 0) return rows;
+
+    const wrapped = try tui_text.wrapTextWithAnsi(allocator, source, content_width);
+    defer allocator.free(wrapped);
+    const clipped = try tui_text.truncateLinesToWidth(allocator, wrapped, content_width, available_lines);
+    defer allocator.free(clipped);
+
+    var next_rows = rows;
+    var lines = std.mem.splitScalar(u8, clipped, '\n');
+    while (lines.next()) |line| {
+        if (next_rows >= height) break;
+        try writer.writeByte('\n');
+        try writer.writeAll("    │ ");
+        const styled = try styleOutputLine(allocator, tool.status, line);
+        defer allocator.free(styled);
+        try writer.writeAll(styled);
+        next_rows += 1;
     }
-    return clipped;
+    return next_rows;
+}
+
+fn styleOutputLine(allocator: std.mem.Allocator, status: tui_state.ToolStatus, line: []const u8) ![]const u8 {
+    if (isDiffLike(line)) return tui_theme.diffLine(line).render(allocator, line);
+    if (status == .@"error") return tui_theme.errorText().render(allocator, line);
+    return tui_theme.muted().render(allocator, line);
+}
+
+fn isDiffLike(line: []const u8) bool {
+    return std.mem.startsWith(u8, line, "+") or std.mem.startsWith(u8, line, "-") or std.mem.startsWith(u8, line, "  anchor");
 }
 
 test "tool panel renders registered tools when idle" {
@@ -121,17 +140,38 @@ test "tool panel renders registered tools when idle" {
     try std.testing.expect(std.mem.indexOf(u8, text, "none") == null);
 }
 
-test "tool panel renders tool status and output" {
+test "tool panel renders tool status and multiline output" {
     var state = tui_state.AppState.init(std.testing.allocator);
     defer state.deinit();
     try state.tools.append(std.testing.allocator, try tui_state.ToolEntry.init(std.testing.allocator, "call-1", "shell_command", "{\"command\":\"pwd\"}", .running));
     state.tools.items[0].expanded = true;
-    try state.tools.items[0].output.appendSlice(std.testing.allocator, "ok");
+    try state.tools.items[0].output.appendSlice(std.testing.allocator, "first line\nsecond line");
 
-    const text = try render(std.testing.allocator, &state, .{ .width = 80, .height = 4 });
+    const text = try render(std.testing.allocator, &state, .{ .width = 80, .height = 5 });
     defer std.testing.allocator.free(text);
 
     try std.testing.expect(std.mem.indexOf(u8, text, "running") != null);
     try std.testing.expect(std.mem.indexOf(u8, text, "shell_command") != null);
-    try std.testing.expect(std.mem.indexOf(u8, text, "ok") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "first line") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "second line") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "expanded") != null);
+}
+
+test "tool panel renders diff and error output" {
+    var state = tui_state.AppState.init(std.testing.allocator);
+    defer state.deinit();
+    try state.tools.append(std.testing.allocator, try tui_state.ToolEntry.init(std.testing.allocator, "call-1", "hashline_edit", "{}", .done));
+    state.tools.items[0].expanded = true;
+    try state.tools.items[0].output.appendSlice(std.testing.allocator, "- 2:hash|old\n+ 2|new");
+    try state.tools.append(std.testing.allocator, try tui_state.ToolEntry.init(std.testing.allocator, "call-2", "shell_command", "{}", .@"error"));
+    state.tools.items[1].expanded = true;
+    try state.tools.items[1].output.appendSlice(std.testing.allocator, "boom");
+
+    const text = try render(std.testing.allocator, &state, .{ .width = 100, .height = 8 });
+    defer std.testing.allocator.free(text);
+
+    try std.testing.expect(std.mem.indexOf(u8, text, "- 2:hash|old") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "+ 2|new") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "error") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "boom") != null);
 }

--- a/zig/src/tui/views/tool_panel.zig
+++ b/zig/src/tui/views/tool_panel.zig
@@ -89,33 +89,89 @@ fn renderExpandedOutput(allocator: std.mem.Allocator, writer: *std.Io.Writer, to
     const content_width = width -| 8;
     if (content_width == 0) return rows;
 
-    const wrapped = try tui_text.wrapTextWithAnsi(allocator, source, content_width);
-    defer allocator.free(wrapped);
-    const clipped = try tui_text.truncateLinesToWidth(allocator, wrapped, content_width, available_lines);
-    defer allocator.free(clipped);
-
     var next_rows = rows;
-    var lines = std.mem.splitScalar(u8, clipped, '\n');
-    while (lines.next()) |line| {
-        if (next_rows >= height) break;
-        try writer.writeByte('\n');
-        try writer.writeAll("    │ ");
-        const styled = try styleOutputLine(allocator, tool.status, line);
-        defer allocator.free(styled);
-        try writer.writeAll(styled);
-        next_rows += 1;
+    var line_iter = std.mem.splitScalar(u8, source, '\n');
+    while (line_iter.next()) |logical_line| {
+        var remaining = logical_line;
+        while (true) {
+            if (next_rows >= height) return try renderTruncationMarker(writer, next_rows, height);
+            const take = takeDisplayWidth(remaining, content_width);
+            const segment = remaining[0..take.bytes];
+            try writer.writeByte('\n');
+            try writer.writeAll("    │ ");
+            const styled = try styleOutputLine(allocator, tool, logical_line, segment);
+            defer allocator.free(styled);
+            try writer.writeAll(styled);
+            next_rows += 1;
+            remaining = remaining[take.bytes..];
+            if (remaining.len == 0) break;
+        }
     }
     return next_rows;
 }
 
-fn styleOutputLine(allocator: std.mem.Allocator, status: tui_state.ToolStatus, line: []const u8) ![]const u8 {
-    if (isDiffLike(line)) return tui_theme.diffLine(line).render(allocator, line);
-    if (status == .@"error") return tui_theme.errorText().render(allocator, line);
-    return tui_theme.muted().render(allocator, line);
+const DisplayTake = struct {
+    bytes: usize,
+    width: usize,
+};
+
+fn takeDisplayWidth(line: []const u8, max_width: usize) DisplayTake {
+    if (line.len == 0 or max_width == 0) return .{ .bytes = 0, .width = 0 };
+    var width: usize = 0;
+    var i: usize = 0;
+    while (i < line.len and width < max_width) {
+        if (line[i] == 0x1b) {
+            const start = i;
+            skipAnsiSequence(line, &i);
+            if (i == start) i += 1;
+            continue;
+        }
+        const len = std.unicode.utf8ByteSequenceLength(line[i]) catch 1;
+        if (i + len > line.len) break;
+        const codepoint = std.unicode.utf8Decode(line[i .. i + len]) catch line[i];
+        const cw = @import("zigzag").measure.charWidth(@intCast(codepoint));
+        if (width + cw > max_width) break;
+        width += cw;
+        i += len;
+    }
+    if (i == 0) i = @min(line.len, 1);
+    return .{ .bytes = i, .width = width };
 }
 
-fn isDiffLike(line: []const u8) bool {
-    return std.mem.startsWith(u8, line, "+") or std.mem.startsWith(u8, line, "-") or std.mem.startsWith(u8, line, "  anchor");
+fn skipAnsiSequence(text: []const u8, index: *usize) void {
+    if (index.* >= text.len or text[index.*] != 0x1b) return;
+    index.* += 1;
+    if (index.* >= text.len) return;
+    const second = text[index.*];
+    index.* += 1;
+    if (second == '[') {
+        while (index.* < text.len) {
+            const c = text[index.*];
+            index.* += 1;
+            if (c >= 0x40 and c <= 0x7e) return;
+        }
+    }
+}
+
+fn renderTruncationMarker(writer: *std.Io.Writer, rows: usize, height: usize) !usize {
+    if (rows == 0 or height == 0) return rows;
+    try writer.writeAll("…");
+    return rows;
+}
+
+fn styleOutputLine(allocator: std.mem.Allocator, tool: tui_state.ToolEntry, logical_line: []const u8, segment: []const u8) ![]const u8 {
+    if (tool.status == .@"error") return tui_theme.errorText().render(allocator, segment);
+    if (isDiffLike(tool.name, logical_line)) return tui_theme.diffLine(logical_line).render(allocator, segment);
+    return tui_theme.muted().render(allocator, segment);
+}
+
+fn isDiffLike(tool_name: []const u8, line: []const u8) bool {
+    if (!isDiffTool(tool_name)) return false;
+    return std.mem.startsWith(u8, line, "+ ") or std.mem.startsWith(u8, line, "- ") or std.mem.startsWith(u8, line, "  anchor ");
+}
+
+fn isDiffTool(tool_name: []const u8) bool {
+    return std.mem.indexOf(u8, tool_name, "edit") != null or std.mem.indexOf(u8, tool_name, "write") != null;
 }
 
 test "tool panel renders registered tools when idle" {
@@ -174,4 +230,37 @@ test "tool panel renders diff and error output" {
     try std.testing.expect(std.mem.indexOf(u8, text, "+ 2|new") != null);
     try std.testing.expect(std.mem.indexOf(u8, text, "error") != null);
     try std.testing.expect(std.mem.indexOf(u8, text, "boom") != null);
+}
+
+test "tool panel preserves spaces and narrows diff detection" {
+    var state = tui_state.AppState.init(std.testing.allocator);
+    defer state.deinit();
+    try state.tools.append(std.testing.allocator, try tui_state.ToolEntry.init(std.testing.allocator, "call-1", "shell_command", "{}", .done));
+    state.tools.items[0].expanded = true;
+    try state.tools.items[0].output.appendSlice(std.testing.allocator, "key    value\n--help\n-42");
+
+    const text = try render(std.testing.allocator, &state, .{ .width = 80, .height = 6 });
+    defer std.testing.allocator.free(text);
+
+    try std.testing.expect(std.mem.indexOf(u8, text, "key    value") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "--help") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "-42") != null);
+}
+
+test "tool panel keeps diff styling across wrapped segments and errors win" {
+    var state = tui_state.AppState.init(std.testing.allocator);
+    defer state.deinit();
+    try state.tools.append(std.testing.allocator, try tui_state.ToolEntry.init(std.testing.allocator, "call-1", "hashline_edit", "{}", .done));
+    state.tools.items[0].expanded = true;
+    try state.tools.items[0].output.appendSlice(std.testing.allocator, "+ 2|abcdefghijklmnopqrstuvwxyz");
+    try state.tools.append(std.testing.allocator, try tui_state.ToolEntry.init(std.testing.allocator, "call-2", "shell_command", "{}", .@"error"));
+    state.tools.items[1].expanded = true;
+    try state.tools.items[1].output.appendSlice(std.testing.allocator, "+ cmd failed");
+
+    const text = try render(std.testing.allocator, &state, .{ .width = 20, .height = 8 });
+    defer std.testing.allocator.free(text);
+
+    try std.testing.expect(std.mem.indexOf(u8, text, "+ 2|abcdefgh") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "ijklmnopqr") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "+ cmd failed") != null);
 }


### PR DESCRIPTION
## Summary
- expand TUI tool panel output across multiple wrapped lines instead of a single truncated row
- preserve status, truncation, artifact, diff, and error styling in expanded tool rows
- add coverage for multiline tool output and diff/error rendering

## Test plan
- [x] `cd zig && zig build test-unit-tui`
- [x] `cd zig && zig build test-unit-makai-cli`
- [x] `cd zig && zig build test`
- [x] `cd zig && zig build run-tui --help` (build target smoke check)