### PR TITLE
Add inline TUI permission prompts

### DIFF
--- a/zig/build.zig
+++ b/zig/build.zig
@@ -980,6 +980,7 @@ pub fn build(b: *std.Build) void {
             .{ .name = "tui_view_approval", .module = tui_view_approval_mod },
             .{ .name = "tui_view_preview", .module = tui_view_preview_mod },
             .{ .name = "tui_view_session_picker", .module = tui_view_session_picker_mod },
+            .{ .name = "permission", .module = permission_mod },
         },
     });
 

--- a/zig/src/agent/agent_loop.zig
+++ b/zig/src/agent/agent_loop.zig
@@ -593,6 +593,14 @@ fn executeToolCalls(
                 .args_json = execution_args,
             };
             if (config.permission_engine) |engine| {
+                const policy_decision = engine.evaluate(tool_call.name, validated_args);
+                if (policy_decision == .deny) {
+                    result = try rejectedToolResult(allocator);
+                    is_error = true;
+                    try finalizeToolExecution(allocator, config, event_stream, &results, tool_call, execution_args, &result, is_error);
+                    continue;
+                }
+
                 const legacy_decision = runLegacyApproval(t, approval_request, allocator);
                 if (legacy_decision == .reject or legacy_decision == .reject_always) {
                     result = try rejectedToolResult(allocator);
@@ -604,18 +612,11 @@ fn executeToolCalls(
                     const call = permission.parseToolCall(allocator, tool_call.name, validated_args) catch null;
                     if (call) |parsed_call| {
                         defer permission.deinitParsedToolCall(allocator, parsed_call);
-                        try engine.persistDecision(parsed_call, .allow);
+                        if (permission.canPersistDecision(parsed_call)) try engine.persistDecision(parsed_call, .allow);
                     }
                 }
 
-                const policy_decision = engine.evaluate(tool_call.name, validated_args);
-                if (policy_decision == .deny) {
-                    result = try rejectedToolResult(allocator);
-                    is_error = true;
-                    try finalizeToolExecution(allocator, config, event_stream, &results, tool_call, execution_args, &result, is_error);
-                    continue;
-                }
-                if (policy_decision == .prompt and engine.approval_callback != null) {
+                if (policy_decision == .prompt and engine.approval_callback != null and legacy_decision != .approve_always) {
                     const decision = try engine.approve(tool_call.name, validated_args);
                     if (decision == .reject or decision == .reject_always) {
                         result = try rejectedToolResult(allocator);
@@ -1740,7 +1741,7 @@ test "executeToolCalls persists legacy approve always with permission engine" {
     };
 
     var approval = ApprovalRecorder{ .decision = .approve_always };
-    const tools = [_]AgentTool{.{
+    const scoped_tools = [_]AgentTool{.{
         .label = "Edit",
         .name = "file_edit",
         .description = "Edit file",
@@ -1749,13 +1750,13 @@ test "executeToolCalls persists legacy approve always with permission engine" {
         .approval_ctx = &approval,
         .approval_fn = recordingApproval,
     }};
-    const assistant_content = [_]ai_types.AssistantContent{.{ .tool_call = .{
+    const scoped_content = [_]ai_types.AssistantContent{.{ .tool_call = .{
         .id = "call_edit",
         .name = "file_edit",
         .arguments_json = "{\"path\":\"src/main.zig\"}",
     } }};
-    const assistant_message = ai_types.AssistantMessage{
-        .content = &assistant_content,
+    const scoped_message = ai_types.AssistantMessage{
+        .content = &scoped_content,
         .api = "test-api",
         .provider = "test-provider",
         .model = "test-model",
@@ -1771,9 +1772,116 @@ test "executeToolCalls persists legacy approve always with permission engine" {
     var agent_events = AgentEventStream.init(allocator);
     defer agent_events.deinit();
 
-    var tool_result = try executeToolCalls(
+    var scoped_result = try executeToolCalls(
         allocator,
-        assistant_message,
+        scoped_message,
+        .{
+            .model = model,
+            .protocol = .{ .stream_fn = undefined },
+            .tools = &scoped_tools,
+            .permission_engine = &engine,
+        },
+        &agent_events,
+    );
+    defer scoped_result.deinit(allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), approval.calls);
+    try std.testing.expectEqual(@as(usize, 1), engine.persisted.items.len);
+    try std.testing.expectEqualStrings("/workspace/src/main.zig", engine.persisted.items[0].path.?);
+    try std.testing.expectEqual(permission.PermissionDecision.allow, engine.evaluate("file_edit", "{\"path\":\"/workspace/src/main.zig\"}"));
+
+    approval.calls = 0;
+    const unscoped_tools = [_]AgentTool{.{
+        .label = "Remote",
+        .name = "remote_tool",
+        .description = "Remote tool",
+        .parameters_schema_json = "{}",
+        .execute = mockLargeOutputTool,
+        .approval_ctx = &approval,
+        .approval_fn = recordingApproval,
+    }};
+    const unscoped_content = [_]ai_types.AssistantContent{.{ .tool_call = .{
+        .id = "call_remote",
+        .name = "remote_tool",
+        .arguments_json = "{\"q\":\"x\"}",
+    } }};
+    const unscoped_message = ai_types.AssistantMessage{
+        .content = &unscoped_content,
+        .api = "test-api",
+        .provider = "test-provider",
+        .model = "test-model",
+        .usage = .{},
+        .stop_reason = .tool_use,
+        .timestamp = 0,
+    };
+    var unscoped_result = try executeToolCalls(
+        allocator,
+        unscoped_message,
+        .{
+            .model = model,
+            .protocol = .{ .stream_fn = undefined },
+            .tools = &unscoped_tools,
+            .permission_engine = &engine,
+        },
+        &agent_events,
+    );
+    defer unscoped_result.deinit(allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), approval.calls);
+    try std.testing.expectEqual(@as(usize, 1), engine.persisted.items.len);
+}
+
+test "executeToolCalls denies policy before legacy approval can persist always" {
+    const allocator = std.testing.allocator;
+
+    const model = ai_types.Model{
+        .id = "test-model",
+        .name = "Test",
+        .api = "test-api",
+        .provider = "test-provider",
+        .base_url = "",
+        .reasoning = false,
+        .input = &.{"text"},
+        .cost = .{ .input = 0, .output = 0, .cache_read = 0, .cache_write = 0 },
+        .context_window = 1024,
+        .max_tokens = 256,
+    };
+
+    var approval = ApprovalRecorder{ .decision = .approve_always };
+    const tools = [_]AgentTool{.{
+        .label = "Edit",
+        .name = "file_edit",
+        .description = "Edit file",
+        .parameters_schema_json = "{}",
+        .execute = mockLargeOutputTool,
+        .approval_ctx = &approval,
+        .approval_fn = recordingApproval,
+    }};
+    const content = [_]ai_types.AssistantContent{.{ .tool_call = .{
+        .id = "call_outside",
+        .name = "file_edit",
+        .arguments_json = "{\"path\":\"/tmp/outside.zig\"}",
+    } }};
+    const message = ai_types.AssistantMessage{
+        .content = &content,
+        .api = "test-api",
+        .provider = "test-provider",
+        .model = "test-model",
+        .usage = .{},
+        .stop_reason = .tool_use,
+        .timestamp = 0,
+    };
+    var engine = try permission.PermissionEngine.init(allocator, .{
+        .workspace_root = "/workspace",
+        .persistence_path = "zig-cache/test-agent-loop-deny-before-approve-always.json",
+    });
+    defer engine.deinit();
+    var agent_events = AgentEventStream.init(allocator);
+    defer agent_events.deinit();
+
+    var result = try executeToolCalls(
+        allocator,
+        message,
         .{
             .model = model,
             .protocol = .{ .stream_fn = undefined },
@@ -1782,12 +1890,11 @@ test "executeToolCalls persists legacy approve always with permission engine" {
         },
         &agent_events,
     );
-    defer tool_result.deinit(allocator);
+    defer result.deinit(allocator);
 
-    try std.testing.expectEqual(@as(usize, 1), approval.calls);
-    try std.testing.expectEqual(@as(usize, 1), engine.persisted.items.len);
-    try std.testing.expectEqualStrings("/workspace/src/main.zig", engine.persisted.items[0].path.?);
-    try std.testing.expectEqual(permission.PermissionDecision.allow, engine.evaluate("file_edit", "{\"path\":\"/workspace/src/main.zig\"}"));
+    try std.testing.expectEqual(@as(usize, 0), approval.calls);
+    try std.testing.expectEqual(@as(usize, 0), engine.persisted.items.len);
+    try std.testing.expect(result.tool_results[0].is_error);
 }
 
 test "executeToolCalls applies output middleware and reports byte telemetry" {

--- a/zig/src/agent/agent_loop.zig
+++ b/zig/src/agent/agent_loop.zig
@@ -600,6 +600,13 @@ fn executeToolCalls(
                     try finalizeToolExecution(allocator, config, event_stream, &results, tool_call, execution_args, &result, is_error);
                     continue;
                 }
+                if (legacy_decision == .approve_always) {
+                    const call = permission.parseToolCall(allocator, tool_call.name, validated_args) catch null;
+                    if (call) |parsed_call| {
+                        defer permission.deinitParsedToolCall(allocator, parsed_call);
+                        try engine.persistDecision(parsed_call, .allow);
+                    }
+                }
 
                 const policy_decision = engine.evaluate(tool_call.name, validated_args);
                 if (policy_decision == .deny) {
@@ -1714,6 +1721,73 @@ test "executeToolCalls runs legacy approval even when permission engine allows" 
     try std.testing.expectEqual(@as(usize, 1), approval.calls);
     try std.testing.expectEqual(@as(usize, 1), tool_result.tool_results.len);
     try std.testing.expect(tool_result.tool_results[0].is_error);
+}
+
+test "executeToolCalls persists legacy approve always with permission engine" {
+    const allocator = std.testing.allocator;
+
+    const model = ai_types.Model{
+        .id = "test-model",
+        .name = "Test",
+        .api = "test-api",
+        .provider = "test-provider",
+        .base_url = "",
+        .reasoning = false,
+        .input = &.{"text"},
+        .cost = .{ .input = 0, .output = 0, .cache_read = 0, .cache_write = 0 },
+        .context_window = 1024,
+        .max_tokens = 256,
+    };
+
+    var approval = ApprovalRecorder{ .decision = .approve_always };
+    const tools = [_]AgentTool{.{
+        .label = "Edit",
+        .name = "file_edit",
+        .description = "Edit file",
+        .parameters_schema_json = "{}",
+        .execute = mockLargeOutputTool,
+        .approval_ctx = &approval,
+        .approval_fn = recordingApproval,
+    }};
+    const assistant_content = [_]ai_types.AssistantContent{.{ .tool_call = .{
+        .id = "call_edit",
+        .name = "file_edit",
+        .arguments_json = "{\"path\":\"src/main.zig\"}",
+    } }};
+    const assistant_message = ai_types.AssistantMessage{
+        .content = &assistant_content,
+        .api = "test-api",
+        .provider = "test-provider",
+        .model = "test-model",
+        .usage = .{},
+        .stop_reason = .tool_use,
+        .timestamp = 0,
+    };
+    var engine = try permission.PermissionEngine.init(allocator, .{
+        .workspace_root = "/workspace",
+        .persistence_path = "zig-cache/test-agent-loop-approve-always.json",
+    });
+    defer engine.deinit();
+    var agent_events = AgentEventStream.init(allocator);
+    defer agent_events.deinit();
+
+    var tool_result = try executeToolCalls(
+        allocator,
+        assistant_message,
+        .{
+            .model = model,
+            .protocol = .{ .stream_fn = undefined },
+            .tools = &tools,
+            .permission_engine = &engine,
+        },
+        &agent_events,
+    );
+    defer tool_result.deinit(allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), approval.calls);
+    try std.testing.expectEqual(@as(usize, 1), engine.persisted.items.len);
+    try std.testing.expectEqualStrings("/workspace/src/main.zig", engine.persisted.items[0].path.?);
+    try std.testing.expectEqual(permission.PermissionDecision.allow, engine.evaluate("file_edit", "{\"path\":\"/workspace/src/main.zig\"}"));
 }
 
 test "executeToolCalls applies output middleware and reports byte telemetry" {

--- a/zig/src/agent/agent_loop.zig
+++ b/zig/src/agent/agent_loop.zig
@@ -600,29 +600,32 @@ fn executeToolCalls(
                     try finalizeToolExecution(allocator, config, event_stream, &results, tool_call, execution_args, &result, is_error);
                     continue;
                 }
-
-                const legacy_decision = runLegacyApproval(t, approval_request, allocator);
-                if (legacy_decision == .reject or legacy_decision == .reject_always) {
-                    result = try rejectedToolResult(allocator);
-                    is_error = true;
-                    try finalizeToolExecution(allocator, config, event_stream, &results, tool_call, execution_args, &result, is_error);
-                    continue;
-                }
-                if (legacy_decision == .approve_always) {
-                    const call = permission.parseToolCall(allocator, tool_call.name, validated_args) catch null;
-                    if (call) |parsed_call| {
-                        defer permission.deinitParsedToolCall(allocator, parsed_call);
-                        if (permission.canPersistDecision(parsed_call)) try engine.persistDecision(parsed_call, .allow);
-                    }
-                }
-
-                if (policy_decision == .prompt and engine.approval_callback != null and legacy_decision != .approve_always) {
-                    const decision = try engine.approve(tool_call.name, validated_args);
-                    if (decision == .reject or decision == .reject_always) {
+                // Skip legacy prompt when a persisted policy already allows the call
+                if (policy_decision != .allow) {
+                    const legacy_decision = runLegacyApproval(t, approval_request, allocator);
+                    if (legacy_decision == .reject or legacy_decision == .reject_always) {
                         result = try rejectedToolResult(allocator);
                         is_error = true;
                         try finalizeToolExecution(allocator, config, event_stream, &results, tool_call, execution_args, &result, is_error);
                         continue;
+                    }
+                    if (legacy_decision == .approve_always) {
+                        const call = permission.parseToolCall(allocator, tool_call.name, validated_args) catch null;
+                        if (call) |parsed_call| {
+                            defer permission.deinitParsedToolCall(allocator, parsed_call);
+                            // Best-effort persistence — I/O failure must not reject the approved tool
+                            if (permission.canPersistDecision(parsed_call)) engine.persistDecision(parsed_call, .allow) catch {};
+                        }
+                    }
+
+                    if (policy_decision == .prompt and engine.approval_callback != null and legacy_decision != .approve_always) {
+                        const decision = try engine.approve(tool_call.name, validated_args);
+                        if (decision == .reject or decision == .reject_always) {
+                            result = try rejectedToolResult(allocator);
+                            is_error = true;
+                            try finalizeToolExecution(allocator, config, event_stream, &results, tool_call, execution_args, &result, is_error);
+                            continue;
+                        }
                     }
                 }
             } else {
@@ -1658,7 +1661,7 @@ test "executeToolCalls uses protocol executor when configured" {
     try std.testing.expect(saw_update);
 }
 
-test "executeToolCalls runs legacy approval even when permission engine allows" {
+test "executeToolCalls skips legacy approval when policy already allows" {
     const allocator = std.testing.allocator;
 
     const model = ai_types.Model{
@@ -1698,9 +1701,8 @@ test "executeToolCalls runs legacy approval even when permission engine allows" 
         .stop_reason = .tool_use,
         .timestamp = 0,
     };
-    var engine = try permission.PermissionEngine.init(allocator, .{
+    var engine = try permission.PermissionEngine.initEmpty(allocator, .{
         .workspace_root = "/workspace",
-        .persistence_path = "zig-cache/test-agent-loop-permission-legacy.json",
     });
     defer engine.deinit();
     var agent_events = AgentEventStream.init(allocator);
@@ -1719,9 +1721,10 @@ test "executeToolCalls runs legacy approval even when permission engine allows" 
     );
     defer tool_result.deinit(allocator);
 
-    try std.testing.expectEqual(@as(usize, 1), approval.calls);
+    // file_read of workspace-internal path is auto-allowed by policy (.read + inside workspace).
+    // Legacy approval callback should NOT fire.
+    try std.testing.expectEqual(@as(usize, 0), approval.calls);
     try std.testing.expectEqual(@as(usize, 1), tool_result.tool_results.len);
-    try std.testing.expect(tool_result.tool_results[0].is_error);
 }
 
 test "executeToolCalls persists legacy approve always with permission engine" {
@@ -1764,9 +1767,8 @@ test "executeToolCalls persists legacy approve always with permission engine" {
         .stop_reason = .tool_use,
         .timestamp = 0,
     };
-    var engine = try permission.PermissionEngine.init(allocator, .{
+    var engine = try permission.PermissionEngine.initEmpty(allocator, .{
         .workspace_root = "/workspace",
-        .persistence_path = "zig-cache/test-agent-loop-approve-always.json",
     });
     defer engine.deinit();
     var agent_events = AgentEventStream.init(allocator);
@@ -1871,9 +1873,8 @@ test "executeToolCalls denies policy before legacy approval can persist always" 
         .stop_reason = .tool_use,
         .timestamp = 0,
     };
-    var engine = try permission.PermissionEngine.init(allocator, .{
+    var engine = try permission.PermissionEngine.initEmpty(allocator, .{
         .workspace_root = "/workspace",
-        .persistence_path = "zig-cache/test-agent-loop-deny-before-approve-always.json",
     });
     defer engine.deinit();
     var agent_events = AgentEventStream.init(allocator);

--- a/zig/src/tools/permission.zig
+++ b/zig/src/tools/permission.zig
@@ -423,7 +423,7 @@ fn optionalStringEql(a: ?[]const u8, b: ?[]const u8) bool {
     return std.mem.eql(u8, a.?, b.?);
 }
 
-fn canPersistDecision(call: ToolCall) bool {
+pub fn canPersistDecision(call: ToolCall) bool {
     return switch (call.operation) {
         .read, .write => call.path != null,
         .shell => call.command != null,

--- a/zig/src/tools/permission.zig
+++ b/zig/src/tools/permission.zig
@@ -319,7 +319,7 @@ pub const PermissionEngine = struct {
     }
 };
 
-fn parseToolCall(allocator: std.mem.Allocator, tool_name: []const u8, args_json: []const u8) !ToolCall {
+pub fn parseToolCall(allocator: std.mem.Allocator, tool_name: []const u8, args_json: []const u8) !ToolCall {
     var parsed = try std.json.parseFromSlice(std.json.Value, allocator, args_json, .{});
     defer parsed.deinit();
 
@@ -356,7 +356,7 @@ fn parseToolCall(allocator: std.mem.Allocator, tool_name: []const u8, args_json:
     };
 }
 
-fn deinitParsedToolCall(allocator: std.mem.Allocator, call: ToolCall) void {
+pub fn deinitParsedToolCall(allocator: std.mem.Allocator, call: ToolCall) void {
     if (call.path) |path| allocator.free(@constCast(path));
     if (call.command) |command| allocator.free(@constCast(command));
 }

--- a/zig/src/tools/permission.zig
+++ b/zig/src/tools/permission.zig
@@ -129,6 +129,26 @@ pub const PermissionEngine = struct {
         return engine;
     }
 
+    /// Initialize engine without loading persisted file.
+    /// Use when on-disk permissions are corrupt or unreadable.
+    pub fn initEmpty(allocator: std.mem.Allocator, options: PermissionEngineOptions) !Self {
+        const workspace_root = try allocator.dupe(u8, options.workspace_root);
+        errdefer allocator.free(workspace_root);
+
+        const persistence_path = if (options.persistence_path) |path|
+            try allocator.dupe(u8, path)
+        else
+            try defaultPersistencePath(allocator);
+        errdefer allocator.free(persistence_path);
+
+        return Self{
+            .allocator = allocator,
+            .workspace_root = workspace_root,
+            .persistence_path = persistence_path,
+            .approval_callback = options.approval_callback,
+        };
+    }
+
     pub fn deinit(self: *Self) void {
         for (self.persisted.items) |*decision| decision.deinit(self.allocator);
         self.persisted.deinit(self.allocator);

--- a/zig/src/tools/permission.zig
+++ b/zig/src/tools/permission.zig
@@ -691,6 +691,24 @@ test "persisted always allow decision reloads and auto-approves" {
     }
 }
 
+test "approve always persists scoped path decision" {
+    const persistence_path = "zig-cache/test-permissions-approve-always-scope.json";
+    compat.fs.getCwd().deleteFile(std.testing.io, persistence_path) catch {};
+
+    approval_recorder = .{ .decision = .approve_always };
+    var engine = try PermissionEngine.init(std.testing.allocator, .{
+        .workspace_root = "/workspace",
+        .persistence_path = persistence_path,
+        .approval_callback = approvalCallback,
+    });
+    defer engine.deinit();
+
+    try std.testing.expectEqual(ApprovalDecision.approve_always, try engine.approve("file:write", "{\"path\":\"src/main.zig\"}"));
+    try std.testing.expectEqual(@as(usize, 1), engine.persisted.items.len);
+    try std.testing.expectEqualStrings("/workspace/src/main.zig", engine.persisted.items[0].path.?);
+    try std.testing.expectEqual(PermissionDecision.allow, engine.evaluate("file:write", "{\"path\":\"/workspace/src/main.zig\"}"));
+}
+
 test "persisted path scope matches normalized equivalent paths" {
     var engine = try PermissionEngine.init(std.testing.allocator, .{
         .workspace_root = "/workspace",

--- a/zig/src/tui/app.zig
+++ b/zig/src/tui/app.zig
@@ -54,7 +54,9 @@ pub const ProductionRuntime = struct {
 
         const workspace_root = try std.process.currentPathAlloc(defaultIo(), allocator);
         defer allocator.free(workspace_root);
-        var permission_engine = try permission.PermissionEngine.init(allocator, .{ .workspace_root = workspace_root });
+        var permission_engine = permission.PermissionEngine.init(allocator, .{ .workspace_root = workspace_root }) catch
+            permission.PermissionEngine.initEmpty(allocator, .{ .workspace_root = workspace_root }) catch
+            @panic("OOM initializing permission engine");
         errdefer permission_engine.deinit();
 
         var runtime = ProductionRuntime{

--- a/zig/src/tui/app.zig
+++ b/zig/src/tui/app.zig
@@ -17,6 +17,7 @@ const approval_view = @import("tui_view_approval");
 const preview_view = @import("tui_view_preview");
 const session_picker_view = @import("tui_view_session_picker");
 const tui_render = @import("tui_render");
+const permission = @import("permission");
 
 pub const ApprovalWaiter = struct {
     allocator: std.mem.Allocator,
@@ -43,16 +44,24 @@ pub const ProductionRuntime = struct {
     allocator: std.mem.Allocator,
     registry: api_registry.ApiRegistry,
     bridge: agent.InProcessProviderProtocolBridge,
+    permission_engine: permission.PermissionEngine,
     models: []ai_types.Model,
 
     pub fn init(allocator: std.mem.Allocator) !ProductionRuntime {
         var registry = api_registry.ApiRegistry.init(allocator);
         errdefer registry.deinit();
         try register_builtins.registerBuiltInApiProviders(&registry);
+
+        const workspace_root = try std.process.currentPathAlloc(defaultIo(), allocator);
+        defer allocator.free(workspace_root);
+        var permission_engine = try permission.PermissionEngine.init(allocator, .{ .workspace_root = workspace_root });
+        errdefer permission_engine.deinit();
+
         var runtime = ProductionRuntime{
             .allocator = allocator,
             .registry = registry,
             .bridge = undefined,
+            .permission_engine = permission_engine,
             .models = try allocator.alloc(ai_types.Model, 1),
         };
         runtime.bridge = agent.InProcessProviderProtocolBridge.init(&runtime.registry);
@@ -64,6 +73,7 @@ pub const ProductionRuntime = struct {
         return .{
             .protocol = (&self.bridge).protocolClient(),
             .models = self.models,
+            .permission_engine = &self.permission_engine,
             .run_async = true,
             .compact_output = true,
         };
@@ -71,6 +81,7 @@ pub const ProductionRuntime = struct {
 
     pub fn deinit(self: *ProductionRuntime) void {
         self.allocator.free(self.models);
+        self.permission_engine.deinit();
         self.registry.deinit();
         self.* = undefined;
     }
@@ -303,9 +314,9 @@ const TuiModel = struct {
                 if (app.state.mode == .approval) {
                     switch (key.key) {
                         .char => |c| switch (c) {
-                            'a' => app.decideApproval(true, false) catch |err| app.recordError(@errorName(err)) catch {},
-                            'A' => app.decideApproval(true, true) catch |err| app.recordError(@errorName(err)) catch {},
-                            'd' => app.decideApproval(false, false) catch |err| app.recordError(@errorName(err)) catch {},
+                            'y' => app.decideApproval(true, false) catch |err| app.recordError(@errorName(err)) catch {},
+                            'a' => app.decideApproval(true, true) catch |err| app.recordError(@errorName(err)) catch {},
+                            'n' => app.decideApproval(false, false) catch |err| app.recordError(@errorName(err)) catch {},
                             else => {},
                         },
                         .escape => app.decideApproval(false, false) catch |err| app.recordError(@errorName(err)) catch {},
@@ -399,6 +410,13 @@ const TuiModel = struct {
     }
 };
 
+fn defaultIo() std.Io {
+    return if (@import("builtin").is_test)
+        std.testing.io
+    else
+        std.Io.Threaded.global_single_threaded.io();
+}
+
 fn defaultModel() ai_types.Model {
     return .{
         .id = "claude-sonnet-4-5",
@@ -436,6 +454,31 @@ test "App init seeds registered tools from runtime" {
     try std.testing.expect(app.state.registered_tools.items.len >= 12);
     try std.testing.expectEqual(app.runtime.?.availableTools().len, app.state.registered_tools.items.len);
     try std.testing.expectEqualStrings("shell_execute", app.state.registered_tools.items[0].name);
+    try std.testing.expect(app.runtime.?.permission_engine.?.workspace_root.len > 0);
+}
+
+test "App approval decisions map to requested choices" {
+    var app = App.initWithoutRuntime(std.testing.allocator);
+    defer app.deinit();
+    try app.state.approval.setPending(std.testing.allocator, "call-approval", "edit_file", "{\"path\":\"README.md\"}");
+    app.state.mode = .approval;
+
+    try app.decideApproval(true, false);
+    try std.testing.expectEqual(tui_state.AppMode.normal, app.state.mode);
+    try std.testing.expectEqual(tui_state.ApprovalStatus.approved, app.state.approval.status);
+    try std.testing.expect(!app.state.approval.always);
+
+    try app.state.approval.setPending(std.testing.allocator, "call-approval", "edit_file", "{\"path\":\"README.md\"}");
+    app.state.mode = .approval;
+    try app.decideApproval(true, true);
+    try std.testing.expectEqual(tui_state.ApprovalStatus.approved, app.state.approval.status);
+    try std.testing.expect(app.state.approval.always);
+
+    try app.state.approval.setPending(std.testing.allocator, "call-approval", "edit_file", "{\"path\":\"README.md\"}");
+    app.state.mode = .approval;
+    try app.decideApproval(false, false);
+    try std.testing.expectEqual(tui_state.ApprovalStatus.rejected, app.state.approval.status);
+    try std.testing.expect(!app.state.approval.always);
 }
 
 test "App submit appends user transcript without runtime" {

--- a/zig/src/tui/state.zig
+++ b/zig/src/tui/state.zig
@@ -705,17 +705,62 @@ pub const AppState = struct {
 };
 
 fn approvalScopeHint(allocator: std.mem.Allocator, tool_name: []const u8, args_json: []const u8) ![]u8 {
-    var parsed = std.json.parseFromSlice(std.json.Value, allocator, args_json, .{}) catch return std.fmt.allocPrint(allocator, "{s} (one tool call)", .{tool_name});
+    const safe_tool_name = try sanitizeTerminalText(allocator, tool_name);
+    defer allocator.free(safe_tool_name);
+
+    var parsed = std.json.parseFromSlice(std.json.Value, allocator, args_json, .{}) catch return std.fmt.allocPrint(allocator, "{s} (one tool call)", .{safe_tool_name});
     defer parsed.deinit();
-    if (parsed.value != .object) return std.fmt.allocPrint(allocator, "{s} (one tool call)", .{tool_name});
+    if (parsed.value != .object) return std.fmt.allocPrint(allocator, "{s} (one tool call)", .{safe_tool_name});
     const obj = parsed.value.object;
     if (firstJsonString(obj, &.{ "path", "file_path", "target_path", "cwd" })) |path| {
-        return std.fmt.allocPrint(allocator, "{s} path {s}", .{ tool_name, path });
+        const safe_path = try sanitizeTerminalText(allocator, path);
+        defer allocator.free(safe_path);
+        return std.fmt.allocPrint(allocator, "{s} path {s}", .{ safe_tool_name, safe_path });
     }
     if (firstJsonString(obj, &.{ "command", "cmd", "script" })) |command| {
-        return std.fmt.allocPrint(allocator, "{s} command {s}", .{ tool_name, command });
+        const safe_command = try sanitizeTerminalText(allocator, command);
+        defer allocator.free(safe_command);
+        return std.fmt.allocPrint(allocator, "{s} command {s}", .{ safe_tool_name, safe_command });
     }
-    return std.fmt.allocPrint(allocator, "{s} (one tool call)", .{tool_name});
+    return std.fmt.allocPrint(allocator, "{s} (one tool call)", .{safe_tool_name});
+}
+
+fn sanitizeTerminalText(allocator: std.mem.Allocator, text: []const u8) ![]u8 {
+    var out: std.Io.Writer.Allocating = .init(allocator);
+    errdefer out.deinit();
+    const writer = &out.writer;
+    var i: usize = 0;
+    while (i < text.len) {
+        const c = text[i];
+        switch (c) {
+            '\n', '\r', '\t' => {
+                try writer.writeByte(' ');
+                i += 1;
+                continue;
+            },
+            0x00...0x08, 0x0b, 0x0c, 0x0e...0x1f, 0x7f => {
+                i += 1;
+                continue;
+            },
+            else => {},
+        }
+        const len = std.unicode.utf8ByteSequenceLength(c) catch {
+            i += 1;
+            continue;
+        };
+        if (i + len > text.len) break;
+        const codepoint = std.unicode.utf8Decode(text[i .. i + len]) catch {
+            i += 1;
+            continue;
+        };
+        if (codepoint < 0x20 or codepoint == 0x7f) {
+            i += len;
+            continue;
+        }
+        try writer.writeAll(text[i .. i + len]);
+        i += len;
+    }
+    return out.toOwnedSlice();
 }
 
 fn firstJsonString(obj: std.json.ObjectMap, keys: []const []const u8) ?[]const u8 {

--- a/zig/src/tui/state.zig
+++ b/zig/src/tui/state.zig
@@ -120,22 +120,27 @@ pub const ApprovalState = struct {
     tool_call_id: []u8 = &.{},
     tool_name: []u8 = &.{},
     args_json: []u8 = &.{},
+    scope_hint: []u8 = &.{},
     always: bool = false,
 
     pub fn deinit(self: *ApprovalState, allocator: std.mem.Allocator) void {
         if (self.tool_call_id.len > 0) allocator.free(self.tool_call_id);
         if (self.tool_name.len > 0) allocator.free(self.tool_name);
         if (self.args_json.len > 0) allocator.free(self.args_json);
+        if (self.scope_hint.len > 0) allocator.free(self.scope_hint);
         self.* = .{};
     }
 
     pub fn setPending(self: *ApprovalState, allocator: std.mem.Allocator, tool_call_id: []const u8, tool_name: []const u8, args_json: []const u8) !void {
         self.deinit(allocator);
+        const scope_hint = try approvalScopeHint(allocator, tool_name, args_json);
+        errdefer allocator.free(scope_hint);
         self.* = .{
             .status = .pending,
             .tool_call_id = try allocator.dupe(u8, tool_call_id),
             .tool_name = try allocator.dupe(u8, tool_name),
             .args_json = try allocator.dupe(u8, args_json),
+            .scope_hint = scope_hint,
         };
     }
 };
@@ -698,6 +703,27 @@ pub const AppState = struct {
         return &self.tools.items[self.tools.items.len - 1];
     }
 };
+
+fn approvalScopeHint(allocator: std.mem.Allocator, tool_name: []const u8, args_json: []const u8) ![]u8 {
+    var parsed = std.json.parseFromSlice(std.json.Value, allocator, args_json, .{}) catch return std.fmt.allocPrint(allocator, "{s} (one tool call)", .{tool_name});
+    defer parsed.deinit();
+    if (parsed.value != .object) return std.fmt.allocPrint(allocator, "{s} (one tool call)", .{tool_name});
+    const obj = parsed.value.object;
+    if (firstJsonString(obj, &.{ "path", "file_path", "target_path", "cwd" })) |path| {
+        return std.fmt.allocPrint(allocator, "{s} path {s}", .{ tool_name, path });
+    }
+    if (firstJsonString(obj, &.{ "command", "cmd", "script" })) |command| {
+        return std.fmt.allocPrint(allocator, "{s} command {s}", .{ tool_name, command });
+    }
+    return std.fmt.allocPrint(allocator, "{s} (one tool call)", .{tool_name});
+}
+
+fn firstJsonString(obj: std.json.ObjectMap, keys: []const []const u8) ?[]const u8 {
+    for (keys) |key| {
+        if (jsonString(obj, key)) |value| return value;
+    }
+    return null;
+}
 
 fn appendHashlinePreview(out: *std.ArrayList(u8), allocator: std.mem.Allocator, text: []const u8) !void {
     if (out.items.len >= max_hashline_preview_bytes) return;

--- a/zig/src/tui/state.zig
+++ b/zig/src/tui/state.zig
@@ -753,7 +753,7 @@ fn sanitizeTerminalText(allocator: std.mem.Allocator, text: []const u8) ![]u8 {
             i += 1;
             continue;
         };
-        if (codepoint < 0x20 or codepoint == 0x7f) {
+        if (codepoint < 0x20 or codepoint == 0x7f or (codepoint >= 0x80 and codepoint <= 0x9f)) {
             i += len;
             continue;
         }
@@ -854,7 +854,7 @@ fn clipSummaryArg(allocator: std.mem.Allocator, value: []const u8) ![]u8 {
                 i += 1;
                 continue;
             };
-            if (codepoint < 0x20 or codepoint == 0x7f) {
+            if (codepoint < 0x20 or codepoint == 0x7f or (codepoint >= 0x80 and codepoint <= 0x9f)) {
                 i += len;
                 continue;
             }

--- a/zig/src/tui/views/approval.zig
+++ b/zig/src/tui/views/approval.zig
@@ -69,6 +69,19 @@ test "approval renders command scope hint" {
     try std.testing.expect(std.mem.indexOf(u8, text, "Always scope: shell_execute command zig build test") != null);
 }
 
+test "approval scope hint strips terminal controls" {
+    var state = tui_state.AppState.init(std.testing.allocator);
+    defer state.deinit();
+    try state.approval.setPending(std.testing.allocator, "call-escape", "edit_file", "{\"path\":\"src/\\u001b[2Jsecret.zig\"}");
+
+    const text = try render(std.testing.allocator, &state, .{ .width = 100 });
+    defer std.testing.allocator.free(text);
+
+    try std.testing.expect(std.mem.indexOfScalar(u8, state.approval.scope_hint, 0x1b) == null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "[2J") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "secret.zig") != null);
+}
+
 test "approval renders hashline preview" {
     var state = tui_state.AppState.init(std.testing.allocator);
     defer state.deinit();

--- a/zig/src/tui/views/approval.zig
+++ b/zig/src/tui/views/approval.zig
@@ -19,6 +19,11 @@ pub fn render(allocator: std.mem.Allocator, state: *const tui_state.AppState, op
     const args = try tui_text.truncateToWidth(allocator, state.approval.args_json, options.width -| 8);
     defer allocator.free(args);
     try parts.append(allocator, try std.fmt.allocPrint(allocator, "Args: {s}", .{args}));
+    if (state.approval.scope_hint.len > 0) {
+        const scope = try tui_text.truncateToWidth(allocator, state.approval.scope_hint, options.width -| 16);
+        defer allocator.free(scope);
+        try parts.append(allocator, try std.fmt.allocPrint(allocator, "Always scope: {s}", .{scope}));
+    }
     if (std.mem.eql(u8, state.approval.tool_name, "hashline_edit") and state.preview.content.len > 0) {
         try parts.append(allocator, try tui_theme.panelTitle().render(allocator, "Preview:"));
         var rows: usize = 0;
@@ -31,7 +36,7 @@ pub fn render(allocator: std.mem.Allocator, state: *const tui_state.AppState, op
             rows += 1;
         }
     }
-    try parts.append(allocator, try tui_theme.muted().render(allocator, "(a) allow once  (A) allow always  (d) deny  Esc abort"));
+    try parts.append(allocator, try tui_theme.muted().render(allocator, "(y) allow once  (a) allow always  (n) deny  Esc abort"));
     const body = try tui_render.joinVertical(allocator, parts.items);
     defer allocator.free(body);
     return tui_theme.panel().borderForeground(tui_theme.palette.warning).width(@intCast(@min(options.width, std.math.maxInt(u16)))).render(allocator, body);
@@ -47,7 +52,21 @@ test "approval renders pending request" {
 
     try std.testing.expect(std.mem.indexOf(u8, text, "Approval required") != null);
     try std.testing.expect(std.mem.indexOf(u8, text, "edit_file") != null);
-    try std.testing.expect(std.mem.indexOf(u8, text, "allow always") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "(y) allow once") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "(a) allow always") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "(n) deny") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "Always scope: edit_file path README.md") != null);
+}
+
+test "approval renders command scope hint" {
+    var state = tui_state.AppState.init(std.testing.allocator);
+    defer state.deinit();
+    try state.approval.setPending(std.testing.allocator, "call-shell", "shell_execute", "{\"command\":\"zig build test\"}");
+
+    const text = try render(std.testing.allocator, &state, .{ .width = 100 });
+    defer std.testing.allocator.free(text);
+
+    try std.testing.expect(std.mem.indexOf(u8, text, "Always scope: shell_execute command zig build test") != null);
 }
 
 test "approval renders hashline preview" {

--- a/zig/src/tui/views/approval.zig
+++ b/zig/src/tui/views/approval.zig
@@ -82,6 +82,20 @@ test "approval scope hint strips terminal controls" {
     try std.testing.expect(std.mem.indexOf(u8, text, "secret.zig") != null);
 }
 
+test "approval scope hint strips C1 control characters" {
+    var state = tui_state.AppState.init(std.testing.allocator);
+    defer state.deinit();
+    // U+009B (CSI) encodes as C2 9B in UTF-8
+    try state.approval.setPending(std.testing.allocator, "call-c1", "edit_file", "{\"path\":\"src/\xC2\x9Bclear.zig\"}");
+
+    const text = try render(std.testing.allocator, &state, .{ .width = 100 });
+    defer std.testing.allocator.free(text);
+
+    // C2 9B (U+009B CSI) should be stripped from scope hint
+    try std.testing.expect(std.mem.indexOf(u8, state.approval.scope_hint, "\xC2\x9B") == null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "clear.zig") != null);
+}
+
 test "approval renders hashline preview" {
     var state = tui_state.AppState.init(std.testing.allocator);
     defer state.deinit();


### PR DESCRIPTION
## Summary
- Adds T8 inline approval prompt keys: `(y) allow once`, `(a) allow always`, `(n) deny`, and Escape abort.
- Wires production TUI runtime to own a `PermissionEngine`, so allow-always decisions persist scoped tool permissions.
- Shows always-scope hints for path and command approvals and adds coverage for prompt rendering, decisions, and persistence.

## Test plan
- [x] `./scripts/check-zig-patterns.sh`
- [x] `zig build test-unit-makai-cli`
- [x] `zig build test-unit-agent`
- [x] `zig build test`