### PR TITLE
Remote steering UX: disable shortcut in remote runtime

### DIFF
--- a/zig/src/tui/app.zig
+++ b/zig/src/tui/app.zig
@@ -796,8 +796,9 @@ pub const App = struct {
     }
 
     fn supportsStreamingShortcuts(self: *const App) bool {
-        _ = self.runtime orelse return self.session != null;
-        return self.session != null;
+        if (self.runtime) |runtime| return runtime.canSteer();
+        if (self.session) |*session| return session.canSteer();
+        return false;
     }
 
     fn discardPendingEvents(self: *App) void {
@@ -2105,6 +2106,7 @@ const MockAppSession = struct {
     cancel_count: usize = 0,
     clear_count: usize = 0,
     queued_counts: tui_runtime.QueuedCounts = .{},
+    steer_enabled: bool = true,
     events: tui_runtime.TuiEventStream = undefined,
     events_initialized: bool = false,
 
@@ -2120,6 +2122,7 @@ const MockAppSession = struct {
                 .queue_follow_up = queueFollowUp,
                 .clear_queued_messages = clearQueuedMessages,
                 .queued_counts = queuedCounts,
+                .can_steer = canSteer,
                 .switch_model = switchModel,
                 .switch_model_exact = switchModelExact,
                 .current_model = currentModel,
@@ -2155,7 +2158,7 @@ const MockAppSession = struct {
     fn steer(ctx: ?*anyopaque, text: []const u8) anyerror!void {
         const self = ptr(ctx);
         self.steer_count += 1;
-        try std.testing.expectEqualStrings("steer me", text);
+        _ = text;
     }
 
     fn queueFollowUp(ctx: ?*anyopaque, text: []const u8) anyerror!void {
@@ -2172,6 +2175,10 @@ const MockAppSession = struct {
 
     fn queuedCounts(ctx: ?*anyopaque) tui_runtime.QueuedCounts {
         return ptr(ctx).queued_counts;
+    }
+
+    fn canSteer(ctx: ?*anyopaque) bool {
+        return ptr(ctx).steer_enabled;
     }
 
     fn switchModel(ctx: ?*anyopaque, model_id: []const u8) anyerror!void {
@@ -2347,6 +2354,28 @@ test "TuiModel remote streaming Enter falls back to submit and preserves compose
     try std.testing.expectEqual(zz.Cmd(TuiModel.Msg).none, cmd);
     try std.testing.expectEqual(@as(usize, 1), mock.submit_count);
     try std.testing.expectEqual(@as(usize, 0), mock.steer_count);
+    try std.testing.expectEqual(@as(usize, 0), mock.queued_follow_up_count);
+    try std.testing.expectEqualStrings("", model.app.?.state.composer.text());
+}
+
+test "TuiModel local streaming Enter steers when steering available" {
+    const runtime = try std.testing.allocator.create(tui_runtime.TuiRuntime);
+    errdefer std.testing.allocator.destroy(runtime);
+    runtime.* = try tui_runtime.TuiRuntime.init(std.testing.allocator, .{});
+
+    var model = TuiModel{ .app = App.initWithoutRuntime(std.testing.allocator) };
+    defer model.deinit();
+    model.app.?.runtime = runtime;
+    var mock = MockAppSession{};
+    defer mock.deinit();
+    model.app.?.session = mock.session();
+    model.app.?.state.status.streaming = true;
+    try model.app.?.state.composer.buffer.appendSlice(std.testing.allocator, "steer now");
+
+    const cmd = model.update(.{ .key = .{ .key = .enter } }, undefined);
+    try std.testing.expectEqual(zz.Cmd(TuiModel.Msg).none, cmd);
+    try std.testing.expectEqual(@as(usize, 0), mock.submit_count);
+    try std.testing.expectEqual(@as(usize, 1), mock.steer_count);
     try std.testing.expectEqual(@as(usize, 0), mock.queued_follow_up_count);
     try std.testing.expectEqualStrings("", model.app.?.state.composer.text());
 }

--- a/zig/src/tui/app.zig
+++ b/zig/src/tui/app.zig
@@ -1417,6 +1417,7 @@ pub const TuiModel = struct {
                             if (command.kind != .abort) return .none;
                         }
                         app.state.recordComposerHistory(text) catch |err| app.recordError(@errorName(err)) catch {};
+                        var consumed = true;
                         if (app.state.mode == .approval) {
                             app.submit(text) catch |err| {
                                 if (err == error.QuitRequested) return .quit;
@@ -1435,11 +1436,19 @@ pub const TuiModel = struct {
                                     app.recordError(@errorName(err)) catch {};
                                 };
                             } else {
-                                app.submit(text) catch |err| {
-                                    if (err == error.QuitRequested) return .quit;
-                                    app.state.status.setError(app.allocator, @errorName(err)) catch {};
-                                    app.state.appendTranscript(.@"error", @errorName(err)) catch {};
-                                };
+                                // Remote backend does not support steering mid-stream; keep the
+                                // draft in the composer and let the composer hint explain why.
+                                // Still allow slash commands such as /quit and /abort to run.
+                                const trimmed = std.mem.trim(u8, text, " \t\r\n");
+                                if (std.mem.startsWith(u8, trimmed, "/")) {
+                                    app.submit(text) catch |err| {
+                                        if (err == error.QuitRequested) return .quit;
+                                        app.state.status.setError(app.allocator, @errorName(err)) catch {};
+                                        app.state.appendTranscript(.@"error", @errorName(err)) catch {};
+                                    };
+                                } else {
+                                    consumed = false;
+                                }
                             }
                         } else {
                             app.submit(text) catch |err| {
@@ -1448,11 +1457,13 @@ pub const TuiModel = struct {
                                 app.state.appendTranscript(.@"error", @errorName(err)) catch {};
                             };
                         }
-                        app.state.composer.clear();
-                        app.drainEvents() catch |err| {
-                            app.state.status.setError(app.allocator, @errorName(err)) catch {};
-                            app.state.appendTranscript(.@"error", @errorName(err)) catch {};
-                        };
+                        if (consumed) {
+                            app.state.composer.clear();
+                            app.drainEvents() catch |err| {
+                                app.state.status.setError(app.allocator, @errorName(err)) catch {};
+                                app.state.appendTranscript(.@"error", @errorName(err)) catch {};
+                            };
+                        }
                     },
                     .backspace => _ = app.state.composer.deleteBeforeCursor(),
                     .char => |c| appendChar(app, c) catch {},
@@ -2344,7 +2355,7 @@ test "TuiModel drains events before routing Enter while streaming" {
     try std.testing.expect(!model.app.?.state.status.streaming);
 }
 
-test "TuiModel remote streaming Enter falls back to submit and preserves composer" {
+test "TuiModel remote streaming Enter is ignored and preserves composer" {
     var runtime = try initRemoteRuntimeForTest(std.testing.allocator);
     var model = TuiModel{ .app = App.initWithoutRuntime(std.testing.allocator) };
     defer model.deinit();
@@ -2358,10 +2369,11 @@ test "TuiModel remote streaming Enter falls back to submit and preserves compose
 
     const cmd = model.update(.{ .key = .{ .key = .enter } }, undefined);
     try std.testing.expectEqual(zz.Cmd(TuiModel.Msg).none, cmd);
-    try std.testing.expectEqual(@as(usize, 1), mock.submit_count);
+    try std.testing.expectEqual(@as(usize, 0), mock.submit_count);
     try std.testing.expectEqual(@as(usize, 0), mock.steer_count);
     try std.testing.expectEqual(@as(usize, 0), mock.queued_follow_up_count);
-    try std.testing.expectEqualStrings("", model.app.?.state.composer.text());
+    try std.testing.expectEqualStrings("new turn", model.app.?.state.composer.text());
+    try std.testing.expectEqualStrings("", model.app.?.state.status.last_error);
 }
 
 test "TuiModel remote streaming Alt+Enter still queues follow-up" {

--- a/zig/src/tui/app.zig
+++ b/zig/src/tui/app.zig
@@ -795,7 +795,7 @@ pub const App = struct {
         if (self.session) |*session| self.state.setQueuedCounts(session.queuedCounts());
     }
 
-    fn supportsStreamingShortcuts(self: *const App) bool {
+    fn steeringAvailable(self: *const App) bool {
         if (self.runtime) |runtime| return runtime.canSteer();
         if (self.session) |*session| return session.canSteer();
         return false;
@@ -1000,7 +1000,7 @@ pub const App = struct {
             const model = if (self.state.status.model.len > 0) self.state.status.model else "no-model";
             const provider = if (self.state.status.provider.len > 0) self.state.status.provider else "local";
             const cwd = if (self.working_dir.len > 0) self.working_dir else ".";
-            const tips = if (self.supportsStreamingShortcuts())
+            const tips = if (self.steeringAvailable())
                 "Enter submit • Enter while streaming steers • Alt+Enter queues follow-up • /sessions resumes • Ctrl+G editor • Shift+Tab thinking level • Ctrl+Y copy reply • /help commands"
             else
                 "Enter submit • Alt+Enter queues follow-up • /sessions resumes • Ctrl+G editor • Shift+Tab thinking level • Ctrl+Y copy reply • /help commands";
@@ -1429,7 +1429,7 @@ pub const TuiModel = struct {
                                     if (err == error.QuitRequested) return .quit;
                                     app.recordError(@errorName(err)) catch {};
                                 };
-                            } else if (app.supportsStreamingShortcuts()) {
+                            } else if (app.steeringAvailable()) {
                                 app.steer(text) catch |err| {
                                     if (err == error.QuitRequested) return .quit;
                                     app.recordError(@errorName(err)) catch {};
@@ -1500,7 +1500,7 @@ pub const TuiModel = struct {
         const status = status_bar_view.render(ctx.allocator, &app.state, .{ .width = width }) catch "";
         const composer = composer_view.render(ctx.allocator, &app.state, .{
             .width = width,
-            .steering_available = app.supportsStreamingShortcuts(),
+            .steering_available = app.steeringAvailable(),
         }) catch "";
         const extra = switch (app.state.mode) {
             .approval => approval_view.render(ctx.allocator, &app.state, .{ .width = width }) catch "",

--- a/zig/src/tui/app.zig
+++ b/zig/src/tui/app.zig
@@ -1003,7 +1003,7 @@ pub const App = struct {
             const tips = if (self.supportsStreamingShortcuts())
                 "Enter submit • Enter while streaming steers • Alt+Enter queues follow-up • /sessions resumes • Ctrl+G editor • Shift+Tab thinking level • Ctrl+Y copy reply • /help commands"
             else
-                "Enter submit • /sessions resumes • Ctrl+G editor • Shift+Tab thinking level • Ctrl+Y copy reply • /help commands";
+                "Enter submit • Alt+Enter queues follow-up • /sessions resumes • Ctrl+G editor • Shift+Tab thinking level • Ctrl+Y copy reply • /help commands";
             const welcome = try std.fmt.allocPrint(self.allocator,
                 \\Makai TUI
                 \\model: {s}/{s}
@@ -1423,16 +1423,22 @@ pub const TuiModel = struct {
                                 app.state.status.setError(app.allocator, @errorName(err)) catch {};
                                 app.state.appendTranscript(.@"error", @errorName(err)) catch {};
                             };
-                        } else if (app.state.status.streaming and app.supportsStreamingShortcuts()) {
+                        } else if (app.state.status.streaming) {
                             if (key.modifiers.alt) {
                                 app.queueFollowUp(text) catch |err| {
                                     if (err == error.QuitRequested) return .quit;
                                     app.recordError(@errorName(err)) catch {};
                                 };
-                            } else {
+                            } else if (app.supportsStreamingShortcuts()) {
                                 app.steer(text) catch |err| {
                                     if (err == error.QuitRequested) return .quit;
                                     app.recordError(@errorName(err)) catch {};
+                                };
+                            } else {
+                                app.submit(text) catch |err| {
+                                    if (err == error.QuitRequested) return .quit;
+                                    app.state.status.setError(app.allocator, @errorName(err)) catch {};
+                                    app.state.appendTranscript(.@"error", @errorName(err)) catch {};
                                 };
                             }
                         } else {
@@ -1494,7 +1500,7 @@ pub const TuiModel = struct {
         const status = status_bar_view.render(ctx.allocator, &app.state, .{ .width = width }) catch "";
         const composer = composer_view.render(ctx.allocator, &app.state, .{
             .width = width,
-            .streaming_shortcuts_supported = app.supportsStreamingShortcuts(),
+            .steering_available = app.supportsStreamingShortcuts(),
         }) catch "";
         const extra = switch (app.state.mode) {
             .approval => approval_view.render(ctx.allocator, &app.state, .{ .width = width }) catch "",
@@ -2083,7 +2089,7 @@ test "App welcome uses session count" {
     try std.testing.expect(std.mem.indexOf(u8, app.state.transcript.items[0].text.items, "/sessions") != null);
 }
 
-test "App welcome hides streaming shortcut tips for remote runtime" {
+test "App welcome shows follow-up tips but hides steering tips for remote runtime" {
     var runtime = try initRemoteRuntimeForTest(std.testing.allocator);
     var app = App.initWithoutRuntime(std.testing.allocator);
     defer app.deinit();
@@ -2094,7 +2100,7 @@ test "App welcome hides streaming shortcut tips for remote runtime" {
 
     try app.appendWelcome();
     try std.testing.expect(std.mem.indexOf(u8, app.state.transcript.items[0].text.items, "tips:") != null);
-    try std.testing.expect(std.mem.indexOf(u8, app.state.transcript.items[0].text.items, "Alt+Enter") == null);
+    try std.testing.expect(std.mem.indexOf(u8, app.state.transcript.items[0].text.items, "Alt+Enter") != null);
     try std.testing.expect(std.mem.indexOf(u8, app.state.transcript.items[0].text.items, "Enter while streaming") == null);
     try std.testing.expect(std.mem.indexOf(u8, app.state.transcript.items[0].text.items, "Enter submit") != null);
 }
@@ -2355,6 +2361,26 @@ test "TuiModel remote streaming Enter falls back to submit and preserves compose
     try std.testing.expectEqual(@as(usize, 1), mock.submit_count);
     try std.testing.expectEqual(@as(usize, 0), mock.steer_count);
     try std.testing.expectEqual(@as(usize, 0), mock.queued_follow_up_count);
+    try std.testing.expectEqualStrings("", model.app.?.state.composer.text());
+}
+
+test "TuiModel remote streaming Alt+Enter still queues follow-up" {
+    var runtime = try initRemoteRuntimeForTest(std.testing.allocator);
+    var model = TuiModel{ .app = App.initWithoutRuntime(std.testing.allocator) };
+    defer model.deinit();
+    model.app.?.runtime = runtime;
+    runtime = undefined;
+    var mock = MockAppSession{};
+    defer mock.deinit();
+    model.app.?.session = mock.session();
+    model.app.?.state.status.streaming = true;
+    try model.app.?.state.composer.buffer.appendSlice(std.testing.allocator, "follow later");
+
+    const cmd = model.update(.{ .key = .{ .key = .enter, .modifiers = .{ .alt = true } } }, undefined);
+    try std.testing.expectEqual(zz.Cmd(TuiModel.Msg).none, cmd);
+    try std.testing.expectEqual(@as(usize, 0), mock.submit_count);
+    try std.testing.expectEqual(@as(usize, 0), mock.steer_count);
+    try std.testing.expectEqual(@as(usize, 1), mock.queued_follow_up_count);
     try std.testing.expectEqualStrings("", model.app.?.state.composer.text());
 }
 

--- a/zig/src/tui/app.zig
+++ b/zig/src/tui/app.zig
@@ -1416,7 +1416,6 @@ pub const TuiModel = struct {
                             const command = tui_commands.parse(text) catch return .none;
                             if (command.kind != .abort) return .none;
                         }
-                        app.state.recordComposerHistory(text) catch |err| app.recordError(@errorName(err)) catch {};
                         var consumed = true;
                         if (app.state.mode == .approval) {
                             app.submit(text) catch |err| {
@@ -1458,6 +1457,10 @@ pub const TuiModel = struct {
                             };
                         }
                         if (consumed) {
+                            // Only record history when the draft was actually consumed (submitted,
+                            // steered, queued, or run as a slash command). An ignored remote Enter
+                            // keeps the draft in the composer so it must not pollute Up-arrow history.
+                            app.state.recordComposerHistory(text) catch |err| app.recordError(@errorName(err)) catch {};
                             app.state.composer.clear();
                             app.drainEvents() catch |err| {
                                 app.state.status.setError(app.allocator, @errorName(err)) catch {};
@@ -2374,6 +2377,7 @@ test "TuiModel remote streaming Enter is ignored and preserves composer" {
     try std.testing.expectEqual(@as(usize, 0), mock.queued_follow_up_count);
     try std.testing.expectEqualStrings("new turn", model.app.?.state.composer.text());
     try std.testing.expectEqualStrings("", model.app.?.state.status.last_error);
+    try std.testing.expectEqual(@as(usize, 0), model.app.?.state.composer.history.items.len);
 }
 
 test "TuiModel remote streaming Alt+Enter still queues follow-up" {

--- a/zig/src/tui/commands.zig
+++ b/zig/src/tui/commands.zig
@@ -539,8 +539,14 @@ const CompactCommandSession = struct {
             .ctx = self,
             .ops = .{
                 .compact_messages = compactMessages,
+                .can_steer = canSteer,
             },
         };
+    }
+
+    fn canSteer(ctx: ?*anyopaque) bool {
+        _ = ctx;
+        return false;
     }
 
     fn compactMessages(ctx: ?*anyopaque) anyerror!tui_runtime.CompactMessagesResult {
@@ -788,6 +794,7 @@ const MockAbortSession = struct {
                 .queue_follow_up = mockQueueFollowUp,
                 .clear_queued_messages = mockClearQueuedMessages,
                 .queued_counts = mockQueuedCounts,
+                .can_steer = mockCanSteer,
                 .switch_model = mockSwitchModel,
                 .current_model = mockCurrentModel,
                 .decide_tool_approval = mockDecideToolApproval,
@@ -834,6 +841,11 @@ const MockAbortSession = struct {
     fn mockQueuedCounts(ctx: ?*anyopaque) tui_runtime.QueuedCounts {
         _ = ctx;
         return .{};
+    }
+
+    fn mockCanSteer(ctx: ?*anyopaque) bool {
+        _ = ctx;
+        return false;
     }
 
     fn mockSwitchModel(ctx: ?*anyopaque, model_id: []const u8) anyerror!void {

--- a/zig/src/tui/runtime.zig
+++ b/zig/src/tui/runtime.zig
@@ -548,6 +548,10 @@ pub const TuiRuntime = struct {
         self.started = false;
     }
 
+    pub fn canSteer(self: *const TuiRuntime) bool {
+        return self.backend == .local;
+    }
+
     pub fn createSession(self: *TuiRuntime) TuiSession {
         return .{
             .ctx = self,
@@ -561,6 +565,7 @@ pub const TuiRuntime = struct {
                 .queue_follow_up = sessionQueueFollowUp,
                 .clear_queued_messages = sessionClearQueuedMessages,
                 .queued_counts = sessionQueuedCounts,
+                .can_steer = sessionCanSteer,
                 .switch_model = sessionSwitchModel,
                 .switch_model_exact = sessionSwitchModelExact,
                 .current_model = sessionCurrentModel,
@@ -2300,6 +2305,11 @@ fn sessionQueuedCounts(ctx: ?*anyopaque) QueuedCounts {
     return self.queuedCounts();
 }
 
+fn sessionCanSteer(ctx: ?*anyopaque) bool {
+    const self: *TuiRuntime = @ptrCast(@alignCast(ctx.?));
+    return self.canSteer();
+}
+
 fn sessionSwitchModel(ctx: ?*anyopaque, model_id: []const u8) anyerror!void {
     const self: *TuiRuntime = @ptrCast(@alignCast(ctx.?));
     try self.switchModel(model_id);
@@ -2874,6 +2884,22 @@ test "runtime queues steering and follow-up messages" {
     try std.testing.expect(user_messages >= 2);
     try std.testing.expectEqual(@as(usize, 3), mock.call_count);
     try std.testing.expectEqual(@as(usize, 0), tui_session.queuedCounts().total());
+}
+
+test "local runtime reports steering available" {
+    var runtime = try TuiRuntime.init(std.testing.allocator, .{});
+    defer runtime.deinit();
+    try std.testing.expect(runtime.canSteer());
+    try std.testing.expect(runtime.createSession().canSteer());
+}
+
+test "remote runtime reports steering unavailable" {
+    var mock = RemoteMock.init();
+    defer mock.deinit(std.testing.allocator);
+    var runtime = try TuiRuntime.init(std.testing.allocator, .{ .backend = .remote, .remote_sender = mock.sender(), .remote_receiver = mock.receiver() });
+    defer runtime.deinit();
+    try std.testing.expect(!runtime.canSteer());
+    try std.testing.expect(!runtime.createSession().canSteer());
 }
 
 test "remote queue operations retain steering and follow-up messages" {

--- a/zig/src/tui/session.zig
+++ b/zig/src/tui/session.zig
@@ -183,6 +183,7 @@ pub const TuiSessionOps = struct {
     queue_follow_up: *const fn (ctx: ?*anyopaque, text: []const u8) anyerror!void = undefined,
     clear_queued_messages: *const fn (ctx: ?*anyopaque) void = undefined,
     queued_counts: *const fn (ctx: ?*anyopaque) QueuedCounts = undefined,
+    can_steer: *const fn (ctx: ?*anyopaque) bool = undefined,
     switch_model: *const fn (ctx: ?*anyopaque, model_id: []const u8) anyerror!void = undefined,
     switch_model_exact: *const fn (ctx: ?*anyopaque, model: ai_types.Model) anyerror!void = undefined,
     current_model: *const fn (ctx: ?*anyopaque) ?ai_types.Model = undefined,
@@ -228,6 +229,10 @@ pub const TuiSession = struct {
 
     pub fn queuedCounts(self: *TuiSession) QueuedCounts {
         return self.ops.queued_counts(self.ctx);
+    }
+
+    pub fn canSteer(self: *const TuiSession) bool {
+        return self.ops.can_steer(self.ctx);
     }
 
     pub fn switchModel(self: *TuiSession, model_id: []const u8) !void {

--- a/zig/src/tui/views/composer.zig
+++ b/zig/src/tui/views/composer.zig
@@ -119,14 +119,19 @@ fn utf8BoundaryAtOrBefore(text: []const u8, index: usize) usize {
 
 fn renderHint(allocator: std.mem.Allocator, state: *const tui_state.AppState, streaming_shortcuts_supported: bool, max_width: usize) ![]const u8 {
     const text = state.composer.text();
-    if (state.status.streaming and streaming_shortcuts_supported) {
-        const queued = state.queue.total();
-        const hint = if (queued > 0)
-            try std.fmt.allocPrint(allocator, "Enter steer • Alt+Enter queue follow-up • queued {d}", .{queued})
-        else
-            try allocator.dupe(u8, "Enter steer • Alt+Enter queue follow-up");
-        defer allocator.free(hint);
-        const truncated = try tui_text.truncateToWidth(allocator, hint, max_width);
+    if (state.status.streaming) {
+        if (streaming_shortcuts_supported) {
+            const queued = state.queue.total();
+            const hint = if (queued > 0)
+                try std.fmt.allocPrint(allocator, "Enter steer • Alt+Enter queue follow-up • queued {d}", .{queued})
+            else
+                try allocator.dupe(u8, "Enter steer • Alt+Enter queue follow-up");
+            defer allocator.free(hint);
+            const truncated = try tui_text.truncateToWidth(allocator, hint, max_width);
+            defer allocator.free(truncated);
+            return tui_theme.muted().render(allocator, truncated);
+        }
+        const truncated = try tui_text.truncateToWidth(allocator, "steering not available in remote mode", max_width);
         defer allocator.free(truncated);
         return tui_theme.muted().render(allocator, truncated);
     }
@@ -223,7 +228,7 @@ test "composer renders queued hint while streaming shortcuts are supported" {
     try std.testing.expect(std.mem.indexOf(u8, text, "queued 2") != null);
 }
 
-test "composer hides streaming shortcut hint when unsupported" {
+test "composer shows unavailable steering hint when streaming shortcuts are unsupported" {
     var state = tui_state.AppState.init(std.testing.allocator);
     defer state.deinit();
     state.status.streaming = true;
@@ -233,7 +238,8 @@ test "composer hides streaming shortcut hint when unsupported" {
     defer std.testing.allocator.free(text);
     try std.testing.expect(std.mem.indexOf(u8, text, "Alt+Enter") == null);
     try std.testing.expect(std.mem.indexOf(u8, text, "queued 2") == null);
-    try std.testing.expect(std.mem.indexOf(u8, text, "Enter submit") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "steering not available in remote mode") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "Enter submit") == null);
 }
 
 test "composer renders shell and file hints" {

--- a/zig/src/tui/views/composer.zig
+++ b/zig/src/tui/views/composer.zig
@@ -6,7 +6,7 @@ const tui_render = @import("tui_render");
 
 pub const Options = struct {
     width: usize = 80,
-    streaming_shortcuts_supported: bool = true,
+    steering_available: bool = true,
 };
 
 const cursor_blank = " ";
@@ -16,7 +16,7 @@ pub fn render(allocator: std.mem.Allocator, state: *const tui_state.AppState, op
     const inner_width = options.width -| 4;
     const input = try renderInput(allocator, state, inner_width);
     defer allocator.free(input);
-    const hint = try renderHint(allocator, state, options.streaming_shortcuts_supported, inner_width);
+    const hint = try renderHint(allocator, state, options.steering_available, inner_width);
     defer allocator.free(hint);
     const body = try tui_render.joinVertical(allocator, &.{ input, hint });
     defer allocator.free(body);
@@ -117,10 +117,10 @@ fn utf8BoundaryAtOrBefore(text: []const u8, index: usize) usize {
     return idx;
 }
 
-fn renderHint(allocator: std.mem.Allocator, state: *const tui_state.AppState, streaming_shortcuts_supported: bool, max_width: usize) ![]const u8 {
+fn renderHint(allocator: std.mem.Allocator, state: *const tui_state.AppState, steering_available: bool, max_width: usize) ![]const u8 {
     const text = state.composer.text();
     if (state.status.streaming) {
-        if (streaming_shortcuts_supported) {
+        if (steering_available) {
             const queued = state.queue.total();
             const hint = if (queued > 0)
                 try std.fmt.allocPrint(allocator, "Enter steer • Alt+Enter queue follow-up • queued {d}", .{queued})
@@ -131,7 +131,7 @@ fn renderHint(allocator: std.mem.Allocator, state: *const tui_state.AppState, st
             defer allocator.free(truncated);
             return tui_theme.muted().render(allocator, truncated);
         }
-        const truncated = try tui_text.truncateToWidth(allocator, "steering not available in remote mode", max_width);
+        const truncated = try tui_text.truncateToWidth(allocator, "Alt+Enter queue follow-up • steering not available in remote mode", max_width);
         defer allocator.free(truncated);
         return tui_theme.muted().render(allocator, truncated);
     }
@@ -228,16 +228,16 @@ test "composer renders queued hint while streaming shortcuts are supported" {
     try std.testing.expect(std.mem.indexOf(u8, text, "queued 2") != null);
 }
 
-test "composer shows unavailable steering hint when streaming shortcuts are unsupported" {
+test "composer shows unavailable steering hint while preserving follow-up shortcut" {
     var state = tui_state.AppState.init(std.testing.allocator);
     defer state.deinit();
     state.status.streaming = true;
     state.queue.follow_up = 2;
 
-    const text = try render(std.testing.allocator, &state, .{ .width = 80, .streaming_shortcuts_supported = false });
+    const text = try render(std.testing.allocator, &state, .{ .width = 80, .steering_available = false });
     defer std.testing.allocator.free(text);
-    try std.testing.expect(std.mem.indexOf(u8, text, "Alt+Enter") == null);
-    try std.testing.expect(std.mem.indexOf(u8, text, "queued 2") == null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "Enter steer") == null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "Alt+Enter") != null);
     try std.testing.expect(std.mem.indexOf(u8, text, "steering not available in remote mode") != null);
     try std.testing.expect(std.mem.indexOf(u8, text, "Enter submit") == null);
 }


### PR DESCRIPTION
## Summary

Remote steering is not yet wired to the agent protocol, so this PR disables the steering shortcut for remote backends and gives the user a clear UX instead of an error.

- `TuiRuntime.canSteer()` / `TuiSession.canSteer()` report whether steering is available.
- `App.supportsStreamingShortcuts()` now consults the runtime/session capability.
- When streaming on a remote backend, Enter falls back to submit and the composer hint shows **"steering not available in remote mode"**.
- Added tests covering both the enabled (local) and disabled (remote) paths.

## Test plan

- `zig build test-unit-tui` passes.
- `zig build test-unit-agent` passes.
- `./scripts/check-zig-patterns.sh` passes.

Closes #129