### PR TITLE
Add WebSocket remote backend transport (#128 subset)

### DIFF
--- a/zig/build.zig
+++ b/zig/build.zig
@@ -914,6 +914,7 @@ pub fn build(b: *std.Build) void {
             .{ .name = "transports/in_process", .module = in_process_transport_mod },
             .{ .name = "transports/stdio", .module = stdio_transport_mod },
             .{ .name = "transports/sse", .module = sse_transport_mod },
+            .{ .name = "transports/websocket", .module = websocket_transport_mod },
             .{ .name = "json_writer", .module = json_writer_mod },
             .{ .name = "model_ref", .module = protocol_model_ref_mod },
             .{ .name = "tui_session", .module = tui_session_mod },
@@ -1339,6 +1340,20 @@ pub fn build(b: *std.Build) void {
                 .{ .name = "transport", .module = transport_mod },
                 .{ .name = "protocol_envelope", .module = protocol_envelope_mod },
                 .{ .name = "stdio", .module = stdio_transport_mod },
+            },
+        }),
+    });
+
+
+    const e2e_tui_websocket_test = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("test/e2e/tui_websocket.zig"),
+            .target = target,
+            .optimize = optimize,
+            .imports = &.{
+                .{ .name = "compat", .module = compat_mod },
+                .{ .name = "ai_types", .module = ai_types_mod },
+                .{ .name = "tui_runtime", .module = tui_runtime_mod },
             },
         }),
     });
@@ -1918,6 +1933,9 @@ pub fn build(b: *std.Build) void {
     test_e2e_protocol_step.dependOn(&b.addRunArtifact(e2e_protocol_test).step);
     test_e2e_protocol_step.dependOn(&b.addRunArtifact(e2e_distributed_fullstack_test).step);
 
+    const test_e2e_tui_websocket_step = b.step("test-e2e-tui-websocket", "Run TUI WebSocket remote backend E2E test (mock-based)");
+    test_e2e_tui_websocket_step.dependOn(&b.addRunArtifact(e2e_tui_websocket_test).step);
+
     const test_e2e_distributed_fullstack_step = b.step("test-e2e-distributed-fullstack", "Run distributed fullstack E2E tests (mock-based)");
     test_e2e_distributed_fullstack_step.dependOn(&b.addRunArtifact(e2e_distributed_fullstack_test).step);
 
@@ -1934,6 +1952,7 @@ pub fn build(b: *std.Build) void {
     test_e2e_step.dependOn(test_e2e_provider_protocol_fullstack_ollama_step);
     test_e2e_step.dependOn(test_e2e_provider_protocol_fullstack_github_step);
     test_e2e_step.dependOn(test_e2e_protocol_step);
+    test_e2e_step.dependOn(test_e2e_tui_websocket_step);
 
     const test_protocol_types_step = b.step("test-protocol-types", "Run protocol types tests");
     test_protocol_types_step.dependOn(&b.addRunArtifact(protocol_types_test).step);

--- a/zig/src/compat/net.zig
+++ b/zig/src/compat/net.zig
@@ -50,6 +50,10 @@ pub const Stream = struct {
         }
     }
 
+    pub fn shutdown(self: *Stream) void {
+        self.inner.shutdown(defaultIo(), .both) catch {};
+    }
+
     pub fn close(self: *Stream) void {
         self.inner.close(defaultIo());
     }

--- a/zig/src/transports/websocket.zig
+++ b/zig/src/transports/websocket.zig
@@ -299,12 +299,22 @@ pub const WebSocketClient = struct {
     /// Close the connection
     pub fn close(self: *Self) void {
         _ = defaultIo();
+
+        // Capture the socket under the state mutex, then drop the mutex before
+        // performing I/O. This prevents a blocked writer from pinning the state
+        // mutex and stalling cancellation paths that need to shut the socket down.
         while (!self.mutex.tryLock()) std.atomic.spinLoopHint();
-        defer self.mutex.unlock();
-        if (self.tcp_stream) |stream| {
+        const maybe_stream = self.tcp_stream;
+        const send_close_frame = self.state == .connected;
+        self.tcp_stream = null;
+        self.state = .closing;
+        self.mutex.unlock();
+
+        if (maybe_stream) |stream| {
             var closable = stream;
-            // Send close frame if connected
-            if (self.state == .connected) {
+            // Hold the write mutex around the close-frame write and socket close
+            // so they cannot interleave with an in-flight message/pong frame.
+            if (send_close_frame) {
                 const close_frame = Frame{
                     .opcode = .close,
                     .payload = &.{},
@@ -313,12 +323,17 @@ pub const WebSocketClient = struct {
                 };
                 if (encodeFrame(close_frame, self.allocator)) |encoded| {
                     defer self.allocator.free(encoded);
+                    while (!self.write_mutex.tryLock()) std.atomic.spinLoopHint();
+                    defer self.write_mutex.unlock();
                     closable.writeAll(encoded) catch {}; // Ignore errors on close
                 } else |_| {}
             }
             closable.close();
-            self.tcp_stream = null;
         }
+
+        // Re-acquire the state mutex to clear buffers and finalize state.
+        while (!self.mutex.tryLock()) std.atomic.spinLoopHint();
+        defer self.mutex.unlock();
         self.send_buffer.clearRetainingCapacity();
         self.recv_buffer.clearRetainingCapacity();
         self.fragment_buffer.clearRetainingCapacity();

--- a/zig/src/transports/websocket.zig
+++ b/zig/src/transports/websocket.zig
@@ -9,14 +9,24 @@
 //! the project default `std.Io.Threaded` context (`std.testing.io` in tests).
 //! Zig 0.16 `std.Io.Evented` networking remains unsupported by that seam.
 //!
-//! Handshake validation checks status/upgrade headers and the presence of
-//! `Sec-WebSocket-Accept`; it does not yet verify the accept value against the
-//! request nonce.
+//! Handshake validation checks status/upgrade headers and verifies the
+//! `Sec-WebSocket-Accept` value per RFC 6455 §4.2.2.
 
 const std = @import("std");
 const transport = @import("transport");
 const ai_types = @import("ai_types");
 const compat = @import("compat");
+
+const default_subprotocol = "makai.v1";
+
+fn defaultIo() std.Io {
+    return if (@import("builtin").is_test)
+        std.testing.io
+    else
+        std.Io.Threaded.global_single_threaded.io();
+}
+
+pub const AsyncStreamHandle = WebSocketClient.AsyncStreamHandle;
 
 fn streamFromSocketHandle(handle: std.Io.net.Socket.Handle) compat.net.Stream {
     return compat.net.Stream.init(.{ .socket = .{ .handle = handle, .address = .{ .ip4 = .loopback(0) } } });
@@ -32,6 +42,8 @@ pub const WebSocketClient = struct {
     // For async operation
     send_buffer: std.ArrayList(u8) = std.ArrayList(u8).empty,
     recv_buffer: std.ArrayList(u8) = std.ArrayList(u8).empty,
+    fragment_buffer: std.ArrayList(u8) = std.ArrayList(u8).empty,
+    fragment_opcode: ?Opcode = null,
 
     // Callbacks
     on_message: ?*const fn (ctx: ?*anyopaque, data: []const u8) void = null,
@@ -39,6 +51,13 @@ pub const WebSocketClient = struct {
 
     // Handshake key (stored for verification)
     handshake_key: [24]u8 = undefined,
+
+    // Serializes tcp_stream state changes. Cancellation uses this mutex only
+    // long enough to call shutdown, so it can bypass blocked writers.
+    mutex: std.atomic.Mutex = .unlocked,
+
+    // Serializes WebSocket frame writes so multi-write frames cannot interleave.
+    write_mutex: std.atomic.Mutex = .unlocked,
 
     // Ping/pong timeout tracking
     ping_timeout_ms: u64 = 30_000,
@@ -61,6 +80,7 @@ pub const WebSocketClient = struct {
             .state = .disconnected,
             .send_buffer = std.ArrayList(u8).empty,
             .recv_buffer = std.ArrayList(u8).empty,
+            .fragment_buffer = std.ArrayList(u8).empty,
         };
     }
 
@@ -68,15 +88,27 @@ pub const WebSocketClient = struct {
         self.close();
         self.send_buffer.deinit(self.allocator);
         self.recv_buffer.deinit(self.allocator);
+        self.fragment_buffer.deinit(self.allocator);
     }
 
-    /// Connect to WebSocket endpoint
+    /// Connect to WebSocket endpoint using the default `makai.v1` subprotocol.
     /// url format: ws://host:port/path or wss://host:port/path
     /// headers: optional headers (e.g., Authorization: Bearer <api_key>)
     pub fn connect(
         self: *Self,
         url: []const u8,
         headers: ?[]const ai_types.HeaderPair,
+    ) !void {
+        return self.connectWithSubprotocol(url, headers, default_subprotocol);
+    }
+
+    /// Connect to WebSocket endpoint with a configurable subprotocol.
+    /// Pass `null` for subprotocol to omit the `Sec-WebSocket-Protocol` header.
+    pub fn connectWithSubprotocol(
+        self: *Self,
+        url: []const u8,
+        headers: ?[]const ai_types.HeaderPair,
+        subprotocol: ?[]const u8,
     ) !void {
         if (!canInitiateConnect(self.state)) {
             return error.AlreadyConnected;
@@ -85,6 +117,8 @@ pub const WebSocketClient = struct {
         // Start each connection attempt from a clean session buffer state.
         self.send_buffer.clearRetainingCapacity();
         self.recv_buffer.clearRetainingCapacity();
+        self.fragment_buffer.clearRetainingCapacity();
+        self.fragment_opcode = null;
         self.resetPingState();
 
         self.state = .connecting;
@@ -110,7 +144,7 @@ pub const WebSocketClient = struct {
         };
 
         // Perform WebSocket handshake
-        performHandshake(self, parsed.host, parsed.port, parsed.path, headers) catch |err| {
+        performHandshake(self, parsed.host, parsed.port, parsed.path, headers, subprotocol) catch |err| {
             if (self.tcp_stream) |stream| {
                 var closable = stream;
                 closable.close();
@@ -129,9 +163,12 @@ pub const WebSocketClient = struct {
             return error.NotConnected;
         }
 
-        const stream = self.tcp_stream orelse return error.NotConnected;
+        _ = defaultIo();
 
-        // Encode the frame
+        // Encode before locking, then hold the write mutex until writeAll
+        // completes so multi-write frames cannot interleave. Do not hold the
+        // transport-state mutex during writeAll; cancellation must be able to
+        // shutdown the socket even when a write is blocked.
         const frame = Frame{
             .opcode = .text,
             .payload = data,
@@ -142,25 +179,39 @@ pub const WebSocketClient = struct {
         const encoded = try encodeFrame(frame, self.allocator);
         defer self.allocator.free(encoded);
 
+        while (!self.mutex.tryLock()) std.atomic.spinLoopHint();
+        const stream = self.tcp_stream orelse {
+            self.mutex.unlock();
+            return error.NotConnected;
+        };
         var writable = stream;
+        self.mutex.unlock();
+
+        while (!self.write_mutex.tryLock()) std.atomic.spinLoopHint();
+        defer self.write_mutex.unlock();
         try writable.writeAll(encoded);
     }
 
     /// Receive a message (blocking)
     pub fn receive(self: *Self, allocator: std.mem.Allocator) !?[]const u8 {
+        _ = defaultIo();
+        while (!self.mutex.tryLock()) std.atomic.spinLoopHint();
         if (self.state != .connected) {
+            self.mutex.unlock();
             return error.NotConnected;
         }
-
-        const stream = self.tcp_stream orelse return error.NotConnected;
+        self.mutex.unlock();
 
         // Read frames until we have a complete message
         while (true) {
             // Try to decode a frame from existing buffer
             if (decodeFrame(self.recv_buffer.items)) |result| {
                 const frame = result.frame;
+                const owned_payload = try allocator.dupe(u8, frame.payload);
+                defer allocator.free(owned_payload);
 
-                // Remove consumed bytes
+                // Remove consumed bytes after copying the payload because decodeFrame
+                // returns slices into recv_buffer.
                 if (result.consumed > 0) {
                     const remaining = self.recv_buffer.items[result.consumed..];
                     std.mem.copyForwards(u8, self.recv_buffer.items[0..remaining.len], remaining);
@@ -170,12 +221,14 @@ pub const WebSocketClient = struct {
                 // Handle control frames
                 switch (frame.opcode) {
                     .close => {
+                        while (!self.mutex.tryLock()) std.atomic.spinLoopHint();
+                        defer self.mutex.unlock();
                         self.state = .closing;
                         return null;
                     },
                     .ping => {
                         // Respond with pong
-                        try self.sendPong(frame.payload);
+                        try self.sendPong(owned_payload);
                         continue;
                     },
                     .pong => {
@@ -183,21 +236,44 @@ pub const WebSocketClient = struct {
                         continue;
                     },
                     .text, .binary => {
-                        // Return text/binary payload
-                        return try allocator.dupe(u8, frame.payload);
+                        if (frame.fin) return try allocator.dupe(u8, owned_payload);
+                        self.fragment_buffer.clearRetainingCapacity();
+                        try self.fragment_buffer.appendSlice(self.allocator, owned_payload);
+                        self.fragment_opcode = frame.opcode;
+                        continue;
                     },
                     .continuation => {
-                        // Continuation frames not fully supported - return payload
-                        return try allocator.dupe(u8, frame.payload);
+                        if (self.fragment_opcode == null) return error.ProtocolError;
+                        try self.fragment_buffer.appendSlice(self.allocator, owned_payload);
+                        if (!frame.fin) continue;
+                        defer {
+                            self.fragment_buffer.clearRetainingCapacity();
+                            self.fragment_opcode = null;
+                        }
+                        return try allocator.dupe(u8, self.fragment_buffer.items);
                     },
                 }
             }
 
             // Need more data - read from stream
-            var read_buf: [4096]u8 = undefined;
+            while (!self.mutex.tryLock()) std.atomic.spinLoopHint();
+            const stream = self.tcp_stream orelse {
+                self.mutex.unlock();
+                return error.NotConnected;
+            };
             var readable = stream;
+            self.mutex.unlock();
+
+            var read_buf: [4096]u8 = undefined;
             const bytes_read = readable.read(&read_buf) catch |err| {
+                while (!self.mutex.tryLock()) std.atomic.spinLoopHint();
+                defer self.mutex.unlock();
                 if (err == error.EndOfStream) {
+                    if (self.tcp_stream) |open_stream| {
+                        var closable = open_stream;
+                        closable.close();
+                        self.tcp_stream = null;
+                    }
                     self.state = .closed;
                     return null;
                 }
@@ -205,6 +281,13 @@ pub const WebSocketClient = struct {
             };
 
             if (bytes_read == 0) {
+                while (!self.mutex.tryLock()) std.atomic.spinLoopHint();
+                defer self.mutex.unlock();
+                if (self.tcp_stream) |open_stream| {
+                    var closable = open_stream;
+                    closable.close();
+                    self.tcp_stream = null;
+                }
                 self.state = .closed;
                 return null;
             }
@@ -215,6 +298,9 @@ pub const WebSocketClient = struct {
 
     /// Close the connection
     pub fn close(self: *Self) void {
+        _ = defaultIo();
+        while (!self.mutex.tryLock()) std.atomic.spinLoopHint();
+        defer self.mutex.unlock();
         if (self.tcp_stream) |stream| {
             var closable = stream;
             // Send close frame if connected
@@ -235,8 +321,22 @@ pub const WebSocketClient = struct {
         }
         self.send_buffer.clearRetainingCapacity();
         self.recv_buffer.clearRetainingCapacity();
+        self.fragment_buffer.clearRetainingCapacity();
+        self.fragment_opcode = null;
         self.resetPingState();
         self.state = .closed;
+    }
+
+    /// Force-close the socket without sending a close frame; safe from cancellation paths.
+    fn abort(self: *Self) void {
+        while (!self.mutex.tryLock()) std.atomic.spinLoopHint();
+        defer self.mutex.unlock();
+        if (self.tcp_stream) |stream| {
+            var closable = stream;
+            closable.shutdown();
+        }
+        self.resetPingState();
+        self.state = .closing;
     }
 
     /// Convert to AsyncSender interface
@@ -260,7 +360,7 @@ pub const WebSocketClient = struct {
     }
 
     fn sendPong(self: *Self, payload: []const u8) !void {
-        const stream = self.tcp_stream orelse return error.NotConnected;
+        _ = defaultIo();
 
         const frame = Frame{
             .opcode = .pong,
@@ -272,7 +372,16 @@ pub const WebSocketClient = struct {
         const encoded = try encodeFrame(frame, self.allocator);
         defer self.allocator.free(encoded);
 
+        while (!self.mutex.tryLock()) std.atomic.spinLoopHint();
+        const stream = self.tcp_stream orelse {
+            self.mutex.unlock();
+            return error.NotConnected;
+        };
         var writable = stream;
+        self.mutex.unlock();
+
+        while (!self.write_mutex.tryLock()) std.atomic.spinLoopHint();
+        defer self.write_mutex.unlock();
         try writable.writeAll(encoded);
     }
 
@@ -322,6 +431,46 @@ pub const WebSocketClient = struct {
         allocator: std.mem.Allocator,
     };
 
+    /// Handle for a cancelable WebSocket reader thread.
+    /// Created by `receiveStreamWithHandle`; call `deinit` to join the thread.
+    pub const AsyncStreamHandle = struct {
+        stream: *transport.ByteStream,
+        thread: std.Thread,
+        cancel_token: *std.atomic.Value(bool),
+        client: *WebSocketClient,
+        allocator: std.mem.Allocator,
+
+        const Handle = @This();
+
+        pub fn deinit(self: *Handle, timeout_ms: u64) bool {
+            self.cancel();
+            const exited = self.stream.waitForThread(timeout_ms);
+            if (!exited) {
+                self.thread.detach();
+                return false;
+            }
+            self.thread.join();
+            self.stream.deinit();
+            self.allocator.destroy(self.stream);
+            self.allocator.destroy(self.cancel_token);
+            self.allocator.destroy(self);
+            return true;
+        }
+
+        pub fn cancel(self: *Handle) void {
+            self.cancel_token.store(true, .release);
+            // Force-closing the socket unblocks a reader thread parked in receive().
+            self.client.abort();
+        }
+    };
+
+    const HandleProducerContext = struct {
+        stream: *transport.ByteStream,
+        client: *WebSocketClient,
+        allocator: std.mem.Allocator,
+        cancel_token: *std.atomic.Value(bool),
+    };
+
     fn receiveStreamFn(ctx: *anyopaque, allocator: std.mem.Allocator) !*transport.ByteStream {
         const self: *Self = @ptrCast(@alignCast(ctx));
 
@@ -339,6 +488,44 @@ pub const WebSocketClient = struct {
         thread.detach();
 
         return stream;
+    }
+
+    /// Create an async stream with explicit thread-lifecycle management.
+    /// The returned handle owns the `ByteStream`, cancel token, and reader thread.
+    pub fn receiveStreamWithHandle(self: *Self, allocator: std.mem.Allocator) !*Self.AsyncStreamHandle {
+        const stream = try allocator.create(transport.ByteStream);
+        stream.* = transport.ByteStream.init(allocator);
+        errdefer {
+            stream.deinit();
+            allocator.destroy(stream);
+        }
+
+        const cancel_token = try allocator.create(std.atomic.Value(bool));
+        cancel_token.* = std.atomic.Value(bool).init(false);
+        errdefer allocator.destroy(cancel_token);
+
+        const handle = try allocator.create(Self.AsyncStreamHandle);
+        errdefer allocator.destroy(handle);
+
+        const thread_ctx = try allocator.create(HandleProducerContext);
+        thread_ctx.* = .{
+            .stream = stream,
+            .client = self,
+            .allocator = allocator,
+            .cancel_token = cancel_token,
+        };
+        errdefer allocator.destroy(thread_ctx);
+
+        const thread = try std.Thread.spawn(.{}, handleProducerThread, .{thread_ctx});
+
+        handle.* = .{
+            .stream = stream,
+            .thread = thread,
+            .cancel_token = cancel_token,
+            .client = self,
+            .allocator = allocator,
+        };
+        return handle;
     }
 
     fn producerThread(ctx: *ProducerContext) void {
@@ -367,6 +554,40 @@ pub const WebSocketClient = struct {
                 return;
             }
         }
+    }
+
+    fn handleProducerThread(ctx: *HandleProducerContext) void {
+        defer {
+            ctx.stream.markThreadDone();
+            ctx.allocator.destroy(ctx);
+        }
+
+        while (!ctx.cancel_token.load(.acquire)) {
+            const msg = ctx.client.receive(ctx.allocator) catch {
+                if (ctx.cancel_token.load(.acquire)) {
+                    ctx.stream.complete({});
+                    return;
+                }
+                ctx.stream.completeWithError("Receive error");
+                return;
+            };
+
+            if (msg) |data| {
+                const chunk = transport.ByteChunk{
+                    .data = data,
+                    .owned = true,
+                };
+                if (!pushChunkOrFail(ctx.stream, chunk, ctx.allocator)) {
+                    return;
+                }
+            } else {
+                // Connection closed
+                ctx.stream.complete({});
+                return;
+            }
+        }
+
+        ctx.stream.complete({});
     }
 
     fn readFn(ctx: *anyopaque, allocator: std.mem.Allocator) anyerror!?[]const u8 {
@@ -403,6 +624,72 @@ fn hasHeaderName(response: []const u8, name: []const u8) bool {
         line_start = if (line_end < response.len) line_end + 1 else response.len;
     }
     return false;
+}
+
+fn headerValueContainsToken(response: []const u8, name: []const u8, token: []const u8) bool {
+    var line_start: usize = 0;
+    while (line_start < response.len) {
+        const line_end = std.mem.indexOfScalarPos(u8, response, line_start, '\n') orelse response.len;
+        var line = response[line_start..line_end];
+        if (std.mem.endsWith(u8, line, "\r")) {
+            line = line[0 .. line.len - 1];
+        }
+
+        if (line.len == 0) return false;
+        if (std.mem.indexOfScalar(u8, line, ':')) |colon| {
+            const header_name = std.mem.trim(u8, line[0..colon], " \t");
+            if (std.ascii.eqlIgnoreCase(header_name, name)) {
+                const value = std.mem.trim(u8, line[colon + 1 ..], " \t");
+                var parts = std.mem.splitScalar(u8, value, ',');
+                while (parts.next()) |part| {
+                    if (std.ascii.eqlIgnoreCase(std.mem.trim(u8, part, " \t"), token)) return true;
+                }
+            }
+        }
+
+        line_start = if (line_end < response.len) line_end + 1 else response.len;
+    }
+    return false;
+}
+
+fn getHeaderValue(response: []const u8, name: []const u8) ?[]const u8 {
+    var line_start: usize = 0;
+    while (line_start < response.len) {
+        const line_end = std.mem.indexOfScalarPos(u8, response, line_start, '\n') orelse response.len;
+        var line = response[line_start..line_end];
+        if (std.mem.endsWith(u8, line, "\r")) {
+            line = line[0 .. line.len - 1];
+        }
+
+        if (line.len == 0) return null;
+        if (std.mem.indexOfScalar(u8, line, ':')) |colon| {
+            const header_name = std.mem.trim(u8, line[0..colon], " \t");
+            if (std.ascii.eqlIgnoreCase(header_name, name)) {
+                return std.mem.trim(u8, line[colon + 1 ..], " \t");
+            }
+        }
+
+        line_start = if (line_end < response.len) line_end + 1 else response.len;
+    }
+    return null;
+}
+
+const websocket_guid = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+
+fn verifyAcceptHeader(response: []const u8, request_key: []const u8) bool {
+    const accept_value = getHeaderValue(response, "Sec-WebSocket-Accept") orelse return false;
+
+    var hash_input: [60]u8 = undefined;
+    @memcpy(hash_input[0..24], request_key);
+    @memcpy(hash_input[24..60], websocket_guid);
+
+    var digest: [20]u8 = undefined;
+    std.crypto.hash.Sha1.hash(&hash_input, &digest, .{});
+
+    var expected: [28]u8 = undefined;
+    _ = std.base64.standard.Encoder.encode(&expected, &digest);
+
+    return std.mem.eql(u8, accept_value, &expected);
 }
 
 // --- Internal types ---
@@ -571,6 +858,7 @@ fn performHandshake(
     port: u16,
     path: []const u8,
     headers: ?[]const ai_types.HeaderPair,
+    subprotocol: ?[]const u8,
 ) !void {
     _ = port; // Port is already resolved and connected before calling this
     const stream = client.tcp_stream orelse return error.NotConnected;
@@ -592,7 +880,9 @@ fn performHandshake(
     try request.print(client.allocator, "Upgrade: websocket\r\n", .{});
     try request.print(client.allocator, "Connection: Upgrade\r\n", .{});
     try request.print(client.allocator, "Sec-WebSocket-Key: {s}\r\n", .{key});
-    try request.print(client.allocator, "Sec-WebSocket-Protocol: makai.v1\r\n", .{});
+    if (subprotocol) |sp| {
+        try request.print(client.allocator, "Sec-WebSocket-Protocol: {s}\r\n", .{sp});
+    }
     try request.print(client.allocator, "Sec-WebSocket-Version: 13\r\n", .{});
 
     // Add custom headers
@@ -608,38 +898,53 @@ fn performHandshake(
     var io_stream = stream;
     try io_stream.writeAll(request.items);
 
-    // Read response
+    // Read response headers. TCP can split the HTTP response across reads, so
+    // keep reading until the header terminator arrives and preserve any frame
+    // bytes coalesced after it.
     var response_buf: [4096]u8 = undefined;
-    const response_len = try io_stream.read(&response_buf);
+    var response_len: usize = 0;
+    var header_end: ?usize = null;
+    while (response_len < response_buf.len) {
+        const n = try io_stream.read(response_buf[response_len..]);
+        if (n == 0) return error.HandshakeFailed;
+        response_len += n;
+        if (std.mem.indexOf(u8, response_buf[0..response_len], "\r\n\r\n")) |idx| {
+            header_end = idx;
+            break;
+        }
+    }
+    const end = header_end orelse return error.HandshakeFailed;
     const response = response_buf[0..response_len];
+    const headers_part = response[0 .. end + 4];
+    const leftover = response[end + 4 ..];
 
     // Verify response
     // Should start with "HTTP/1.1 101"
-    if (!std.mem.startsWith(u8, response, "HTTP/1.1 101")) {
+    if (!std.mem.startsWith(u8, headers_part, "HTTP/1.1 101")) {
         return error.HandshakeFailed;
     }
 
-    // Verify Upgrade: websocket
-    if (std.mem.find(u8, response, "Upgrade: websocket") == null and
-        std.mem.find(u8, response, "Upgrade: Websocket") == null)
-    {
+    // Verify Upgrade and Connection headers case-insensitively.
+    if (!headerValueContainsToken(headers_part, "Upgrade", "websocket")) {
         return error.HandshakeFailed;
     }
 
-    // Verify Connection: Upgrade
-    if (std.mem.find(u8, response, "Connection: Upgrade") == null and
-        std.mem.find(u8, response, "Connection: upgrade") == null)
-    {
+    if (!headerValueContainsToken(headers_part, "Connection", "upgrade")) {
         return error.HandshakeFailed;
     }
 
-    // Verify Sec-WebSocket-Accept header.
-    // The expected accept key is base64(sha1(key ++
-    // "258EAFA5-E914-47DA-95CA-C5AB0DC85B11")). Full value verification is
-    // intentionally deferred; this migration preserves existing behavior by
-    // only requiring the accept header to be present.
-    if (!hasHeaderName(response, "Sec-WebSocket-Accept")) {
+    if (subprotocol) |expected_protocol| {
+        const selected_protocol = getHeaderValue(headers_part, "Sec-WebSocket-Protocol") orelse return error.HandshakeFailed;
+        if (!std.mem.eql(u8, selected_protocol, expected_protocol)) return error.HandshakeFailed;
+    }
+
+    // Verify Sec-WebSocket-Accept header matches the request key (RFC 6455 §4.2.2).
+    if (!verifyAcceptHeader(headers_part, client.handshake_key[0..24])) {
         return error.HandshakeFailed;
+    }
+
+    if (leftover.len > 0) {
+        try client.recv_buffer.appendSlice(client.allocator, leftover);
     }
 }
 

--- a/zig/src/tui/runtime.zig
+++ b/zig/src/tui/runtime.zig
@@ -672,8 +672,11 @@ pub const TuiRuntime = struct {
                 self.remote_error_emitted = false;
                 self.remote_reconnect_attempted = false;
                 self.pumpRemoteIncoming() catch |err| {
+                    // Cancel the WebSocket reader before closing the sender so the
+                    // close path cannot clear buffers while receive() is using them.
+                    if (self.remote_config_websocket_owned) _ = self.shutdownWebSocketReader();
                     if (self.remote_sender) |remote_sender| remote_sender.close();
-                    if (self.remote_config_stream_handle == null and self.websocket_handle == null) {
+                    if (self.remote_config_stream_handle == null and self.websocket_handle == null and !self.remote_config_websocket_owned) {
                         if (self.remote_receiver) |*remote_receiver| remote_receiver.close();
                     }
                     self.clearWebSocketRemote();
@@ -728,8 +731,11 @@ pub const TuiRuntime = struct {
                 _ = client.sendAgentStop(sid, "client disconnect") catch {};
                 client.removeSessionState(sid);
             }
+            // Cancel and join the WebSocket reader before closing the sender so
+            // the close path cannot clear buffers while receive() is using them.
+            if (self.remote_config_websocket_owned) _ = self.shutdownWebSocketReader();
             if (self.remote_sender) |sender| sender.close();
-            if (self.remote_config_stream_handle == null and self.websocket_handle == null) {
+            if (self.remote_config_stream_handle == null and self.websocket_handle == null and !self.remote_config_websocket_owned) {
                 if (self.remote_receiver) |*receiver| receiver.close();
             }
             self.clearWebSocketRemote();
@@ -1458,8 +1464,10 @@ pub const TuiRuntime = struct {
 
     fn sendRemoteMessages(self: *TuiRuntime, messages: []const ai_types.Message, emit_tail_prompt: bool) !void {
         try self.ensureRemoteSession();
+        if (self.remote_config_websocket_owned) try self.ensureRemoteWebSocketConnection();
+        try self.ensureRemoteSession();
         const client = &(self.remote_client orelse return error.RuntimeNotStarted);
-        const sid = self.remote_session_id orelse return error.RemoteAgentStartFailed;
+        var sid = self.remote_session_id orelse return error.RemoteAgentStartFailed;
         const message_json = try makeRemoteMessageJson(self.allocator, self.currentModel(), messages, self.remoteSerializableTools());
         defer self.allocator.free(message_json);
         self.resetEventStreamForTurn();
@@ -1475,7 +1483,23 @@ pub const TuiRuntime = struct {
         defer self.allocator.free(options_json);
         self.remote_echo_suppression_remaining = messages.len;
         self.remote_current_message_role = null;
-        _ = try client.sendAgentMessage(sid, message_json, options_json);
+
+        var reconnected_once = false;
+        while (true) {
+            const result = client.sendAgentMessage(sid, message_json, options_json) catch |err| {
+                if (self.remote_config_websocket_owned and err == error.NotConnected and !reconnected_once) {
+                    reconnected_once = true;
+                    try self.ensureRemoteWebSocketConnection();
+                    try self.ensureRemoteSession();
+                    sid = self.remote_session_id orelse return error.RemoteAgentStartFailed;
+                    continue;
+                }
+                return err;
+            };
+            _ = result;
+            break;
+        }
+
         if (emit_tail_prompt) try self.pushRemoteTailPromptEvent(messages);
         self.pumpRemoteIncoming() catch |err| {
             try self.completeRemoteWithError(@errorName(err));
@@ -1641,6 +1665,51 @@ pub const TuiRuntime = struct {
         if (self.remote_config_websocket_owned) {
             self.remote_sender = null;
             self.remote_receiver = null;
+        }
+    }
+
+    /// Cancel and join the WebSocket reader thread, returning true if the thread
+    /// exited cleanly. On a timeout/detach the client reference is dropped to
+    /// avoid use-after-free by any dangling sender/receiver handles.
+    fn shutdownWebSocketReader(self: *TuiRuntime) bool {
+        if (self.websocket_handle) |handle| {
+            self.websocket_handle = null;
+            if (!handle.deinit(5_000)) {
+                self.websocket_client = null;
+                if (self.remote_config_websocket_owned) {
+                    self.remote_sender = null;
+                    self.remote_receiver = null;
+                }
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /// Detect an idle WebSocket disconnect before writing a turn. If the reader
+    /// thread has finished the byte stream, clear the stale session and reconnect
+    /// so the next send goes through a live socket.
+    fn ensureRemoteWebSocketConnection(self: *TuiRuntime) !void {
+        if (!self.remote_config_websocket_owned) return;
+        const disconnected = blk: {
+            if (self.websocket_client == null) break :blk true;
+            if (self.websocket_handle) |handle| if (handle.stream.isDone()) break :blk true;
+            break :blk false;
+        };
+        if (!disconnected) return;
+
+        if (self.remote_session_id) |sid| {
+            if (self.remote_client) |*client| client.removeSessionState(sid);
+            self.remote_session_id = null;
+        }
+        self.remote_pending_session_id = null;
+        self.clearWebSocketRemote();
+        if (self.remote_config_sse_endpoint.len == 0) return error.NoRemoteTransportConfigured;
+        try self.reconnectWebSocketRemote();
+        if (self.remote_client) |*client| {
+            client.setSender(self.remote_sender orelse return error.NoRemoteTransportConfigured);
+        } else {
+            return error.RuntimeNotStarted;
         }
     }
 

--- a/zig/src/tui/runtime.zig
+++ b/zig/src/tui/runtime.zig
@@ -1463,7 +1463,6 @@ pub const TuiRuntime = struct {
     }
 
     fn sendRemoteMessages(self: *TuiRuntime, messages: []const ai_types.Message, emit_tail_prompt: bool) !void {
-        try self.ensureRemoteSession();
         if (self.remote_config_websocket_owned) try self.ensureRemoteWebSocketConnection();
         try self.ensureRemoteSession();
         const client = &(self.remote_client orelse return error.RuntimeNotStarted);

--- a/zig/src/tui/runtime.zig
+++ b/zig/src/tui/runtime.zig
@@ -13,6 +13,7 @@ const transport = @import("transport");
 const in_process = @import("transports/in_process");
 const stdio_transport = @import("transports/stdio");
 const sse_transport = @import("transports/sse");
+const websocket_transport = @import("transports/websocket");
 const json_writer = @import("json_writer");
 const model_ref = @import("model_ref");
 const session = @import("tui_session");
@@ -105,6 +106,7 @@ pub const TuiRemoteConfig = struct {
     command: []const u8 = "",
     auth_token: []const u8 = "",
     auth_headers: []const ai_types.HeaderPair = &.{},
+    subprotocol: ?[]const u8 = "makai.v1",
 
     pub fn deinit(self: *TuiRemoteConfig, allocator: std.mem.Allocator) void {
         if (self.endpoint.len > 0) allocator.free(self.endpoint);
@@ -272,6 +274,16 @@ fn deinitModels(allocator: std.mem.Allocator, models: []ai_types.Model) void {
     allocator.free(models);
 }
 
+fn mapWebSocketConnectError(err: anyerror) anyerror {
+    return switch (err) {
+        error.InvalidUrl, error.InvalidScheme, error.MissingHost, error.InvalidPort => error.InvalidRemoteUrl,
+        error.TlsNotSupported => error.RemoteTlsNotSupported,
+        error.ConnectionFailed, error.ConnectionRefused, error.NetworkUnreachable, error.HostLacksNetworkAddresses, error.TemporaryNameServerFailure, error.NameServerFailure, error.UnknownHostName => error.RemoteConnectionFailed,
+        error.HandshakeFailed, error.NotConnected, error.EndOfStream, error.ConnectionResetByPeer, error.BrokenPipe, error.UnexpectedReadFailure, error.UnexpectedWriteFailure => error.RemoteHandshakeFailed,
+        else => err,
+    };
+}
+
 pub const TuiRuntime = struct {
     allocator: std.mem.Allocator,
     backend: TuiBackendMode,
@@ -286,6 +298,10 @@ pub const TuiRuntime = struct {
     remote_config_sse_client: ?*sse_transport.SseHttpClient = null,
     remote_config_sse_endpoint: []u8 = &.{},
     remote_config_sse_headers: []ai_types.HeaderPair = &.{},
+    websocket_client: ?*websocket_transport.WebSocketClient = null,
+    websocket_handle: ?*websocket_transport.AsyncStreamHandle = null,
+    websocket_subprotocol: ?[]u8 = null,
+    remote_config_websocket_owned: bool = false,
     remote_sender: ?transport.AsyncSender = null,
     remote_receiver: ?RemoteLineReceiver = null,
     remote_session_id: ?agent_protocol_types.SessionId = null,
@@ -376,6 +392,10 @@ pub const TuiRuntime = struct {
         var remote_config_sse_client: ?*sse_transport.SseHttpClient = null;
         var remote_config_sse_endpoint: []u8 = &.{};
         var remote_config_sse_headers: []ai_types.HeaderPair = &.{};
+        var websocket_client: ?*websocket_transport.WebSocketClient = null;
+        var websocket_handle: ?*websocket_transport.AsyncStreamHandle = null;
+        var websocket_subprotocol: ?[]u8 = null;
+        var remote_config_websocket_owned = false;
         var remote_sender = options.remote_sender;
         var remote_receiver = options.remote_receiver;
         errdefer if (remote_config_stream_handle) |handle| {
@@ -393,6 +413,13 @@ pub const TuiRuntime = struct {
             for (remote_config_sse_headers) |*header| header.deinit(allocator);
             if (remote_config_sse_headers.len > 0) allocator.free(remote_config_sse_headers);
         }
+        errdefer if (websocket_client) |client| { client.deinit(); allocator.destroy(client); };
+        errdefer if (websocket_subprotocol) |sp| allocator.free(sp);
+        errdefer if (websocket_handle) |handle| {
+            if (!handle.deinit(5_000)) {
+                websocket_client = null;
+            }
+        };
         if (resolved_backend == .remote and remote_sender == null and remote_receiver == null and options.remote_config.mode == .remote) {
             switch (options.remote_config.transport) {
                 .stdio => {
@@ -446,7 +473,37 @@ pub const TuiRuntime = struct {
                     remote_sender = client.asyncSender();
                     remote_receiver = .{ .ctx = client, .read_line_fn = remoteConfigSseReadLine, .read_result_fn = remoteConfigSseReadResult, .close_fn = remoteConfigSseClose };
                 },
-                .websocket => return error.UnsupportedRemoteTransport,
+                .websocket => {
+                    if (options.remote_config.endpoint.len == 0) return error.UnsupportedRemoteEndpoint;
+                    const client = try allocator.create(websocket_transport.WebSocketClient);
+                    client.* = websocket_transport.WebSocketClient.init(allocator);
+                    errdefer { client.deinit(); allocator.destroy(client); }
+                    client.connectWithSubprotocol(options.remote_config.endpoint, options.remote_config.auth_headers, options.remote_config.subprotocol) catch |err| return mapWebSocketConnectError(err);
+                    const handle = try client.receiveStreamWithHandle(allocator);
+                    var handle_moved = false;
+                    errdefer if (!handle_moved) { _ = handle.deinit(5_000); };
+                    remote_config_sse_endpoint = try allocator.dupe(u8, options.remote_config.endpoint);
+                    const cloned_headers = try allocator.alloc(ai_types.HeaderPair, options.remote_config.auth_headers.len);
+                    var cloned_header_count: usize = 0;
+                    var cloned_headers_moved = false;
+                    errdefer if (!cloned_headers_moved) {
+                        for (cloned_headers[0..cloned_header_count]) |*header| header.deinit(allocator);
+                        allocator.free(cloned_headers);
+                    };
+                    for (options.remote_config.auth_headers, 0..) |header, i| {
+                        cloned_headers[i] = .{ .name = try allocator.dupe(u8, header.name), .value = try allocator.dupe(u8, header.value) };
+                        cloned_header_count += 1;
+                    }
+                    remote_config_sse_headers = cloned_headers;
+                    cloned_headers_moved = true;
+                    if (options.remote_config.subprotocol) |sp| websocket_subprotocol = try allocator.dupe(u8, sp);
+                    websocket_client = client;
+                    websocket_handle = handle;
+                    handle_moved = true;
+                    remote_config_websocket_owned = true;
+                    remote_sender = client.asyncSender();
+                    remote_receiver = .{ .ctx = handle, .read_line_fn = websocketReadLine, .read_result_fn = websocketReadResult, .close_fn = websocketClose };
+                },
             }
         }
 
@@ -466,6 +523,10 @@ pub const TuiRuntime = struct {
             .remote_config_sse_client = remote_config_sse_client,
             .remote_config_sse_endpoint = remote_config_sse_endpoint,
             .remote_config_sse_headers = remote_config_sse_headers,
+            .websocket_client = websocket_client,
+            .websocket_handle = websocket_handle,
+            .websocket_subprotocol = websocket_subprotocol,
+            .remote_config_websocket_owned = remote_config_websocket_owned,
             .remote_sender = remote_sender,
             .remote_receiver = remote_receiver,
             .remote_session_timeout_ms = options.remote_session_timeout_ms,
@@ -493,6 +554,9 @@ pub const TuiRuntime = struct {
         remote_config_sse_client = null;
         remote_config_sse_endpoint = &.{};
         remote_config_sse_headers = &.{};
+        websocket_client = null;
+        websocket_handle = null;
+        websocket_subprotocol = null;
         original_tools = &.{};
         wrapped_tools = &.{};
         models = &.{};
@@ -557,6 +621,12 @@ pub const TuiRuntime = struct {
         if (self.remote_config_sse_endpoint.len > 0) self.allocator.free(self.remote_config_sse_endpoint);
         for (self.remote_config_sse_headers) |*header| header.deinit(self.allocator);
         if (self.remote_config_sse_headers.len > 0) self.allocator.free(self.remote_config_sse_headers);
+        var websocket_handle_exited = true;
+        if (self.websocket_handle) |handle| websocket_handle_exited = handle.deinit(5_000);
+        if (websocket_handle_exited) {
+            if (self.websocket_client) |client| { client.deinit(); self.allocator.destroy(client); }
+        }
+        if (self.websocket_subprotocol) |sp| self.allocator.free(sp);
         self.clearPendingApproval();
         self.tool_protocol.deinit();
         self.allocator.free(self.workspace_root);
@@ -579,8 +649,12 @@ pub const TuiRuntime = struct {
                 var client = agent_protocol_client.AgentProtocolClient.init(self.allocator);
                 var client_moved = false;
                 errdefer if (!client_moved) client.deinit();
+                errdefer if (!client_moved and self.remote_config_websocket_owned) self.clearWebSocketRemote();
                 if (self.remote_config_sse_client) |sse_client| {
                     if (!sse_client.connected) try sse_client.connect(self.remote_config_sse_endpoint, self.remote_config_sse_headers);
+                }
+                if (self.remote_config_sse_client == null and self.websocket_client == null and self.remote_config_sse_endpoint.len > 0) {
+                    try self.reconnectWebSocketRemote();
                 }
                 const sender = self.remote_sender orelse return error.NoRemoteTransportConfigured;
                 _ = self.remote_receiver orelse return error.NoRemoteTransportConfigured;
@@ -599,9 +673,10 @@ pub const TuiRuntime = struct {
                 self.remote_reconnect_attempted = false;
                 self.pumpRemoteIncoming() catch |err| {
                     if (self.remote_sender) |remote_sender| remote_sender.close();
-                    if (self.remote_config_stream_handle == null) {
+                    if (self.remote_config_stream_handle == null and self.websocket_handle == null) {
                         if (self.remote_receiver) |*remote_receiver| remote_receiver.close();
                     }
+                    self.clearWebSocketRemote();
                     if (self.remote_client) |*remote_client| remote_client.deinit();
                     self.remote_client = null;
                     self.remote_session_id = null;
@@ -654,9 +729,10 @@ pub const TuiRuntime = struct {
                 client.removeSessionState(sid);
             }
             if (self.remote_sender) |sender| sender.close();
-            if (self.remote_config_stream_handle == null) {
+            if (self.remote_config_stream_handle == null and self.websocket_handle == null) {
                 if (self.remote_receiver) |*receiver| receiver.close();
             }
+            self.clearWebSocketRemote();
             client.deinit();
             self.remote_client = null;
             self.remote_session_id = null;
@@ -1545,6 +1621,47 @@ pub const TuiRuntime = struct {
         self.stream_active = false;
     }
 
+    fn clearWebSocketRemote(self: *TuiRuntime) void {
+        if (self.websocket_handle) |handle| {
+            self.websocket_handle = null;
+            if (!handle.deinit(5_000)) {
+                self.websocket_client = null;
+                if (self.remote_config_websocket_owned) {
+                    self.remote_sender = null;
+                    self.remote_receiver = null;
+                }
+                return;
+            }
+        }
+        if (self.websocket_client) |ws_client| {
+            ws_client.deinit();
+            self.allocator.destroy(ws_client);
+            self.websocket_client = null;
+        }
+        if (self.remote_config_websocket_owned) {
+            self.remote_sender = null;
+            self.remote_receiver = null;
+        }
+    }
+
+    fn reconnectWebSocketRemote(self: *TuiRuntime) !void {
+        const client = try self.allocator.create(websocket_transport.WebSocketClient);
+        client.* = websocket_transport.WebSocketClient.init(self.allocator);
+        errdefer {
+            client.deinit();
+            self.allocator.destroy(client);
+        }
+
+        client.connectWithSubprotocol(self.remote_config_sse_endpoint, self.remote_config_sse_headers, self.websocket_subprotocol) catch |err| return mapWebSocketConnectError(err);
+        const handle = try client.receiveStreamWithHandle(self.allocator);
+        errdefer { _ = handle.deinit(5_000); }
+
+        self.websocket_client = client;
+        self.websocket_handle = handle;
+        self.remote_sender = client.asyncSender();
+        self.remote_receiver = .{ .ctx = handle, .read_line_fn = websocketReadLine, .read_result_fn = websocketReadResult, .close_fn = websocketClose };
+    }
+
     fn handleRemoteDisconnect(self: *TuiRuntime) !void {
         if (!self.started) return error.ConnectionRefused;
         if (!self.remote_reconnect_attempted) {
@@ -1555,6 +1672,11 @@ pub const TuiRuntime = struct {
             self.remote_session_id = null;
             if (self.remote_config_sse_client) |sse_client| {
                 try sse_client.connect(self.remote_config_sse_endpoint, self.remote_config_sse_headers);
+            }
+            self.clearWebSocketRemote();
+            if (self.remote_config_sse_client == null and self.remote_config_sse_endpoint.len > 0) {
+                try self.reconnectWebSocketRemote();
+                client.setSender(self.remote_sender orelse return error.NoRemoteTransportConfigured);
             }
             if (was_stream_active) {
                 try self.completeRemoteWithError("remote connection disconnected");
@@ -4107,8 +4229,20 @@ test "remote config rejects unsupported endpoint" {
     try std.testing.expectError(error.UnsupportedRemoteEndpoint, TuiRuntime.init(std.testing.allocator, .{ .remote_config = .{ .mode = .remote, .transport = .stdio, .endpoint = "remote" } }));
 }
 
-test "remote config rejects unsupported transport" {
-    try std.testing.expectError(error.UnsupportedRemoteTransport, TuiRuntime.init(std.testing.allocator, .{ .remote_config = .{ .mode = .remote, .transport = .websocket, .endpoint = "ws://localhost:1" } }));
+test "remote config websocket rejects empty endpoint" {
+    try std.testing.expectError(error.UnsupportedRemoteEndpoint, TuiRuntime.init(std.testing.allocator, .{ .remote_config = .{ .mode = .remote, .transport = .websocket, .endpoint = "" } }));
+}
+
+test "remote config websocket maps invalid url to InvalidRemoteUrl" {
+    try std.testing.expectError(error.InvalidRemoteUrl, TuiRuntime.init(std.testing.allocator, .{ .remote_config = .{ .mode = .remote, .transport = .websocket, .endpoint = "not-a-url" } }));
+}
+
+test "remote config websocket maps wss to RemoteTlsNotSupported" {
+    try std.testing.expectError(error.RemoteTlsNotSupported, TuiRuntime.init(std.testing.allocator, .{ .remote_config = .{ .mode = .remote, .transport = .websocket, .endpoint = "wss://localhost:1/" } }));
+}
+
+test "remote config websocket maps refused connection to RemoteConnectionFailed" {
+    try std.testing.expectError(error.RemoteConnectionFailed, TuiRuntime.init(std.testing.allocator, .{ .remote_config = .{ .mode = .remote, .transport = .websocket, .endpoint = "ws://127.0.0.1:1/" } }));
 }
 
 test "remoteConfigFromConfig falls back to local for saved stdio" {
@@ -5526,4 +5660,36 @@ fn remotePipeReadLine(ctx: *anyopaque, allocator: std.mem.Allocator) !?[]const u
 
 fn remotePipeReadResult(ctx: *anyopaque, allocator: std.mem.Allocator) !RemoteReadResult {
     return if (try remotePipeReadLine(ctx, allocator)) |line| .{ .line = line } else .pending;
+}
+
+fn byteStreamReadResult(stream: *transport.ByteStream, allocator: std.mem.Allocator) !RemoteReadResult {
+    if (stream.poll()) |chunk| {
+        var owned_chunk = chunk;
+        const line = try allocator.dupe(u8, owned_chunk.data);
+        owned_chunk.deinit(allocator);
+        return .{ .line = line };
+    }
+    if (stream.isDone()) {
+        if (stream.getError()) |_| return error.RemoteTransportError;
+        return .disconnected;
+    }
+    return .pending;
+}
+
+fn websocketReadLine(ctx: *anyopaque, allocator: std.mem.Allocator) !?[]const u8 {
+    const handle: *websocket_transport.AsyncStreamHandle = @ptrCast(@alignCast(ctx));
+    return switch (try byteStreamReadResult(handle.stream, allocator)) {
+        .line => |line| line,
+        .pending, .disconnected => null,
+    };
+}
+
+fn websocketReadResult(ctx: *anyopaque, allocator: std.mem.Allocator) !RemoteReadResult {
+    const handle: *websocket_transport.AsyncStreamHandle = @ptrCast(@alignCast(ctx));
+    return byteStreamReadResult(handle.stream, allocator);
+}
+
+fn websocketClose(ctx: *anyopaque) void {
+    const handle: *websocket_transport.AsyncStreamHandle = @ptrCast(@alignCast(ctx));
+    handle.cancel();
 }

--- a/zig/src/tui/runtime.zig
+++ b/zig/src/tui/runtime.zig
@@ -1463,7 +1463,7 @@ pub const TuiRuntime = struct {
     }
 
     fn sendRemoteMessages(self: *TuiRuntime, messages: []const ai_types.Message, emit_tail_prompt: bool) !void {
-        if (self.remote_config_websocket_owned) try self.ensureRemoteWebSocketConnection();
+        if (self.remote_config_websocket_owned) try self.ensureRemoteWebSocketConnection(false);
         try self.ensureRemoteSession();
         const client = &(self.remote_client orelse return error.RuntimeNotStarted);
         var sid = self.remote_session_id orelse return error.RemoteAgentStartFailed;
@@ -1486,9 +1486,10 @@ pub const TuiRuntime = struct {
         var reconnected_once = false;
         while (true) {
             const result = client.sendAgentMessage(sid, message_json, options_json) catch |err| {
-                if (self.remote_config_websocket_owned and err == error.NotConnected and !reconnected_once) {
+                const reconnectable = err == error.NotConnected or err == error.BrokenPipe or err == error.ConnectionResetByPeer;
+                if (self.remote_config_websocket_owned and reconnectable and !reconnected_once) {
                     reconnected_once = true;
-                    try self.ensureRemoteWebSocketConnection();
+                    try self.ensureRemoteWebSocketConnection(true);
                     try self.ensureRemoteSession();
                     sid = self.remote_session_id orelse return error.RemoteAgentStartFailed;
                     continue;
@@ -1687,10 +1688,11 @@ pub const TuiRuntime = struct {
 
     /// Detect an idle WebSocket disconnect before writing a turn. If the reader
     /// thread has finished the byte stream, clear the stale session and reconnect
-    /// so the next send goes through a live socket.
-    fn ensureRemoteWebSocketConnection(self: *TuiRuntime) !void {
+    /// so the next send goes through a live socket. When `force` is true, reconnect
+    /// regardless of the current liveness heuristic (used after a write-side error).
+    fn ensureRemoteWebSocketConnection(self: *TuiRuntime, force: bool) !void {
         if (!self.remote_config_websocket_owned) return;
-        const disconnected = blk: {
+        const disconnected = force or blk: {
             if (self.websocket_client == null) break :blk true;
             if (self.websocket_handle) |handle| if (handle.stream.isDone()) break :blk true;
             break :blk false;

--- a/zig/test/e2e/tui_websocket.zig
+++ b/zig/test/e2e/tui_websocket.zig
@@ -1,0 +1,156 @@
+const std = @import("std");
+const compat = @import("compat");
+const ai_types = @import("ai_types");
+const runtime_mod = @import("tui_runtime");
+
+const websocket_mock_server_py =
+    \\import base64, hashlib, json, socket, struct, sys
+    \\
+    \\port_file, auth_file = sys.argv[1], sys.argv[2]
+    \\def mark(v):
+    \\    with open(auth_file + ".phase", "w") as f:
+    \\        f.write(v)
+    \\sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    \\sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    \\sock.bind(("127.0.0.1", 0))
+    \\sock.listen(1)
+    \\with open(port_file, "w") as f:
+    \\    f.write(str(sock.getsockname()[1]))
+    \\
+    \\def recv_all(conn, n):
+    \\    data = b""
+    \\    while len(data) < n:
+    \\        chunk = conn.recv(n - len(data))
+    \\        if not chunk:
+    \\            raise SystemExit(1)
+    \\        data += chunk
+    \\    return data
+    \\
+    \\conn, _ = sock.accept()
+    \\mark("accepted")
+    \\conn.settimeout(30)
+    \\data = b""
+    \\while b"\r\n\r\n" not in data:
+    \\    chunk = conn.recv(1024)
+    \\    if not chunk:
+    \\        raise SystemExit(1)
+    \\    data += chunk
+    \\headers = data.decode("iso-8859-1").split("\r\n")
+    \\key = None
+    \\auth_ok = False
+    \\proto_ok = False
+    \\for line in headers:
+    \\    lower = line.lower()
+    \\    if lower.startswith("sec-websocket-key:"):
+    \\        key = line.split(":", 1)[1].strip()
+    \\    if lower == "authorization: bearer test-token":
+    \\        auth_ok = True
+    \\    if lower == "sec-websocket-protocol: makai.v1":
+    \\        proto_ok = True
+    \\with open(auth_file, "w") as f:
+    \\    f.write("ok" if auth_ok and proto_ok else "missing")
+    \\accept = base64.b64encode(hashlib.sha1((key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11").encode()).digest()).decode()
+    \\response = ("HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Protocol: makai.v1\r\nSec-WebSocket-Accept: " + accept + "\r\n\r\n").encode()
+    \\sid = "01ARZ3NDEKTSV4RRFFQ69G5FAV"
+    \\reply = json.dumps({"version":1,"session_id":sid,"message_id":"01BRZ3NDEKTSV4RRFFQ69G5FAV","sequence":1,"timestamp":0,"payload":{"agent_started":{"session_id":sid}}}).encode()
+    \\frame = bytearray([0x81])
+    \\if len(reply) < 126:
+    \\    frame.append(len(reply))
+    \\else:
+    \\    frame.append(126); frame.extend(struct.pack(">H", len(reply)))
+    \\frame.extend(reply)
+    \\conn.sendall(response + bytes(frame))
+    \\conn.close()
+;
+
+fn writeFile(path: []const u8, data: []const u8) !void {
+    var file = try std.Io.Dir.createFileAbsolute(std.testing.io, path, .{});
+    defer file.close(std.testing.io);
+    try file.writeStreamingAll(std.testing.io, data);
+}
+
+fn readSmallFile(path: []const u8, buf: []u8) ![]const u8 {
+    var file = try std.Io.Dir.openFileAbsolute(std.testing.io, path, .{});
+    defer file.close(std.testing.io);
+    var reader = file.reader(std.testing.io, &.{});
+    const n = try reader.interface.readSliceShort(buf);
+    return buf[0..n];
+}
+
+fn deleteIgnore(path: []const u8) void {
+    std.Io.Dir.deleteFile(.cwd(), std.testing.io, path) catch {};
+}
+
+fn waitForPort(path: []const u8) !u16 {
+    const start = compat.time.nowMillis();
+    var buf: [32]u8 = undefined;
+    while (@as(u64, @intCast(compat.time.nowMillis() - start)) < 5_000) {
+        const data = readSmallFile(path, &buf) catch {
+            compat.time.sleepMs(10);
+            continue;
+        };
+        return std.fmt.parseUnsigned(u16, std.mem.trim(u8, data, " \n\r\t"), 10) catch {
+            compat.time.sleepMs(10);
+            continue;
+        };
+    }
+    return error.MockServerTimeout;
+}
+
+test "TUI remote WebSocket connects, sends auth/subprotocol, and exchanges envelopes" {
+    const allocator = std.testing.allocator;
+    const unique = compat.time.nowMillis();
+    const script_path = try std.fmt.allocPrint(allocator, "/tmp/makai-ws-{d}.py", .{unique});
+    defer allocator.free(script_path);
+    const port_path = try std.fmt.allocPrint(allocator, "/tmp/makai-ws-{d}.port", .{unique});
+    defer allocator.free(port_path);
+    const auth_path = try std.fmt.allocPrint(allocator, "/tmp/makai-ws-{d}.auth", .{unique});
+    defer allocator.free(auth_path);
+    defer deleteIgnore(script_path);
+    defer deleteIgnore(port_path);
+    defer deleteIgnore(auth_path);
+
+    try writeFile(script_path, websocket_mock_server_py);
+    var child = std.process.spawn(std.testing.io, .{ .argv = &.{ "python3", script_path, port_path, auth_path }, .stdin = .ignore, .stdout = .ignore, .stderr = .ignore }) catch |err| switch (err) {
+        error.FileNotFound => return error.SkipZigTest,
+        else => |e| return e,
+    };
+    defer {
+        if (child.id != null) _ = child.kill(std.testing.io);
+        if (child.id != null) _ = child.wait(std.testing.io) catch {};
+    }
+
+    const port = try waitForPort(port_path);
+    const endpoint = try std.fmt.allocPrint(allocator, "ws://127.0.0.1:{d}/agent", .{port});
+    defer allocator.free(endpoint);
+
+    var runtime = try runtime_mod.TuiRuntime.init(allocator, .{
+        .remote_config = .{ .mode = .remote, .transport = .websocket, .endpoint = endpoint, .auth_headers = &.{.{ .name = "Authorization", .value = "Bearer test-token" }}, .subprotocol = "makai.v1" },
+        .models = &[_]ai_types.Model{.{ .id = "test-model", .name = "Test Model", .api = "test", .provider = "test", .base_url = "", .reasoning = false, .input = &.{}, .cost = .{ .input = 0, .output = 0, .cache_read = 0, .cache_write = 0 }, .context_window = 4096, .max_tokens = 1024 }},
+    });
+    defer runtime.deinit();
+
+    try std.testing.expect(runtime.websocket_client != null);
+    try std.testing.expect(runtime.websocket_handle != null);
+    try std.testing.expect(runtime.remote_sender != null);
+    try std.testing.expect(runtime.remote_receiver != null);
+
+    const start = compat.time.nowMillis();
+    while (true) {
+        if (@as(u64, @intCast(compat.time.nowMillis() - start)) >= 5_000) return error.NoWebSocketReply;
+        const inbound = try runtime.remote_receiver.?.read(allocator);
+        switch (inbound) {
+            .line => |line| {
+                defer allocator.free(line);
+                try std.testing.expect(line.len > 0);
+                break;
+            },
+            .pending => compat.time.sleepMs(10),
+            .disconnected => return error.NoWebSocketReply,
+        }
+    }
+
+    var auth_buf: [16]u8 = undefined;
+    const auth = try readSmallFile(auth_path, &auth_buf);
+    try std.testing.expectEqualStrings("ok", std.mem.trim(u8, auth, " \n\r\t"));
+}


### PR DESCRIPTION
## Summary
- Wire `TuiRemoteConfig.transport = .websocket` so the TUI can connect to a remote agent over a WebSocket endpoint.
- Add `WebSocketClient.connectWithSubprotocol(url, headers, subprotocol)` and an owned `AsyncStreamHandle` for cancelable reader-thread lifecycle.
- Translate transport errors into actionable runtime errors (`InvalidRemoteUrl`, `RemoteTlsNotSupported`, `RemoteConnectionFailed`, `RemoteHandshakeFailed`).

## Out of scope
- TLS (`wss://`) support — returns `error.RemoteTlsNotSupported`.
- Disk-config wiring in `tui/config.zig` and changes to `protocol/agent/client.zig` (per task notes).

## Test plan
- [x] `zig build test-unit-transport`
- [x] `zig build test-unit-tui`
- [ ] Integration test with mock WebSocket server (currently skipped — see review)

Relates-to #128.