### PR TITLE
Add SSE remote backend transport

### DIFF
--- a/zig/build.zig
+++ b/zig/build.zig
@@ -444,6 +444,7 @@ pub fn build(b: *std.Build) void {
             .{ .name = "transport", .module = transport_mod },
             .{ .name = "sse_parser", .module = sse_parser_mod },
             .{ .name = "ai_types", .module = ai_types_mod },
+            .{ .name = "compat", .module = compat_mod },
         },
     });
 
@@ -912,6 +913,7 @@ pub fn build(b: *std.Build) void {
             .{ .name = "transport", .module = transport_mod },
             .{ .name = "transports/in_process", .module = in_process_transport_mod },
             .{ .name = "transports/stdio", .module = stdio_transport_mod },
+            .{ .name = "transports/sse", .module = sse_transport_mod },
             .{ .name = "json_writer", .module = json_writer_mod },
             .{ .name = "model_ref", .module = protocol_model_ref_mod },
             .{ .name = "tui_session", .module = tui_session_mod },

--- a/zig/src/transports/sse.zig
+++ b/zig/src/transports/sse.zig
@@ -124,6 +124,7 @@ pub const ParsedHttpUrl = struct {
     host: []const u8,
     port: u16,
     path: []const u8,
+    explicit_port: bool = false,
 
     pub const Scheme = enum { http, https };
 };
@@ -142,16 +143,17 @@ pub fn parseHttpUrl(url: []const u8) !ParsedHttpUrl {
     }
 
     const host_start = offset;
-    var host_end = url.len;
-    if (std.mem.indexOfScalarPos(u8, url, offset, '/')) |slash| host_end = slash;
+    var authority_end = url.len;
+    if (std.mem.indexOfAnyPos(u8, url, offset, "/?")) |end| authority_end = end;
+    var host_end = authority_end;
     if (std.mem.indexOfScalarPos(u8, url, offset, ':')) |colon| {
-        if (colon < host_end) {
+        if (colon < authority_end) {
             host_end = colon;
-            const port_end = std.mem.indexOfScalarPos(u8, url, colon + 1, '/') orelse url.len;
-            result.port = try std.fmt.parseInt(u16, url[colon + 1 .. port_end], 10);
-            offset = port_end;
-        } else offset = host_end;
-    } else offset = host_end;
+            result.explicit_port = true;
+            result.port = try std.fmt.parseInt(u16, url[colon + 1 .. authority_end], 10);
+        }
+    }
+    offset = authority_end;
 
     if (host_end == host_start) return error.InvalidUrl;
     result.host = url[host_start..host_end];
@@ -197,7 +199,11 @@ pub const SseHttpClient = struct {
         errdefer stream.close();
         var request = std.ArrayList(u8).empty;
         defer request.deinit(self.allocator);
-        try request.print(self.allocator, "GET {s} HTTP/1.1\r\nHost: {s}\r\nAccept: text/event-stream\r\nCache-Control: no-cache\r\nConnection: close\r\n", .{ parsed.path, parsed.host });
+        const host_header = try formatHostHeader(self.allocator, parsed);
+        defer self.allocator.free(host_header);
+        const path = try formatPath(self.allocator, parsed.path);
+        defer self.allocator.free(path);
+        try request.print(self.allocator, "GET {s} HTTP/1.1\r\nHost: {s}\r\nAccept: text/event-stream\r\nCache-Control: no-cache\r\nConnection: close\r\n", .{ path, host_header });
         for (self.headers) |header| try request.print(self.allocator, "{s}: {s}\r\n", .{ header.name, header.value });
         try request.appendSlice(self.allocator, "\r\n");
         stream.writeAll(request.items) catch return error.ConnectionFailed;
@@ -315,7 +321,11 @@ pub const SseHttpClient = struct {
         defer stream.close();
         var request = std.ArrayList(u8).empty;
         defer request.deinit(self.allocator);
-        try request.print(self.allocator, "POST {s} HTTP/1.1\r\nHost: {s}\r\nContent-Type: application/json\r\nContent-Length: {d}\r\nConnection: close\r\n", .{ parsed.path, parsed.host, data.len });
+        const host_header = try formatHostHeader(self.allocator, parsed);
+        defer self.allocator.free(host_header);
+        const path = try formatPath(self.allocator, parsed.path);
+        defer self.allocator.free(path);
+        try request.print(self.allocator, "POST {s} HTTP/1.1\r\nHost: {s}\r\nContent-Type: application/json\r\nContent-Length: {d}\r\nConnection: close\r\n", .{ path, host_header, data.len });
         for (self.headers) |header| try request.print(self.allocator, "{s}: {s}\r\n", .{ header.name, header.value });
         try request.appendSlice(self.allocator, "\r\n");
         try request.appendSlice(self.allocator, data);
@@ -335,6 +345,16 @@ pub const SseHttpClient = struct {
         self.close();
     }
 };
+
+fn formatPath(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
+    if (path.len > 0 and path[0] == '?') return std.fmt.allocPrint(allocator, "/{s}", .{path});
+    return allocator.dupe(u8, path);
+}
+
+fn formatHostHeader(allocator: std.mem.Allocator, parsed: ParsedHttpUrl) ![]u8 {
+    if (!parsed.explicit_port) return allocator.dupe(u8, parsed.host);
+    return std.fmt.allocPrint(allocator, "{s}:{d}", .{ parsed.host, parsed.port });
+}
 
 const HttpProducer = struct {
     allocator: std.mem.Allocator,
@@ -752,6 +772,11 @@ test "parseHttpUrl validates HTTP SSE URLs" {
     try std.testing.expectEqualStrings("127.0.0.1", a.host);
     try std.testing.expectEqual(@as(u16, 8080), a.port);
     try std.testing.expectEqualStrings("/events", a.path);
+    try std.testing.expect(a.explicit_port);
+    const query_only = try parseHttpUrl("http://backend:8080?token=abc");
+    try std.testing.expectEqualStrings("backend", query_only.host);
+    try std.testing.expectEqual(@as(u16, 8080), query_only.port);
+    try std.testing.expectEqualStrings("?token=abc", query_only.path);
     const b = try parseHttpUrl("https://example.com/sse");
     try std.testing.expectEqual(ParsedHttpUrl.Scheme.https, b.scheme);
     try std.testing.expectEqual(@as(u16, 443), b.port);

--- a/zig/src/transports/sse.zig
+++ b/zig/src/transports/sse.zig
@@ -1,6 +1,8 @@
 const std = @import("std");
 const transport = @import("transport");
 const sse_parser = @import("sse_parser");
+const ai_types = @import("ai_types");
+const compat = @import("compat");
 
 fn defaultIo() std.Io {
     return if (@import("builtin").is_test)
@@ -114,6 +116,184 @@ pub const SseReceiver = struct {
     fn closeFn(ctx: *anyopaque) void {
         const self: *SseReceiver = @ptrCast(@alignCast(ctx));
         self.deinit();
+    }
+};
+
+pub const ParsedHttpUrl = struct {
+    scheme: Scheme,
+    host: []const u8,
+    port: u16,
+    path: []const u8,
+
+    pub const Scheme = enum { http, https };
+};
+
+pub fn parseHttpUrl(url: []const u8) !ParsedHttpUrl {
+    var result = ParsedHttpUrl{ .scheme = .http, .host = "", .port = 80, .path = "/" };
+    var offset: usize = 0;
+    if (std.mem.startsWith(u8, url, "http://")) {
+        offset = 7;
+    } else if (std.mem.startsWith(u8, url, "https://")) {
+        result.scheme = .https;
+        result.port = 443;
+        offset = 8;
+    } else {
+        return error.InvalidScheme;
+    }
+
+    const host_start = offset;
+    var host_end = url.len;
+    if (std.mem.indexOfScalarPos(u8, url, offset, '/')) |slash| host_end = slash;
+    if (std.mem.indexOfScalarPos(u8, url, offset, ':')) |colon| {
+        if (colon < host_end) {
+            host_end = colon;
+            const port_end = std.mem.indexOfScalarPos(u8, url, colon + 1, '/') orelse url.len;
+            result.port = try std.fmt.parseInt(u16, url[colon + 1 .. port_end], 10);
+            offset = port_end;
+        } else offset = host_end;
+    } else offset = host_end;
+
+    if (host_end == host_start) return error.InvalidUrl;
+    result.host = url[host_start..host_end];
+    if (offset < url.len) result.path = url[offset..];
+    return result;
+}
+
+pub const SseHttpClient = struct {
+    allocator: std.mem.Allocator,
+    endpoint: []u8 = &.{},
+    headers: []ai_types.HeaderPair = &.{},
+    stream: ?compat.net.Stream = null,
+    parser: sse_parser.SSEParser,
+    pending: std.ArrayList([]u8) = .empty,
+    pending_index: usize = 0,
+    read_buf: [4096]u8 = undefined,
+    transfer_buf: [4096]u8 = undefined,
+    connected: bool = false,
+
+    pub fn init(allocator: std.mem.Allocator) SseHttpClient {
+        return .{ .allocator = allocator, .parser = sse_parser.SSEParser.init(allocator) };
+    }
+
+    pub fn deinit(self: *SseHttpClient) void {
+        self.close();
+        for (self.headers) |*header| header.deinit(self.allocator);
+        if (self.headers.len > 0) self.allocator.free(self.headers);
+        if (self.endpoint.len > 0) self.allocator.free(self.endpoint);
+        self.pending.deinit(self.allocator);
+        self.parser.deinit();
+        self.* = undefined;
+    }
+
+    pub fn connect(self: *SseHttpClient, url: []const u8, headers: []const ai_types.HeaderPair) !void {
+        self.close();
+        const parsed = parseHttpUrl(url) catch return error.InvalidUrl;
+        if (parsed.scheme == .https) return error.TlsNotSupported;
+        if (self.endpoint.len > 0) self.allocator.free(self.endpoint);
+        self.endpoint = try self.allocator.dupe(u8, url);
+        try self.replaceHeaders(headers);
+        var stream = compat.net.tcpConnectHost(self.allocator, parsed.host, parsed.port) catch return error.ConnectionFailed;
+        errdefer stream.close();
+        var request = std.ArrayList(u8).empty;
+        defer request.deinit(self.allocator);
+        try request.print(self.allocator, "GET {s} HTTP/1.1\r\nHost: {s}\r\nAccept: text/event-stream\r\nCache-Control: no-cache\r\nConnection: close\r\n", .{ parsed.path, parsed.host });
+        for (self.headers) |header| try request.print(self.allocator, "{s}: {s}\r\n", .{ header.name, header.value });
+        try request.appendSlice(self.allocator, "\r\n");
+        stream.writeAll(request.items) catch return error.ConnectionFailed;
+        try self.readResponseHeaders(&stream);
+        self.stream = stream;
+        self.connected = true;
+    }
+
+    pub fn asyncSender(self: *SseHttpClient) transport.AsyncSender {
+        return .{ .context = @ptrCast(self), .write_fn = writeFn, .flush_fn = flushFn, .close_fn = closeFn };
+    }
+
+    pub fn readLine(self: *SseHttpClient, allocator: std.mem.Allocator) !?[]const u8 {
+        while (true) {
+            if (self.pending_index < self.pending.items.len) {
+                const data = self.pending.items[self.pending_index];
+                self.pending_index += 1;
+                if (allocator.ptr == self.allocator.ptr) return data;
+                defer self.allocator.free(data);
+                return try allocator.dupe(u8, data);
+            }
+            self.pending.clearRetainingCapacity();
+            self.pending_index = 0;
+            if (!self.connected) return null;
+            var stream = self.stream orelse return null;
+            const n = stream.read(&self.read_buf) catch return error.ConnectionFailed;
+            self.stream = stream;
+            if (n == 0) {
+                self.connected = false;
+                return null;
+            }
+            const events = try self.parser.feed(self.read_buf[0..n]);
+            for (events) |event| try self.pending.append(self.allocator, try self.allocator.dupe(u8, event.data));
+        }
+    }
+
+    pub fn close(self: *SseHttpClient) void {
+        if (self.stream) |*stream| stream.close();
+        self.stream = null;
+        for (self.pending.items[self.pending_index..]) |item| self.allocator.free(item);
+        self.pending.clearRetainingCapacity();
+        self.pending_index = 0;
+        self.connected = false;
+    }
+
+    fn replaceHeaders(self: *SseHttpClient, headers: []const ai_types.HeaderPair) !void {
+        for (self.headers) |*header| header.deinit(self.allocator);
+        if (self.headers.len > 0) self.allocator.free(self.headers);
+        self.headers = try self.allocator.alloc(ai_types.HeaderPair, headers.len);
+        for (headers, 0..) |header, i| self.headers[i] = .{ .name = try self.allocator.dupe(u8, header.name), .value = try self.allocator.dupe(u8, header.value) };
+    }
+
+    fn readResponseHeaders(self: *SseHttpClient, stream: *compat.net.Stream) !void {
+        var buffer = std.ArrayList(u8).empty;
+        defer buffer.deinit(self.allocator);
+        var tmp: [512]u8 = undefined;
+        while (std.mem.indexOf(u8, buffer.items, "\r\n\r\n") == null) {
+            const n = stream.read(&tmp) catch return error.ConnectionFailed;
+            if (n == 0) return error.ConnectionFailed;
+            try buffer.appendSlice(self.allocator, tmp[0..n]);
+            if (buffer.items.len > 16 * 1024) return error.UnexpectedStatus;
+        }
+        if (!std.mem.startsWith(u8, buffer.items, "HTTP/1.1 2") and !std.mem.startsWith(u8, buffer.items, "HTTP/1.0 2")) return error.UnexpectedStatus;
+        if (std.mem.indexOf(u8, buffer.items, "\r\n\r\n")) |headers_end| {
+            const body_start = headers_end + 4;
+            if (body_start < buffer.items.len) {
+                const events = try self.parser.feed(buffer.items[body_start..]);
+                for (events) |event| try self.pending.append(self.allocator, try self.allocator.dupe(u8, event.data));
+            }
+        }
+    }
+
+    fn post(self: *SseHttpClient, data: []const u8) !void {
+        if (self.endpoint.len == 0) return error.NotConnected;
+        const parsed = parseHttpUrl(self.endpoint) catch return error.InvalidUrl;
+        var stream = compat.net.tcpConnectHost(self.allocator, parsed.host, parsed.port) catch return error.ConnectionFailed;
+        defer stream.close();
+        var request = std.ArrayList(u8).empty;
+        defer request.deinit(self.allocator);
+        try request.print(self.allocator, "POST {s} HTTP/1.1\r\nHost: {s}\r\nContent-Type: application/json\r\nContent-Length: {d}\r\nConnection: close\r\n", .{ parsed.path, parsed.host, data.len });
+        for (self.headers) |header| try request.print(self.allocator, "{s}: {s}\r\n", .{ header.name, header.value });
+        try request.appendSlice(self.allocator, "\r\n");
+        try request.appendSlice(self.allocator, data);
+        stream.writeAll(request.items) catch return error.ConnectionFailed;
+        self.readResponseHeaders(&stream) catch return error.HttpPostFailed;
+    }
+
+    fn writeFn(ctx: *anyopaque, data: []const u8) !void {
+        const self: *SseHttpClient = @ptrCast(@alignCast(ctx));
+        try self.post(data);
+    }
+
+    fn flushFn(_: *anyopaque) !void {}
+
+    fn closeFn(ctx: *anyopaque) void {
+        const self: *SseHttpClient = @ptrCast(@alignCast(ctx));
+        self.close();
     }
 };
 
@@ -353,6 +533,93 @@ pub const AsyncSseReceiver = struct {
 
 // Tests
 
+const MockHttpSseServer = struct {
+    server: compat.net.Server,
+    thread: ?std.Thread = null,
+    saw_get_auth: bool = false,
+    saw_post_auth: bool = false,
+    saw_post_body: bool = false,
+
+    fn start(self: *MockHttpSseServer) !void {
+        self.thread = try std.Thread.spawn(.{}, serve, .{self});
+    }
+
+    fn stop(self: *MockHttpSseServer) void {
+        if (self.thread) |thread| thread.join();
+        compat.net.closeServer(&self.server);
+    }
+
+    fn serve(self: *MockHttpSseServer) void {
+        handleGet(self) catch return;
+        handlePost(self) catch return;
+    }
+
+    fn readRequest(allocator: std.mem.Allocator, stream: *compat.net.Stream) ![]u8 {
+        var buf = std.ArrayList(u8).empty;
+        errdefer buf.deinit(allocator);
+        var tmp: [512]u8 = undefined;
+        while (true) {
+            const n = try stream.read(&tmp);
+            if (n == 0) break;
+            try buf.appendSlice(allocator, tmp[0..n]);
+            if (std.mem.indexOf(u8, buf.items, "\r\n\r\n")) |headers_end| {
+                const content_length = parseContentLength(buf.items[0..headers_end]) orelse 0;
+                const total = headers_end + 4 + content_length;
+                while (buf.items.len < total) {
+                    const more = try stream.read(&tmp);
+                    if (more == 0) break;
+                    try buf.appendSlice(allocator, tmp[0..more]);
+                }
+                break;
+            }
+        }
+        return buf.toOwnedSlice(allocator);
+    }
+
+    fn parseContentLength(request: []const u8) ?usize {
+        var lines = std.mem.splitSequence(u8, request, "\r\n");
+        while (lines.next()) |line| {
+            if (std.ascii.startsWithIgnoreCase(line, "Content-Length:")) {
+                return std.fmt.parseInt(usize, std.mem.trim(u8, line[15..], " \t"), 10) catch null;
+            }
+        }
+        return null;
+    }
+
+    fn handleGet(self: *MockHttpSseServer) !void {
+        var conn = try compat.net.accept(&self.server);
+        defer conn.stream.close();
+        const req = try readRequest(std.testing.allocator, &conn.stream);
+        defer std.testing.allocator.free(req);
+        self.saw_get_auth = std.mem.indexOf(u8, req, "Authorization: Bearer test-token") != null;
+        try conn.stream.writeAll("HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nConnection: close\r\n\r\ndata: {\"type\":\"agent_started\"}\n\n");
+    }
+
+    fn handlePost(self: *MockHttpSseServer) !void {
+        var conn = try compat.net.accept(&self.server);
+        defer conn.stream.close();
+        const req = try readRequest(std.testing.allocator, &conn.stream);
+        defer std.testing.allocator.free(req);
+        self.saw_post_auth = std.mem.indexOf(u8, req, "Authorization: Bearer test-token") != null;
+        self.saw_post_body = std.mem.indexOf(u8, req, "{\"hello\":true}") != null;
+        try conn.stream.writeAll("HTTP/1.1 204 No Content\r\nContent-Length: 0\r\nConnection: close\r\n\r\n");
+    }
+};
+
+test "parseHttpUrl validates HTTP SSE URLs" {
+    const a = try parseHttpUrl("http://127.0.0.1:8080/events");
+    try std.testing.expectEqual(ParsedHttpUrl.Scheme.http, a.scheme);
+    try std.testing.expectEqualStrings("127.0.0.1", a.host);
+    try std.testing.expectEqual(@as(u16, 8080), a.port);
+    try std.testing.expectEqualStrings("/events", a.path);
+    const b = try parseHttpUrl("https://example.com/sse");
+    try std.testing.expectEqual(ParsedHttpUrl.Scheme.https, b.scheme);
+    try std.testing.expectEqual(@as(u16, 443), b.port);
+    try std.testing.expectError(error.InvalidUrl, parseHttpUrl("http:///bad"));
+    try std.testing.expectError(error.InvalidScheme, parseHttpUrl("ws://example.com"));
+}
+
+
 test "SseSender writes SSE format" {
     // Create a pipe
     const pipe = try std.Io.Threaded.pipe2(.{});
@@ -420,7 +687,6 @@ test "SseSender and SseReceiver round-trip with transport" {
     var sse_sender = SseSender.init(write_file);
     var s = sse_sender.sender();
 
-    const ai_types = @import("ai_types");
     const empty_partial = ai_types.AssistantMessage{
         .content = &.{},
         .api = "",

--- a/zig/src/transports/sse.zig
+++ b/zig/src/transports/sse.zig
@@ -207,7 +207,8 @@ pub const SseHttpClient = struct {
         for (self.headers) |header| try request.print(self.allocator, "{s}: {s}\r\n", .{ header.name, header.value });
         try request.appendSlice(self.allocator, "\r\n");
         stream.writeAll(request.items) catch return error.ConnectionFailed;
-        const header_info = try self.readResponseHeaders(&stream, true);
+        var header_info = try self.readResponseHeaders(&stream, true);
+        defer header_info.deinit(self.allocator);
         self.chunked = header_info.chunked;
         const byte_stream = try self.allocator.create(transport.ByteStream);
         errdefer self.allocator.destroy(byte_stream);
@@ -215,7 +216,8 @@ pub const SseHttpClient = struct {
         errdefer byte_stream.deinit();
         const producer = try self.allocator.create(HttpProducer);
         errdefer self.allocator.destroy(producer);
-        producer.* = .{ .allocator = self.allocator, .stream = stream, .out = byte_stream, .chunked = header_info.chunked };
+        producer.* = .{ .allocator = self.allocator, .stream = stream, .out = byte_stream, .chunked = header_info.chunked, .prefix = header_info.body_prefix };
+        header_info.body_prefix = &.{};
         const thread = try std.Thread.spawn(.{}, httpProducerThread, .{producer});
         self.producer = producer;
         self.byte_stream = byte_stream;
@@ -261,6 +263,10 @@ pub const SseHttpClient = struct {
         }
         if (self.thread) |thread| thread.join();
         self.thread = null;
+        if (self.producer) |producer| {
+            producer.deinit();
+            self.allocator.destroy(producer);
+        }
         self.producer = null;
         if (self.byte_stream) |byte_stream| {
             byte_stream.deinit();
@@ -272,6 +278,8 @@ pub const SseHttpClient = struct {
         self.pending_index = 0;
         self.connected = false;
         self.chunked = false;
+        self.parser.deinit();
+        self.parser = sse_parser.SSEParser.init(self.allocator);
     }
 
     fn replaceHeaders(self: *SseHttpClient, headers: []const ai_types.HeaderPair) !void {
@@ -281,7 +289,15 @@ pub const SseHttpClient = struct {
         for (headers, 0..) |header, i| self.headers[i] = .{ .name = try self.allocator.dupe(u8, header.name), .value = try self.allocator.dupe(u8, header.value) };
     }
 
-    const HeaderInfo = struct { chunked: bool = false };
+    const HeaderInfo = struct {
+        chunked: bool = false,
+        body_prefix: []u8 = &.{},
+
+        fn deinit(self: *HeaderInfo, allocator: std.mem.Allocator) void {
+            if (self.body_prefix.len > 0) allocator.free(self.body_prefix);
+            self.* = .{};
+        }
+    };
 
     fn readResponseHeaders(self: *SseHttpClient, stream: *compat.net.Stream, feed_body: bool) !HeaderInfo {
         var buffer = std.ArrayList(u8).empty;
@@ -296,16 +312,14 @@ pub const SseHttpClient = struct {
         if (!std.mem.startsWith(u8, buffer.items, "HTTP/1.1 2") and !std.mem.startsWith(u8, buffer.items, "HTTP/1.0 2")) return error.UnexpectedStatus;
         const headers_end = std.mem.indexOf(u8, buffer.items, "\r\n\r\n") orelse return error.UnexpectedStatus;
         const headers = buffer.items[0..headers_end];
-        const info = HeaderInfo{ .chunked = hasHeaderValue(headers, "Transfer-Encoding", "chunked") };
+        var info = HeaderInfo{ .chunked = hasHeaderValue(headers, "Transfer-Encoding", "chunked") };
+        errdefer info.deinit(self.allocator);
         if (!feed_body) return info;
         const body_start = headers_end + 4;
         if (body_start < buffer.items.len) {
             const body = buffer.items[body_start..];
             if (info.chunked) {
-                const dechunked = try dechunkHttpBody(self.allocator, body);
-                defer self.allocator.free(dechunked);
-                const events = try self.parser.feed(dechunked);
-                for (events) |event| try self.pending.append(self.allocator, try self.allocator.dupe(u8, event.data));
+                info.body_prefix = try self.allocator.dupe(u8, body);
             } else {
                 const events = try self.parser.feed(body);
                 for (events) |event| try self.pending.append(self.allocator, try self.allocator.dupe(u8, event.data));
@@ -361,15 +375,19 @@ const HttpProducer = struct {
     stream: compat.net.Stream,
     out: *transport.ByteStream,
     chunked: bool,
+    prefix: []u8 = &.{},
     cancel: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+
+    fn deinit(self: *HttpProducer) void {
+        if (self.prefix.len > 0) self.allocator.free(self.prefix);
+        self.* = undefined;
+    }
 };
 
 fn httpProducerThread(ctx: *HttpProducer) void {
-    const allocator = ctx.allocator;
     defer {
         ctx.stream.close();
         ctx.out.markThreadDone();
-        allocator.destroy(ctx);
     }
     if (ctx.chunked) {
         readChunkedBody(ctx) catch |err| ctx.out.completeWithError(@errorName(err));
@@ -379,6 +397,11 @@ fn httpProducerThread(ctx: *HttpProducer) void {
 }
 
 fn readPlainBody(ctx: *HttpProducer) !void {
+    if (ctx.prefix.len > 0) {
+        try ctx.out.push(.{ .data = try ctx.allocator.dupe(u8, ctx.prefix), .owned = true });
+        ctx.allocator.free(ctx.prefix);
+        ctx.prefix = &.{};
+    }
     var buf: [4096]u8 = undefined;
     while (!ctx.cancel.load(.acquire)) {
         const n = try ctx.stream.read(&buf);
@@ -396,6 +419,15 @@ fn readPlainBody(ctx: *HttpProducer) !void {
 fn readChunkedBody(ctx: *HttpProducer) !void {
     var raw = std.ArrayList(u8).empty;
     defer raw.deinit(ctx.allocator);
+    if (ctx.prefix.len > 0) {
+        try raw.appendSlice(ctx.allocator, ctx.prefix);
+        ctx.allocator.free(ctx.prefix);
+        ctx.prefix = &.{};
+        while (try popHttpChunk(ctx.allocator, &raw)) |chunk| {
+            errdefer ctx.allocator.free(chunk);
+            try ctx.out.push(.{ .data = chunk, .owned = true });
+        }
+    }
     var buf: [4096]u8 = undefined;
     while (!ctx.cancel.load(.acquire)) {
         const n = try ctx.stream.read(&buf);

--- a/zig/src/transports/sse.zig
+++ b/zig/src/transports/sse.zig
@@ -163,13 +163,14 @@ pub const SseHttpClient = struct {
     allocator: std.mem.Allocator,
     endpoint: []u8 = &.{},
     headers: []ai_types.HeaderPair = &.{},
-    stream: ?compat.net.Stream = null,
+    producer: ?*HttpProducer = null,
+    byte_stream: ?*transport.ByteStream = null,
+    thread: ?std.Thread = null,
     parser: sse_parser.SSEParser,
     pending: std.ArrayList([]u8) = .empty,
     pending_index: usize = 0,
-    read_buf: [4096]u8 = undefined,
-    transfer_buf: [4096]u8 = undefined,
     connected: bool = false,
+    chunked: bool = false,
 
     pub fn init(allocator: std.mem.Allocator) SseHttpClient {
         return .{ .allocator = allocator, .parser = sse_parser.SSEParser.init(allocator) };
@@ -200,8 +201,19 @@ pub const SseHttpClient = struct {
         for (self.headers) |header| try request.print(self.allocator, "{s}: {s}\r\n", .{ header.name, header.value });
         try request.appendSlice(self.allocator, "\r\n");
         stream.writeAll(request.items) catch return error.ConnectionFailed;
-        try self.readResponseHeaders(&stream);
-        self.stream = stream;
+        const header_info = try self.readResponseHeaders(&stream, true);
+        self.chunked = header_info.chunked;
+        const byte_stream = try self.allocator.create(transport.ByteStream);
+        errdefer self.allocator.destroy(byte_stream);
+        byte_stream.* = transport.ByteStream.init(self.allocator);
+        errdefer byte_stream.deinit();
+        const producer = try self.allocator.create(HttpProducer);
+        errdefer self.allocator.destroy(producer);
+        producer.* = .{ .allocator = self.allocator, .stream = stream, .out = byte_stream, .chunked = header_info.chunked };
+        const thread = try std.Thread.spawn(.{}, httpProducerThread, .{producer});
+        self.producer = producer;
+        self.byte_stream = byte_stream;
+        self.thread = thread;
         self.connected = true;
     }
 
@@ -220,26 +232,40 @@ pub const SseHttpClient = struct {
             }
             self.pending.clearRetainingCapacity();
             self.pending_index = 0;
-            if (!self.connected) return null;
-            var stream = self.stream orelse return null;
-            const n = stream.read(&self.read_buf) catch return error.ConnectionFailed;
-            self.stream = stream;
-            if (n == 0) {
+            const byte_stream = self.byte_stream orelse return null;
+            if (byte_stream.poll()) |chunk| {
+                var mutable = chunk;
+                defer mutable.deinit(byte_stream.allocator);
+                const events = try self.parser.feed(chunk.data);
+                for (events) |event| try self.pending.append(self.allocator, try self.allocator.dupe(u8, event.data));
+                continue;
+            }
+            if (byte_stream.isDone()) {
                 self.connected = false;
                 return null;
             }
-            const events = try self.parser.feed(self.read_buf[0..n]);
-            for (events) |event| try self.pending.append(self.allocator, try self.allocator.dupe(u8, event.data));
+            return null;
         }
     }
 
     pub fn close(self: *SseHttpClient) void {
-        if (self.stream) |*stream| stream.close();
-        self.stream = null;
+        if (self.producer) |producer| {
+            producer.cancel.store(true, .release);
+            producer.stream.close();
+        }
+        if (self.thread) |thread| thread.join();
+        self.thread = null;
+        self.producer = null;
+        if (self.byte_stream) |byte_stream| {
+            byte_stream.deinit();
+            self.allocator.destroy(byte_stream);
+        }
+        self.byte_stream = null;
         for (self.pending.items[self.pending_index..]) |item| self.allocator.free(item);
         self.pending.clearRetainingCapacity();
         self.pending_index = 0;
         self.connected = false;
+        self.chunked = false;
     }
 
     fn replaceHeaders(self: *SseHttpClient, headers: []const ai_types.HeaderPair) !void {
@@ -249,7 +275,9 @@ pub const SseHttpClient = struct {
         for (headers, 0..) |header, i| self.headers[i] = .{ .name = try self.allocator.dupe(u8, header.name), .value = try self.allocator.dupe(u8, header.value) };
     }
 
-    fn readResponseHeaders(self: *SseHttpClient, stream: *compat.net.Stream) !void {
+    const HeaderInfo = struct { chunked: bool = false };
+
+    fn readResponseHeaders(self: *SseHttpClient, stream: *compat.net.Stream, feed_body: bool) !HeaderInfo {
         var buffer = std.ArrayList(u8).empty;
         defer buffer.deinit(self.allocator);
         var tmp: [512]u8 = undefined;
@@ -260,13 +288,24 @@ pub const SseHttpClient = struct {
             if (buffer.items.len > 16 * 1024) return error.UnexpectedStatus;
         }
         if (!std.mem.startsWith(u8, buffer.items, "HTTP/1.1 2") and !std.mem.startsWith(u8, buffer.items, "HTTP/1.0 2")) return error.UnexpectedStatus;
-        if (std.mem.indexOf(u8, buffer.items, "\r\n\r\n")) |headers_end| {
-            const body_start = headers_end + 4;
-            if (body_start < buffer.items.len) {
-                const events = try self.parser.feed(buffer.items[body_start..]);
+        const headers_end = std.mem.indexOf(u8, buffer.items, "\r\n\r\n") orelse return error.UnexpectedStatus;
+        const headers = buffer.items[0..headers_end];
+        const info = HeaderInfo{ .chunked = hasHeaderValue(headers, "Transfer-Encoding", "chunked") };
+        if (!feed_body) return info;
+        const body_start = headers_end + 4;
+        if (body_start < buffer.items.len) {
+            const body = buffer.items[body_start..];
+            if (info.chunked) {
+                const dechunked = try dechunkHttpBody(self.allocator, body);
+                defer self.allocator.free(dechunked);
+                const events = try self.parser.feed(dechunked);
+                for (events) |event| try self.pending.append(self.allocator, try self.allocator.dupe(u8, event.data));
+            } else {
+                const events = try self.parser.feed(body);
                 for (events) |event| try self.pending.append(self.allocator, try self.allocator.dupe(u8, event.data));
             }
         }
+        return info;
     }
 
     fn post(self: *SseHttpClient, data: []const u8) !void {
@@ -281,7 +320,7 @@ pub const SseHttpClient = struct {
         try request.appendSlice(self.allocator, "\r\n");
         try request.appendSlice(self.allocator, data);
         stream.writeAll(request.items) catch return error.ConnectionFailed;
-        self.readResponseHeaders(&stream) catch return error.HttpPostFailed;
+        _ = self.readResponseHeaders(&stream, false) catch return error.HttpPostFailed;
     }
 
     fn writeFn(ctx: *anyopaque, data: []const u8) !void {
@@ -296,6 +335,107 @@ pub const SseHttpClient = struct {
         self.close();
     }
 };
+
+const HttpProducer = struct {
+    allocator: std.mem.Allocator,
+    stream: compat.net.Stream,
+    out: *transport.ByteStream,
+    chunked: bool,
+    cancel: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+};
+
+fn httpProducerThread(ctx: *HttpProducer) void {
+    const allocator = ctx.allocator;
+    defer {
+        ctx.stream.close();
+        ctx.out.markThreadDone();
+        allocator.destroy(ctx);
+    }
+    if (ctx.chunked) {
+        readChunkedBody(ctx) catch |err| ctx.out.completeWithError(@errorName(err));
+    } else {
+        readPlainBody(ctx) catch |err| ctx.out.completeWithError(@errorName(err));
+    }
+}
+
+fn readPlainBody(ctx: *HttpProducer) !void {
+    var buf: [4096]u8 = undefined;
+    while (!ctx.cancel.load(.acquire)) {
+        const n = try ctx.stream.read(&buf);
+        if (n == 0) {
+            ctx.out.complete({});
+            return;
+        }
+        const data = try ctx.allocator.dupe(u8, buf[0..n]);
+        errdefer ctx.allocator.free(data);
+        try ctx.out.push(.{ .data = data, .owned = true });
+    }
+    ctx.out.completeWithError("Cancelled");
+}
+
+fn readChunkedBody(ctx: *HttpProducer) !void {
+    var raw = std.ArrayList(u8).empty;
+    defer raw.deinit(ctx.allocator);
+    var buf: [4096]u8 = undefined;
+    while (!ctx.cancel.load(.acquire)) {
+        const n = try ctx.stream.read(&buf);
+        if (n == 0) {
+            ctx.out.complete({});
+            return;
+        }
+        try raw.appendSlice(ctx.allocator, buf[0..n]);
+        while (try popHttpChunk(ctx.allocator, &raw)) |chunk| {
+            errdefer ctx.allocator.free(chunk);
+            try ctx.out.push(.{ .data = chunk, .owned = true });
+        }
+    }
+    ctx.out.completeWithError("Cancelled");
+}
+
+fn popHttpChunk(allocator: std.mem.Allocator, raw: *std.ArrayList(u8)) !?[]u8 {
+    const line_end = std.mem.indexOf(u8, raw.items, "\r\n") orelse return null;
+    const size_text = raw.items[0..line_end];
+    const semi = std.mem.indexOfScalar(u8, size_text, ';') orelse size_text.len;
+    const size = try std.fmt.parseInt(usize, std.mem.trim(u8, size_text[0..semi], " \t"), 16);
+    const data_start = line_end + 2;
+    const total = data_start + size + 2;
+    if (raw.items.len < total) return null;
+    if (size == 0) {
+        raw.clearRetainingCapacity();
+        return null;
+    }
+    const out = try allocator.dupe(u8, raw.items[data_start..][0..size]);
+    const remaining = raw.items[total..];
+    std.mem.copyForwards(u8, raw.items[0..remaining.len], remaining);
+    raw.shrinkRetainingCapacity(remaining.len);
+    return out;
+}
+
+fn dechunkHttpBody(allocator: std.mem.Allocator, body: []const u8) ![]u8 {
+    var raw = std.ArrayList(u8).empty;
+    defer raw.deinit(allocator);
+    try raw.appendSlice(allocator, body);
+    var out = std.ArrayList(u8).empty;
+    errdefer out.deinit(allocator);
+    while (try popHttpChunk(allocator, &raw)) |chunk| {
+        defer allocator.free(chunk);
+        try out.appendSlice(allocator, chunk);
+    }
+    return out.toOwnedSlice(allocator);
+}
+
+fn hasHeaderValue(headers: []const u8, name: []const u8, value: []const u8) bool {
+    var lines = std.mem.splitSequence(u8, headers, "\r\n");
+    _ = lines.next();
+    while (lines.next()) |line| {
+        const colon = std.mem.indexOfScalar(u8, line, ':') orelse continue;
+        const header_name = std.mem.trim(u8, line[0..colon], " \t");
+        if (!std.ascii.eqlIgnoreCase(header_name, name)) continue;
+        const header_value = std.mem.trim(u8, line[colon + 1 ..], " \t");
+        if (std.ascii.indexOfIgnoreCase(header_value, value) != null) return true;
+    }
+    return false;
+}
 
 // --- Async implementations ---
 
@@ -619,6 +759,12 @@ test "parseHttpUrl validates HTTP SSE URLs" {
     try std.testing.expectError(error.InvalidScheme, parseHttpUrl("ws://example.com"));
 }
 
+test "SseHttpClient dechunks HTTP body before SSE parsing" {
+    const chunked = "7\r\ndata: {\r\nC\r\n\"ok\":true}\n\n\r\n0\r\n\r\n";
+    const body = try dechunkHttpBody(std.testing.allocator, chunked);
+    defer std.testing.allocator.free(body);
+    try std.testing.expectEqualStrings("data: {\"ok\":true}\n\n", body);
+}
 
 test "SseSender writes SSE format" {
     // Create a pipe

--- a/zig/src/tui/runtime.zig
+++ b/zig/src/tui/runtime.zig
@@ -12,6 +12,7 @@ const agent_protocol_runtime = @import("agent_protocol_runtime");
 const transport = @import("transport");
 const in_process = @import("transports/in_process");
 const stdio_transport = @import("transports/stdio");
+const sse_transport = @import("transports/sse");
 const json_writer = @import("json_writer");
 const model_ref = @import("model_ref");
 const session = @import("tui_session");
@@ -100,6 +101,7 @@ pub const TuiRemoteConfig = struct {
     mode: TuiBackendMode = .local,
     transport: TuiRemoteTransport = .stdio,
     endpoint: []const u8 = "",
+    auth_headers: []const ai_types.HeaderPair = &.{},
 };
 
 pub const TuiRuntimeOptions = struct {
@@ -167,6 +169,7 @@ pub const TuiRuntime = struct {
     remote_config_sender: ?*stdio_transport.AsyncStdioSender = null,
     remote_config_receiver: ?*stdio_transport.AsyncStdioReceiver = null,
     remote_config_stream_handle: ?*stdio_transport.AsyncStreamHandle = null,
+    remote_config_sse_client: ?*sse_transport.SseHttpClient = null,
     remote_sender: ?transport.AsyncSender = null,
     remote_receiver: ?RemoteLineReceiver = null,
     remote_session_id: ?agent_protocol_types.SessionId = null,
@@ -243,6 +246,7 @@ pub const TuiRuntime = struct {
         var remote_config_sender: ?*stdio_transport.AsyncStdioSender = null;
         var remote_config_receiver: ?*stdio_transport.AsyncStdioReceiver = null;
         var remote_config_stream_handle: ?*stdio_transport.AsyncStreamHandle = null;
+        var remote_config_sse_client: ?*sse_transport.SseHttpClient = null;
         var remote_sender = options.remote_sender;
         var remote_receiver = options.remote_receiver;
         errdefer if (remote_config_stream_handle) |handle| {
@@ -251,6 +255,10 @@ pub const TuiRuntime = struct {
         };
         errdefer if (remote_config_sender) |sender| allocator.destroy(sender);
         errdefer if (remote_config_receiver) |receiver| allocator.destroy(receiver);
+        errdefer if (remote_config_sse_client) |client| {
+            client.deinit();
+            allocator.destroy(client);
+        };
         if (resolved_backend == .remote and remote_sender == null and remote_receiver == null and options.remote_config.mode == .remote) {
             switch (options.remote_config.transport) {
                 .stdio => {
@@ -283,7 +291,16 @@ pub const TuiRuntime = struct {
                     remote_sender = sender.sender();
                     remote_receiver = .{ .ctx = handle, .read_line_fn = remoteConfigStdioReadLine, .read_result_fn = remoteConfigStdioReadResult, .close_fn = remoteConfigStdioClose };
                 },
-                .sse, .websocket => return error.UnsupportedRemoteTransport,
+                .sse => {
+                    if (options.remote_config.endpoint.len == 0) return error.UnsupportedRemoteEndpoint;
+                    const client = try allocator.create(sse_transport.SseHttpClient);
+                    client.* = sse_transport.SseHttpClient.init(allocator);
+                    try client.connect(options.remote_config.endpoint, options.remote_config.auth_headers);
+                    remote_config_sse_client = client;
+                    remote_sender = client.asyncSender();
+                    remote_receiver = .{ .ctx = client, .read_line_fn = remoteConfigSseReadLine, .read_result_fn = remoteConfigSseReadResult, .close_fn = remoteConfigSseClose };
+                },
+                .websocket => return error.UnsupportedRemoteTransport,
             }
         }
 
@@ -300,6 +317,7 @@ pub const TuiRuntime = struct {
             .remote_config_sender = remote_config_sender,
             .remote_config_receiver = remote_config_receiver,
             .remote_config_stream_handle = remote_config_stream_handle,
+            .remote_config_sse_client = remote_config_sse_client,
             .remote_sender = remote_sender,
             .remote_receiver = remote_receiver,
             .remote_session_timeout_ms = options.remote_session_timeout_ms,
@@ -324,6 +342,7 @@ pub const TuiRuntime = struct {
         remote_config_sender = null;
         remote_config_receiver = null;
         remote_config_stream_handle = null;
+        remote_config_sse_client = null;
         original_tools = &.{};
         wrapped_tools = &.{};
         models = &.{};
@@ -378,6 +397,10 @@ pub const TuiRuntime = struct {
         }
         if (self.remote_config_receiver) |receiver| self.allocator.destroy(receiver);
         if (self.remote_config_sender) |sender| self.allocator.destroy(sender);
+        if (self.remote_config_sse_client) |client| {
+            client.deinit();
+            self.allocator.destroy(client);
+        }
         self.clearPendingApproval();
         self.tool_protocol.deinit();
         self.allocator.free(self.workspace_root);
@@ -1616,6 +1639,24 @@ fn remoteConfigStdioReadResult(ctx: *anyopaque, allocator: std.mem.Allocator) !R
 fn remoteConfigStdioClose(ctx: *anyopaque) void {
     const handle: *stdio_transport.AsyncStreamHandle = @ptrCast(@alignCast(ctx));
     handle.cancel();
+}
+
+fn remoteConfigSseReadLine(ctx: *anyopaque, allocator: std.mem.Allocator) !?[]const u8 {
+    return switch (try remoteConfigSseReadResult(ctx, allocator)) {
+        .line => |line| line,
+        .pending, .disconnected => null,
+    };
+}
+
+fn remoteConfigSseReadResult(ctx: *anyopaque, allocator: std.mem.Allocator) !RemoteReadResult {
+    const client: *sse_transport.SseHttpClient = @ptrCast(@alignCast(ctx));
+    if (try client.readLine(allocator)) |line| return .{ .line = line };
+    return if (client.connected) .pending else .disconnected;
+}
+
+fn remoteConfigSseClose(ctx: *anyopaque) void {
+    const client: *sse_transport.SseHttpClient = @ptrCast(@alignCast(ctx));
+    client.close();
 }
 
 fn parseStopReason(value: []const u8) ai_types.StopReason {

--- a/zig/src/tui/runtime.zig
+++ b/zig/src/tui/runtime.zig
@@ -1266,6 +1266,9 @@ pub const TuiRuntime = struct {
             var client = &(self.remote_client orelse return error.RuntimeNotStarted);
             if (self.remote_session_id) |sid| client.removeSessionState(sid);
             self.remote_session_id = null;
+            if (self.remote_config_sse_client) |sse_client| {
+                try sse_client.connect(self.remote_config_sse_endpoint, self.remote_config_sse_headers);
+            }
             if (was_stream_active) {
                 try self.completeRemoteWithError("remote connection disconnected");
             } else if (self.remote_turn_in_flight) {

--- a/zig/src/tui/runtime.zig
+++ b/zig/src/tui/runtime.zig
@@ -309,12 +309,21 @@ pub const TuiRuntime = struct {
                 .sse => {
                     if (options.remote_config.endpoint.len == 0) return error.UnsupportedRemoteEndpoint;
                     const client = try allocator.create(sse_transport.SseHttpClient);
+                    var client_initialized = false;
+                    errdefer if (!client_initialized) allocator.destroy(client);
                     client.* = sse_transport.SseHttpClient.init(allocator);
+                    client_initialized = true;
+                    var client_moved = false;
+                    errdefer if (!client_moved) {
+                        client.deinit();
+                        allocator.destroy(client);
+                    };
                     try client.connect(options.remote_config.endpoint, options.remote_config.auth_headers);
                     remote_config_sse_endpoint = try allocator.dupe(u8, options.remote_config.endpoint);
                     remote_config_sse_headers = try allocator.alloc(ai_types.HeaderPair, options.remote_config.auth_headers.len);
                     for (options.remote_config.auth_headers, 0..) |header, i| remote_config_sse_headers[i] = .{ .name = try allocator.dupe(u8, header.name), .value = try allocator.dupe(u8, header.value) };
                     remote_config_sse_client = client;
+                    client_moved = true;
                     remote_sender = client.asyncSender();
                     remote_receiver = .{ .ctx = client, .read_line_fn = remoteConfigSseReadLine, .read_result_fn = remoteConfigSseReadResult, .close_fn = remoteConfigSseClose };
                 },

--- a/zig/src/tui/runtime.zig
+++ b/zig/src/tui/runtime.zig
@@ -170,6 +170,8 @@ pub const TuiRuntime = struct {
     remote_config_receiver: ?*stdio_transport.AsyncStdioReceiver = null,
     remote_config_stream_handle: ?*stdio_transport.AsyncStreamHandle = null,
     remote_config_sse_client: ?*sse_transport.SseHttpClient = null,
+    remote_config_sse_endpoint: []u8 = &.{},
+    remote_config_sse_headers: []ai_types.HeaderPair = &.{},
     remote_sender: ?transport.AsyncSender = null,
     remote_receiver: ?RemoteLineReceiver = null,
     remote_session_id: ?agent_protocol_types.SessionId = null,
@@ -253,6 +255,8 @@ pub const TuiRuntime = struct {
         var remote_config_receiver: ?*stdio_transport.AsyncStdioReceiver = null;
         var remote_config_stream_handle: ?*stdio_transport.AsyncStreamHandle = null;
         var remote_config_sse_client: ?*sse_transport.SseHttpClient = null;
+        var remote_config_sse_endpoint: []u8 = &.{};
+        var remote_config_sse_headers: []ai_types.HeaderPair = &.{};
         var remote_sender = options.remote_sender;
         var remote_receiver = options.remote_receiver;
         errdefer if (remote_config_stream_handle) |handle| {
@@ -265,6 +269,11 @@ pub const TuiRuntime = struct {
             client.deinit();
             allocator.destroy(client);
         };
+        errdefer if (remote_config_sse_endpoint.len > 0) allocator.free(remote_config_sse_endpoint);
+        errdefer {
+            for (remote_config_sse_headers) |*header| header.deinit(allocator);
+            if (remote_config_sse_headers.len > 0) allocator.free(remote_config_sse_headers);
+        }
         if (resolved_backend == .remote and remote_sender == null and remote_receiver == null and options.remote_config.mode == .remote) {
             switch (options.remote_config.transport) {
                 .stdio => {
@@ -302,6 +311,9 @@ pub const TuiRuntime = struct {
                     const client = try allocator.create(sse_transport.SseHttpClient);
                     client.* = sse_transport.SseHttpClient.init(allocator);
                     try client.connect(options.remote_config.endpoint, options.remote_config.auth_headers);
+                    remote_config_sse_endpoint = try allocator.dupe(u8, options.remote_config.endpoint);
+                    remote_config_sse_headers = try allocator.alloc(ai_types.HeaderPair, options.remote_config.auth_headers.len);
+                    for (options.remote_config.auth_headers, 0..) |header, i| remote_config_sse_headers[i] = .{ .name = try allocator.dupe(u8, header.name), .value = try allocator.dupe(u8, header.value) };
                     remote_config_sse_client = client;
                     remote_sender = client.asyncSender();
                     remote_receiver = .{ .ctx = client, .read_line_fn = remoteConfigSseReadLine, .read_result_fn = remoteConfigSseReadResult, .close_fn = remoteConfigSseClose };
@@ -324,6 +336,8 @@ pub const TuiRuntime = struct {
             .remote_config_receiver = remote_config_receiver,
             .remote_config_stream_handle = remote_config_stream_handle,
             .remote_config_sse_client = remote_config_sse_client,
+            .remote_config_sse_endpoint = remote_config_sse_endpoint,
+            .remote_config_sse_headers = remote_config_sse_headers,
             .remote_sender = remote_sender,
             .remote_receiver = remote_receiver,
             .remote_session_timeout_ms = options.remote_session_timeout_ms,
@@ -349,6 +363,8 @@ pub const TuiRuntime = struct {
         remote_config_receiver = null;
         remote_config_stream_handle = null;
         remote_config_sse_client = null;
+        remote_config_sse_endpoint = &.{};
+        remote_config_sse_headers = &.{};
         original_tools = &.{};
         wrapped_tools = &.{};
         models = &.{};
@@ -410,6 +426,9 @@ pub const TuiRuntime = struct {
             client.deinit();
             self.allocator.destroy(client);
         }
+        if (self.remote_config_sse_endpoint.len > 0) self.allocator.free(self.remote_config_sse_endpoint);
+        for (self.remote_config_sse_headers) |*header| header.deinit(self.allocator);
+        if (self.remote_config_sse_headers.len > 0) self.allocator.free(self.remote_config_sse_headers);
         self.clearPendingApproval();
         self.tool_protocol.deinit();
         self.allocator.free(self.workspace_root);
@@ -432,6 +451,9 @@ pub const TuiRuntime = struct {
                 var client = agent_protocol_client.AgentProtocolClient.init(self.allocator);
                 var client_moved = false;
                 errdefer if (!client_moved) client.deinit();
+                if (self.remote_config_sse_client) |sse_client| {
+                    if (!sse_client.connected) try sse_client.connect(self.remote_config_sse_endpoint, self.remote_config_sse_headers);
+                }
                 const sender = self.remote_sender orelse return error.NoRemoteTransportConfigured;
                 _ = self.remote_receiver orelse return error.NoRemoteTransportConfigured;
                 client.setSender(sender);


### PR DESCRIPTION
## Summary
- Add HTTP SSE transport client for TUI remote backend server-to-client events
- Send client-to-server agent protocol envelopes via HTTP POST with configurable auth headers
- Wire `.sse` remote config into TUI runtime setup and cleanup

Relates-to #128

## Test plan
- [x] `zig build test-unit-transport`
- [x] `zig build test-unit-makai-cli`
- [x] `zig build test`