### PR TITLE
Add TUI scroll sessions and external editor

### DIFF
--- a/zig/build.zig
+++ b/zig/build.zig
@@ -972,6 +972,7 @@ pub fn build(b: *std.Build) void {
             .{ .name = "tui_state", .module = tui_state_mod },
             .{ .name = "tui_commands", .module = tui_commands_mod },
             .{ .name = "tui_render", .module = tui_render_mod },
+            .{ .name = "tui_session_store", .module = tui_session_store_mod },
             .{ .name = "tui_view_transcript", .module = tui_view_transcript_mod },
             .{ .name = "tui_view_composer", .module = tui_view_composer_mod },
             .{ .name = "tui_view_status_bar", .module = tui_view_status_bar_mod },

--- a/zig/src/tui/app.zig
+++ b/zig/src/tui/app.zig
@@ -419,13 +419,12 @@ fn createExternalEditorTempFile(allocator: std.mem.Allocator, content: []const u
     const tmp_dir = compat.getEnvVarOwned(allocator, "TMPDIR") catch try allocator.dupe(u8, "/tmp");
     defer allocator.free(tmp_dir);
     const dir_path = try std.fs.path.join(allocator, &.{ tmp_dir, editor_tmp_dir_prefix ++ random_hex });
-    errdefer allocator.free(dir_path);
+    defer allocator.free(dir_path);
     try std.Io.Dir.createDirAbsolute(defaultIo(), dir_path, @enumFromInt(0o700));
     errdefer std.Io.Dir.deleteDirAbsolute(defaultIo(), dir_path) catch {};
 
     const file_path = try std.fs.path.join(allocator, &.{ dir_path, editor_tmp_file_name });
     errdefer allocator.free(file_path);
-    allocator.free(dir_path);
 
     var file = try std.Io.Dir.createFileAbsolute(defaultIo(), file_path, .{ .exclusive = true, .truncate = false, .permissions = @enumFromInt(0o600) });
     errdefer std.Io.Dir.deleteFileAbsolute(defaultIo(), file_path) catch {};

--- a/zig/src/tui/app.zig
+++ b/zig/src/tui/app.zig
@@ -249,7 +249,8 @@ pub const App = struct {
         var session = &(self.session orelse return);
         while (session.popEvent()) |event| {
             var ev = event;
-            ev.deinit(self.allocator);
+            defer ev.deinit(self.allocator);
+            self.saveEvent(ev);
         }
     }
 

--- a/zig/src/tui/app.zig
+++ b/zig/src/tui/app.zig
@@ -371,9 +371,8 @@ fn approvalCallback(ctx: ?*anyopaque, request: tui_runtime.ToolApprovalRequest) 
 }
 
 /// Module-level state for the external editor launch (T11).
-/// Stores the temp file path so the stateless `perform` fn can access it.
-var editor_tmp_path: [512]u8 = undefined;
-var editor_tmp_path_len: usize = 0;
+/// Stores the owned temp file path so the stateless `perform` fn can access it.
+var editor_tmp_path: []u8 = &.{};
 var editor_tmp_allocator: ?std.mem.Allocator = null;
 
 const editor_tmp_dir_prefix = "makai-editor-";
@@ -387,12 +386,17 @@ fn launchExternalEditor(app: *App, allocator: std.mem.Allocator) ?zz.Cmd(TuiMode
 
     const content = app.state.composer.buffer.items;
     const tmp_path = createExternalEditorTempFile(allocator, content) catch return null;
-    defer allocator.free(tmp_path);
+    errdefer {
+        cleanupExternalEditorTempPath(tmp_path);
+        allocator.free(tmp_path);
+    }
 
-    // Store path in module-level state for the perform fn.
-    if (tmp_path.len >= editor_tmp_path.len) return null;
-    @memcpy(editor_tmp_path[0..tmp_path.len], tmp_path);
-    editor_tmp_path_len = tmp_path.len;
+    // Store owned path in module-level state for the perform fn.
+    if (editor_tmp_path.len > 0) {
+        cleanupExternalEditorTempPath(editor_tmp_path);
+        allocator.free(editor_tmp_path);
+    }
+    editor_tmp_path = tmp_path;
     editor_tmp_allocator = allocator;
 
     return zz.Cmd(TuiModel.Msg){ .sequence = &.{
@@ -497,12 +501,14 @@ fn freeEditorArgv(allocator: std.mem.Allocator, argv: []const []const u8) void {
 
 /// Stateless perform fn: spawns $EDITOR on the temp file and reads result back.
 fn runEditorPerform() ?TuiModel.Msg {
-    if (editor_tmp_path_len == 0) return TuiModel.Msg{ .editor_failed = {} };
-    const path = editor_tmp_path[0..editor_tmp_path_len];
+    if (editor_tmp_path.len == 0) return TuiModel.Msg{ .editor_failed = {} };
     const allocator = editor_tmp_allocator orelse return TuiModel.Msg{ .editor_failed = {} };
+    const path = editor_tmp_path;
     defer {
         cleanupExternalEditorTempPath(path);
-        editor_tmp_path_len = 0;
+        allocator.free(path);
+        editor_tmp_path = &.{};
+        editor_tmp_allocator = null;
     }
 
     // Resolve $EDITOR or fall back to vi.
@@ -760,7 +766,7 @@ fn newerSessionFirst(_: void, a: session_store.SessionMetadata, b: session_store
     return a.last_active > b.last_active;
 }
 
-/// Generate a timestamp-based session ID, e.g. "20260523-150405-123".
+/// Generate a collision-resistant session ID, e.g. "20260523-150405-123-a1b2c3d4e5f60708".
 fn generateSessionId(allocator: std.mem.Allocator) ![]u8 {
     const millis = compat.time.nowMillis();
     const secs: i64 = @divFloor(millis, 1000);
@@ -770,9 +776,13 @@ fn generateSessionId(allocator: std.mem.Allocator) ![]u8 {
     const year_day = day.calculateYearDay();
     const month_day = year_day.calculateMonthDay();
     const day_secs = epoch.getDaySeconds();
+    var random_bytes: [8]u8 = undefined;
+    compat.random.fillSecureBytes(&random_bytes);
+    var random_hex: [16]u8 = undefined;
+    encodeHexLower(&random_hex, &random_bytes);
     return std.fmt.allocPrint(
         allocator,
-        "{d:0>4}{d:0>2}{d:0>2}-{d:0>2}{d:0>2}{d:0>2}-{d:0>3}",
+        "{d:0>4}{d:0>2}{d:0>2}-{d:0>2}{d:0>2}{d:0>2}-{d:0>3}-{s}",
         .{
             year_day.year,
             month_day.month.numeric(),
@@ -781,6 +791,7 @@ fn generateSessionId(allocator: std.mem.Allocator) ![]u8 {
             day_secs.getMinutesIntoHour(),
             day_secs.getSecondsIntoMinute(),
             ms,
+            random_hex,
         },
     );
 }

--- a/zig/src/tui/app.zig
+++ b/zig/src/tui/app.zig
@@ -177,8 +177,10 @@ pub const App = struct {
         const idx = self.state.session_index;
         if (idx >= sessions.len) return;
         const id = sessions[idx].id;
+        self.discardPendingEvents();
         var loaded = try store.resumeSession(id, runtime);
         defer loaded.deinit(self.allocator);
+        self.discardPendingEvents();
         self.state.resetReplayState();
         if (self.session_id.len > 0) self.allocator.free(self.session_id);
         self.session_id = try self.allocator.dupe(u8, loaded.metadata.session_id);
@@ -241,6 +243,14 @@ pub const App = struct {
             defer ev.deinit(self.allocator);
             self.saveEvent(ev);
             try self.state.applyEvent(ev);
+        }
+    }
+
+    fn discardPendingEvents(self: *App) void {
+        var session = &(self.session orelse return);
+        while (session.popEvent()) |event| {
+            var ev = event;
+            ev.deinit(self.allocator);
         }
     }
 
@@ -366,6 +376,9 @@ var editor_tmp_path: [512]u8 = undefined;
 var editor_tmp_path_len: usize = 0;
 var editor_tmp_allocator: ?std.mem.Allocator = null;
 
+const editor_tmp_dir_prefix = "makai-editor-";
+const editor_tmp_file_name = "composer.txt";
+
 /// T11: Write composer buffer to a temp file and return a batch command that
 /// exits alt screen, runs the editor, and returns an editor_done message.
 fn launchExternalEditor(app: *App, allocator: std.mem.Allocator) ?zz.Cmd(TuiModel.Msg) {
@@ -373,16 +386,8 @@ fn launchExternalEditor(app: *App, allocator: std.mem.Allocator) ?zz.Cmd(TuiMode
     if (@import("builtin").os.tag == .windows) return null;
 
     const content = app.state.composer.buffer.items;
-    const tmp_path = std.fmt.allocPrint(allocator, "/tmp/makai_edit_{d}.txt", .{compat.time.nowMillis()}) catch return null;
+    const tmp_path = createExternalEditorTempFile(allocator, content) catch return null;
     defer allocator.free(tmp_path);
-
-    // Write current buffer to temp file.
-    var file = std.Io.Dir.createFileAbsolute(defaultIo(), tmp_path, .{}) catch return null;
-    file.writeStreamingAll(defaultIo(), content) catch {
-        file.close(defaultIo());
-        return null;
-    };
-    file.close(defaultIo());
 
     // Store path in module-level state for the perform fn.
     if (tmp_path.len >= editor_tmp_path.len) return null;
@@ -397,13 +402,71 @@ fn launchExternalEditor(app: *App, allocator: std.mem.Allocator) ?zz.Cmd(TuiMode
     } };
 }
 
+fn encodeHexLower(out: []u8, bytes: []const u8) void {
+    const alphabet = "0123456789abcdef";
+    for (bytes, 0..) |byte, i| {
+        out[i * 2] = alphabet[byte >> 4];
+        out[i * 2 + 1] = alphabet[byte & 0x0f];
+    }
+}
+
+fn createExternalEditorTempFile(allocator: std.mem.Allocator, content: []const u8) ![]u8 {
+    var random_bytes: [16]u8 = undefined;
+    compat.random.fillSecureBytes(&random_bytes);
+    var random_hex: [32]u8 = undefined;
+    encodeHexLower(&random_hex, &random_bytes);
+
+    const tmp_dir = compat.getEnvVarOwned(allocator, "TMPDIR") catch try allocator.dupe(u8, "/tmp");
+    defer allocator.free(tmp_dir);
+    const dir_path = try std.fs.path.join(allocator, &.{ tmp_dir, editor_tmp_dir_prefix ++ random_hex });
+    errdefer allocator.free(dir_path);
+    try std.Io.Dir.createDirAbsolute(defaultIo(), dir_path, @enumFromInt(0o700));
+    errdefer std.Io.Dir.deleteDirAbsolute(defaultIo(), dir_path) catch {};
+
+    const file_path = try std.fs.path.join(allocator, &.{ dir_path, editor_tmp_file_name });
+    errdefer allocator.free(file_path);
+    allocator.free(dir_path);
+
+    var file = try std.Io.Dir.createFileAbsolute(defaultIo(), file_path, .{ .exclusive = true, .truncate = false, .permissions = @enumFromInt(0o600) });
+    errdefer std.Io.Dir.deleteFileAbsolute(defaultIo(), file_path) catch {};
+    defer file.close(defaultIo());
+    try file.writeStreamingAll(defaultIo(), content);
+    return file_path;
+}
+
+fn cleanupExternalEditorTempPath(path: []const u8) void {
+    std.Io.Dir.deleteFileAbsolute(defaultIo(), path) catch {};
+    if (std.fs.path.dirname(path)) |dir| std.Io.Dir.deleteDirAbsolute(defaultIo(), dir) catch {};
+}
+
+fn buildEditorArgv(allocator: std.mem.Allocator, editor: []const u8, path: []const u8) ![]const []const u8 {
+    var parts: std.ArrayList([]u8) = .empty;
+    errdefer {
+        for (parts.items) |part| allocator.free(part);
+        parts.deinit(allocator);
+    }
+
+    var it = std.mem.tokenizeScalar(u8, editor, ' ');
+    while (it.next()) |part| {
+        try parts.append(allocator, try allocator.dupe(u8, part));
+    }
+    if (parts.items.len == 0) try parts.append(allocator, try allocator.dupe(u8, "vi"));
+    try parts.append(allocator, try allocator.dupe(u8, path));
+    return parts.toOwnedSlice(allocator);
+}
+
+fn freeEditorArgv(allocator: std.mem.Allocator, argv: []const []const u8) void {
+    for (argv) |arg| allocator.free(arg);
+    allocator.free(argv);
+}
+
 /// Stateless perform fn: spawns $EDITOR on the temp file and reads result back.
 fn runEditorPerform() ?TuiModel.Msg {
     if (editor_tmp_path_len == 0) return TuiModel.Msg{ .editor_failed = {} };
     const path = editor_tmp_path[0..editor_tmp_path_len];
     const allocator = editor_tmp_allocator orelse return TuiModel.Msg{ .editor_failed = {} };
     defer {
-        std.Io.Dir.deleteFileAbsolute(defaultIo(), path) catch {};
+        cleanupExternalEditorTempPath(path);
         editor_tmp_path_len = 0;
     }
 
@@ -411,11 +474,12 @@ fn runEditorPerform() ?TuiModel.Msg {
     const editor_owned = compat.getEnvVarOwned(allocator, "EDITOR") catch
         (compat.getEnvVarOwned(allocator, "VISUAL") catch allocator.dupe(u8, "vi") catch return TuiModel.Msg{ .editor_failed = {} });
     defer allocator.free(editor_owned);
-    const editor = editor_owned;
+    const argv = buildEditorArgv(allocator, editor_owned, path) catch return TuiModel.Msg{ .editor_failed = {} };
+    defer freeEditorArgv(allocator, argv);
 
     // Spawn editor and wait.
     var child = std.process.spawn(defaultIo(), .{
-        .argv = &[_][]const u8{ editor, path },
+        .argv = argv,
         .stdin = .inherit,
         .stdout = .inherit,
         .stderr = .inherit,

--- a/zig/src/tui/app.zig
+++ b/zig/src/tui/app.zig
@@ -20,6 +20,8 @@ const session_picker_view = @import("tui_view_session_picker");
 const tui_render = @import("tui_render");
 const permission = @import("permission");
 
+const max_session_event_jsonl_bytes = 8 * 1024 * 1024;
+
 pub const ApprovalWaiter = struct {
     allocator: std.mem.Allocator,
     mutex: std.atomic.Mutex = .unlocked,
@@ -100,6 +102,7 @@ pub const App = struct {
     session_id: []u8 = &.{},
     session_created_at: i64 = 0,
     working_dir: []u8 = &.{},
+    last_view_height: usize = 8,
 
     pub fn init(allocator: std.mem.Allocator, options: tui_runtime.TuiRuntimeOptions) !App {
         var runtime_options = options;
@@ -204,7 +207,10 @@ pub const App = struct {
         const store = self.store orelse return;
         // Only save events that are needed for session replay.
         switch (event) {
-            .message_start, .message_end, .tool_execution_start, .tool_execution_end, .context_usage, .prompt_segment_usage, .agent_start, .turn_start, .turn_end, .agent_end => {},
+            .message_start, .message_end, .tool_execution_start, .context_usage, .prompt_segment_usage, .agent_start, .turn_start, .turn_end, .agent_end => {},
+            .tool_execution_end => |payload| {
+                if (payload.result_json.slice().len + payload.tool_call_id.slice().len + payload.tool_name.slice().len + payload.artifact_refs.slice().len > max_session_event_jsonl_bytes / 2) return;
+            },
             else => return,
         }
         const meta = self.currentSessionMetadata();
@@ -543,7 +549,7 @@ const TuiModel = struct {
         mouse: zz.MouseEvent,
         tick: struct { timestamp: u64, delta: u64 },
         quit: void,
-        /// Content read back from the external editor (owned by allocator stored in editor_tmp_allocator).
+        /// Content read back from the external editor (owned by persistent allocator).
         editor_done: []u8,
         /// External editor failed after leaving alt screen; restore terminal state.
         editor_failed: void,
@@ -581,7 +587,7 @@ const TuiModel = struct {
         switch (msg) {
             .editor_done => |content| {
                 // Content was read back from the external editor. Load into composer.
-                defer if (editor_tmp_allocator) |alloc| alloc.free(content);
+                defer ctx.persistent_allocator.free(content);
                 app.state.replaceComposerBuffer(content) catch {};
                 // Re-enter alt screen and hide cursor after editor exit.
                 return .{ .sequence = &.{
@@ -633,7 +639,7 @@ const TuiModel = struct {
                             if (app.state.session_index > 0) app.state.session_index -= 1;
                         },
                         .down => {
-                            const n = app.state.sessions.items.len;
+                            const n = visibleSessionCount(app);
                             if (n > 0 and app.state.session_index < n - 1) app.state.session_index += 1;
                         },
                         .char => |c| switch (c) {
@@ -641,7 +647,7 @@ const TuiModel = struct {
                                 if (app.state.session_index > 0) app.state.session_index -= 1;
                             },
                             'j' => {
-                                const n = app.state.sessions.items.len;
+                                const n = visibleSessionCount(app);
                                 if (n > 0 and app.state.session_index < n - 1) app.state.session_index += 1;
                             },
                             else => {},
@@ -706,6 +712,7 @@ const TuiModel = struct {
         const app = &(self.app orelse return "Makai TUI failed to initialize");
         const width: usize = @max(ctx.width, 20);
         const height: usize = @max(ctx.height, 8);
+        app.last_view_height = height;
         const status = status_bar_view.render(ctx.allocator, &app.state, .{ .width = width }) catch "";
         const composer = composer_view.render(ctx.allocator, &app.state, .{ .width = width }) catch "";
         const tool_height: usize = if (app.state.tools.items.len > 0) @min(@as(usize, 8), height / 4) else 2;
@@ -714,7 +721,7 @@ const TuiModel = struct {
         const extra = switch (app.state.mode) {
             .approval => approval_view.render(ctx.allocator, &app.state, .{ .width = width }) catch "",
             .preview => preview_view.render(ctx.allocator, &app.state, .{ .width = width, .height = height / 2 }) catch "",
-            .session_picker => session_picker_view.render(ctx.allocator, &app.state, .{ .height = height / 2 }) catch "",
+            .session_picker => session_picker_view.render(ctx.allocator, &app.state, .{ .height = sessionPickerHeight(app) }) catch "",
             .normal => "",
         };
         const fixed = countLines(status) + countLines(composer) + countLines(tools) + countLines(telemetry) + countLines(extra) + 5;
@@ -745,6 +752,14 @@ const TuiModel = struct {
             if (c == '\n') count += 1;
         }
         return count;
+    }
+
+    fn visibleSessionCount(app: *const App) usize {
+        return @min(app.state.sessions.items.len, sessionPickerHeight(app));
+    }
+
+    fn sessionPickerHeight(app: *const App) usize {
+        return @max(app.last_view_height, 8) / 2;
     }
 };
 
@@ -914,4 +929,17 @@ test "App submit quit command requests quit" {
     var app = App.initWithoutRuntime(std.testing.allocator);
     defer app.deinit();
     try std.testing.expectError(error.QuitRequested, app.submit("/quit"));
+}
+
+test "session picker navigation is capped to visible rows" {
+    var app = App.initWithoutRuntime(std.testing.allocator);
+    defer app.deinit();
+    app.last_view_height = 8;
+    try app.state.addSession("s1", "One");
+    try app.state.addSession("s2", "Two");
+    try app.state.addSession("s3", "Three");
+    try app.state.addSession("s4", "Four");
+    try app.state.addSession("s5", "Five");
+
+    try std.testing.expectEqual(@as(usize, 4), TuiModel.visibleSessionCount(&app));
 }

--- a/zig/src/tui/app.zig
+++ b/zig/src/tui/app.zig
@@ -179,17 +179,22 @@ pub const App = struct {
         const id = sessions[idx].id;
         var loaded = try store.resumeSession(id, runtime);
         defer loaded.deinit(self.allocator);
-        self.state.clearTranscript();
+        self.state.resetReplayState();
         if (self.session_id.len > 0) self.allocator.free(self.session_id);
         self.session_id = try self.allocator.dupe(u8, loaded.metadata.session_id);
         self.session_created_at = loaded.metadata.created_at;
         try self.state.status.setSessionId(self.allocator, self.session_id);
-        try self.state.status.setModelWithContext(self.allocator, loaded.metadata.model, loaded.metadata.provider, self.state.status.context_limit);
-        self.state.status.turn_count = loaded.metadata.turn_count;
-        // Replay events into transcript.
+        if (runtime.currentModel()) |model| {
+            try self.state.status.setModelWithContext(self.allocator, model.id, model.provider, model.context_window);
+            self.state.telemetry.context_window = model.context_window;
+        } else {
+            try self.state.status.setModelWithContext(self.allocator, loaded.metadata.model, loaded.metadata.provider, 0);
+        }
+        // Replay events into transcript and status counters.
         for (loaded.events.items) |*event| {
             try self.state.applyEvent(event.*);
         }
+        self.state.status.streaming = false;
         self.state.mode = .normal;
     }
 
@@ -198,7 +203,7 @@ pub const App = struct {
         const store = self.store orelse return;
         // Only save events that are needed for session replay.
         switch (event) {
-            .message_start, .message_end, .tool_execution_start, .tool_execution_end, .agent_start, .turn_start, .turn_end, .agent_end => {},
+            .message_start, .message_end, .tool_execution_start, .tool_execution_end, .context_usage, .prompt_segment_usage, .agent_start, .turn_start, .turn_end, .agent_end => {},
             else => return,
         }
         const meta = self.currentSessionMetadata();
@@ -244,8 +249,6 @@ pub const App = struct {
         if (trimmed.len == 0) return;
         if (trimmed[0] == '/') return try self.submitCommand(trimmed);
         try self.state.appendUserMessage(trimmed);
-        self.saveEvent(.{ .message_start = .{ .role = .user } });
-        self.saveEvent(.{ .message_end = .{ .role = .user, .text = .initBorrowed(trimmed) } });
         if (self.session) |*session| {
             session.submitTurn(trimmed) catch |err| {
                 try self.state.status.setError(self.allocator, @errorName(err));
@@ -271,6 +274,8 @@ pub const App = struct {
             },
             .command => |command| command,
         };
+
+        if (command.kind == .sessions) self.loadSessions() catch {};
 
         var result = tui_commands.dispatch(.{
             .allocator = self.allocator,
@@ -394,13 +399,17 @@ fn launchExternalEditor(app: *App, allocator: std.mem.Allocator) ?zz.Cmd(TuiMode
 
 /// Stateless perform fn: spawns $EDITOR on the temp file and reads result back.
 fn runEditorPerform() ?TuiModel.Msg {
-    if (editor_tmp_path_len == 0) return null;
+    if (editor_tmp_path_len == 0) return TuiModel.Msg{ .editor_failed = {} };
     const path = editor_tmp_path[0..editor_tmp_path_len];
-    const allocator = editor_tmp_allocator orelse return null;
+    const allocator = editor_tmp_allocator orelse return TuiModel.Msg{ .editor_failed = {} };
+    defer {
+        std.Io.Dir.deleteFileAbsolute(defaultIo(), path) catch {};
+        editor_tmp_path_len = 0;
+    }
 
     // Resolve $EDITOR or fall back to vi.
     const editor_owned = compat.getEnvVarOwned(allocator, "EDITOR") catch
-        (compat.getEnvVarOwned(allocator, "VISUAL") catch allocator.dupe(u8, "vi") catch return null);
+        (compat.getEnvVarOwned(allocator, "VISUAL") catch allocator.dupe(u8, "vi") catch return TuiModel.Msg{ .editor_failed = {} });
     defer allocator.free(editor_owned);
     const editor = editor_owned;
 
@@ -410,15 +419,12 @@ fn runEditorPerform() ?TuiModel.Msg {
         .stdin = .inherit,
         .stdout = .inherit,
         .stderr = .inherit,
-    }) catch return null;
+    }) catch return TuiModel.Msg{ .editor_failed = {} };
     defer if (child.id != null) child.kill(defaultIo());
-    _ = child.wait(defaultIo()) catch return null;
+    _ = child.wait(defaultIo()) catch return TuiModel.Msg{ .editor_failed = {} };
 
     // Read file back.
-    const content = std.Io.Dir.readFileAlloc(.cwd(), defaultIo(), path, allocator, .limited(10 * 1024 * 1024)) catch return null;
-    // Clean up temp file (best-effort).
-    std.Io.Dir.deleteFileAbsolute(defaultIo(), path) catch {};
-    editor_tmp_path_len = 0;
+    const content = std.Io.Dir.readFileAlloc(.cwd(), defaultIo(), path, allocator, .limited(10 * 1024 * 1024)) catch return TuiModel.Msg{ .editor_failed = {} };
 
     return TuiModel.Msg{ .editor_done = content };
 }
@@ -434,6 +440,8 @@ const TuiModel = struct {
         quit: void,
         /// Content read back from the external editor (owned by allocator stored in editor_tmp_allocator).
         editor_done: []u8,
+        /// External editor failed after leaving alt screen; restore terminal state.
+        editor_failed: void,
     };
 
     pub fn init(self: *TuiModel, ctx: *zz.Context) zz.Cmd(Msg) {
@@ -471,6 +479,13 @@ const TuiModel = struct {
                 defer if (editor_tmp_allocator) |alloc| alloc.free(content);
                 app.state.replaceComposerBuffer(content) catch {};
                 // Re-enter alt screen and hide cursor after editor exit.
+                return .{ .sequence = &.{
+                    .enter_alt_screen,
+                    .hide_cursor,
+                } };
+            },
+            .editor_failed => {
+                app.recordError("external editor failed") catch {};
                 return .{ .sequence = &.{
                     .enter_alt_screen,
                     .hide_cursor,

--- a/zig/src/tui/app.zig
+++ b/zig/src/tui/app.zig
@@ -8,6 +8,7 @@ const agent = @import("agent");
 const tui_runtime = @import("tui_runtime");
 const tui_state = @import("tui_state");
 const tui_commands = @import("tui_commands");
+const session_store = @import("tui_session_store");
 const transcript_view = @import("tui_view_transcript");
 const composer_view = @import("tui_view_composer");
 const status_bar_view = @import("tui_view_status_bar");
@@ -52,7 +53,7 @@ pub const ProductionRuntime = struct {
         errdefer registry.deinit();
         try register_builtins.registerBuiltInApiProviders(&registry);
 
-        const workspace_root = try std.process.currentPathAlloc(defaultIo(), allocator);
+        const workspace_root = try currentPathOwned(allocator);
         defer allocator.free(workspace_root);
         var permission_engine = permission.PermissionEngine.init(allocator, .{ .workspace_root = workspace_root }) catch
             permission.PermissionEngine.initEmpty(allocator, .{ .workspace_root = workspace_root }) catch
@@ -95,6 +96,10 @@ pub const App = struct {
     runtime: ?tui_runtime.TuiRuntime = null,
     session: ?tui_runtime.TuiSession = null,
     approval_waiter: ?*ApprovalWaiter = null,
+    store: ?session_store.Store = null,
+    session_id: []u8 = &.{},
+    session_created_at: i64 = 0,
+    working_dir: []u8 = &.{},
 
     pub fn init(allocator: std.mem.Allocator, options: tui_runtime.TuiRuntimeOptions) !App {
         var runtime_options = options;
@@ -116,6 +121,14 @@ pub const App = struct {
             try app.state.status.setModelWithContext(allocator, model.id, model.provider, model.context_window);
             app.state.telemetry.context_window = model.context_window;
         }
+        // Initialize session store and generate a session ID.
+        app.store = session_store.Store.initDefault(allocator) catch null;
+        app.session_id = generateSessionId(allocator) catch try allocator.dupe(u8, "default");
+        app.session_created_at = compat.time.nowMillis();
+        app.working_dir = currentPathOwned(allocator) catch try allocator.dupe(u8, "");
+        try app.state.status.setSessionId(allocator, app.session_id);
+        // Pre-populate sessions list.
+        try app.loadSessions();
         return app;
     }
 
@@ -130,8 +143,78 @@ pub const App = struct {
             waiter.deinit();
             self.allocator.destroy(waiter);
         }
+        if (self.store) |*store| store.deinit();
+        if (self.session_id.len > 0) self.allocator.free(self.session_id);
+        if (self.working_dir.len > 0) self.allocator.free(self.working_dir);
         self.state.deinit();
         self.* = undefined;
+    }
+
+    /// Load sessions from the store into state.sessions.
+    pub fn loadSessions(self: *App) !void {
+        const store = self.store orelse return;
+        for (self.state.sessions.items) |*s| s.deinit(self.allocator);
+        self.state.sessions.clearRetainingCapacity();
+        var metas = store.list() catch return;
+        defer {
+            for (metas.items) |*meta| meta.deinit(self.allocator);
+            metas.deinit(self.allocator);
+        }
+        std.mem.sort(session_store.SessionMetadata, metas.items, {}, newerSessionFirst);
+        for (metas.items) |meta| {
+            const label = try formatSessionLabel(self.allocator, meta);
+            defer self.allocator.free(label);
+            try self.state.addSession(meta.session_id, label);
+        }
+    }
+
+    /// Resume the session currently selected in the session picker.
+    pub fn resumeSelectedSession(self: *App) !void {
+        const store = self.store orelse return error.NoStoreConfigured;
+        const runtime = if (self.runtime) |*r| r else return error.NoRuntimeConfigured;
+        const sessions = self.state.sessions.items;
+        if (sessions.len == 0) return;
+        const idx = self.state.session_index;
+        if (idx >= sessions.len) return;
+        const id = sessions[idx].id;
+        var loaded = try store.resumeSession(id, runtime);
+        defer loaded.deinit(self.allocator);
+        self.state.clearTranscript();
+        if (self.session_id.len > 0) self.allocator.free(self.session_id);
+        self.session_id = try self.allocator.dupe(u8, loaded.metadata.session_id);
+        self.session_created_at = loaded.metadata.created_at;
+        try self.state.status.setSessionId(self.allocator, self.session_id);
+        try self.state.status.setModelWithContext(self.allocator, loaded.metadata.model, loaded.metadata.provider, self.state.status.context_limit);
+        self.state.status.turn_count = loaded.metadata.turn_count;
+        // Replay events into transcript.
+        for (loaded.events.items) |*event| {
+            try self.state.applyEvent(event.*);
+        }
+        self.state.mode = .normal;
+    }
+
+    /// Save one event to the session store (best-effort: ignores errors).
+    fn saveEvent(self: *App, event: tui_runtime.TuiEvent) void {
+        const store = self.store orelse return;
+        // Only save events that are needed for session replay.
+        switch (event) {
+            .message_start, .message_end, .tool_execution_start, .tool_execution_end, .agent_start, .turn_start, .turn_end, .agent_end => {},
+            else => return,
+        }
+        const meta = self.currentSessionMetadata();
+        store.save(meta, event) catch {};
+    }
+
+    fn currentSessionMetadata(self: *App) session_store.SessionMetadata {
+        return .{
+            .session_id = self.session_id,
+            .model = self.state.status.model,
+            .provider = self.state.status.provider,
+            .created_at = self.session_created_at,
+            .last_active = compat.time.nowMillis(),
+            .turn_count = self.state.status.turn_count,
+            .working_dir = self.working_dir,
+        };
     }
 
     pub fn start(self: *App) !void {
@@ -151,6 +234,7 @@ pub const App = struct {
         while (session.popEvent()) |event| {
             var ev = event;
             defer ev.deinit(self.allocator);
+            self.saveEvent(ev);
             try self.state.applyEvent(ev);
         }
     }
@@ -160,6 +244,8 @@ pub const App = struct {
         if (trimmed.len == 0) return;
         if (trimmed[0] == '/') return try self.submitCommand(trimmed);
         try self.state.appendUserMessage(trimmed);
+        self.saveEvent(.{ .message_start = .{ .role = .user } });
+        self.saveEvent(.{ .message_end = .{ .role = .user, .text = .initBorrowed(trimmed) } });
         if (self.session) |*session| {
             session.submitTurn(trimmed) catch |err| {
                 try self.state.status.setError(self.allocator, @errorName(err));
@@ -201,6 +287,12 @@ pub const App = struct {
         switch (result.action) {
             .quit => return error.QuitRequested,
             .clear_transcript => self.state.clearTranscript(),
+            .open_session_picker => {
+                // Refresh sessions list from store then open the picker.
+                self.loadSessions() catch {};
+                self.state.session_index = 0;
+                self.state.mode = .session_picker;
+            },
             .none => {},
         }
         if (result.output.len > 0) {
@@ -263,14 +355,85 @@ fn approvalCallback(ctx: ?*anyopaque, request: tui_runtime.ToolApprovalRequest) 
     }
 }
 
+/// Module-level state for the external editor launch (T11).
+/// Stores the temp file path so the stateless `perform` fn can access it.
+var editor_tmp_path: [512]u8 = undefined;
+var editor_tmp_path_len: usize = 0;
+var editor_tmp_allocator: ?std.mem.Allocator = null;
+
+/// T11: Write composer buffer to a temp file and return a batch command that
+/// exits alt screen, runs the editor, and returns an editor_done message.
+fn launchExternalEditor(app: *App, allocator: std.mem.Allocator) ?zz.Cmd(TuiModel.Msg) {
+    if (@import("builtin").is_test) return null; // skip in tests
+    if (@import("builtin").os.tag == .windows) return null;
+
+    const content = app.state.composer.buffer.items;
+    const tmp_path = std.fmt.allocPrint(allocator, "/tmp/makai_edit_{d}.txt", .{compat.time.nowMillis()}) catch return null;
+    defer allocator.free(tmp_path);
+
+    // Write current buffer to temp file.
+    var file = std.Io.Dir.createFileAbsolute(defaultIo(), tmp_path, .{}) catch return null;
+    file.writeStreamingAll(defaultIo(), content) catch {
+        file.close(defaultIo());
+        return null;
+    };
+    file.close(defaultIo());
+
+    // Store path in module-level state for the perform fn.
+    if (tmp_path.len >= editor_tmp_path.len) return null;
+    @memcpy(editor_tmp_path[0..tmp_path.len], tmp_path);
+    editor_tmp_path_len = tmp_path.len;
+    editor_tmp_allocator = allocator;
+
+    return zz.Cmd(TuiModel.Msg){ .sequence = &.{
+        .exit_alt_screen,
+        .show_cursor,
+        .{ .perform = runEditorPerform },
+    } };
+}
+
+/// Stateless perform fn: spawns $EDITOR on the temp file and reads result back.
+fn runEditorPerform() ?TuiModel.Msg {
+    if (editor_tmp_path_len == 0) return null;
+    const path = editor_tmp_path[0..editor_tmp_path_len];
+    const allocator = editor_tmp_allocator orelse return null;
+
+    // Resolve $EDITOR or fall back to vi.
+    const editor_owned = compat.getEnvVarOwned(allocator, "EDITOR") catch
+        (compat.getEnvVarOwned(allocator, "VISUAL") catch allocator.dupe(u8, "vi") catch return null);
+    defer allocator.free(editor_owned);
+    const editor = editor_owned;
+
+    // Spawn editor and wait.
+    var child = std.process.spawn(defaultIo(), .{
+        .argv = &[_][]const u8{ editor, path },
+        .stdin = .inherit,
+        .stdout = .inherit,
+        .stderr = .inherit,
+    }) catch return null;
+    defer if (child.id != null) child.kill(defaultIo());
+    _ = child.wait(defaultIo()) catch return null;
+
+    // Read file back.
+    const content = std.Io.Dir.readFileAlloc(.cwd(), defaultIo(), path, allocator, .limited(10 * 1024 * 1024)) catch return null;
+    // Clean up temp file (best-effort).
+    std.Io.Dir.deleteFileAbsolute(defaultIo(), path) catch {};
+    editor_tmp_path_len = 0;
+
+    return TuiModel.Msg{ .editor_done = content };
+}
+
 const TuiModel = struct {
     app: ?App = null,
     options: tui_runtime.TuiRuntimeOptions = .{},
 
     pub const Msg = union(enum) {
         key: zz.KeyEvent,
+        mouse: zz.MouseEvent,
         tick: struct { timestamp: u64, delta: u64 },
         quit: void,
+        /// Content read back from the external editor (owned by allocator stored in editor_tmp_allocator).
+        editor_done: []u8,
     };
 
     pub fn init(self: *TuiModel, ctx: *zz.Context) zz.Cmd(Msg) {
@@ -289,7 +452,10 @@ const TuiModel = struct {
             app.state.appendTranscript(.system, "Makai TUI") catch {};
             app.state.appendTranscript(.system, "Enter submits composer, Ctrl+C or /quit exits") catch {};
         }
-        return .{ .every = 50 * std.time.ns_per_ms };
+        return .{ .batch = &.{
+            .{ .every = 50 * std.time.ns_per_ms },
+            .enable_mouse,
+        } };
     }
 
     pub fn deinit(self: *TuiModel) void {
@@ -298,13 +464,27 @@ const TuiModel = struct {
     }
 
     pub fn update(self: *TuiModel, msg: Msg, ctx: *zz.Context) zz.Cmd(Msg) {
-        _ = ctx;
         const app = &(self.app orelse return .none);
         switch (msg) {
+            .editor_done => |content| {
+                // Content was read back from the external editor. Load into composer.
+                defer if (editor_tmp_allocator) |alloc| alloc.free(content);
+                app.state.replaceComposerBuffer(content) catch {};
+                // Re-enter alt screen and hide cursor after editor exit.
+                return .{ .sequence = &.{
+                    .enter_alt_screen,
+                    .hide_cursor,
+                } };
+            },
             .key => |key| {
                 if (key.modifiers.ctrl) switch (key.key) {
                     .char => |c| switch (c) {
                         'c' => return .quit,
+                        'g' => {
+                            // T11: Open external editor with current composer buffer.
+                            if (launchExternalEditor(app, ctx.persistent_allocator)) |cmd| return cmd;
+                            return .none;
+                        },
                         'r' => {
                             app.state.toggleThinking();
                             return .none;
@@ -322,6 +502,34 @@ const TuiModel = struct {
                             else => {},
                         },
                         .escape => app.decideApproval(false, false) catch |err| app.recordError(@errorName(err)) catch {},
+                        else => {},
+                    }
+                    return .none;
+                }
+                // Session picker navigation (T10).
+                if (app.state.mode == .session_picker) {
+                    switch (key.key) {
+                        .up => {
+                            if (app.state.session_index > 0) app.state.session_index -= 1;
+                        },
+                        .down => {
+                            const n = app.state.sessions.items.len;
+                            if (n > 0 and app.state.session_index < n - 1) app.state.session_index += 1;
+                        },
+                        .char => |c| switch (c) {
+                            'k' => {
+                                if (app.state.session_index > 0) app.state.session_index -= 1;
+                            },
+                            'j' => {
+                                const n = app.state.sessions.items.len;
+                                if (n > 0 and app.state.session_index < n - 1) app.state.session_index += 1;
+                            },
+                            else => {},
+                        },
+                        .enter => {
+                            app.resumeSelectedSession() catch |err| app.recordError(@errorName(err)) catch {};
+                        },
+                        .escape => app.state.mode = .normal,
                         else => {},
                     }
                     return .none;
@@ -354,11 +562,19 @@ const TuiModel = struct {
                     .down => {
                         if (!(app.state.composerHistoryNext() catch false)) app.state.transcript_scroll -|= 1;
                     },
-                    .page_up => app.state.transcript_scroll += 1,
-                    .page_down => app.state.transcript_scroll -|= 1,
+                    // PageUp/PageDown scroll by 5 lines for faster navigation.
+                    .page_up => app.state.transcript_scroll += 5,
+                    .page_down => app.state.transcript_scroll -|= 5,
                     .escape => app.state.mode = .normal,
                     else => {},
                 }
+            },
+            .mouse => |mouse| {
+                if (mouse.event_type == .press) switch (mouse.button) {
+                    .wheel_up => app.state.transcript_scroll += 3,
+                    .wheel_down => app.state.transcript_scroll -|= 3,
+                    else => {},
+                };
             },
             .tick => app.drainEvents() catch {},
             .quit => return .quit,
@@ -417,6 +633,66 @@ fn defaultIo() std.Io {
         std.testing.io
     else
         std.Io.Threaded.global_single_threaded.io();
+}
+
+fn currentPathOwned(allocator: std.mem.Allocator) ![]u8 {
+    const path_z = try std.process.currentPathAlloc(defaultIo(), allocator);
+    defer allocator.free(path_z);
+    return allocator.dupe(u8, path_z);
+}
+
+fn newerSessionFirst(_: void, a: session_store.SessionMetadata, b: session_store.SessionMetadata) bool {
+    if (a.last_active == b.last_active) return std.mem.lessThan(u8, a.session_id, b.session_id);
+    return a.last_active > b.last_active;
+}
+
+/// Generate a timestamp-based session ID, e.g. "20260523-150405-123".
+fn generateSessionId(allocator: std.mem.Allocator) ![]u8 {
+    const millis = compat.time.nowMillis();
+    const secs: i64 = @divFloor(millis, 1000);
+    const ms: i64 = @mod(millis, 1000);
+    const epoch = std.time.epoch.EpochSeconds{ .secs = @as(u64, @intCast(@max(secs, 0))) };
+    const day = epoch.getEpochDay();
+    const year_day = day.calculateYearDay();
+    const month_day = year_day.calculateMonthDay();
+    const day_secs = epoch.getDaySeconds();
+    return std.fmt.allocPrint(
+        allocator,
+        "{d:0>4}{d:0>2}{d:0>2}-{d:0>2}{d:0>2}{d:0>2}-{d:0>3}",
+        .{
+            year_day.year,
+            month_day.month.numeric(),
+            month_day.day_index + 1,
+            day_secs.getHoursIntoDay(),
+            day_secs.getMinutesIntoHour(),
+            day_secs.getSecondsIntoMinute(),
+            ms,
+        },
+    );
+}
+
+/// Format a session label from metadata: "model provider YYYY-MM-DD HH:MM".
+fn formatSessionLabel(allocator: std.mem.Allocator, meta: session_store.SessionMetadata) ![]u8 {
+    const ts = meta.last_active;
+    const secs: i64 = @divFloor(ts, 1000);
+    const epoch = std.time.epoch.EpochSeconds{ .secs = @as(u64, @intCast(@max(secs, 0))) };
+    const day = epoch.getEpochDay();
+    const year_day = day.calculateYearDay();
+    const month_day = year_day.calculateMonthDay();
+    const day_secs = epoch.getDaySeconds();
+    return std.fmt.allocPrint(
+        allocator,
+        "{s} {s} {d:0>4}-{d:0>2}-{d:0>2} {d:0>2}:{d:0>2}",
+        .{
+            if (meta.model.len > 0) meta.model else "unknown",
+            if (meta.provider.len > 0) meta.provider else "",
+            year_day.year,
+            month_day.month.numeric(),
+            month_day.day_index + 1,
+            day_secs.getHoursIntoDay(),
+            day_secs.getMinutesIntoHour(),
+        },
+    );
 }
 
 fn defaultModel() ai_types.Model {

--- a/zig/src/tui/app.zig
+++ b/zig/src/tui/app.zig
@@ -131,8 +131,9 @@ pub const App = struct {
         app.session_created_at = compat.time.nowMillis();
         app.working_dir = currentPathOwned(allocator) catch try allocator.dupe(u8, "");
         try app.state.status.setSessionId(allocator, app.session_id);
-        // Pre-populate sessions list.
-        try app.loadSessions();
+        // Pre-populate sessions list on a best-effort basis. Startup should not
+        // lose the interactive runtime just because saved-session discovery fails.
+        app.loadSessions() catch |err| try app.recordError(@errorName(err));
         return app;
     }
 
@@ -176,6 +177,7 @@ pub const App = struct {
     pub fn resumeSelectedSession(self: *App) !void {
         const store = self.store orelse return error.NoStoreConfigured;
         const runtime = if (self.runtime) |*r| r else return error.NoRuntimeConfigured;
+        if (runtime.backend == .remote) return error.SessionResumeUnsupportedForRemoteRuntime;
         const sessions = self.state.sessions.items;
         if (sessions.len == 0) return;
         const idx = self.state.session_index;
@@ -1005,4 +1007,22 @@ test "session picker navigation pages through hidden rows" {
     try std.testing.expectEqual(@as(usize, 4), app.state.session_index);
     try std.testing.expectEqual(@as(usize, 1), app.state.session_scroll);
     try std.testing.expectEqual(@as(usize, 4), TuiModel.visibleSessionCount(&app));
+}
+
+fn initRemoteRuntimeForTest(allocator: std.mem.Allocator) !tui_runtime.TuiRuntime {
+    return tui_runtime.TuiRuntime.init(allocator, .{ .backend = .remote });
+}
+
+test "resume selected session rejects remote runtime before store replay" {
+    var runtime = try initRemoteRuntimeForTest(std.testing.allocator);
+    var app = App.initWithoutRuntime(std.testing.allocator);
+    defer app.deinit();
+    app.runtime = runtime;
+    runtime = undefined;
+
+    try std.testing.expectError(error.NoStoreConfigured, app.resumeSelectedSession());
+
+    app.store = try session_store.Store.init(std.testing.allocator, ".");
+
+    try std.testing.expectError(error.SessionResumeUnsupportedForRemoteRuntime, app.resumeSelectedSession());
 }

--- a/zig/src/tui/app.zig
+++ b/zig/src/tui/app.zig
@@ -177,7 +177,6 @@ pub const App = struct {
         const idx = self.state.session_index;
         if (idx >= sessions.len) return;
         const id = sessions[idx].id;
-        self.discardPendingEvents();
         var loaded = try store.resumeSession(id, runtime);
         defer loaded.deinit(self.allocator);
         self.discardPendingEvents();
@@ -438,17 +437,53 @@ fn cleanupExternalEditorTempPath(path: []const u8) void {
     if (std.fs.path.dirname(path)) |dir| std.Io.Dir.deleteDirAbsolute(defaultIo(), dir) catch {};
 }
 
+fn appendEditorArg(parts: *std.ArrayList([]u8), allocator: std.mem.Allocator, buffer: *std.ArrayList(u8)) !void {
+    if (buffer.items.len == 0) return;
+    try parts.append(allocator, try allocator.dupe(u8, buffer.items));
+    buffer.clearRetainingCapacity();
+}
+
 fn buildEditorArgv(allocator: std.mem.Allocator, editor: []const u8, path: []const u8) ![]const []const u8 {
     var parts: std.ArrayList([]u8) = .empty;
     errdefer {
         for (parts.items) |part| allocator.free(part);
         parts.deinit(allocator);
     }
+    var current: std.ArrayList(u8) = .empty;
+    defer current.deinit(allocator);
 
-    var it = std.mem.tokenizeScalar(u8, editor, ' ');
-    while (it.next()) |part| {
-        try parts.append(allocator, try allocator.dupe(u8, part));
+    var quote: ?u8 = null;
+    var escape = false;
+    for (editor) |c| {
+        if (escape) {
+            try current.append(allocator, c);
+            escape = false;
+            continue;
+        }
+        if (c == '\\') {
+            escape = true;
+            continue;
+        }
+        if (quote) |q| {
+            if (c == q) {
+                quote = null;
+            } else {
+                try current.append(allocator, c);
+            }
+            continue;
+        }
+        if (c == '\'' or c == '"') {
+            quote = c;
+            continue;
+        }
+        if (std.ascii.isWhitespace(c)) {
+            try appendEditorArg(&parts, allocator, &current);
+            continue;
+        }
+        try current.append(allocator, c);
     }
+    if (escape) try current.append(allocator, '\\');
+    try appendEditorArg(&parts, allocator, &current);
     if (parts.items.len == 0) try parts.append(allocator, try allocator.dupe(u8, "vi"));
     try parts.append(allocator, try allocator.dupe(u8, path));
     return parts.toOwnedSlice(allocator);

--- a/zig/src/tui/app.zig
+++ b/zig/src/tui/app.zig
@@ -157,9 +157,9 @@ pub const App = struct {
     /// Load sessions from the store into state.sessions.
     pub fn loadSessions(self: *App) !void {
         const store = self.store orelse return;
+        var metas = try store.list();
         for (self.state.sessions.items) |*s| s.deinit(self.allocator);
         self.state.sessions.clearRetainingCapacity();
-        var metas = store.list() catch return;
         defer {
             for (metas.items) |*meta| meta.deinit(self.allocator);
             metas.deinit(self.allocator);
@@ -211,10 +211,10 @@ pub const App = struct {
         switch (event) {
             .message_start, .tool_execution_start, .context_usage, .prompt_segment_usage, .agent_start, .turn_start, .turn_end, .agent_end => {},
             .text_delta => |payload| {
-                if (payload.delta.slice().len > max_session_event_payload_bytes) return;
+                if (jsonStringBudget(payload.delta.slice()) > max_session_event_payload_bytes) return;
             },
             .tool_call_delta => |payload| {
-                if (payload.delta.slice().len > max_session_event_payload_bytes) return;
+                if (jsonStringBudget(payload.delta.slice()) > max_session_event_payload_bytes) return;
             },
             .message_end => |payload| {
                 if (messageEndPayloadSize(payload) > max_session_event_payload_bytes) return;
@@ -229,21 +229,29 @@ pub const App = struct {
     }
 
     fn messageEndPayloadSize(payload: @TypeOf(@as(tui_runtime.TuiEvent, undefined).message_end)) usize {
-        return payload.text.slice().len +
-            payload.content_json.slice().len +
-            payload.tool_call_id.slice().len +
-            payload.tool_name.slice().len +
-            payload.args_json.slice().len +
-            payload.tool_calls_json.slice().len +
-            payload.details_json.slice().len +
-            payload.artifacts_json.slice().len;
+        return jsonStringBudget(payload.text.slice()) +
+            jsonStringBudget(payload.content_json.slice()) +
+            jsonStringBudget(payload.tool_call_id.slice()) +
+            jsonStringBudget(payload.tool_name.slice()) +
+            jsonStringBudget(payload.args_json.slice()) +
+            jsonStringBudget(payload.tool_calls_json.slice()) +
+            jsonStringBudget(payload.details_json.slice()) +
+            jsonStringBudget(payload.artifacts_json.slice());
     }
 
     fn toolExecutionEndPayloadSize(payload: @TypeOf(@as(tui_runtime.TuiEvent, undefined).tool_execution_end)) usize {
-        return payload.result_json.slice().len +
-            payload.tool_call_id.slice().len +
-            payload.tool_name.slice().len +
-            payload.artifact_refs.slice().len;
+        return jsonStringBudget(payload.result_json.slice()) +
+            jsonStringBudget(payload.tool_call_id.slice()) +
+            jsonStringBudget(payload.tool_name.slice()) +
+            jsonStringBudget(payload.artifact_refs.slice());
+    }
+
+    fn jsonStringBudget(value: []const u8) usize {
+        return value.len * 6;
+    }
+
+    test "json string budget accounts for worst-case escaping" {
+        try std.testing.expectEqual(@as(usize, 24), jsonStringBudget("\\\\\\\\"));
     }
 
     fn currentSessionMetadata(self: *App) session_store.SessionMetadata {
@@ -320,7 +328,11 @@ pub const App = struct {
             .command => |command| command,
         };
 
-        if (command.kind == .sessions) self.loadSessions() catch {};
+        if (command.kind == .sessions) self.loadSessions() catch |err| {
+            try self.state.status.setError(self.allocator, @errorName(err));
+            try self.state.appendTranscript(.@"error", @errorName(err));
+            return;
+        };
 
         var result = tui_commands.dispatch(.{
             .allocator = self.allocator,
@@ -339,7 +351,7 @@ pub const App = struct {
             .clear_transcript => self.state.clearTranscript(),
             .open_session_picker => {
                 // Refresh sessions list from store then open the picker.
-                self.loadSessions() catch {};
+                try self.loadSessions();
                 self.state.session_index = 0;
                 self.state.session_scroll = 0;
                 self.state.mode = .session_picker;

--- a/zig/src/tui/app.zig
+++ b/zig/src/tui/app.zig
@@ -183,10 +183,11 @@ pub const App = struct {
         const id = sessions[idx].id;
         var loaded = try store.resumeSession(id, runtime);
         defer loaded.deinit(self.allocator);
+        const new_session_id = try self.allocator.dupe(u8, loaded.metadata.session_id);
         self.discardPendingEvents();
         self.state.resetReplayState();
         if (self.session_id.len > 0) self.allocator.free(self.session_id);
-        self.session_id = try self.allocator.dupe(u8, loaded.metadata.session_id);
+        self.session_id = new_session_id;
         self.session_created_at = loaded.metadata.created_at;
         try self.state.status.setSessionId(self.allocator, self.session_id);
         if (runtime.currentModel()) |model| {

--- a/zig/src/tui/app.zig
+++ b/zig/src/tui/app.zig
@@ -21,6 +21,7 @@ const tui_render = @import("tui_render");
 const permission = @import("permission");
 
 const max_session_event_jsonl_bytes = 8 * 1024 * 1024;
+const max_session_event_payload_bytes = max_session_event_jsonl_bytes / 2;
 
 pub const ApprovalWaiter = struct {
     allocator: std.mem.Allocator,
@@ -207,14 +208,41 @@ pub const App = struct {
         const store = self.store orelse return;
         // Only save events that are needed for session replay.
         switch (event) {
-            .message_start, .message_end, .tool_execution_start, .context_usage, .prompt_segment_usage, .agent_start, .turn_start, .turn_end, .agent_end => {},
+            .message_start, .tool_execution_start, .context_usage, .prompt_segment_usage, .agent_start, .turn_start, .turn_end, .agent_end => {},
+            .text_delta => |payload| {
+                if (payload.delta.slice().len > max_session_event_payload_bytes) return;
+            },
+            .tool_call_delta => |payload| {
+                if (payload.delta.slice().len > max_session_event_payload_bytes) return;
+            },
+            .message_end => |payload| {
+                if (messageEndPayloadSize(payload) > max_session_event_payload_bytes) return;
+            },
             .tool_execution_end => |payload| {
-                if (payload.result_json.slice().len + payload.tool_call_id.slice().len + payload.tool_name.slice().len + payload.artifact_refs.slice().len > max_session_event_jsonl_bytes / 2) return;
+                if (toolExecutionEndPayloadSize(payload) > max_session_event_payload_bytes) return;
             },
             else => return,
         }
         const meta = self.currentSessionMetadata();
         store.save(meta, event) catch {};
+    }
+
+    fn messageEndPayloadSize(payload: @TypeOf(@as(tui_runtime.TuiEvent, undefined).message_end)) usize {
+        return payload.text.slice().len +
+            payload.content_json.slice().len +
+            payload.tool_call_id.slice().len +
+            payload.tool_name.slice().len +
+            payload.args_json.slice().len +
+            payload.tool_calls_json.slice().len +
+            payload.details_json.slice().len +
+            payload.artifacts_json.slice().len;
+    }
+
+    fn toolExecutionEndPayloadSize(payload: @TypeOf(@as(tui_runtime.TuiEvent, undefined).tool_execution_end)) usize {
+        return payload.result_json.slice().len +
+            payload.tool_call_id.slice().len +
+            payload.tool_name.slice().len +
+            payload.artifact_refs.slice().len;
     }
 
     fn currentSessionMetadata(self: *App) session_store.SessionMetadata {
@@ -312,6 +340,7 @@ pub const App = struct {
                 // Refresh sessions list from store then open the picker.
                 self.loadSessions() catch {};
                 self.state.session_index = 0;
+                self.state.session_scroll = 0;
                 self.state.mode = .session_picker;
             },
             .none => {},
@@ -635,21 +664,11 @@ const TuiModel = struct {
                 // Session picker navigation (T10).
                 if (app.state.mode == .session_picker) {
                     switch (key.key) {
-                        .up => {
-                            if (app.state.session_index > 0) app.state.session_index -= 1;
-                        },
-                        .down => {
-                            const n = visibleSessionCount(app);
-                            if (n > 0 and app.state.session_index < n - 1) app.state.session_index += 1;
-                        },
+                        .up => moveSessionSelection(app, -1),
+                        .down => moveSessionSelection(app, 1),
                         .char => |c| switch (c) {
-                            'k' => {
-                                if (app.state.session_index > 0) app.state.session_index -= 1;
-                            },
-                            'j' => {
-                                const n = visibleSessionCount(app);
-                                if (n > 0 and app.state.session_index < n - 1) app.state.session_index += 1;
-                            },
+                            'k' => moveSessionSelection(app, -1),
+                            'j' => moveSessionSelection(app, 1),
                             else => {},
                         },
                         .enter => {
@@ -721,7 +740,7 @@ const TuiModel = struct {
         const extra = switch (app.state.mode) {
             .approval => approval_view.render(ctx.allocator, &app.state, .{ .width = width }) catch "",
             .preview => preview_view.render(ctx.allocator, &app.state, .{ .width = width, .height = height / 2 }) catch "",
-            .session_picker => session_picker_view.render(ctx.allocator, &app.state, .{ .height = sessionPickerHeight(app) }) catch "",
+            .session_picker => session_picker_view.render(ctx.allocator, &app.state, .{ .height = sessionPickerHeight(app), .offset = app.state.session_scroll }) catch "",
             .normal => "",
         };
         const fixed = countLines(status) + countLines(composer) + countLines(tools) + countLines(telemetry) + countLines(extra) + 5;
@@ -754,8 +773,32 @@ const TuiModel = struct {
         return count;
     }
 
+    fn moveSessionSelection(app: *App, delta: isize) void {
+        const n = app.state.sessions.items.len;
+        if (n == 0) {
+            app.state.session_index = 0;
+            app.state.session_scroll = 0;
+            return;
+        }
+        if (delta < 0) {
+            app.state.session_index -|= @as(usize, @intCast(-delta));
+        } else {
+            app.state.session_index = @min(n - 1, app.state.session_index + @as(usize, @intCast(delta)));
+        }
+        ensureSessionSelectionVisible(app);
+    }
+
+    fn ensureSessionSelectionVisible(app: *App) void {
+        const height = sessionPickerHeight(app);
+        if (app.state.session_index < app.state.session_scroll) {
+            app.state.session_scroll = app.state.session_index;
+        } else if (height > 0 and app.state.session_index >= app.state.session_scroll + height) {
+            app.state.session_scroll = app.state.session_index + 1 - height;
+        }
+    }
+
     fn visibleSessionCount(app: *const App) usize {
-        return @min(app.state.sessions.items.len, sessionPickerHeight(app));
+        return @min(app.state.sessions.items.len -| app.state.session_scroll, sessionPickerHeight(app));
     }
 
     fn sessionPickerHeight(app: *const App) usize {
@@ -931,7 +974,7 @@ test "App submit quit command requests quit" {
     try std.testing.expectError(error.QuitRequested, app.submit("/quit"));
 }
 
-test "session picker navigation is capped to visible rows" {
+test "session picker navigation pages through hidden rows" {
     var app = App.initWithoutRuntime(std.testing.allocator);
     defer app.deinit();
     app.last_view_height = 8;
@@ -941,5 +984,12 @@ test "session picker navigation is capped to visible rows" {
     try app.state.addSession("s4", "Four");
     try app.state.addSession("s5", "Five");
 
+    try std.testing.expectEqual(@as(usize, 4), TuiModel.visibleSessionCount(&app));
+    TuiModel.moveSessionSelection(&app, 1);
+    TuiModel.moveSessionSelection(&app, 1);
+    TuiModel.moveSessionSelection(&app, 1);
+    TuiModel.moveSessionSelection(&app, 1);
+    try std.testing.expectEqual(@as(usize, 4), app.state.session_index);
+    try std.testing.expectEqual(@as(usize, 1), app.state.session_scroll);
     try std.testing.expectEqual(@as(usize, 4), TuiModel.visibleSessionCount(&app));
 }

--- a/zig/src/tui/commands.zig
+++ b/zig/src/tui/commands.zig
@@ -33,6 +33,7 @@ pub const CommandAction = enum {
     none,
     quit,
     clear_transcript,
+    open_session_picker,
 };
 
 pub const CommandResult = struct {
@@ -238,27 +239,25 @@ fn handleProvider(ctx: CommandContext, command: Command) !CommandResult {
 fn handleStatus(ctx: CommandContext, command: Command) !CommandResult {
     _ = command;
     const status = ctx.state.status;
-    return .{ .output = try std.fmt.allocPrint(ctx.allocator,
-        "session: {s}\nmodel: {s}\nprovider: {s}\nturns: {d}\ncontext: {d}/{d}\nstreaming: {s}",
-        .{
-            if (status.session_id.len > 0) status.session_id else "(current)",
-            if (status.model.len > 0) status.model else "none",
-            if (status.provider.len > 0) status.provider else "none",
-            status.turn_count,
-            status.context_used,
-            status.context_limit,
-            if (status.streaming) "yes" else "no",
-        }) };
+    return .{ .output = try std.fmt.allocPrint(ctx.allocator, "session: {s}\nmodel: {s}\nprovider: {s}\nturns: {d}\ncontext: {d}/{d}\nstreaming: {s}", .{
+        if (status.session_id.len > 0) status.session_id else "(current)",
+        if (status.model.len > 0) status.model else "none",
+        if (status.provider.len > 0) status.provider else "none",
+        status.turn_count,
+        status.context_used,
+        status.context_limit,
+        if (status.streaming) "yes" else "no",
+    }) };
 }
 
 fn handleSessions(ctx: CommandContext, command: Command) !CommandResult {
     _ = command;
-    if (ctx.state.sessions.items.len == 0) return .{ .output = try ctx.allocator.dupe(u8, "no saved sessions (saved-session discovery is not wired yet)") };
-    var out: std.Io.Writer.Allocating = .init(ctx.allocator);
-    const writer = &out.writer;
-    try writer.writeAll("saved sessions:");
-    for (ctx.state.sessions.items) |session| try writer.print("\n  {s}  {s}", .{ session.id, session.label });
-    return .{ .output = try out.toOwnedSlice() };
+    // Sessions are loaded by App.loadSessions() before dispatch.
+    // Return the open_session_picker action so App can switch mode.
+    if (ctx.state.sessions.items.len == 0) {
+        return .{ .output = try ctx.allocator.dupe(u8, "no saved sessions") };
+    }
+    return .{ .action = .open_session_picker };
 }
 
 fn handleResume(ctx: CommandContext, command: Command) !CommandResult {
@@ -388,6 +387,8 @@ test "dispatch reaches command handlers" {
             try std.testing.expectEqual(CommandAction.quit, result.action);
         } else if (kind == .clear) {
             try std.testing.expectEqual(CommandAction.clear_transcript, result.action);
+        } else if (kind == .sessions) {
+            try std.testing.expectEqual(CommandAction.open_session_picker, result.action);
         } else {
             try std.testing.expect(result.output.len > 0);
         }
@@ -406,14 +407,25 @@ test "resume by id does not resume current context" {
     try std.testing.expect(std.mem.indexOf(u8, result.output, "not wired") != null);
 }
 
-test "sessions reports discovery gap when runtime has no source" {
+test "sessions opens picker when sessions exist" {
+    var state = tui_state.AppState.init(std.testing.allocator);
+    defer state.deinit();
+    try state.addSession("s1", "Saved");
+
+    var result = try dispatch(.{ .allocator = std.testing.allocator, .state = &state }, .{ .kind = .sessions });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(CommandAction.open_session_picker, result.action);
+}
+
+test "sessions reports empty store" {
     var state = tui_state.AppState.init(std.testing.allocator);
     defer state.deinit();
 
     var result = try dispatch(.{ .allocator = std.testing.allocator, .state = &state }, .{ .kind = .sessions });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "not wired") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "no saved sessions") != null);
 }
 
 test "permissions reports runtime approval state not hardcoded policy" {

--- a/zig/src/tui/session_store.zig
+++ b/zig/src/tui/session_store.zig
@@ -144,10 +144,7 @@ pub const Store = struct {
     }
 
     pub fn initDefault(allocator: std.mem.Allocator) !Store {
-        const home = std.process.getEnvVarOwned(allocator, "HOME") catch |err| switch (err) {
-            error.EnvironmentVariableNotFound => return error.HomeNotFound,
-            else => return err,
-        };
+        const home = compat.getEnvVarOwned(allocator, "HOME") catch return error.HomeNotFound;
         defer allocator.free(home);
         const base = try std.fs.path.join(allocator, &.{ home, ".makai", "sessions" });
         defer allocator.free(base);

--- a/zig/src/tui/session_store.zig
+++ b/zig/src/tui/session_store.zig
@@ -144,7 +144,10 @@ pub const Store = struct {
     }
 
     pub fn initDefault(allocator: std.mem.Allocator) !Store {
-        const home = compat.getEnvVarOwned(allocator, "HOME") catch return error.HomeNotFound;
+        const home = compat.getEnvVarOwned(allocator, "HOME") catch |err| switch (err) {
+            error.EnvironmentVariableMissing => return error.HomeNotFound,
+            else => return err,
+        };
         defer allocator.free(home);
         const base = try std.fs.path.join(allocator, &.{ home, ".makai", "sessions" });
         defer allocator.free(base);

--- a/zig/src/tui/state.zig
+++ b/zig/src/tui/state.zig
@@ -352,6 +352,10 @@ pub const AppState = struct {
         self.status.context_used = 0;
         self.status.turn_count = 0;
         self.status.streaming = false;
+        if (self.status.last_error.len > 0) {
+            self.allocator.free(self.status.last_error);
+            self.status.last_error = &.{};
+        }
     }
 
     pub fn appendUserMessage(self: *AppState, text: []const u8) !void {

--- a/zig/src/tui/state.zig
+++ b/zig/src/tui/state.zig
@@ -209,6 +209,11 @@ pub const StatusState = struct {
         if (self.last_error.len > 0) allocator.free(self.last_error);
         self.last_error = try allocator.dupe(u8, message);
     }
+
+    pub fn setSessionId(self: *StatusState, allocator: std.mem.Allocator, session_id: []const u8) !void {
+        if (self.session_id.len > 0) allocator.free(self.session_id);
+        self.session_id = try allocator.dupe(u8, session_id);
+    }
 };
 
 pub const PreviewState = struct {

--- a/zig/src/tui/state.zig
+++ b/zig/src/tui/state.zig
@@ -336,6 +336,22 @@ pub const AppState = struct {
         for (self.transcript.items) |*entry| entry.deinit(self.allocator);
         self.transcript.clearRetainingCapacity();
         self.transcript_scroll = 0;
+        self.clearActiveTranscriptEntries();
+    }
+
+    pub fn clearTools(self: *AppState) void {
+        for (self.tools.items) |*tool| tool.deinit(self.allocator);
+        self.tools.clearRetainingCapacity();
+        self.tool_scroll = 0;
+    }
+
+    pub fn resetReplayState(self: *AppState) void {
+        self.clearTranscript();
+        self.clearTools();
+        self.telemetry = .{};
+        self.status.context_used = 0;
+        self.status.turn_count = 0;
+        self.status.streaming = false;
     }
 
     pub fn appendUserMessage(self: *AppState, text: []const u8) !void {

--- a/zig/src/tui/state.zig
+++ b/zig/src/tui/state.zig
@@ -211,8 +211,9 @@ pub const StatusState = struct {
     }
 
     pub fn setSessionId(self: *StatusState, allocator: std.mem.Allocator, session_id: []const u8) !void {
+        const new_session_id = try allocator.dupe(u8, session_id);
         if (self.session_id.len > 0) allocator.free(self.session_id);
-        self.session_id = try allocator.dupe(u8, session_id);
+        self.session_id = new_session_id;
     }
 };
 
@@ -298,6 +299,7 @@ pub const AppState = struct {
     transcript_scroll: usize = 0,
     tool_scroll: usize = 0,
     session_index: usize = 0,
+    session_scroll: usize = 0,
     active_assistant_entry: ?usize = null,
     active_tool_result_entry: ?usize = null,
 

--- a/zig/src/tui/views/session_picker.zig
+++ b/zig/src/tui/views/session_picker.zig
@@ -5,6 +5,7 @@ const tui_text = @import("tui_text");
 
 pub const Options = struct {
     height: usize = 12,
+    offset: usize = 0,
 };
 
 pub fn render(allocator: std.mem.Allocator, state: *const tui_state.AppState, options: Options) ![]const u8 {
@@ -22,8 +23,8 @@ pub fn render(allocator: std.mem.Allocator, state: *const tui_state.AppState, op
         defer allocator.free(body);
         return tui_theme.panel().render(allocator, body);
     }
-    for (state.sessions.items, 0..) |session, i| {
-        if (i >= options.height) break;
+    const end = @min(state.sessions.items.len, options.offset + options.height);
+    for (state.sessions.items[options.offset..end], options.offset..) |session, i| {
         try writer.writeByte('\n');
         const marker = if (i == state.session_index) ">" else " ";
         const row = try std.fmt.allocPrint(allocator, "{s} {s} ({s})", .{ marker, session.label, session.id });
@@ -50,4 +51,21 @@ test "session picker renders selected session" {
     try std.testing.expect(std.mem.indexOf(u8, text, "First (s1)") != null);
     try std.testing.expect(std.mem.indexOf(u8, text, "> Second (s2)") != null);
     try std.testing.expect(tui_text.visibleWidth(text) > 0);
+}
+
+test "session picker renders from offset" {
+    var state = tui_state.AppState.init(std.testing.allocator);
+    defer state.deinit();
+    try state.addSession("s1", "First");
+    try state.addSession("s2", "Second");
+    try state.addSession("s3", "Third");
+    state.session_index = 2;
+    state.session_scroll = 1;
+
+    const text = try render(std.testing.allocator, &state, .{ .height = 2, .offset = state.session_scroll });
+    defer std.testing.allocator.free(text);
+
+    try std.testing.expect(std.mem.indexOf(u8, text, "First (s1)") == null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "Second (s2)") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "> Third (s3)") != null);
 }

--- a/zig/src/tui/views/transcript.zig
+++ b/zig/src/tui/views/transcript.zig
@@ -39,7 +39,42 @@ pub fn render(allocator: std.mem.Allocator, state: *const AppState, options: Opt
         try all_writer.writeAll(row);
     }
 
-    return lineWindow(allocator, all_rows.written(), options.height, state.transcript_scroll);
+    const all_text = all_rows.written();
+    const total_lines = tui_text.lineCount(all_text);
+    // Reserve one line for scroll indicator when scrolled; use full height otherwise.
+    const view_height = if (state.transcript_scroll > 0 and total_lines > options.height)
+        options.height -| 1
+    else
+        options.height;
+    const windowed = try lineWindow(allocator, all_text, view_height, state.transcript_scroll);
+    defer allocator.free(windowed);
+
+    if (state.transcript_scroll == 0 or total_lines <= options.height) {
+        return allocator.dupe(u8, windowed);
+    }
+
+    // Prepend a scroll indicator line: "↑ SCROLL N%"
+    const pct = scrollPercent(total_lines, view_height, state.transcript_scroll);
+    const raw_indicator = try std.fmt.allocPrint(allocator, "\u{2191} SCROLL {d}%", .{pct});
+    defer allocator.free(raw_indicator);
+    const indicator = try tui_theme.muted().render(allocator, raw_indicator);
+    defer allocator.free(indicator);
+
+    var out: std.Io.Writer.Allocating = .init(allocator);
+    errdefer out.deinit();
+    const writer = &out.writer;
+    try writer.writeAll(indicator);
+    try writer.writeByte('\n');
+    try writer.writeAll(windowed);
+    return out.toOwnedSlice();
+}
+
+/// Return scroll percentage: 100 = at top, 0 = at bottom.
+fn scrollPercent(total_lines: usize, view_height: usize, scroll: usize) usize {
+    if (total_lines <= view_height) return 0;
+    const max_scroll = total_lines - view_height;
+    const clamped = @min(scroll, max_scroll);
+    return clamped * 100 / max_scroll;
 }
 
 fn renderEntry(allocator: std.mem.Allocator, entry: *const TranscriptEntry, width: usize) ![]u8 {
@@ -214,4 +249,37 @@ test "transcript preserves non-assistant whitespace" {
 
     try std.testing.expect(std.mem.indexOf(u8, text, "  alpha   beta") != null);
     try std.testing.expect(std.mem.indexOf(u8, text, "    gamma") != null);
+}
+
+test "transcript shows scroll indicator when scrolled up" {
+    var state = AppState.init(std.testing.allocator);
+    defer state.deinit();
+    // Add more lines than fit in the viewport
+    for (0..20) |i| {
+        const msg = try std.fmt.allocPrint(std.testing.allocator, "line {d}", .{i});
+        defer std.testing.allocator.free(msg);
+        try state.appendTranscript(.assistant, msg);
+    }
+    state.transcript_scroll = 5; // scrolled up
+
+    const text = try render(std.testing.allocator, &state, .{ .width = 80, .height = 5 });
+    defer std.testing.allocator.free(text);
+
+    try std.testing.expect(std.mem.indexOf(u8, text, "SCROLL") != null);
+}
+
+test "transcript hides scroll indicator when at bottom" {
+    var state = AppState.init(std.testing.allocator);
+    defer state.deinit();
+    for (0..10) |i| {
+        const msg = try std.fmt.allocPrint(std.testing.allocator, "line {d}", .{i});
+        defer std.testing.allocator.free(msg);
+        try state.appendTranscript(.assistant, msg);
+    }
+    state.transcript_scroll = 0; // at bottom
+
+    const text = try render(std.testing.allocator, &state, .{ .width = 80, .height = 5 });
+    defer std.testing.allocator.free(text);
+
+    try std.testing.expect(std.mem.indexOf(u8, text, "SCROLL") == null);
 }

--- a/zig/src/tui/views/transcript.zig
+++ b/zig/src/tui/views/transcript.zig
@@ -41,17 +41,13 @@ pub fn render(allocator: std.mem.Allocator, state: *const AppState, options: Opt
 
     const all_text = all_rows.written();
     const total_lines = tui_text.lineCount(all_text);
-    // Reserve one line for scroll indicator when scrolled; use full height otherwise.
-    const view_height = if (state.transcript_scroll > 0 and total_lines > options.height)
-        options.height -| 1
-    else
-        options.height;
+    // Reserve one line for scroll indicator when scrolled and enough space exists; use full height otherwise.
+    const show_indicator = state.transcript_scroll > 0 and total_lines > options.height and options.height >= 2;
+    const view_height = if (show_indicator) options.height - 1 else options.height;
     const windowed = try lineWindow(allocator, all_text, view_height, state.transcript_scroll);
     defer allocator.free(windowed);
 
-    if (state.transcript_scroll == 0 or total_lines <= options.height) {
-        return allocator.dupe(u8, windowed);
-    }
+    if (!show_indicator) return allocator.dupe(u8, windowed);
 
     // Prepend a scroll indicator line: "↑ SCROLL N%"
     const pct = scrollPercent(total_lines, view_height, state.transcript_scroll);
@@ -281,5 +277,18 @@ test "transcript hides scroll indicator when at bottom" {
     const text = try render(std.testing.allocator, &state, .{ .width = 80, .height = 5 });
     defer std.testing.allocator.free(text);
 
+    try std.testing.expect(std.mem.indexOf(u8, text, "SCROLL") == null);
+}
+
+test "transcript keeps one-line viewport within height when scrolled" {
+    var state = AppState.init(std.testing.allocator);
+    defer state.deinit();
+    try state.appendTranscript(.assistant, "one\ntwo\nthree");
+    state.transcript_scroll = 1;
+
+    const text = try render(std.testing.allocator, &state, .{ .width = 80, .height = 1 });
+    defer std.testing.allocator.free(text);
+
+    try std.testing.expectEqual(@as(usize, 1), tui_text.lineCount(text));
     try std.testing.expect(std.mem.indexOf(u8, text, "SCROLL") == null);
 }


### PR DESCRIPTION
## Summary
- add scrollback controls for the transcript, including PageUp/PageDown, mouse wheel support, and an in-view scroll indicator
- persist and list TUI sessions, wire `/sessions` into a picker, and resume saved session context from the session store
- add Ctrl+G external editor handoff that exits alt screen, launches `$EDITOR`/`$VISUAL`, and restores edited composer text

## Test plan
- [x] `zig build test`
- [x] `zig build install`
- [x] `../scripts/check-zig-patterns.sh`
- [x] `git diff --check -- .`