### PR TITLE
TUI: add /abort slash command

### DIFF
--- a/zig/src/tui/app.zig
+++ b/zig/src/tui/app.zig
@@ -42,6 +42,16 @@ pub const ApprovalWaiter = struct {
         self.decision = .reject;
     }
 
+    /// Reject the currently pending approval wait without shutting the waiter
+    /// down, so future approval requests can still block normally.
+    pub fn rejectPending(self: *ApprovalWaiter) void {
+        while (!self.mutex.tryLock()) std.atomic.spinLoopHint();
+        defer self.mutex.unlock();
+        if (self.tool_call_id.len > 0) {
+            self.decision = .reject;
+        }
+    }
+
     pub fn deinit(self: *ApprovalWaiter) void {
         self.cancel();
         if (self.tool_call_id.len > 0) self.allocator.free(self.tool_call_id);
@@ -803,8 +813,8 @@ pub const App = struct {
     pub fn submit(self: *App, text: []const u8) !void {
         const trimmed = std.mem.trim(u8, text, " \t\r\n");
         if (trimmed.len == 0) return;
-        self.state.stream_aborted = false;
         if (trimmed[0] == '/') return try self.submitCommand(trimmed);
+        self.state.stream_aborted = false;
         try self.state.appendUserMessage(trimmed);
         if (self.session) |*session| {
             session.submitTurn(trimmed) catch |err| {
@@ -876,7 +886,7 @@ pub const App = struct {
         defer result.deinit(self.allocator);
 
         if (command.kind == .abort) {
-            if (self.approval_waiter) |waiter| waiter.cancel();
+            if (self.approval_waiter) |waiter| waiter.rejectPending();
         }
 
         switch (result.action) {
@@ -1401,10 +1411,13 @@ pub const TuiModel = struct {
                             app.state.appendTranscript(.@"error", @errorName(err)) catch {};
                         };
                         const text = app.state.composer.text();
+                        if (app.state.mode == .approval) {
+                            // Only /abort is allowed while a tool approval is pending.
+                            const command = tui_commands.parse(text) catch return .none;
+                            if (command.kind != .abort) return .none;
+                        }
                         app.state.recordComposerHistory(text) catch |err| app.recordError(@errorName(err)) catch {};
                         if (app.state.mode == .approval) {
-                            // Allow slash commands (e.g. /abort) while a tool approval is pending.
-                            if (!std.mem.startsWith(u8, text, "/")) return .none;
                             app.submit(text) catch |err| {
                                 if (err == error.QuitRequested) return .quit;
                                 app.state.status.setError(app.allocator, @errorName(err)) catch {};
@@ -2018,6 +2031,37 @@ test "App submit abort when streaming via runtime-only cancels and reports trans
     try std.testing.expectEqualStrings("Turn aborted.", app.state.transcript.items[0].text.items);
 }
 
+test "App submit does not clear stream_aborted for slash commands" {
+    var app = App.initWithoutRuntime(std.testing.allocator);
+    defer app.deinit();
+    app.state.stream_aborted = true;
+
+    try app.submit("/help");
+
+    try std.testing.expect(app.state.stream_aborted);
+    try std.testing.expect(app.state.transcript.items.len > 0);
+}
+
+test "App submit abort does not permanently shut down approval waiter" {
+    var app = App.initWithoutRuntime(std.testing.allocator);
+    defer app.deinit();
+    const waiter = try app.allocator.create(ApprovalWaiter);
+    waiter.* = .{ .allocator = app.allocator };
+    app.approval_waiter = waiter;
+    waiter.tool_call_id = try app.allocator.dupe(u8, "call-1");
+
+    try app.submit("/abort");
+
+    try std.testing.expect(!waiter.shutting_down);
+    try std.testing.expect(waiter.decision == .reject);
+
+    // Verify the waiter can still accept a future approval decision.
+    waiter.decision = null;
+    try app.state.approval.setPending(app.allocator, "call-1", "edit_file", "{}");
+    try app.decideApproval(true, false);
+    try std.testing.expect(waiter.decision == .approve);
+}
+
 test "App welcome uses session count" {
     var app = App.initWithoutRuntime(std.testing.allocator);
     defer app.deinit();
@@ -2352,6 +2396,26 @@ test "TuiModel allows /abort slash command during approval mode" {
     try std.testing.expectEqual(@as(usize, 1), model.app.?.state.transcript.items.len);
     try std.testing.expectEqual(tui_state.TranscriptKind.system, model.app.?.state.transcript.items[0].kind);
     try std.testing.expectEqualStrings("Turn aborted.", model.app.?.state.transcript.items[0].text.items);
+}
+
+test "TuiModel blocks non-abort slash commands during approval mode" {
+    var model = TuiModel{ .app = App.initWithoutRuntime(std.testing.allocator) };
+    defer model.deinit();
+    var mock = MockAppSession{};
+    defer mock.deinit();
+    model.app.?.session = mock.session();
+    model.app.?.state.status.streaming = true;
+    try model.app.?.state.approval.setPending(std.testing.allocator, "call-approval", "edit_file", "{\"path\":\"README.md\"}");
+    model.app.?.state.mode = .approval;
+
+    const keys = [_]u21{ '/', 'h', 'e', 'l', 'p' };
+    for (keys) |c| _ = model.update(.{ .key = .{ .key = .{ .char = c } } }, undefined);
+
+    const cmd = model.update(.{ .key = .{ .key = .enter } }, undefined);
+    try std.testing.expectEqual(zz.Cmd(TuiModel.Msg).none, cmd);
+    try std.testing.expectEqual(tui_state.AppMode.approval, model.app.?.state.mode);
+    try std.testing.expectEqual(@as(usize, 0), model.app.?.state.transcript.items.len);
+    try std.testing.expectEqualStrings("/help", model.app.?.state.composer.text());
 }
 
 test "TuiModel moves composer cursor and edits in place" {

--- a/zig/src/tui/app.zig
+++ b/zig/src/tui/app.zig
@@ -875,6 +875,10 @@ pub const App = struct {
         };
         defer result.deinit(self.allocator);
 
+        if (command.kind == .abort) {
+            if (self.approval_waiter) |waiter| waiter.cancel();
+        }
+
         switch (result.action) {
             .quit => return error.QuitRequested,
             .clear_transcript => self.state.clearTranscript(),
@@ -1301,18 +1305,24 @@ pub const TuiModel = struct {
                     return .none;
                 }
                 if (app.state.mode == .approval) {
-                    var decided = false;
-                    switch (key.key) {
-                        .char => |c| switch (c) {
-                            'y' => { app.decideApproval(true, false) catch |err| app.recordError(@errorName(err)) catch {}; decided = true; },
-                            'a' => { app.decideApproval(true, true) catch |err| app.recordError(@errorName(err)) catch {}; decided = true; },
-                            'n' => { app.decideApproval(false, false) catch |err| app.recordError(@errorName(err)) catch {}; decided = true; },
+                    const composer_empty = app.state.composer.buffer.items.len == 0;
+                    if (composer_empty) {
+                        var decided = false;
+                        switch (key.key) {
+                            .char => |c| switch (c) {
+                                'y' => { app.decideApproval(true, false) catch |err| app.recordError(@errorName(err)) catch {}; decided = true; },
+                                'a' => { app.decideApproval(true, true) catch |err| app.recordError(@errorName(err)) catch {}; decided = true; },
+                                'n' => { app.decideApproval(false, false) catch |err| app.recordError(@errorName(err)) catch {}; decided = true; },
+                                else => {},
+                            },
+                            .escape => { app.decideApproval(false, false) catch |err| app.recordError(@errorName(err)) catch {}; decided = true; },
                             else => {},
-                        },
-                        .escape => { app.decideApproval(false, false) catch |err| app.recordError(@errorName(err)) catch {}; decided = true; },
-                        else => {},
+                        }
+                        if (decided) return .none;
+                    } else if (key.key == .escape) {
+                        app.state.composer.clear();
+                        return .none;
                     }
-                    if (decided) return .none;
                 }
                 // Session picker navigation (T10).
                 if (app.state.mode == .session_picker) {
@@ -1990,6 +2000,24 @@ test "App submit abort when streaming cancels and reports transcript" {
     try std.testing.expectEqualStrings("Turn aborted.", app.state.transcript.items[0].text.items);
 }
 
+test "App submit abort when streaming via runtime-only cancels and reports transcript" {
+    var runtime = try initRemoteRuntimeForTest(std.testing.allocator);
+    var app = App.initWithoutRuntime(std.testing.allocator);
+    defer app.deinit();
+    app.runtime = runtime;
+    runtime = undefined;
+    app.runtime.?.stream_active = true;
+
+    try app.submit("/abort");
+
+    try std.testing.expect(app.runtime.?.cancelled.load(.acquire));
+    try std.testing.expect(!app.state.status.streaming);
+    try std.testing.expect(app.state.stream_aborted);
+    try std.testing.expectEqual(@as(usize, 1), app.state.transcript.items.len);
+    try std.testing.expectEqual(tui_state.TranscriptKind.system, app.state.transcript.items[0].kind);
+    try std.testing.expectEqualStrings("Turn aborted.", app.state.transcript.items[0].text.items);
+}
+
 test "App welcome uses session count" {
     var app = App.initWithoutRuntime(std.testing.allocator);
     defer app.deinit();
@@ -2312,7 +2340,9 @@ test "TuiModel allows /abort slash command during approval mode" {
     model.app.?.state.status.streaming = true;
     try model.app.?.state.approval.setPending(std.testing.allocator, "call-approval", "edit_file", "{\"path\":\"README.md\"}");
     model.app.?.state.mode = .approval;
-    try model.app.?.state.composer.buffer.appendSlice(std.testing.allocator, "/abort");
+
+    const keys = [_]u21{ '/', 'a', 'b', 'o', 'r', 't' };
+    for (keys) |c| _ = model.update(.{ .key = .{ .key = .{ .char = c } } }, undefined);
 
     const cmd = model.update(.{ .key = .{ .key = .enter } }, undefined);
     try std.testing.expectEqual(zz.Cmd(TuiModel.Msg).none, cmd);

--- a/zig/src/tui/app.zig
+++ b/zig/src/tui/app.zig
@@ -1955,6 +1955,32 @@ test "App submit routes unknown command to error transcript" {
     try std.testing.expect(std.mem.indexOf(u8, app.state.transcript.items[0].text.items, "unknown command") != null);
 }
 
+test "App submit abort when idle reports idle transcript" {
+    var app = App.initWithoutRuntime(std.testing.allocator);
+    defer app.deinit();
+    try app.submit("/abort");
+    try std.testing.expectEqual(@as(usize, 1), app.state.transcript.items.len);
+    try std.testing.expectEqual(tui_state.TranscriptKind.system, app.state.transcript.items[0].kind);
+    try std.testing.expectEqualStrings("Nothing to abort — agent is idle.", app.state.transcript.items[0].text.items);
+}
+
+test "App submit abort when streaming cancels and reports transcript" {
+    var app = App.initWithoutRuntime(std.testing.allocator);
+    defer app.deinit();
+    var mock = MockAppSession{};
+    defer mock.deinit();
+    app.session = mock.session();
+    app.state.status.streaming = true;
+
+    try app.submit("/abort");
+
+    try std.testing.expectEqual(@as(usize, 1), mock.cancel_count);
+    try std.testing.expect(!app.state.status.streaming);
+    try std.testing.expectEqual(@as(usize, 1), app.state.transcript.items.len);
+    try std.testing.expectEqual(tui_state.TranscriptKind.system, app.state.transcript.items[0].kind);
+    try std.testing.expectEqualStrings("Turn aborted.", app.state.transcript.items[0].text.items);
+}
+
 test "App welcome uses session count" {
     var app = App.initWithoutRuntime(std.testing.allocator);
     defer app.deinit();
@@ -1996,6 +2022,7 @@ const MockAppSession = struct {
     steer_count: usize = 0,
     queued_follow_up_count: usize = 0,
     submit_count: usize = 0,
+    cancel_count: usize = 0,
     clear_count: usize = 0,
     queued_counts: tui_runtime.QueuedCounts = .{},
     events: tui_runtime.TuiEventStream = undefined,
@@ -2035,7 +2062,8 @@ const MockAppSession = struct {
     }
 
     fn cancel(ctx: ?*anyopaque) void {
-        _ = ctx;
+        const self = ptr(ctx);
+        self.cancel_count += 1;
     }
 
     fn submitTurn(ctx: ?*anyopaque, text: []const u8) anyerror!void {

--- a/zig/src/tui/app.zig
+++ b/zig/src/tui/app.zig
@@ -803,6 +803,7 @@ pub const App = struct {
     pub fn submit(self: *App, text: []const u8) !void {
         const trimmed = std.mem.trim(u8, text, " \t\r\n");
         if (trimmed.len == 0) return;
+        self.state.stream_aborted = false;
         if (trimmed[0] == '/') return try self.submitCommand(trimmed);
         try self.state.appendUserMessage(trimmed);
         if (self.session) |*session| {
@@ -1300,17 +1301,18 @@ pub const TuiModel = struct {
                     return .none;
                 }
                 if (app.state.mode == .approval) {
+                    var decided = false;
                     switch (key.key) {
                         .char => |c| switch (c) {
-                            'y' => app.decideApproval(true, false) catch |err| app.recordError(@errorName(err)) catch {},
-                            'a' => app.decideApproval(true, true) catch |err| app.recordError(@errorName(err)) catch {},
-                            'n' => app.decideApproval(false, false) catch |err| app.recordError(@errorName(err)) catch {},
+                            'y' => { app.decideApproval(true, false) catch |err| app.recordError(@errorName(err)) catch {}; decided = true; },
+                            'a' => { app.decideApproval(true, true) catch |err| app.recordError(@errorName(err)) catch {}; decided = true; },
+                            'n' => { app.decideApproval(false, false) catch |err| app.recordError(@errorName(err)) catch {}; decided = true; },
                             else => {},
                         },
-                        .escape => app.decideApproval(false, false) catch |err| app.recordError(@errorName(err)) catch {},
+                        .escape => { app.decideApproval(false, false) catch |err| app.recordError(@errorName(err)) catch {}; decided = true; },
                         else => {},
                     }
-                    return .none;
+                    if (decided) return .none;
                 }
                 // Session picker navigation (T10).
                 if (app.state.mode == .session_picker) {
@@ -1388,10 +1390,17 @@ pub const TuiModel = struct {
                             app.state.status.setError(app.allocator, @errorName(err)) catch {};
                             app.state.appendTranscript(.@"error", @errorName(err)) catch {};
                         };
-                        if (app.state.mode == .approval) return .none;
                         const text = app.state.composer.text();
                         app.state.recordComposerHistory(text) catch |err| app.recordError(@errorName(err)) catch {};
-                        if (app.state.status.streaming and app.supportsStreamingShortcuts()) {
+                        if (app.state.mode == .approval) {
+                            // Allow slash commands (e.g. /abort) while a tool approval is pending.
+                            if (!std.mem.startsWith(u8, text, "/")) return .none;
+                            app.submit(text) catch |err| {
+                                if (err == error.QuitRequested) return .quit;
+                                app.state.status.setError(app.allocator, @errorName(err)) catch {};
+                                app.state.appendTranscript(.@"error", @errorName(err)) catch {};
+                            };
+                        } else if (app.state.status.streaming and app.supportsStreamingShortcuts()) {
                             if (key.modifiers.alt) {
                                 app.queueFollowUp(text) catch |err| {
                                     if (err == error.QuitRequested) return .quit;
@@ -2292,6 +2301,27 @@ test "TuiModel stops Enter routing when drained event enters approval mode" {
     try std.testing.expectEqual(@as(usize, 0), mock.steer_count);
     try std.testing.expectEqual(@as(usize, 0), mock.queued_follow_up_count);
     try std.testing.expectEqualStrings("should wait", model.app.?.state.composer.text());
+}
+
+test "TuiModel allows /abort slash command during approval mode" {
+    var model = TuiModel{ .app = App.initWithoutRuntime(std.testing.allocator) };
+    defer model.deinit();
+    var mock = MockAppSession{};
+    defer mock.deinit();
+    model.app.?.session = mock.session();
+    model.app.?.state.status.streaming = true;
+    try model.app.?.state.approval.setPending(std.testing.allocator, "call-approval", "edit_file", "{\"path\":\"README.md\"}");
+    model.app.?.state.mode = .approval;
+    try model.app.?.state.composer.buffer.appendSlice(std.testing.allocator, "/abort");
+
+    const cmd = model.update(.{ .key = .{ .key = .enter } }, undefined);
+    try std.testing.expectEqual(zz.Cmd(TuiModel.Msg).none, cmd);
+    try std.testing.expectEqual(tui_state.AppMode.normal, model.app.?.state.mode);
+    try std.testing.expectEqual(@as(usize, 1), mock.cancel_count);
+    try std.testing.expect(!model.app.?.state.status.streaming);
+    try std.testing.expectEqual(@as(usize, 1), model.app.?.state.transcript.items.len);
+    try std.testing.expectEqual(tui_state.TranscriptKind.system, model.app.?.state.transcript.items[0].kind);
+    try std.testing.expectEqualStrings("Turn aborted.", model.app.?.state.transcript.items[0].text.items);
 }
 
 test "TuiModel moves composer cursor and edits in place" {

--- a/zig/src/tui/commands.zig
+++ b/zig/src/tui/commands.zig
@@ -19,6 +19,7 @@ pub const CommandKind = enum {
     clear,
     copy,
     diff,
+    abort,
     quit,
 };
 
@@ -95,6 +96,7 @@ pub const commands = [_]CommandInfo{
     .{ .name = "clear", .kind = .clear, .usage = "/clear", .description = "Clear transcript display", .handler = handleClear },
     .{ .name = "copy", .kind = .copy, .usage = "/copy [all]", .description = "Copy last reply (or whole transcript) to clipboard", .handler = handleCopy },
     .{ .name = "diff", .kind = .diff, .usage = "/diff", .description = "Show pending file changes", .handler = handleDiff },
+    .{ .name = "abort", .kind = .abort, .usage = "/abort", .description = "Cancel the active streaming turn", .handler = handleAbort },
     .{ .name = "quit", .kind = .quit, .usage = "/quit", .description = "Exit TUI", .handler = handleQuit },
 };
 
@@ -412,6 +414,22 @@ fn handleDiff(ctx: CommandContext, command: Command) !CommandResult {
     return .{ .output = try out.toOwnedSlice() };
 }
 
+fn handleAbort(ctx: CommandContext, command: Command) !CommandResult {
+    _ = command;
+    if (ctx.state.status.streaming) {
+        if (ctx.session) |session| {
+            session.cancel();
+        } else if (ctx.runtime) |runtime| {
+            runtime.cancel();
+        } else {
+            return .{ .output = try ctx.allocator.dupe(u8, "Nothing to abort — agent is idle.") };
+        }
+        ctx.state.status.streaming = false;
+        return .{ .output = try ctx.allocator.dupe(u8, "Turn aborted.") };
+    }
+    return .{ .output = try ctx.allocator.dupe(u8, "Nothing to abort — agent is idle.") };
+}
+
 fn handleQuit(ctx: CommandContext, command: Command) !CommandResult {
     _ = ctx;
     _ = command;
@@ -428,6 +446,11 @@ test "parse model command with argument" {
     const command = try parse("/model gpt-4o");
     try std.testing.expectEqual(CommandKind.model, command.kind);
     try std.testing.expectEqualStrings("gpt-4o", command.arg.?);
+}
+
+test "parse abort command" {
+    const command = try parse("/abort");
+    try std.testing.expectEqual(CommandKind.abort, command.kind);
 }
 
 test "parse unknown command returns unknown message" {
@@ -455,7 +478,7 @@ test "dispatch reaches command handlers" {
     _ = try state.upsertToolForTest("t1", "file_write", "{}", .done);
 
     const ctx = CommandContext{ .allocator = std.testing.allocator, .state = &state };
-    const kinds = [_]CommandKind{ .help, .status, .sessions, .permissions, .think, .view, .clear, .diff, .quit };
+    const kinds = [_]CommandKind{ .help, .status, .sessions, .permissions, .think, .view, .clear, .diff, .abort, .quit };
     for (kinds) |kind| {
         var result = try dispatch(ctx, .{ .kind = kind });
         defer result.deinit(std.testing.allocator);
@@ -654,3 +677,129 @@ test "copy command selects last reply or whole transcript" {
     defer all.deinit(std.testing.allocator);
     try std.testing.expectEqual(CommandAction.copy_all, all.action);
 }
+
+test "abort when idle reports idle" {
+    var state = tui_state.AppState.init(std.testing.allocator);
+    defer state.deinit();
+
+    var result = try dispatch(.{ .allocator = std.testing.allocator, .state = &state }, .{ .kind = .abort });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqualStrings("Nothing to abort — agent is idle.", result.output);
+    try std.testing.expect(!state.status.streaming);
+}
+
+test "abort when streaming cancels session" {
+    var state = tui_state.AppState.init(std.testing.allocator);
+    defer state.deinit();
+    state.status.streaming = true;
+
+    var mock = MockAbortSession{};
+    defer mock.deinit();
+    var session = mock.session();
+
+    var result = try dispatch(.{ .allocator = std.testing.allocator, .state = &state, .session = &session }, .{ .kind = .abort });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqualStrings("Turn aborted.", result.output);
+    try std.testing.expect(!state.status.streaming);
+    try std.testing.expectEqual(@as(usize, 1), mock.cancel_count);
+}
+
+const MockAbortSession = struct {
+    cancel_count: usize = 0,
+    events: tui_runtime.TuiEventStream = undefined,
+    events_initialized: bool = false,
+
+    fn session(self: *MockAbortSession) tui_runtime.TuiSession {
+        return .{
+            .ctx = self,
+            .ops = .{
+                .start = mockStart,
+                .resume_session = mockResumeSession,
+                .cancel = mockCancel,
+                .submit_turn = mockSubmitTurn,
+                .steer = mockSteer,
+                .queue_follow_up = mockQueueFollowUp,
+                .clear_queued_messages = mockClearQueuedMessages,
+                .queued_counts = mockQueuedCounts,
+                .switch_model = mockSwitchModel,
+                .current_model = mockCurrentModel,
+                .decide_tool_approval = mockDecideToolApproval,
+                .stream_events = mockStreamEvents,
+            },
+        };
+    }
+
+    fn ptr(ctx: ?*anyopaque) *MockAbortSession {
+        return @ptrCast(@alignCast(ctx.?));
+    }
+
+    fn mockStart(ctx: ?*anyopaque) anyerror!void {
+        _ = ctx;
+    }
+
+    fn mockResumeSession(ctx: ?*anyopaque) anyerror!void {
+        _ = ctx;
+    }
+
+    fn mockCancel(ctx: ?*anyopaque) void {
+        ptr(ctx).cancel_count += 1;
+    }
+
+    fn mockSubmitTurn(ctx: ?*anyopaque, text: []const u8) anyerror!void {
+        _ = ctx;
+        _ = text;
+    }
+
+    fn mockSteer(ctx: ?*anyopaque, text: []const u8) anyerror!void {
+        _ = ctx;
+        _ = text;
+    }
+
+    fn mockQueueFollowUp(ctx: ?*anyopaque, text: []const u8) anyerror!void {
+        _ = ctx;
+        _ = text;
+    }
+
+    fn mockClearQueuedMessages(ctx: ?*anyopaque) void {
+        _ = ctx;
+    }
+
+    fn mockQueuedCounts(ctx: ?*anyopaque) tui_runtime.QueuedCounts {
+        _ = ctx;
+        return .{};
+    }
+
+    fn mockSwitchModel(ctx: ?*anyopaque, model_id: []const u8) anyerror!void {
+        _ = ctx;
+        _ = model_id;
+    }
+
+    fn mockCurrentModel(ctx: ?*anyopaque) ?ai_types.Model {
+        _ = ctx;
+        return null;
+    }
+
+    fn mockDecideToolApproval(ctx: ?*anyopaque, tool_call_id: []const u8, decision: tui_runtime.ToolApprovalDecision) anyerror!void {
+        _ = ctx;
+        _ = tool_call_id;
+        _ = decision;
+    }
+
+    fn eventStream(self: *MockAbortSession) *tui_runtime.TuiEventStream {
+        if (!self.events_initialized) {
+            self.events = tui_runtime.TuiEventStream.init(std.testing.allocator);
+            self.events_initialized = true;
+        }
+        return &self.events;
+    }
+
+    fn mockStreamEvents(ctx: ?*anyopaque) *tui_runtime.TuiEventStream {
+        return ptr(ctx).eventStream();
+    }
+
+    fn deinit(self: *MockAbortSession) void {
+        if (self.events_initialized) self.events.deinit();
+    }
+};

--- a/zig/src/tui/commands.zig
+++ b/zig/src/tui/commands.zig
@@ -751,6 +751,26 @@ test "abort during approval clears approval state" {
     try std.testing.expectEqual(@as(usize, 1), mock.cancel_count);
 }
 
+test "double abort is harmless after first cancellation" {
+    var state = tui_state.AppState.init(std.testing.allocator);
+    defer state.deinit();
+    state.status.streaming = true;
+
+    var mock = MockAbortSession{};
+    defer mock.deinit();
+    var session = mock.session();
+
+    var first = try dispatch(.{ .allocator = std.testing.allocator, .state = &state, .session = &session }, .{ .kind = .abort });
+    defer first.deinit(std.testing.allocator);
+    try std.testing.expectEqualStrings("Turn aborted.", first.output);
+    try std.testing.expectEqual(@as(usize, 1), mock.cancel_count);
+
+    var second = try dispatch(.{ .allocator = std.testing.allocator, .state = &state, .session = &session }, .{ .kind = .abort });
+    defer second.deinit(std.testing.allocator);
+    try std.testing.expectEqualStrings("Nothing to abort — agent is idle.", second.output);
+    try std.testing.expectEqual(@as(usize, 1), mock.cancel_count);
+}
+
 const MockAbortSession = struct {
     cancel_count: usize = 0,
     events: tui_runtime.TuiEventStream = undefined,

--- a/zig/src/tui/commands.zig
+++ b/zig/src/tui/commands.zig
@@ -416,7 +416,9 @@ fn handleDiff(ctx: CommandContext, command: Command) !CommandResult {
 
 fn handleAbort(ctx: CommandContext, command: Command) !CommandResult {
     _ = command;
-    if (ctx.state.status.streaming) {
+    const active = ctx.state.status.streaming or
+        (ctx.runtime != null and ctx.runtime.?.stream_active);
+    if (active) {
         if (ctx.session) |session| {
             session.cancel();
         } else if (ctx.runtime) |runtime| {
@@ -425,6 +427,11 @@ fn handleAbort(ctx: CommandContext, command: Command) !CommandResult {
             return .{ .output = try ctx.allocator.dupe(u8, "Nothing to abort — agent is idle.") };
         }
         ctx.state.status.streaming = false;
+        ctx.state.stream_aborted = true;
+        if (ctx.state.mode == .approval) {
+            ctx.state.approval.deinit(ctx.allocator);
+            ctx.state.mode = .normal;
+        }
         return .{ .output = try ctx.allocator.dupe(u8, "Turn aborted.") };
     }
     return .{ .output = try ctx.allocator.dupe(u8, "Nothing to abort — agent is idle.") };
@@ -703,6 +710,44 @@ test "abort when streaming cancels session" {
 
     try std.testing.expectEqualStrings("Turn aborted.", result.output);
     try std.testing.expect(!state.status.streaming);
+    try std.testing.expect(state.stream_aborted);
+    try std.testing.expectEqual(@as(usize, 1), mock.cancel_count);
+}
+
+test "abort cancels active turn before streaming status is set" {
+    var runtime = try tui_runtime.TuiRuntime.init(std.testing.allocator, .{ .backend = .local });
+    defer runtime.deinit();
+    runtime.stream_active = true;
+
+    var state = tui_state.AppState.init(std.testing.allocator);
+    defer state.deinit();
+
+    var result = try dispatch(.{ .allocator = std.testing.allocator, .state = &state, .runtime = &runtime }, .{ .kind = .abort });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqualStrings("Turn aborted.", result.output);
+    try std.testing.expect(!state.status.streaming);
+    try std.testing.expect(state.stream_aborted);
+    try std.testing.expect(runtime.cancelled.load(.acquire));
+}
+
+test "abort during approval clears approval state" {
+    var state = tui_state.AppState.init(std.testing.allocator);
+    defer state.deinit();
+    state.status.streaming = true;
+    state.mode = .approval;
+    try state.approval.setPending(std.testing.allocator, "call-1", "edit_file", "{\"path\":\"README.md\"}");
+
+    var mock = MockAbortSession{};
+    defer mock.deinit();
+    var session = mock.session();
+
+    var result = try dispatch(.{ .allocator = std.testing.allocator, .state = &state, .session = &session }, .{ .kind = .abort });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqualStrings("Turn aborted.", result.output);
+    try std.testing.expectEqual(tui_state.AppMode.normal, state.mode);
+    try std.testing.expectEqual(tui_state.ApprovalStatus.none, state.approval.status);
     try std.testing.expectEqual(@as(usize, 1), mock.cancel_count);
 }
 

--- a/zig/src/tui/state.zig
+++ b/zig/src/tui/state.zig
@@ -423,6 +423,10 @@ pub const AppState = struct {
     menu_scroll: usize = 0,
     active_assistant_entry: ?usize = null,
     active_tool_result_entry: ?usize = null,
+    /// Set when the user aborts the active turn. Lifecycle events from the
+    /// cancelled turn that are drained afterwards must not flip the status bar
+    /// back to streaming.
+    stream_aborted: bool = false,
 
     pub fn init(allocator: std.mem.Allocator) AppState {
         return .{ .allocator = allocator };
@@ -513,6 +517,7 @@ pub const AppState = struct {
         self.status.context_used = 0;
         self.status.turn_count = 0;
         self.status.streaming = false;
+        self.stream_aborted = false;
         if (self.status.last_error.len > 0) {
             self.allocator.free(self.status.last_error);
             self.status.last_error = &.{};
@@ -615,11 +620,11 @@ pub const AppState = struct {
         try self.appendProtocolEvent(event);
         switch (event) {
             .agent_start => {
-                self.status.streaming = true;
+                if (!self.stream_aborted) self.status.streaming = true;
                 try self.appendTranscript(.system, "agent started");
             },
             .turn_start => {
-                self.status.streaming = true;
+                if (!self.stream_aborted) self.status.streaming = true;
                 self.status.turn_count += 1;
                 self.cleanupActiveTranscriptEntries();
             },
@@ -675,10 +680,12 @@ pub const AppState = struct {
             .prompt_segment_usage => |payload| self.applyPromptSegmentUsage(payload),
             .turn_end => {
                 self.status.streaming = false;
+                self.stream_aborted = false;
                 self.cleanupActiveTranscriptEntries();
             },
             .agent_end => |payload| {
                 self.status.streaming = false;
+                self.stream_aborted = false;
                 self.cleanupActiveTranscriptEntries();
                 switch (payload.reason) {
                     .completed => {},
@@ -693,6 +700,7 @@ pub const AppState = struct {
             },
             .@"error" => |payload| {
                 self.cleanupActiveTranscriptEntries();
+                self.stream_aborted = false;
                 try self.status.setError(self.allocator, payload.message.slice());
                 try self.appendTranscript(.@"error", payload.message.slice());
             },
@@ -2079,4 +2087,20 @@ test "transcriptToText renders role-prefixed plain text" {
     const text = try state.transcriptToText(std.testing.allocator);
     defer std.testing.allocator.free(text);
     try std.testing.expectEqualStrings("> ping\npong\n[error] boom", text);
+}
+
+test "AppState stream_aborted ignores stale lifecycle events" {
+    var state = AppState.init(std.testing.allocator);
+    defer state.deinit();
+
+    state.stream_aborted = true;
+    try state.applyEvent(.agent_start);
+    try std.testing.expect(!state.status.streaming);
+
+    try state.applyEvent(.turn_start);
+    try std.testing.expect(!state.status.streaming);
+
+    try state.applyEvent(.{ .agent_end = .{ .reason = .cancelled } });
+    try std.testing.expect(!state.status.streaming);
+    try std.testing.expect(!state.stream_aborted);
 }

--- a/zig/src/tui/state.zig
+++ b/zig/src/tui/state.zig
@@ -618,13 +618,17 @@ pub const AppState = struct {
 
     pub fn applyEvent(self: *AppState, event: tui_runtime.TuiEvent) !void {
         try self.appendProtocolEvent(event);
+        if (self.stream_aborted) switch (event) {
+            .turn_end, .agent_end, .@"error" => {},
+            else => return,
+        };
         switch (event) {
             .agent_start => {
-                if (!self.stream_aborted) self.status.streaming = true;
+                self.status.streaming = true;
                 try self.appendTranscript(.system, "agent started");
             },
             .turn_start => {
-                if (!self.stream_aborted) self.status.streaming = true;
+                self.status.streaming = true;
                 self.status.turn_count += 1;
                 self.cleanupActiveTranscriptEntries();
             },


### PR DESCRIPTION
## Summary
Adds a `/abort` slash command to the TUI that cancels the active streaming turn.

- Registered `abort` in the slash-command parser/dispatcher (`zig/src/tui/commands.zig`).
- `handleAbort` cancels the current `TuiSession` (or `TuiRuntime` stream as a fallback) when `status.streaming` is true.
- Immediately clears `status.streaming` so the status bar updates from “streaming” to “idle”.
- Reports results in the transcript:
  - Idle: `Nothing to abort — agent is idle.`
  - Active: `Turn aborted.`
- Added unit tests for parsing, idle abort, active abort, and App-level transcript output.

Closes #125

## Test plan
- [x] `zig build test-unit-tui` passes
- [x] `zig build test` passes