### PR TITLE
tui: place composer at absolute bottom

### DIFF
--- a/zig/src/tui/app.zig
+++ b/zig/src/tui/app.zig
@@ -850,7 +850,7 @@ const TuiModel = struct {
         const fixed = countLines(status) + countLines(composer) + countLines(tools) + countLines(telemetry) + @max(countLines(extra), 1);
         const transcript_height = if (height > fixed) height - fixed else 3;
         const transcript = transcript_view.render(ctx.allocator, &app.state, .{ .width = width, .height = transcript_height }) catch "";
-        const frame = tui_render.joinVertical(ctx.allocator, &.{ transcript, tools, telemetry, extra, composer, status }) catch "";
+        const frame = tui_render.joinVertical(ctx.allocator, &.{ transcript, tools, telemetry, extra, status, composer }) catch "";
         return tui_render.withSynchronizedOutput(ctx.allocator, frame) catch frame;
     }
 


### PR DESCRIPTION
## Summary
Swap `status` and `composer` in the TUI vertical layout so the input prompt sits on the bottom-most line, matching Claude Code / Codex CLI / Pi.

## Changes
- `zig/src/tui/app.zig`: reorder `joinVertical` panels from `..., composer, status` to `..., status, composer`
- Fixed height calculation is a commutative sum, so no height math change needed

## Test plan
- [x] `zig build test` passes all groups
- [x] `./zig-out/bin/makai --tui` in 80x24 terminal shows `> Ask Makai…` on bottom line
- [x] Status bar renders directly above composer
- [x] Layout stays anchored during streaming