### PR TITLE
Add TUI message queueing and welcome state

### DIFF
--- a/zig/build.zig
+++ b/zig/build.zig
@@ -983,6 +983,7 @@ pub fn build(b: *std.Build) void {
             .{ .name = "tui_view_preview", .module = tui_view_preview_mod },
             .{ .name = "tui_view_session_picker", .module = tui_view_session_picker_mod },
             .{ .name = "permission", .module = permission_mod },
+            .{ .name = "owned_slice", .module = owned_slice_mod },
         },
     });
 

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -847,6 +847,7 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
         .imports = &.{
+            .{ .name = "agent", .module = agent_mod },
             .{ .name = "ai_types", .module = ai_types_mod },
             .{ .name = "event_stream", .module = event_stream_mod },
             .{ .name = "owned_slice", .module = owned_slice_mod },

--- a/zig/src/agent/agent.zig
+++ b/zig/src/agent/agent.zig
@@ -246,9 +246,28 @@ pub const Agent = struct {
         return self._state.is_streaming;
     }
 
+    pub const QueuedCounts = struct {
+        steering: usize = 0,
+        follow_up: usize = 0,
+
+        pub fn total(self: QueuedCounts) usize {
+            return self.steering + self.follow_up;
+        }
+    };
+
     /// Check if there are queued messages.
     pub fn hasQueuedMessages(self: Agent) bool {
         return self._steering_queue.items.len > 0 or self._follow_up_queue.items.len > 0;
+    }
+
+    /// Return queued steering and follow-up counts.
+    pub fn queuedCounts(self: *Agent) QueuedCounts {
+        self._mutex.lockUncancelable(defaultIo());
+        defer self._mutex.unlock(defaultIo());
+        return .{
+            .steering = self._steering_queue.items.len,
+            .follow_up = self._follow_up_queue.items.len,
+        };
     }
 
     /// Validate continueFromContext without mutating queues.

--- a/zig/src/tui/app.zig
+++ b/zig/src/tui/app.zig
@@ -288,6 +288,11 @@ pub const App = struct {
             self.saveEvent(ev);
             try self.state.applyEvent(ev);
         }
+        self.refreshQueuedCounts();
+    }
+
+    fn refreshQueuedCounts(self: *App) void {
+        if (self.session) |*session| self.state.setQueuedCounts(session.queuedCounts());
     }
 
     fn discardPendingEvents(self: *App) void {
@@ -311,6 +316,33 @@ pub const App = struct {
                 return;
             };
         }
+        self.refreshQueuedCounts();
+    }
+
+    pub fn steer(self: *App, text: []const u8) !void {
+        const trimmed = std.mem.trim(u8, text, " \t\r\n");
+        if (trimmed.len == 0) return;
+        if (trimmed[0] == '/') return try self.submitCommand(trimmed);
+        if (self.session) |*session| {
+            try session.steer(trimmed);
+            try self.state.appendUserMessage(trimmed);
+            self.refreshQueuedCounts();
+            return;
+        }
+        try self.state.appendUserMessage(trimmed);
+    }
+
+    pub fn queueFollowUp(self: *App, text: []const u8) !void {
+        const trimmed = std.mem.trim(u8, text, " \t\r\n");
+        if (trimmed.len == 0) return;
+        if (trimmed[0] == '/') return try self.submitCommand(trimmed);
+        if (self.session) |*session| {
+            try session.queueFollowUp(trimmed);
+            try self.state.appendUserMessage(trimmed);
+            self.refreshQueuedCounts();
+            return;
+        }
+        try self.state.appendUserMessage(trimmed);
     }
 
     fn submitCommand(self: *App, text: []const u8) !void {
@@ -369,6 +401,28 @@ pub const App = struct {
     pub fn recordError(self: *App, message: []const u8) !void {
         try self.state.status.setError(self.allocator, message);
         try self.state.appendTranscript(.@"error", message);
+    }
+
+    pub fn appendWelcome(self: *App) !void {
+        if (self.state.sessions.items.len == 0) {
+            const model = if (self.state.status.model.len > 0) self.state.status.model else "no-model";
+            const provider = if (self.state.status.provider.len > 0) self.state.status.provider else "local";
+            const cwd = if (self.working_dir.len > 0) self.working_dir else ".";
+            const welcome = try std.fmt.allocPrint(self.allocator,
+                \\Makai TUI
+                \\model: {s}/{s}
+                \\cwd: {s}
+                \\tips: Enter submit • Enter while streaming steers • Alt+Enter queues follow-up • /sessions resumes • Ctrl+G editor • Ctrl+R thinking • /help commands
+            , .{ provider, model, cwd });
+            defer self.allocator.free(welcome);
+            try self.state.appendTranscript(.system, welcome);
+            return;
+        }
+        const model = if (self.state.status.model.len > 0) self.state.status.model else "no-model";
+        const provider = if (self.state.status.provider.len > 0) self.state.status.provider else "local";
+        const welcome = try std.fmt.allocPrint(self.allocator, "Makai TUI • {s}/{s} • /sessions resumes saved work", .{ provider, model });
+        defer self.allocator.free(welcome);
+        try self.state.appendTranscript(.system, welcome);
     }
 
     pub fn decideApproval(self: *App, approved: bool, always: bool) !void {
@@ -612,8 +666,7 @@ const TuiModel = struct {
                 app.state.status.setError(app.allocator, @errorName(err)) catch {};
                 app.state.appendTranscript(.@"error", @errorName(err)) catch {};
             };
-            app.state.appendTranscript(.system, "Makai TUI") catch {};
-            app.state.appendTranscript(.system, "Enter submits composer, Ctrl+C or /quit exits") catch {};
+            app.appendWelcome() catch |err| app.recordError(@errorName(err)) catch {};
         }
         return .{ .batch = &.{
             .{ .every = 50 * std.time.ns_per_ms },
@@ -702,11 +755,19 @@ const TuiModel = struct {
                         }
                         const text = app.state.composer.text();
                         app.state.recordComposerHistory(text) catch |err| app.recordError(@errorName(err)) catch {};
-                        app.submit(text) catch |err| {
-                            if (err == error.QuitRequested) return .quit;
-                            app.state.status.setError(app.allocator, @errorName(err)) catch {};
-                            app.state.appendTranscript(.@"error", @errorName(err)) catch {};
-                        };
+                        if (app.state.status.streaming) {
+                            if (key.modifiers.alt) {
+                                app.queueFollowUp(text) catch |err| app.recordError(@errorName(err)) catch {};
+                            } else {
+                                app.steer(text) catch |err| app.recordError(@errorName(err)) catch {};
+                            }
+                        } else {
+                            app.submit(text) catch |err| {
+                                if (err == error.QuitRequested) return .quit;
+                                app.state.status.setError(app.allocator, @errorName(err)) catch {};
+                                app.state.appendTranscript(.@"error", @errorName(err)) catch {};
+                            };
+                        }
                         app.state.composer.clear();
                         app.drainEvents() catch |err| {
                             app.state.status.setError(app.allocator, @errorName(err)) catch {};
@@ -981,6 +1042,24 @@ test "App submit routes unknown command to error transcript" {
     try std.testing.expectEqual(@as(usize, 1), app.state.transcript.items.len);
     try std.testing.expectEqual(tui_state.TranscriptKind.@"error", app.state.transcript.items[0].kind);
     try std.testing.expect(std.mem.indexOf(u8, app.state.transcript.items[0].text.items, "unknown command") != null);
+}
+
+test "App welcome uses session count" {
+    var app = App.initWithoutRuntime(std.testing.allocator);
+    defer app.deinit();
+    try app.state.status.setModel(std.testing.allocator, "model-a", "provider-a");
+    app.working_dir = try std.testing.allocator.dupe(u8, "/tmp/work");
+
+    try app.appendWelcome();
+    try std.testing.expectEqual(tui_state.TranscriptKind.system, app.state.transcript.items[0].kind);
+    try std.testing.expect(std.mem.indexOf(u8, app.state.transcript.items[0].text.items, "tips:") != null);
+    try std.testing.expect(std.mem.indexOf(u8, app.state.transcript.items[0].text.items, "Alt+Enter") != null);
+
+    app.state.clearTranscript();
+    try app.state.addSession("s1", "saved");
+    try app.appendWelcome();
+    try std.testing.expect(std.mem.indexOf(u8, app.state.transcript.items[0].text.items, "tips:") == null);
+    try std.testing.expect(std.mem.indexOf(u8, app.state.transcript.items[0].text.items, "/sessions") != null);
 }
 
 test "App submit quit command requests quit" {

--- a/zig/src/tui/app.zig
+++ b/zig/src/tui/app.zig
@@ -757,9 +757,15 @@ const TuiModel = struct {
                         app.state.recordComposerHistory(text) catch |err| app.recordError(@errorName(err)) catch {};
                         if (app.state.status.streaming) {
                             if (key.modifiers.alt) {
-                                app.queueFollowUp(text) catch |err| app.recordError(@errorName(err)) catch {};
+                                app.queueFollowUp(text) catch |err| {
+                                    if (err == error.QuitRequested) return .quit;
+                                    app.recordError(@errorName(err)) catch {};
+                                };
                             } else {
-                                app.steer(text) catch |err| app.recordError(@errorName(err)) catch {};
+                                app.steer(text) catch |err| {
+                                    if (err == error.QuitRequested) return .quit;
+                                    app.recordError(@errorName(err)) catch {};
+                                };
                             }
                         } else {
                             app.submit(text) catch |err| {
@@ -1062,10 +1068,139 @@ test "App welcome uses session count" {
     try std.testing.expect(std.mem.indexOf(u8, app.state.transcript.items[0].text.items, "/sessions") != null);
 }
 
+const MockAppSession = struct {
+    steer_count: usize = 0,
+    queued_follow_up_count: usize = 0,
+    queued_counts: tui_runtime.QueuedCounts = .{},
+
+    fn session(self: *MockAppSession) tui_runtime.TuiSession {
+        return .{
+            .ctx = self,
+            .ops = .{
+                .start = start,
+                .resume_session = resumeSession,
+                .cancel = cancel,
+                .submit_turn = submitTurn,
+                .steer = steer,
+                .queue_follow_up = queueFollowUp,
+                .queued_counts = queuedCounts,
+                .switch_model = switchModel,
+                .current_model = currentModel,
+                .decide_tool_approval = decideToolApproval,
+                .stream_events = streamEvents,
+            },
+        };
+    }
+
+    fn ptr(ctx: ?*anyopaque) *MockAppSession {
+        return @ptrCast(@alignCast(ctx.?));
+    }
+
+    fn start(ctx: ?*anyopaque) anyerror!void {
+        _ = ctx;
+    }
+
+    fn resumeSession(ctx: ?*anyopaque) anyerror!void {
+        _ = ctx;
+    }
+
+    fn cancel(ctx: ?*anyopaque) void {
+        _ = ctx;
+    }
+
+    fn submitTurn(ctx: ?*anyopaque, text: []const u8) anyerror!void {
+        _ = ctx;
+        _ = text;
+    }
+
+    fn steer(ctx: ?*anyopaque, text: []const u8) anyerror!void {
+        const self = ptr(ctx);
+        self.steer_count += 1;
+        try std.testing.expectEqualStrings("steer me", text);
+    }
+
+    fn queueFollowUp(ctx: ?*anyopaque, text: []const u8) anyerror!void {
+        const self = ptr(ctx);
+        self.queued_follow_up_count += 1;
+        try std.testing.expectEqualStrings("follow later", text);
+    }
+
+    fn queuedCounts(ctx: ?*anyopaque) tui_runtime.QueuedCounts {
+        return ptr(ctx).queued_counts;
+    }
+
+    fn switchModel(ctx: ?*anyopaque, model_id: []const u8) anyerror!void {
+        _ = ctx;
+        _ = model_id;
+    }
+
+    fn currentModel(ctx: ?*anyopaque) ?ai_types.Model {
+        _ = ctx;
+        return null;
+    }
+
+    fn decideToolApproval(ctx: ?*anyopaque, tool_call_id: []const u8, decision: tui_runtime.ToolApprovalDecision) anyerror!void {
+        _ = ctx;
+        _ = tool_call_id;
+        _ = decision;
+    }
+
+    fn streamEvents(ctx: ?*anyopaque) *tui_runtime.TuiEventStream {
+        _ = ctx;
+        unreachable;
+    }
+};
+
 test "App submit quit command requests quit" {
     var app = App.initWithoutRuntime(std.testing.allocator);
     defer app.deinit();
     try std.testing.expectError(error.QuitRequested, app.submit("/quit"));
+}
+
+test "App steer and queue follow-up handle fallback empty and session paths" {
+    var app = App.initWithoutRuntime(std.testing.allocator);
+    defer app.deinit();
+
+    try app.steer("  steer fallback  ");
+    try std.testing.expectEqual(@as(usize, 1), app.state.transcript.items.len);
+    try std.testing.expectEqualStrings("steer fallback", app.state.transcript.items[0].text.items);
+
+    try app.queueFollowUp("\tfollow fallback\n");
+    try std.testing.expectEqual(@as(usize, 2), app.state.transcript.items.len);
+    try std.testing.expectEqualStrings("follow fallback", app.state.transcript.items[1].text.items);
+
+    try app.steer("   ");
+    try app.queueFollowUp("\n\t");
+    try std.testing.expectEqual(@as(usize, 2), app.state.transcript.items.len);
+
+    app.state.clearTranscript();
+    var mock = MockAppSession{ .queued_counts = .{ .steering = 1, .follow_up = 2 } };
+    app.session = mock.session();
+
+    try app.steer(" steer me ");
+    try std.testing.expectEqual(@as(usize, 1), mock.steer_count);
+    try std.testing.expectEqual(@as(usize, 1), app.state.transcript.items.len);
+    try std.testing.expectEqualStrings("steer me", app.state.transcript.items[0].text.items);
+    try std.testing.expectEqual(@as(usize, 1), app.state.queue.steering);
+    try std.testing.expectEqual(@as(usize, 2), app.state.queue.follow_up);
+
+    mock.queued_counts = .{ .steering = 3, .follow_up = 4 };
+    try app.queueFollowUp(" follow later ");
+    try std.testing.expectEqual(@as(usize, 1), mock.queued_follow_up_count);
+    try std.testing.expectEqual(@as(usize, 2), app.state.transcript.items.len);
+    try std.testing.expectEqualStrings("follow later", app.state.transcript.items[1].text.items);
+    try std.testing.expectEqual(@as(usize, 3), app.state.queue.steering);
+    try std.testing.expectEqual(@as(usize, 4), app.state.queue.follow_up);
+}
+
+test "TuiModel exits quit command while streaming" {
+    var model = TuiModel{ .app = App.initWithoutRuntime(std.testing.allocator) };
+    defer model.deinit();
+    model.app.?.state.status.streaming = true;
+    try model.app.?.state.composer.buffer.appendSlice(std.testing.allocator, "/quit");
+
+    const cmd = model.update(.{ .key = .{ .key = .enter } }, undefined);
+    try std.testing.expectEqual(zz.Cmd(TuiModel.Msg).quit, cmd);
 }
 
 test "session picker navigation pages through hidden rows" {

--- a/zig/src/tui/app.zig
+++ b/zig/src/tui/app.zig
@@ -414,12 +414,16 @@ pub const App = struct {
             const model = if (self.state.status.model.len > 0) self.state.status.model else "no-model";
             const provider = if (self.state.status.provider.len > 0) self.state.status.provider else "local";
             const cwd = if (self.working_dir.len > 0) self.working_dir else ".";
+            const tips = if (self.supportsStreamingShortcuts())
+                "Enter submit • Enter while streaming steers • Alt+Enter queues follow-up • /sessions resumes • Ctrl+G editor • Ctrl+R thinking • /help commands"
+            else
+                "Enter submit • /sessions resumes • Ctrl+G editor • Ctrl+R thinking • /help commands";
             const welcome = try std.fmt.allocPrint(self.allocator,
                 \\Makai TUI
                 \\model: {s}/{s}
                 \\cwd: {s}
-                \\tips: Enter submit • Enter while streaming steers • Alt+Enter queues follow-up • /sessions resumes • Ctrl+G editor • Ctrl+R thinking • /help commands
-            , .{ provider, model, cwd });
+                \\tips: {s}
+            , .{ provider, model, cwd, tips });
             defer self.allocator.free(welcome);
             try self.state.appendTranscript(.system, welcome);
             return;
@@ -1067,6 +1071,9 @@ test "App submit routes unknown command to error transcript" {
 test "App welcome uses session count" {
     var app = App.initWithoutRuntime(std.testing.allocator);
     defer app.deinit();
+    var mock = MockAppSession{};
+    defer mock.deinit();
+    app.session = mock.session();
     try app.state.status.setModel(std.testing.allocator, "model-a", "provider-a");
     app.working_dir = try std.testing.allocator.dupe(u8, "/tmp/work");
 
@@ -1080,6 +1087,22 @@ test "App welcome uses session count" {
     try app.appendWelcome();
     try std.testing.expect(std.mem.indexOf(u8, app.state.transcript.items[0].text.items, "tips:") == null);
     try std.testing.expect(std.mem.indexOf(u8, app.state.transcript.items[0].text.items, "/sessions") != null);
+}
+
+test "App welcome hides streaming shortcut tips for remote runtime" {
+    var runtime = try initRemoteRuntimeForTest(std.testing.allocator);
+    var app = App.initWithoutRuntime(std.testing.allocator);
+    defer app.deinit();
+    app.runtime = runtime;
+    runtime = undefined;
+    try app.state.status.setModel(std.testing.allocator, "model-a", "provider-a");
+    app.working_dir = try std.testing.allocator.dupe(u8, "/tmp/work");
+
+    try app.appendWelcome();
+    try std.testing.expect(std.mem.indexOf(u8, app.state.transcript.items[0].text.items, "tips:") != null);
+    try std.testing.expect(std.mem.indexOf(u8, app.state.transcript.items[0].text.items, "Alt+Enter") == null);
+    try std.testing.expect(std.mem.indexOf(u8, app.state.transcript.items[0].text.items, "Enter while streaming") == null);
+    try std.testing.expect(std.mem.indexOf(u8, app.state.transcript.items[0].text.items, "Enter submit") != null);
 }
 
 const MockAppSession = struct {

--- a/zig/src/tui/app.zig
+++ b/zig/src/tui/app.zig
@@ -298,6 +298,11 @@ pub const App = struct {
         if (self.session) |*session| self.state.setQueuedCounts(session.queuedCounts());
     }
 
+    fn supportsStreamingShortcuts(self: *const App) bool {
+        const runtime = self.runtime orelse return self.session != null;
+        return runtime.backend == .local;
+    }
+
     fn discardPendingEvents(self: *App) void {
         var session = &(self.session orelse return);
         while (session.popEvent()) |event| {
@@ -328,7 +333,6 @@ pub const App = struct {
         if (trimmed[0] == '/') return try self.submitCommand(trimmed);
         if (self.session) |*session| {
             try session.steer(trimmed);
-            try self.state.appendUserMessage(trimmed);
             self.refreshQueuedCounts();
             return;
         }
@@ -341,7 +345,6 @@ pub const App = struct {
         if (trimmed[0] == '/') return try self.submitCommand(trimmed);
         if (self.session) |*session| {
             try session.queueFollowUp(trimmed);
-            try self.state.appendUserMessage(trimmed);
             self.refreshQueuedCounts();
             return;
         }
@@ -763,7 +766,7 @@ const TuiModel = struct {
                         if (app.state.mode == .approval) return .none;
                         const text = app.state.composer.text();
                         app.state.recordComposerHistory(text) catch |err| app.recordError(@errorName(err)) catch {};
-                        if (app.state.status.streaming) {
+                        if (app.state.status.streaming and app.supportsStreamingShortcuts()) {
                             if (key.modifiers.alt) {
                                 app.queueFollowUp(text) catch |err| {
                                     if (err == error.QuitRequested) return .quit;
@@ -1210,16 +1213,14 @@ test "App steer and queue follow-up handle fallback empty and session paths" {
 
     try app.steer(" steer me ");
     try std.testing.expectEqual(@as(usize, 1), mock.steer_count);
-    try std.testing.expectEqual(@as(usize, 1), app.state.transcript.items.len);
-    try std.testing.expectEqualStrings("steer me", app.state.transcript.items[0].text.items);
+    try std.testing.expectEqual(@as(usize, 0), app.state.transcript.items.len);
     try std.testing.expectEqual(@as(usize, 1), app.state.queue.steering);
     try std.testing.expectEqual(@as(usize, 2), app.state.queue.follow_up);
 
     mock.queued_counts = .{ .steering = 3, .follow_up = 4 };
     try app.queueFollowUp(" follow later ");
     try std.testing.expectEqual(@as(usize, 1), mock.queued_follow_up_count);
-    try std.testing.expectEqual(@as(usize, 2), app.state.transcript.items.len);
-    try std.testing.expectEqualStrings("follow later", app.state.transcript.items[1].text.items);
+    try std.testing.expectEqual(@as(usize, 0), app.state.transcript.items.len);
     try std.testing.expectEqual(@as(usize, 3), app.state.queue.steering);
     try std.testing.expectEqual(@as(usize, 4), app.state.queue.follow_up);
 }
@@ -1250,6 +1251,26 @@ test "TuiModel drains events before routing Enter while streaming" {
     try std.testing.expectEqual(@as(usize, 1), mock.submit_count);
     try std.testing.expectEqual(@as(usize, 0), mock.steer_count);
     try std.testing.expect(!model.app.?.state.status.streaming);
+}
+
+test "TuiModel remote streaming Enter falls back to submit and preserves composer" {
+    var runtime = try initRemoteRuntimeForTest(std.testing.allocator);
+    var model = TuiModel{ .app = App.initWithoutRuntime(std.testing.allocator) };
+    defer model.deinit();
+    model.app.?.runtime = runtime;
+    runtime = undefined;
+    var mock = MockAppSession{};
+    defer mock.deinit();
+    model.app.?.session = mock.session();
+    model.app.?.state.status.streaming = true;
+    try model.app.?.state.composer.buffer.appendSlice(std.testing.allocator, "new turn");
+
+    const cmd = model.update(.{ .key = .{ .key = .enter } }, undefined);
+    try std.testing.expectEqual(zz.Cmd(TuiModel.Msg).none, cmd);
+    try std.testing.expectEqual(@as(usize, 1), mock.submit_count);
+    try std.testing.expectEqual(@as(usize, 0), mock.steer_count);
+    try std.testing.expectEqual(@as(usize, 0), mock.queued_follow_up_count);
+    try std.testing.expectEqualStrings("", model.app.?.state.composer.text());
 }
 
 test "TuiModel stops Enter routing when drained event enters approval mode" {

--- a/zig/src/tui/app.zig
+++ b/zig/src/tui/app.zig
@@ -19,6 +19,7 @@ const preview_view = @import("tui_view_preview");
 const session_picker_view = @import("tui_view_session_picker");
 const tui_render = @import("tui_render");
 const permission = @import("permission");
+const OwnedSlice = @import("owned_slice").OwnedSlice;
 
 const max_session_event_jsonl_bytes = 8 * 1024 * 1024;
 const max_session_event_payload_bytes = max_session_event_jsonl_bytes / 2;
@@ -759,6 +760,7 @@ const TuiModel = struct {
                             app.state.status.setError(app.allocator, @errorName(err)) catch {};
                             app.state.appendTranscript(.@"error", @errorName(err)) catch {};
                         };
+                        if (app.state.mode == .approval) return .none;
                         const text = app.state.composer.text();
                         app.state.recordComposerHistory(text) catch |err| app.recordError(@errorName(err)) catch {};
                         if (app.state.status.streaming) {
@@ -1248,6 +1250,29 @@ test "TuiModel drains events before routing Enter while streaming" {
     try std.testing.expectEqual(@as(usize, 1), mock.submit_count);
     try std.testing.expectEqual(@as(usize, 0), mock.steer_count);
     try std.testing.expect(!model.app.?.state.status.streaming);
+}
+
+test "TuiModel stops Enter routing when drained event enters approval mode" {
+    var model = TuiModel{ .app = App.initWithoutRuntime(std.testing.allocator) };
+    defer model.deinit();
+    var mock = MockAppSession{};
+    defer mock.deinit();
+    model.app.?.session = mock.session();
+    model.app.?.state.status.streaming = true;
+    try mock.eventStream().push(.{ .tool_approval_requested = .{
+        .tool_call_id = OwnedSlice(u8).initOwned(try std.testing.allocator.dupe(u8, "call-approval")),
+        .tool_name = OwnedSlice(u8).initOwned(try std.testing.allocator.dupe(u8, "edit_file")),
+        .args_json = OwnedSlice(u8).initOwned(try std.testing.allocator.dupe(u8, "{\"path\":\"README.md\"}")),
+    } });
+    try model.app.?.state.composer.buffer.appendSlice(std.testing.allocator, "should wait");
+
+    const cmd = model.update(.{ .key = .{ .key = .enter } }, undefined);
+    try std.testing.expectEqual(zz.Cmd(TuiModel.Msg).none, cmd);
+    try std.testing.expectEqual(tui_state.AppMode.approval, model.app.?.state.mode);
+    try std.testing.expectEqual(@as(usize, 0), mock.submit_count);
+    try std.testing.expectEqual(@as(usize, 0), mock.steer_count);
+    try std.testing.expectEqual(@as(usize, 0), mock.queued_follow_up_count);
+    try std.testing.expectEqualStrings("should wait", model.app.?.state.composer.text());
 }
 
 test "session picker navigation pages through hidden rows" {

--- a/zig/src/tui/app.zig
+++ b/zig/src/tui/app.zig
@@ -826,7 +826,10 @@ const TuiModel = struct {
         const height: usize = @max(ctx.height, 8);
         app.last_view_height = height;
         const status = status_bar_view.render(ctx.allocator, &app.state, .{ .width = width }) catch "";
-        const composer = composer_view.render(ctx.allocator, &app.state, .{ .width = width }) catch "";
+        const composer = composer_view.render(ctx.allocator, &app.state, .{
+            .width = width,
+            .streaming_shortcuts_supported = app.supportsStreamingShortcuts(),
+        }) catch "";
         const tool_height: usize = if (app.state.tools.items.len > 0) @min(@as(usize, 8), height / 4) else 2;
         const tools = tool_panel_view.render(ctx.allocator, &app.state, .{ .width = width, .height = tool_height }) catch "";
         const telemetry = telemetry_view.render(ctx.allocator, &app.state, .{ .width = width }) catch "";

--- a/zig/src/tui/app.zig
+++ b/zig/src/tui/app.zig
@@ -202,6 +202,8 @@ pub const App = struct {
         for (loaded.events.items) |*event| {
             try self.state.applyEvent(event.*);
         }
+        if (self.session) |*session| session.clearQueuedMessages();
+        self.refreshQueuedCounts();
         self.state.status.streaming = false;
         self.state.mode = .normal;
     }
@@ -753,6 +755,10 @@ const TuiModel = struct {
                             app.state.composer.buffer.append(app.allocator, '\n') catch |err| app.recordError(@errorName(err)) catch {};
                             return .none;
                         }
+                        app.drainEvents() catch |err| {
+                            app.state.status.setError(app.allocator, @errorName(err)) catch {};
+                            app.state.appendTranscript(.@"error", @errorName(err)) catch {};
+                        };
                         const text = app.state.composer.text();
                         app.state.recordComposerHistory(text) catch |err| app.recordError(@errorName(err)) catch {};
                         if (app.state.status.streaming) {
@@ -1071,7 +1077,11 @@ test "App welcome uses session count" {
 const MockAppSession = struct {
     steer_count: usize = 0,
     queued_follow_up_count: usize = 0,
+    submit_count: usize = 0,
+    clear_count: usize = 0,
     queued_counts: tui_runtime.QueuedCounts = .{},
+    events: tui_runtime.TuiEventStream = undefined,
+    events_initialized: bool = false,
 
     fn session(self: *MockAppSession) tui_runtime.TuiSession {
         return .{
@@ -1083,6 +1093,7 @@ const MockAppSession = struct {
                 .submit_turn = submitTurn,
                 .steer = steer,
                 .queue_follow_up = queueFollowUp,
+                .clear_queued_messages = clearQueuedMessages,
                 .queued_counts = queuedCounts,
                 .switch_model = switchModel,
                 .current_model = currentModel,
@@ -1109,8 +1120,9 @@ const MockAppSession = struct {
     }
 
     fn submitTurn(ctx: ?*anyopaque, text: []const u8) anyerror!void {
-        _ = ctx;
-        _ = text;
+        const self = ptr(ctx);
+        self.submit_count += 1;
+        try std.testing.expectEqualStrings("new turn", text);
     }
 
     fn steer(ctx: ?*anyopaque, text: []const u8) anyerror!void {
@@ -1123,6 +1135,12 @@ const MockAppSession = struct {
         const self = ptr(ctx);
         self.queued_follow_up_count += 1;
         try std.testing.expectEqualStrings("follow later", text);
+    }
+
+    fn clearQueuedMessages(ctx: ?*anyopaque) void {
+        const self = ptr(ctx);
+        self.clear_count += 1;
+        self.queued_counts = .{};
     }
 
     fn queuedCounts(ctx: ?*anyopaque) tui_runtime.QueuedCounts {
@@ -1145,9 +1163,20 @@ const MockAppSession = struct {
         _ = decision;
     }
 
+    fn eventStream(self: *MockAppSession) *tui_runtime.TuiEventStream {
+        if (!self.events_initialized) {
+            self.events = tui_runtime.TuiEventStream.init(std.testing.allocator);
+            self.events_initialized = true;
+        }
+        return &self.events;
+    }
+
     fn streamEvents(ctx: ?*anyopaque) *tui_runtime.TuiEventStream {
-        _ = ctx;
-        unreachable;
+        return ptr(ctx).eventStream();
+    }
+
+    fn deinit(self: *MockAppSession) void {
+        if (self.events_initialized) self.events.deinit();
     }
 };
 
@@ -1201,6 +1230,24 @@ test "TuiModel exits quit command while streaming" {
 
     const cmd = model.update(.{ .key = .{ .key = .enter } }, undefined);
     try std.testing.expectEqual(zz.Cmd(TuiModel.Msg).quit, cmd);
+}
+
+test "TuiModel drains events before routing Enter while streaming" {
+    var model = TuiModel{ .app = App.initWithoutRuntime(std.testing.allocator) };
+    defer model.deinit();
+    var mock = MockAppSession{};
+    defer mock.deinit();
+    model.app.?.session = mock.session();
+    model.app.?.state.status.streaming = true;
+    try mock.eventStream().push(.{ .turn_end = .{ .stop_reason = .stop } });
+    try mock.eventStream().push(.{ .agent_end = .{ .reason = .completed } });
+    try model.app.?.state.composer.buffer.appendSlice(std.testing.allocator, "new turn");
+
+    const cmd = model.update(.{ .key = .{ .key = .enter } }, undefined);
+    try std.testing.expectEqual(zz.Cmd(TuiModel.Msg).none, cmd);
+    try std.testing.expectEqual(@as(usize, 1), mock.submit_count);
+    try std.testing.expectEqual(@as(usize, 0), mock.steer_count);
+    try std.testing.expect(!model.app.?.state.status.streaming);
 }
 
 test "session picker navigation pages through hidden rows" {

--- a/zig/src/tui/runtime.zig
+++ b/zig/src/tui/runtime.zig
@@ -418,6 +418,7 @@ pub const TuiRuntime = struct {
                 .submit_turn = sessionSubmitTurn,
                 .steer = sessionSteer,
                 .queue_follow_up = sessionQueueFollowUp,
+                .clear_queued_messages = sessionClearQueuedMessages,
                 .queued_counts = sessionQueuedCounts,
                 .switch_model = sessionSwitchModel,
                 .current_model = sessionCurrentModel,
@@ -548,6 +549,16 @@ pub const TuiRuntime = struct {
         }
     }
 
+    pub fn clearQueuedMessages(self: *TuiRuntime) void {
+        switch (self.backend) {
+            .remote => {},
+            .local => {
+                const local = &(self.local_agent orelse return);
+                local.clearAllQueues();
+            },
+        }
+    }
+
     pub fn queuedCounts(self: *TuiRuntime) QueuedCounts {
         switch (self.backend) {
             .remote => return .{},
@@ -565,6 +576,7 @@ pub const TuiRuntime = struct {
                 if (!self.started) try self.start();
                 const local = &(self.local_agent orelse return error.RuntimeNotStarted);
                 if (self.run_async) local.waitForIdle();
+                local.clearAllQueues();
                 try local.replaceMessages(messages);
             },
         }
@@ -1760,6 +1772,11 @@ fn sessionQueueFollowUp(ctx: ?*anyopaque, text: []const u8) anyerror!void {
     try self.queueFollowUp(text);
 }
 
+fn sessionClearQueuedMessages(ctx: ?*anyopaque) void {
+    const self: *TuiRuntime = @ptrCast(@alignCast(ctx.?));
+    self.clearQueuedMessages();
+}
+
 fn sessionQueuedCounts(ctx: ?*anyopaque) QueuedCounts {
     const self: *TuiRuntime = @ptrCast(@alignCast(ctx.?));
     return self.queuedCounts();
@@ -2287,6 +2304,23 @@ test "remote queue operations report unsupported" {
     var tui_session = runtime.createSession();
     try std.testing.expectError(error.RemoteSteeringUnsupported, tui_session.steer("hi"));
     try std.testing.expectError(error.RemoteQueueUnsupported, tui_session.queueFollowUp("hi"));
+}
+
+test "runtime clears queued messages before replacing messages" {
+    var mock = MockProtocolCtx{};
+    const models = [_]ai_types.Model{test_model_a};
+    var runtime = try TuiRuntime.init(std.testing.allocator, .{ .protocol = makeProtocol(&mock), .models = &models });
+    defer runtime.deinit();
+
+    var tui_session = runtime.createSession();
+    try tui_session.start();
+    try tui_session.steer("steer now");
+    try tui_session.queueFollowUp("later");
+    try std.testing.expectEqual(@as(usize, 2), tui_session.queuedCounts().total());
+
+    try runtime.replaceMessages(&.{});
+
+    try std.testing.expectEqual(@as(usize, 0), tui_session.queuedCounts().total());
 }
 
 test "event stream resets between turns" {

--- a/zig/src/tui/runtime.zig
+++ b/zig/src/tui/runtime.zig
@@ -24,6 +24,7 @@ pub const TuiSession = session.TuiSession;
 pub const TuiEvent = session.TuiEvent;
 pub const TuiEventStream = session.TuiEventStream;
 pub const TuiEndReason = session.TuiEndReason;
+pub const QueuedCounts = session.QueuedCounts;
 pub const ToolApprovalCallback = session.ToolApprovalCallback;
 pub const ToolApprovalDecision = session.ToolApprovalDecision;
 pub const ToolApprovalRequest = session.ToolApprovalRequest;
@@ -415,6 +416,9 @@ pub const TuiRuntime = struct {
                 .resume_session = sessionResume,
                 .cancel = sessionCancel,
                 .submit_turn = sessionSubmitTurn,
+                .steer = sessionSteer,
+                .queue_follow_up = sessionQueueFollowUp,
+                .queued_counts = sessionQueuedCounts,
                 .switch_model = sessionSwitchModel,
                 .current_model = sessionCurrentModel,
                 .decide_tool_approval = sessionDecideToolApproval,
@@ -449,6 +453,14 @@ pub const TuiRuntime = struct {
             }
         }
         return error.ModelNotFound;
+    }
+
+    fn makeUserMessage(self: *TuiRuntime, text: []const u8) !ai_types.Message {
+        const owned_text = try self.allocator.dupe(u8, text);
+        return .{ .user = .{
+            .content = .{ .text = owned_text },
+            .timestamp = compat.time.nowMillis(),
+        } };
     }
 
     pub fn submitTurn(self: *TuiRuntime, text: []const u8) !void {
@@ -499,22 +511,50 @@ pub const TuiRuntime = struct {
                 self.completed = false;
                 self.last_turn_stop_reason = null;
                 if (self.run_async) {
-                    const owned_text = try self.allocator.dupe(u8, text);
-                    errdefer self.allocator.free(owned_text);
-                    const msg = ai_types.Message{ .user = .{
-                        .content = .{ .text = owned_text },
-                        .timestamp = compat.time.nowMillis(),
-                    } };
+                    var msg = try self.makeUserMessage(text);
+                    defer msg.deinit(self.allocator);
                     try local.promptAsync(msg);
-                    self.allocator.free(owned_text);
                 } else {
-                    const owned_text = try self.allocator.dupe(u8, text);
-                    const msg = ai_types.Message{ .user = .{
-                        .content = .{ .text = owned_text },
-                        .timestamp = compat.time.nowMillis(),
-                    } };
+                    const msg = try self.makeUserMessage(text);
                     try local.prompt(msg);
                 }
+            },
+        }
+    }
+
+    pub fn steer(self: *TuiRuntime, text: []const u8) !void {
+        switch (self.backend) {
+            .remote => return error.RemoteSteeringUnsupported,
+            .local => {
+                if (!self.started) return error.RuntimeNotStarted;
+                const local = &(self.local_agent orelse return error.RuntimeNotStarted);
+                var msg = try self.makeUserMessage(text);
+                errdefer msg.deinit(self.allocator);
+                try local.steer(msg);
+            },
+        }
+    }
+
+    pub fn queueFollowUp(self: *TuiRuntime, text: []const u8) !void {
+        switch (self.backend) {
+            .remote => return error.RemoteQueueUnsupported,
+            .local => {
+                if (!self.started) return error.RuntimeNotStarted;
+                const local = &(self.local_agent orelse return error.RuntimeNotStarted);
+                var msg = try self.makeUserMessage(text);
+                errdefer msg.deinit(self.allocator);
+                try local.followUp(msg);
+            },
+        }
+    }
+
+    pub fn queuedCounts(self: *TuiRuntime) QueuedCounts {
+        switch (self.backend) {
+            .remote => return .{},
+            .local => {
+                const local = &(self.local_agent orelse return .{});
+                const counts = local.queuedCounts();
+                return .{ .steering = counts.steering, .follow_up = counts.follow_up };
             },
         }
     }
@@ -1711,6 +1751,21 @@ fn sessionSubmitTurn(ctx: ?*anyopaque, text: []const u8) anyerror!void {
     try self.submitTurn(text);
 }
 
+fn sessionSteer(ctx: ?*anyopaque, text: []const u8) anyerror!void {
+    const self: *TuiRuntime = @ptrCast(@alignCast(ctx.?));
+    try self.steer(text);
+}
+
+fn sessionQueueFollowUp(ctx: ?*anyopaque, text: []const u8) anyerror!void {
+    const self: *TuiRuntime = @ptrCast(@alignCast(ctx.?));
+    try self.queueFollowUp(text);
+}
+
+fn sessionQueuedCounts(ctx: ?*anyopaque) QueuedCounts {
+    const self: *TuiRuntime = @ptrCast(@alignCast(ctx.?));
+    return self.queuedCounts();
+}
+
 fn sessionSwitchModel(ctx: ?*anyopaque, model_id: []const u8) anyerror!void {
     const self: *TuiRuntime = @ptrCast(@alignCast(ctx.?));
     try self.switchModel(model_id);
@@ -1763,6 +1818,7 @@ const MockProtocolCtx = struct {
     wait_for_cancel: bool = false,
     flood_count: usize = 0,
     tool_first: bool = false,
+    wait_after_tool_first: bool = false,
     tool_name: []const u8 = "demo_tool",
     force_error: bool = false,
 };
@@ -1893,6 +1949,12 @@ fn mockStream(
     }
 
     if (mock.tool_first and mock.call_count == 1) {
+        if (mock.wait_after_tool_first) {
+            var waits: usize = 0;
+            while (waits < 50) : (waits += 1) {
+                std.testing.io.sleep(.fromNanoseconds(1 * std.time.ns_per_ms), .boot) catch {};
+            }
+        }
         const content = [_]ai_types.AssistantContent{.{ .tool_call = .{ .id = "call-1", .name = mock.tool_name, .arguments_json = "{}" } }};
         try stream.push(.{ .start = .{ .partial = emptyAssistantMessage(model, .tool_use) } });
         try pushDoneAndComplete(stream, allocator, model, &content, .tool_use);
@@ -2184,6 +2246,48 @@ test "tool approval approve and reject paths emit tool events" {
     }
     try std.testing.expectEqual(@as(usize, 1), reject_ctx.calls);
     try std.testing.expect(reject_saw_error_tool);
+}
+
+test "runtime queues steering and follow-up messages" {
+    var mock = MockProtocolCtx{ .tool_first = true, .wait_after_tool_first = true };
+    const models = [_]ai_types.Model{test_model_a};
+    var runtime = try TuiRuntime.init(std.testing.allocator, .{ .protocol = makeProtocol(&mock), .models = &models, .run_async = true });
+    defer runtime.deinit();
+
+    var tui_session = runtime.createSession();
+    try tui_session.start();
+    try tui_session.submitTurn("first");
+    try tui_session.steer("steer now");
+    try tui_session.queueFollowUp("later");
+    const queued = tui_session.queuedCounts();
+    try std.testing.expectEqual(@as(usize, 1), queued.steering);
+    try std.testing.expectEqual(@as(usize, 1), queued.follow_up);
+
+    if (runtime.local_agent) |*local| local.waitForIdle();
+
+    var user_messages: usize = 0;
+    while (tui_session.waitEvent()) |event| {
+        var ev = event;
+        defer ev.deinit(std.testing.allocator);
+        switch (ev) {
+            .message_end => |payload| {
+                if (payload.role == .user) user_messages += 1;
+            },
+            .agent_end => break,
+            else => {},
+        }
+    }
+    try std.testing.expect(user_messages >= 2);
+    try std.testing.expectEqual(@as(usize, 3), mock.call_count);
+    try std.testing.expectEqual(@as(usize, 0), tui_session.queuedCounts().total());
+}
+
+test "remote queue operations report unsupported" {
+    var runtime = try TuiRuntime.init(std.testing.allocator, .{ .backend = .remote });
+    defer runtime.deinit();
+    var tui_session = runtime.createSession();
+    try std.testing.expectError(error.RemoteSteeringUnsupported, tui_session.steer("hi"));
+    try std.testing.expectError(error.RemoteQueueUnsupported, tui_session.queueFollowUp("hi"));
 }
 
 test "event stream resets between turns" {

--- a/zig/src/tui/runtime.zig
+++ b/zig/src/tui/runtime.zig
@@ -553,8 +553,7 @@ pub const TuiRuntime = struct {
             .remote => return .{},
             .local => {
                 const local = &(self.local_agent orelse return .{});
-                const counts = local.queuedCounts();
-                return .{ .steering = counts.steering, .follow_up = counts.follow_up };
+                return local.queuedCounts();
             },
         }
     }

--- a/zig/src/tui/session.zig
+++ b/zig/src/tui/session.zig
@@ -165,11 +165,23 @@ pub const TuiSessionResult = struct {
 
 pub const TuiEventStream = event_stream.EventStream(TuiEvent, TuiSessionResult);
 
+pub const QueuedCounts = struct {
+    steering: usize = 0,
+    follow_up: usize = 0,
+
+    pub fn total(self: QueuedCounts) usize {
+        return self.steering + self.follow_up;
+    }
+};
+
 pub const TuiSessionOps = struct {
     start: *const fn (ctx: ?*anyopaque) anyerror!void = undefined,
     resume_session: *const fn (ctx: ?*anyopaque) anyerror!void = undefined,
     cancel: *const fn (ctx: ?*anyopaque) void = undefined,
     submit_turn: *const fn (ctx: ?*anyopaque, text: []const u8) anyerror!void = undefined,
+    steer: *const fn (ctx: ?*anyopaque, text: []const u8) anyerror!void = undefined,
+    queue_follow_up: *const fn (ctx: ?*anyopaque, text: []const u8) anyerror!void = undefined,
+    queued_counts: *const fn (ctx: ?*anyopaque) QueuedCounts = undefined,
     switch_model: *const fn (ctx: ?*anyopaque, model_id: []const u8) anyerror!void = undefined,
     current_model: *const fn (ctx: ?*anyopaque) ?ai_types.Model = undefined,
     decide_tool_approval: *const fn (ctx: ?*anyopaque, tool_call_id: []const u8, decision: ToolApprovalDecision) anyerror!void = undefined,
@@ -194,6 +206,18 @@ pub const TuiSession = struct {
 
     pub fn submitTurn(self: *TuiSession, text: []const u8) !void {
         try self.ops.submit_turn(self.ctx, text);
+    }
+
+    pub fn steer(self: *TuiSession, text: []const u8) !void {
+        try self.ops.steer(self.ctx, text);
+    }
+
+    pub fn queueFollowUp(self: *TuiSession, text: []const u8) !void {
+        try self.ops.queue_follow_up(self.ctx, text);
+    }
+
+    pub fn queuedCounts(self: *TuiSession) QueuedCounts {
+        return self.ops.queued_counts(self.ctx);
     }
 
     pub fn switchModel(self: *TuiSession, model_id: []const u8) !void {

--- a/zig/src/tui/session.zig
+++ b/zig/src/tui/session.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const agent = @import("agent");
 const ai_types = @import("ai_types");
 const event_stream = @import("event_stream");
 const OwnedSlice = @import("owned_slice").OwnedSlice;
@@ -165,14 +166,7 @@ pub const TuiSessionResult = struct {
 
 pub const TuiEventStream = event_stream.EventStream(TuiEvent, TuiSessionResult);
 
-pub const QueuedCounts = struct {
-    steering: usize = 0,
-    follow_up: usize = 0,
-
-    pub fn total(self: QueuedCounts) usize {
-        return self.steering + self.follow_up;
-    }
-};
+pub const QueuedCounts = agent.Agent.QueuedCounts;
 
 pub const TuiSessionOps = struct {
     start: *const fn (ctx: ?*anyopaque) anyerror!void = undefined,

--- a/zig/src/tui/session.zig
+++ b/zig/src/tui/session.zig
@@ -175,6 +175,7 @@ pub const TuiSessionOps = struct {
     submit_turn: *const fn (ctx: ?*anyopaque, text: []const u8) anyerror!void = undefined,
     steer: *const fn (ctx: ?*anyopaque, text: []const u8) anyerror!void = undefined,
     queue_follow_up: *const fn (ctx: ?*anyopaque, text: []const u8) anyerror!void = undefined,
+    clear_queued_messages: *const fn (ctx: ?*anyopaque) void = undefined,
     queued_counts: *const fn (ctx: ?*anyopaque) QueuedCounts = undefined,
     switch_model: *const fn (ctx: ?*anyopaque, model_id: []const u8) anyerror!void = undefined,
     current_model: *const fn (ctx: ?*anyopaque) ?ai_types.Model = undefined,
@@ -208,6 +209,10 @@ pub const TuiSession = struct {
 
     pub fn queueFollowUp(self: *TuiSession, text: []const u8) !void {
         try self.ops.queue_follow_up(self.ctx, text);
+    }
+
+    pub fn clearQueuedMessages(self: *TuiSession) void {
+        self.ops.clear_queued_messages(self.ctx);
     }
 
     pub fn queuedCounts(self: *TuiSession) QueuedCounts {

--- a/zig/src/tui/state.zig
+++ b/zig/src/tui/state.zig
@@ -175,14 +175,7 @@ pub const TelemetryState = struct {
     }
 };
 
-pub const QueueState = struct {
-    steering_count: usize = 0,
-    follow_up_count: usize = 0,
-
-    pub fn total(self: QueueState) usize {
-        return self.steering_count + self.follow_up_count;
-    }
-};
+pub const QueueState = tui_runtime.QueuedCounts;
 
 pub const StatusState = struct {
     model: []u8 = &.{},
@@ -437,8 +430,7 @@ pub const AppState = struct {
     }
 
     pub fn setQueuedCounts(self: *AppState, counts: tui_runtime.QueuedCounts) void {
-        self.queue.steering_count = counts.steering;
-        self.queue.follow_up_count = counts.follow_up;
+        self.queue = counts;
     }
 
     pub fn applyEvent(self: *AppState, event: tui_runtime.TuiEvent) !void {

--- a/zig/src/tui/state.zig
+++ b/zig/src/tui/state.zig
@@ -354,6 +354,7 @@ pub const AppState = struct {
         self.clearTranscript();
         self.clearTools();
         self.telemetry = .{};
+        self.queue = .{};
         self.status.context_used = 0;
         self.status.turn_count = 0;
         self.status.streaming = false;
@@ -1353,6 +1354,16 @@ test "AppState toggles thinking visibility" {
     try std.testing.expect(state.show_thinking);
     state.toggleThinking();
     try std.testing.expect(!state.show_thinking);
+}
+
+test "AppState reset replay clears stale queue counts" {
+    var state = AppState.init(std.testing.allocator);
+    defer state.deinit();
+    state.queue = .{ .steering = 1, .follow_up = 2 };
+
+    state.resetReplayState();
+
+    try std.testing.expectEqual(@as(usize, 0), state.queue.total());
 }
 
 test "AppState applies thinking tool call and lifecycle events" {

--- a/zig/src/tui/state.zig
+++ b/zig/src/tui/state.zig
@@ -175,6 +175,15 @@ pub const TelemetryState = struct {
     }
 };
 
+pub const QueueState = struct {
+    steering_count: usize = 0,
+    follow_up_count: usize = 0,
+
+    pub fn total(self: QueueState) usize {
+        return self.steering_count + self.follow_up_count;
+    }
+};
+
 pub const StatusState = struct {
     model: []u8 = &.{},
     provider: []u8 = &.{},
@@ -293,6 +302,7 @@ pub const AppState = struct {
     composer: ComposerState = .{},
     approval: ApprovalState = .{},
     status: StatusState = .{},
+    queue: QueueState = .{},
     telemetry: TelemetryState = .{},
     preview: PreviewState = .{},
     show_thinking: bool = true,
@@ -424,6 +434,11 @@ pub const AppState = struct {
 
     pub fn toggleThinking(self: *AppState) void {
         self.show_thinking = !self.show_thinking;
+    }
+
+    pub fn setQueuedCounts(self: *AppState, counts: tui_runtime.QueuedCounts) void {
+        self.queue.steering_count = counts.steering;
+        self.queue.follow_up_count = counts.follow_up;
     }
 
     pub fn applyEvent(self: *AppState, event: tui_runtime.TuiEvent) !void {

--- a/zig/src/tui/views/composer.zig
+++ b/zig/src/tui/views/composer.zig
@@ -112,7 +112,7 @@ test "composer renders queued hint while streaming" {
     var state = tui_state.AppState.init(std.testing.allocator);
     defer state.deinit();
     state.status.streaming = true;
-    state.queue.follow_up_count = 2;
+    state.queue.follow_up = 2;
 
     const text = try render(std.testing.allocator, &state, .{ .width = 80 });
     defer std.testing.allocator.free(text);

--- a/zig/src/tui/views/composer.zig
+++ b/zig/src/tui/views/composer.zig
@@ -37,6 +37,15 @@ fn renderInput(allocator: std.mem.Allocator, state: *const tui_state.AppState, w
 
 fn renderHint(allocator: std.mem.Allocator, state: *const tui_state.AppState) ![]const u8 {
     const text = state.composer.text();
+    if (state.status.streaming) {
+        const queued = state.queue.total();
+        const hint = if (queued > 0)
+            try std.fmt.allocPrint(allocator, "Enter steer • Alt+Enter queue follow-up • queued {d}", .{queued})
+        else
+            try allocator.dupe(u8, "Enter steer • Alt+Enter queue follow-up");
+        defer allocator.free(hint);
+        return tui_theme.muted().render(allocator, hint);
+    }
     if (std.mem.startsWith(u8, text, "!"))
         return tui_theme.muted().render(allocator, "shell mode • Enter runs command through agent");
     if (std.mem.startsWith(u8, text, "@"))
@@ -97,6 +106,18 @@ test "composer renders multiline draft content" {
 
     try std.testing.expect(std.mem.indexOf(u8, text, "first line") != null);
     try std.testing.expect(std.mem.indexOf(u8, text, "second line") != null);
+}
+
+test "composer renders queued hint while streaming" {
+    var state = tui_state.AppState.init(std.testing.allocator);
+    defer state.deinit();
+    state.status.streaming = true;
+    state.queue.follow_up_count = 2;
+
+    const text = try render(std.testing.allocator, &state, .{ .width = 80 });
+    defer std.testing.allocator.free(text);
+    try std.testing.expect(std.mem.indexOf(u8, text, "Alt+Enter") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "queued 2") != null);
 }
 
 test "composer renders shell and file hints" {

--- a/zig/src/tui/views/composer.zig
+++ b/zig/src/tui/views/composer.zig
@@ -6,13 +6,14 @@ const tui_render = @import("tui_render");
 
 pub const Options = struct {
     width: usize = 80,
+    streaming_shortcuts_supported: bool = true,
 };
 
 pub fn render(allocator: std.mem.Allocator, state: *const tui_state.AppState, options: Options) ![]const u8 {
     const inner_width = options.width -| 4;
     const input = try renderInput(allocator, state, inner_width);
     defer allocator.free(input);
-    const hint = try renderHint(allocator, state);
+    const hint = try renderHint(allocator, state, options.streaming_shortcuts_supported);
     defer allocator.free(hint);
     const body = try tui_render.joinVertical(allocator, &.{ input, hint });
     defer allocator.free(body);
@@ -35,9 +36,9 @@ fn renderInput(allocator: std.mem.Allocator, state: *const tui_state.AppState, w
     return prefixFirstLine(allocator, prompt, content);
 }
 
-fn renderHint(allocator: std.mem.Allocator, state: *const tui_state.AppState) ![]const u8 {
+fn renderHint(allocator: std.mem.Allocator, state: *const tui_state.AppState, streaming_shortcuts_supported: bool) ![]const u8 {
     const text = state.composer.text();
-    if (state.status.streaming) {
+    if (state.status.streaming and streaming_shortcuts_supported) {
         const queued = state.queue.total();
         const hint = if (queued > 0)
             try std.fmt.allocPrint(allocator, "Enter steer • Alt+Enter queue follow-up • queued {d}", .{queued})
@@ -108,7 +109,7 @@ test "composer renders multiline draft content" {
     try std.testing.expect(std.mem.indexOf(u8, text, "second line") != null);
 }
 
-test "composer renders queued hint while streaming" {
+test "composer renders queued hint while streaming shortcuts are supported" {
     var state = tui_state.AppState.init(std.testing.allocator);
     defer state.deinit();
     state.status.streaming = true;
@@ -118,6 +119,19 @@ test "composer renders queued hint while streaming" {
     defer std.testing.allocator.free(text);
     try std.testing.expect(std.mem.indexOf(u8, text, "Alt+Enter") != null);
     try std.testing.expect(std.mem.indexOf(u8, text, "queued 2") != null);
+}
+
+test "composer hides streaming shortcut hint when unsupported" {
+    var state = tui_state.AppState.init(std.testing.allocator);
+    defer state.deinit();
+    state.status.streaming = true;
+    state.queue.follow_up = 2;
+
+    const text = try render(std.testing.allocator, &state, .{ .width = 80, .streaming_shortcuts_supported = false });
+    defer std.testing.allocator.free(text);
+    try std.testing.expect(std.mem.indexOf(u8, text, "Alt+Enter") == null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "queued 2") == null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "Enter submit") != null);
 }
 
 test "composer renders shell and file hints" {

--- a/zig/src/tui/views/status_bar.zig
+++ b/zig/src/tui/views/status_bar.zig
@@ -121,8 +121,8 @@ test "status bar renders model and clips width" {
 test "status bar renders queue count when queued" {
     var state = tui_state.AppState.init(std.testing.allocator);
     defer state.deinit();
-    state.queue.steering_count = 1;
-    state.queue.follow_up_count = 2;
+    state.queue.steering = 1;
+    state.queue.follow_up = 2;
 
     const text = try render(std.testing.allocator, &state, .{ .width = 160 });
     defer std.testing.allocator.free(text);

--- a/zig/src/tui/views/status_bar.zig
+++ b/zig/src/tui/views/status_bar.zig
@@ -29,6 +29,10 @@ pub fn render(allocator: std.mem.Allocator, state: *const tui_state.AppState, op
     try writeOwnedSegment(writer, allocator, "cost", try estimatedCost(allocator, state));
     try writer.writeAll(" • ");
     try writeStyledValue(writer, allocator, "state", stream, if (state.status.streaming) tui_theme.successText() else tui_theme.muted());
+    if (state.queue.total() > 0) {
+        try writer.writeAll(" • ");
+        try writeOwnedSegment(writer, allocator, "queue", try std.fmt.allocPrint(allocator, "{d}", .{state.queue.total()}));
+    }
     try writer.writeAll(" • ");
     try writeSegment(writer, allocator, "perm", perm);
     try writer.writeAll(" • ");
@@ -112,6 +116,19 @@ test "status bar renders model and clips width" {
 
     try std.testing.expect(tui_text.visibleWidth(text) <= 24);
     try std.testing.expect(std.mem.indexOf(u8, text, "anthropic") != null);
+}
+
+test "status bar renders queue count when queued" {
+    var state = tui_state.AppState.init(std.testing.allocator);
+    defer state.deinit();
+    state.queue.steering_count = 1;
+    state.queue.follow_up_count = 2;
+
+    const text = try render(std.testing.allocator, &state, .{ .width = 160 });
+    defer std.testing.allocator.free(text);
+
+    try std.testing.expect(std.mem.indexOf(u8, text, "queue") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "3") != null);
 }
 
 test "status bar renders context gauge cost and permission" {


### PR DESCRIPTION
## Summary
- Add TUI runtime/session queue operations for local steering and follow-up queues, with remote unsupported errors.
- Route Enter while streaming to steering and Alt+Enter to queued follow-up, with queue counts in composer/status UI.
- Add session-count based welcome transcript: full first-launch guidance and compact saved-session greeting.

## Test plan
- [x] zig build test-unit-makai-cli
- [x] zig build test-unit-agent
- [x] zig build test