### PR TITLE
TUI transport config UI and selector

### DIFF
--- a/zig/build.zig
+++ b/zig/build.zig
@@ -922,6 +922,7 @@ pub fn build(b: *std.Build) void {
             .{ .name = "json/writer", .module = json_writer_mod },
             .{ .name = "json_writer", .module = json_writer_mod },
             .{ .name = "owned_slice", .module = owned_slice_mod },
+            .{ .name = "tui_config", .module = tui_config_mod },
         },
     });
 
@@ -960,8 +961,10 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
         .imports = &.{
             .{ .name = "ai_types", .module = ai_types_mod },
+            .{ .name = "compat", .module = compat_mod },
             .{ .name = "tui_runtime", .module = tui_runtime_mod },
             .{ .name = "tui_state", .module = tui_state_mod },
+            .{ .name = "tui_config", .module = tui_config_mod },
         },
     });
 

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -965,6 +965,7 @@ pub fn build(b: *std.Build) void {
             .{ .name = "tui_runtime", .module = tui_runtime_mod },
             .{ .name = "tui_state", .module = tui_state_mod },
             .{ .name = "tui_config", .module = tui_config_mod },
+            .{ .name = "transports/sse", .module = sse_transport_mod },
         },
     });
 

--- a/zig/src/tui/app.zig
+++ b/zig/src/tui/app.zig
@@ -253,7 +253,13 @@ pub const ProductionRuntime = struct {
         };
         if (maybe_store) |*store| {
             defer store.deinit();
-            saved_config = try store.loadIfExists();
+            // A malformed or unreadable config file must not brick TUI startup;
+            // fall back to defaults on non-OOM load errors (matching the
+            // previous saved-model loader behavior).
+            saved_config = store.loadIfExists() catch |err| switch (err) {
+                error.OutOfMemory => return error.OutOfMemory,
+                else => null,
+            };
         }
         errdefer if (saved_config) |*cfg| cfg.deinit(allocator);
 

--- a/zig/src/tui/app.zig
+++ b/zig/src/tui/app.zig
@@ -229,6 +229,7 @@ pub const ProductionRuntime = struct {
     permission_engine: permission.PermissionEngine,
     models: []ai_types.Model,
     initial_model: ?SavedModelRef = null,
+    remote_config: tui_runtime.TuiRemoteConfig = .{},
 
     pub fn init(allocator: std.mem.Allocator) !ProductionRuntime {
         var registry = api_registry.ApiRegistry.init(allocator);
@@ -245,11 +246,34 @@ pub const ProductionRuntime = struct {
         const models = try loadRuntimeModels(allocator);
         errdefer tui_model_catalog.deinitModels(allocator, models);
 
-        var initial_model = loadSavedModelRef(allocator) catch |err| switch (err) {
-            error.OutOfMemory => return error.OutOfMemory,
-            else => null,
+        var saved_config: ?tui_config.Config = null;
+        var maybe_store: ?tui_config.Store = tui_config.Store.initDefault(allocator) catch |err| switch (err) {
+            error.HomeNotFound => null,
+            else => return err,
         };
+        if (maybe_store) |*store| {
+            defer store.deinit();
+            saved_config = try store.loadIfExists();
+        }
+        errdefer if (saved_config) |*cfg| cfg.deinit(allocator);
+
+        var initial_model: ?SavedModelRef = null;
+        if (saved_config) |cfg| {
+            if (cfg.model.len > 0) {
+                initial_model = SavedModelRef{
+                    .id = try allocator.dupe(u8, cfg.model),
+                    .provider = try allocator.dupe(u8, cfg.provider),
+                    .api = try allocator.dupe(u8, cfg.api),
+                };
+            }
+        }
         errdefer if (initial_model) |*model| model.deinit(allocator);
+
+        var remote_config: tui_runtime.TuiRemoteConfig = .{};
+        if (saved_config) |cfg| {
+            remote_config = try tui_runtime.remoteConfigFromConfig(allocator, cfg);
+        }
+        errdefer remote_config.deinit(allocator);
 
         const runtime = ProductionRuntime{
             .allocator = allocator,
@@ -258,8 +282,12 @@ pub const ProductionRuntime = struct {
             .permission_engine = permission_engine,
             .models = models,
             .initial_model = initial_model,
+            .remote_config = remote_config,
         };
         initial_model = null;
+        remote_config = .{};
+        if (saved_config) |*cfg| cfg.deinit(allocator);
+        saved_config = null;
         return runtime;
     }
 
@@ -280,12 +308,14 @@ pub const ProductionRuntime = struct {
             .workspace_root = self.permission_engine.workspace_root,
             .run_async = true,
             .compact_output = true,
+            .remote_config = self.remote_config,
         };
     }
 
     pub fn deinit(self: *ProductionRuntime) void {
         tui_model_catalog.deinitModels(self.allocator, self.models);
         if (self.initial_model) |*model| model.deinit(self.allocator);
+        self.remote_config.deinit(self.allocator);
         self.permission_engine.deinit();
         self.registry.deinit();
         self.* = undefined;

--- a/zig/src/tui/commands.zig
+++ b/zig/src/tui/commands.zig
@@ -4,6 +4,7 @@ const compat = @import("compat");
 const tui_runtime = @import("tui_runtime");
 const tui_state = @import("tui_state");
 const tui_config = @import("tui_config");
+const sse_transport = @import("transports/sse");
 
 pub const CommandKind = enum {
     help,
@@ -466,6 +467,7 @@ fn applyRemoteCommand(allocator: std.mem.Allocator, store: tui_config.Store, arg
     var cfg = try store.load();
     defer cfg.deinit(allocator);
 
+    var restart_notice = false;
     if (arg) |value| {
         var iter = std.mem.splitScalar(u8, value, ' ');
         const sub = iter.first();
@@ -520,10 +522,17 @@ fn applyRemoteCommand(allocator: std.mem.Allocator, store: tui_config.Store, arg
             try replaceRemoteString(allocator, &cfg.remote.auth_header_value, header_value);
         } else if (std.mem.eql(u8, sub, "off")) {
             cfg.remote.enabled = false;
+            restart_notice = true;
         } else {
             return .{ .output = try std.fmt.allocPrint(allocator, "unknown remote subcommand: {s}", .{sub}), .is_error = true };
         }
         try store.save(cfg);
+    }
+
+    if (restart_notice) {
+        const status = try formatRemoteStatus(allocator, cfg.remote);
+        defer allocator.free(status);
+        return .{ .output = try std.fmt.allocPrint(allocator, "{s}\nNote: change applies on next TUI start; active remote sessions keep using the current runtime.", .{status}) };
     }
 
     return .{ .output = try formatRemoteStatus(allocator, cfg.remote) };
@@ -547,17 +556,18 @@ fn validateUrlScheme(url: []const u8, schemes: []const []const u8) !void {
     }
     if (!matched) return error.InvalidUrl;
 
-    // Authority runs from after "://" up to the first path/query/fragment.
+    if (std.mem.eql(u8, scheme, "http") or std.mem.eql(u8, scheme, "https")) {
+        _ = sse_transport.parseHttpUrl(url) catch return error.InvalidUrl;
+        return;
+    }
+
     const after = url[scheme_end + 3 ..];
     var auth_end: usize = 0;
     while (auth_end < after.len and after[auth_end] != '/' and after[auth_end] != '?' and after[auth_end] != '#') : (auth_end += 1) {}
     const authority = after[0..auth_end];
     if (authority.len == 0) return error.InvalidUrl;
-
-    // Strip userinfo (everything up to and including the last '@').
     var host = authority;
     if (std.mem.lastIndexOfScalar(u8, authority, '@')) |at| host = authority[at + 1 ..];
-    // Strip port.
     if (std.mem.indexOfScalar(u8, host, ':')) |colon| host = host[0..colon];
     if (host.len == 0) return error.InvalidUrl;
 }
@@ -1169,6 +1179,7 @@ test "remote command off disables remote" {
     defer off_result.deinit(std.testing.allocator);
     try std.testing.expect(!off_result.is_error);
     try std.testing.expect(std.mem.indexOf(u8, off_result.output, "disabled") != null);
+    try std.testing.expect(std.mem.indexOf(u8, off_result.output, "applies on next TUI start") != null);
 
     var loaded = try store.load();
     defer loaded.deinit(std.testing.allocator);
@@ -1243,6 +1254,36 @@ test "remote command rejects sse endpoint with port-only authority" {
     defer store.deinit();
 
     var result = try applyRemoteCommand(std.testing.allocator, store, "sse http://:8080");
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(result.is_error);
+
+    var loaded = try store.load();
+    defer loaded.deinit(std.testing.allocator);
+    try std.testing.expect(!loaded.remote.enabled);
+}
+
+test "remote command rejects sse endpoint with malformed port" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var store = try remoteTestStore(std.testing.allocator, &tmp);
+    defer store.deinit();
+
+    var result = try applyRemoteCommand(std.testing.allocator, store, "sse http://localhost:abc");
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(result.is_error);
+
+    var loaded = try store.load();
+    defer loaded.deinit(std.testing.allocator);
+    try std.testing.expect(!loaded.remote.enabled);
+}
+
+test "remote command rejects sse endpoint with out-of-range port" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var store = try remoteTestStore(std.testing.allocator, &tmp);
+    defer store.deinit();
+
+    var result = try applyRemoteCommand(std.testing.allocator, store, "sse http://localhost:70000");
     defer result.deinit(std.testing.allocator);
     try std.testing.expect(result.is_error);
 

--- a/zig/src/tui/commands.zig
+++ b/zig/src/tui/commands.zig
@@ -475,7 +475,10 @@ fn applyRemoteCommand(allocator: std.mem.Allocator, store: tui_config.Store, arg
             if (rest.len > 0) {
                 return .{ .output = try allocator.dupe(u8, "stdio transport uses the current process; no command argument is supported"), .is_error = true };
             }
-            cfg.remote.enabled = true;
+            // stdio remote would bind the agent protocol to the TUI's own
+            // stdin/stdout. Until subprocess spawning is wired up, persist the
+            // transport preference but do not enable remote mode.
+            cfg.remote.enabled = false;
             try replaceRemoteString(allocator, &cfg.remote.transport, "stdio");
             try replaceRemoteString(allocator, &cfg.remote.command, "");
             try replaceRemoteString(allocator, &cfg.remote.endpoint, "");
@@ -483,8 +486,8 @@ fn applyRemoteCommand(allocator: std.mem.Allocator, store: tui_config.Store, arg
             if (rest.len == 0) {
                 return .{ .output = try allocator.dupe(u8, "usage: /remote sse <url>"), .is_error = true };
             }
-            validateUrlScheme(rest, &.{ "http", "https" }) catch {
-                return .{ .output = try allocator.dupe(u8, "SSE endpoint must use http or https scheme"), .is_error = true };
+            validateUrlScheme(rest, &.{"http"}) catch {
+                return .{ .output = try allocator.dupe(u8, "SSE endpoint must use http scheme (TLS not yet supported)"), .is_error = true };
             };
             cfg.remote.enabled = true;
             try replaceRemoteString(allocator, &cfg.remote.transport, "sse");
@@ -995,14 +998,17 @@ const MockAbortSession = struct {
     }
 };
 
+fn remoteTestStore(allocator: std.mem.Allocator, tmp: *std.testing.TmpDir) !tui_config.Store {
+    const base = try std.fs.path.join(allocator, &.{ ".zig-cache", "tmp", &tmp.sub_path, "makai" });
+    defer allocator.free(base);
+    try compat.fs.createDir(compat.fs.getCwd(), base);
+    return try tui_config.Store.init(allocator, base);
+}
+
 test "remote command sets sse transport and persists" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
-    const base = try std.fs.path.join(std.testing.allocator, &.{ ".zig-cache", "tmp", &tmp.sub_path, "makai" });
-    defer std.testing.allocator.free(base);
-    try compat.fs.createDir(compat.fs.getCwd(), base);
-
-    var store = try tui_config.Store.init(std.testing.allocator, base);
+    var store = try remoteTestStore(std.testing.allocator, &tmp);
     defer store.deinit();
 
     var result = try applyRemoteCommand(std.testing.allocator, store, "sse http://localhost:8080");
@@ -1018,30 +1024,52 @@ test "remote command sets sse transport and persists" {
 }
 
 test "remote command rejects invalid sse endpoint scheme" {
-    var state = tui_state.AppState.init(std.testing.allocator);
-    defer state.deinit();
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var store = try remoteTestStore(std.testing.allocator, &tmp);
+    defer store.deinit();
 
-    var result = try dispatch(.{ .allocator = std.testing.allocator, .state = &state }, .{ .kind = .remote, .arg = "sse ftp://localhost:8080" });
+    var result = try applyRemoteCommand(std.testing.allocator, store, "sse ftp://localhost:8080");
     defer result.deinit(std.testing.allocator);
     try std.testing.expect(result.is_error);
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "SSE endpoint must use http or https scheme") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "SSE endpoint must use http scheme") != null);
+}
+
+test "remote command rejects https sse endpoint until TLS supported" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var store = try remoteTestStore(std.testing.allocator, &tmp);
+    defer store.deinit();
+
+    var result = try applyRemoteCommand(std.testing.allocator, store, "sse https://localhost:8080");
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(result.is_error);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "TLS not yet supported") != null);
+
+    var loaded = try store.load();
+    defer loaded.deinit(std.testing.allocator);
+    try std.testing.expect(!loaded.remote.enabled);
 }
 
 test "remote command rejects unsupported websocket transport" {
-    var state = tui_state.AppState.init(std.testing.allocator);
-    defer state.deinit();
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var store = try remoteTestStore(std.testing.allocator, &tmp);
+    defer store.deinit();
 
-    var result = try dispatch(.{ .allocator = std.testing.allocator, .state = &state }, .{ .kind = .remote, .arg = "ws ws://localhost:8080" });
+    var result = try applyRemoteCommand(std.testing.allocator, store, "ws ws://localhost:8080");
     defer result.deinit(std.testing.allocator);
     try std.testing.expect(result.is_error);
     try std.testing.expect(std.mem.indexOf(u8, result.output, "WebSocket remote transport is not yet supported") != null);
 }
 
 test "remote command rejects invalid websocket endpoint scheme" {
-    var state = tui_state.AppState.init(std.testing.allocator);
-    defer state.deinit();
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var store = try remoteTestStore(std.testing.allocator, &tmp);
+    defer store.deinit();
 
-    var result = try dispatch(.{ .allocator = std.testing.allocator, .state = &state }, .{ .kind = .remote, .arg = "ws http://localhost:8080" });
+    var result = try applyRemoteCommand(std.testing.allocator, store, "ws http://localhost:8080");
     defer result.deinit(std.testing.allocator);
     try std.testing.expect(result.is_error);
     try std.testing.expect(std.mem.indexOf(u8, result.output, "WebSocket endpoint must use ws or wss scheme") != null);
@@ -1050,11 +1078,7 @@ test "remote command rejects invalid websocket endpoint scheme" {
 test "remote command sets auth token and persists" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
-    const base = try std.fs.path.join(std.testing.allocator, &.{ ".zig-cache", "tmp", &tmp.sub_path, "makai" });
-    defer std.testing.allocator.free(base);
-    try compat.fs.createDir(compat.fs.getCwd(), base);
-
-    var store = try tui_config.Store.init(std.testing.allocator, base);
+    var store = try remoteTestStore(std.testing.allocator, &tmp);
     defer store.deinit();
 
     var result = try applyRemoteCommand(std.testing.allocator, store, "auth secret-token");
@@ -1069,11 +1093,7 @@ test "remote command sets auth token and persists" {
 test "remote command shows current config" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
-    const base = try std.fs.path.join(std.testing.allocator, &.{ ".zig-cache", "tmp", &tmp.sub_path, "makai" });
-    defer std.testing.allocator.free(base);
-    try compat.fs.createDir(compat.fs.getCwd(), base);
-
-    var store = try tui_config.Store.init(std.testing.allocator, base);
+    var store = try remoteTestStore(std.testing.allocator, &tmp);
     defer store.deinit();
 
     var result = try applyRemoteCommand(std.testing.allocator, store, null);
@@ -1088,14 +1108,10 @@ test "remote command parses as slash command" {
     try std.testing.expectEqualStrings("sse http://localhost:8080", command.arg.?);
 }
 
-test "remote command sets stdio transport and persists" {
+test "remote command sets stdio transport without enabling remote" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
-    const base = try std.fs.path.join(std.testing.allocator, &.{ ".zig-cache", "tmp", &tmp.sub_path, "makai" });
-    defer std.testing.allocator.free(base);
-    try compat.fs.createDir(compat.fs.getCwd(), base);
-
-    var store = try tui_config.Store.init(std.testing.allocator, base);
+    var store = try remoteTestStore(std.testing.allocator, &tmp);
     defer store.deinit();
 
     var result = try applyRemoteCommand(std.testing.allocator, store, "stdio");
@@ -1105,17 +1121,21 @@ test "remote command sets stdio transport and persists" {
 
     var loaded = try store.load();
     defer loaded.deinit(std.testing.allocator);
-    try std.testing.expect(loaded.remote.enabled);
+    // stdio remote would hijack the TUI's own stdio; keep it disabled until
+    // subprocess spawning is implemented.
+    try std.testing.expect(!loaded.remote.enabled);
     try std.testing.expectEqualStrings("stdio", loaded.remote.transport);
     try std.testing.expectEqualStrings("", loaded.remote.command);
     try std.testing.expectEqualStrings("", loaded.remote.endpoint);
 }
 
 test "remote command stdio rejects command argument" {
-    var state = tui_state.AppState.init(std.testing.allocator);
-    defer state.deinit();
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var store = try remoteTestStore(std.testing.allocator, &tmp);
+    defer store.deinit();
 
-    var result = try dispatch(.{ .allocator = std.testing.allocator, .state = &state }, .{ .kind = .remote, .arg = "stdio /bin/foo" });
+    var result = try applyRemoteCommand(std.testing.allocator, store, "stdio /bin/foo");
     defer result.deinit(std.testing.allocator);
     try std.testing.expect(result.is_error);
     try std.testing.expect(std.mem.indexOf(u8, result.output, "no command argument is supported") != null);
@@ -1124,11 +1144,7 @@ test "remote command stdio rejects command argument" {
 test "remote command off disables remote" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
-    const base = try std.fs.path.join(std.testing.allocator, &.{ ".zig-cache", "tmp", &tmp.sub_path, "makai" });
-    defer std.testing.allocator.free(base);
-    try compat.fs.createDir(compat.fs.getCwd(), base);
-
-    var store = try tui_config.Store.init(std.testing.allocator, base);
+    var store = try remoteTestStore(std.testing.allocator, &tmp);
     defer store.deinit();
 
     var sse_result = try applyRemoteCommand(std.testing.allocator, store, "sse http://localhost:8080");
@@ -1149,11 +1165,7 @@ test "remote command off disables remote" {
 test "remote command header sets header and clears auth token" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
-    const base = try std.fs.path.join(std.testing.allocator, &.{ ".zig-cache", "tmp", &tmp.sub_path, "makai" });
-    defer std.testing.allocator.free(base);
-    try compat.fs.createDir(compat.fs.getCwd(), base);
-
-    var store = try tui_config.Store.init(std.testing.allocator, base);
+    var store = try remoteTestStore(std.testing.allocator, &tmp);
     defer store.deinit();
 
     var auth_result = try applyRemoteCommand(std.testing.allocator, store, "auth secret-token");
@@ -1172,22 +1184,26 @@ test "remote command header sets header and clears auth token" {
 }
 
 test "remote command rejects unknown subcommand" {
-    var state = tui_state.AppState.init(std.testing.allocator);
-    defer state.deinit();
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var store = try remoteTestStore(std.testing.allocator, &tmp);
+    defer store.deinit();
 
-    var result = try dispatch(.{ .allocator = std.testing.allocator, .state = &state }, .{ .kind = .remote, .arg = "bogus" });
+    var result = try applyRemoteCommand(std.testing.allocator, store, "bogus");
     defer result.deinit(std.testing.allocator);
     try std.testing.expect(result.is_error);
     try std.testing.expect(std.mem.indexOf(u8, result.output, "unknown remote subcommand: bogus") != null);
 }
 
 test "remote command rejects sse endpoint with empty host" {
-    var state = tui_state.AppState.init(std.testing.allocator);
-    defer state.deinit();
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var store = try remoteTestStore(std.testing.allocator, &tmp);
+    defer store.deinit();
 
-    var result = try dispatch(.{ .allocator = std.testing.allocator, .state = &state }, .{ .kind = .remote, .arg = "sse http://" });
+    var result = try applyRemoteCommand(std.testing.allocator, store, "sse http://");
     defer result.deinit(std.testing.allocator);
     try std.testing.expect(result.is_error);
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "SSE endpoint must use http or https scheme") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "SSE endpoint must use http scheme") != null);
 }
 

--- a/zig/src/tui/commands.zig
+++ b/zig/src/tui/commands.zig
@@ -481,6 +481,7 @@ fn applyRemoteCommand(allocator: std.mem.Allocator, store: tui_config.Store, arg
             // stdin/stdout. Until subprocess spawning is wired up, persist the
             // transport preference but do not enable remote mode.
             cfg.remote.enabled = false;
+            restart_notice = true;
             try replaceRemoteString(allocator, &cfg.remote.transport, "stdio");
             try replaceRemoteString(allocator, &cfg.remote.command, "");
             try replaceRemoteString(allocator, &cfg.remote.endpoint, "");
@@ -1191,6 +1192,7 @@ test "remote command sets stdio transport without enabling remote" {
     defer result.deinit(std.testing.allocator);
     try std.testing.expect(!result.is_error);
     try std.testing.expect(std.mem.indexOf(u8, result.output, "transport: stdio") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "applies on next TUI start") != null);
 
     var loaded = try store.load();
     defer loaded.deinit(std.testing.allocator);

--- a/zig/src/tui/commands.zig
+++ b/zig/src/tui/commands.zig
@@ -1,7 +1,9 @@
 const std = @import("std");
 const ai_types = @import("ai_types");
+const compat = @import("compat");
 const tui_runtime = @import("tui_runtime");
 const tui_state = @import("tui_state");
+const tui_config = @import("tui_config");
 
 pub const CommandKind = enum {
     help,
@@ -22,6 +24,7 @@ pub const CommandKind = enum {
     diff,
     abort,
     quit,
+    remote,
 };
 
 pub const Command = struct {
@@ -101,6 +104,7 @@ pub const commands = [_]CommandInfo{
     .{ .name = "diff", .kind = .diff, .usage = "/diff", .description = "Show pending file changes", .handler = handleDiff },
     .{ .name = "abort", .kind = .abort, .usage = "/abort", .description = "Cancel the active streaming turn", .handler = handleAbort },
     .{ .name = "quit", .kind = .quit, .usage = "/quit", .description = "Exit TUI", .handler = handleQuit },
+    .{ .name = "remote", .kind = .remote, .usage = "/remote [stdio|sse|ws|auth|header|off]", .description = "Configure remote transport", .handler = handleRemote },
 };
 
 pub fn parse(input: []const u8) ParseError!Command {
@@ -450,6 +454,103 @@ fn handleQuit(ctx: CommandContext, command: Command) !CommandResult {
     _ = ctx;
     _ = command;
     return .{ .action = .quit };
+}
+
+fn handleRemote(ctx: CommandContext, command: Command) !CommandResult {
+    var store = try tui_config.Store.initDefault(ctx.allocator);
+    defer store.deinit();
+    return try applyRemoteCommand(ctx.allocator, store, command.arg);
+}
+
+fn applyRemoteCommand(allocator: std.mem.Allocator, store: tui_config.Store, arg: ?[]const u8) !CommandResult {
+    var cfg = try store.load();
+    defer cfg.deinit(allocator);
+
+    if (arg) |value| {
+        var iter = std.mem.splitScalar(u8, value, ' ');
+        const sub = iter.first();
+        const rest = std.mem.trim(u8, iter.rest(), " \t");
+
+        if (std.mem.eql(u8, sub, "stdio")) {
+            if (rest.len > 0) {
+                return .{ .output = try allocator.dupe(u8, "stdio command spawn not yet supported"), .is_error = true };
+            }
+            cfg.remote.enabled = true;
+            try replaceRemoteString(allocator, &cfg.remote.transport, "stdio");
+            try replaceRemoteString(allocator, &cfg.remote.command, rest);
+            try replaceRemoteString(allocator, &cfg.remote.endpoint, "");
+        } else if (std.mem.eql(u8, sub, "sse")) {
+            if (rest.len == 0) {
+                return .{ .output = try allocator.dupe(u8, "usage: /remote sse <url>"), .is_error = true };
+            }
+            validateUrlScheme(rest, &.{ "http", "https" }) catch {
+                return .{ .output = try allocator.dupe(u8, "SSE endpoint must use http or https scheme"), .is_error = true };
+            };
+            cfg.remote.enabled = true;
+            try replaceRemoteString(allocator, &cfg.remote.transport, "sse");
+            try replaceRemoteString(allocator, &cfg.remote.endpoint, rest);
+            try replaceRemoteString(allocator, &cfg.remote.command, "");
+        } else if (std.mem.eql(u8, sub, "ws") or std.mem.eql(u8, sub, "websocket")) {
+            if (rest.len == 0) {
+                return .{ .output = try allocator.dupe(u8, "usage: /remote ws <url>"), .is_error = true };
+            }
+            validateUrlScheme(rest, &.{ "ws", "wss" }) catch {
+                return .{ .output = try allocator.dupe(u8, "WebSocket endpoint must use ws or wss scheme"), .is_error = true };
+            };
+            return .{ .output = try allocator.dupe(u8, "WebSocket remote transport is not yet supported"), .is_error = true };
+        } else if (std.mem.eql(u8, sub, "auth")) {
+            if (rest.len == 0) {
+                return .{ .output = try allocator.dupe(u8, "usage: /remote auth <token>"), .is_error = true };
+            }
+            try replaceRemoteString(allocator, &cfg.remote.auth_token, rest);
+            try replaceRemoteString(allocator, &cfg.remote.auth_header_value, "");
+        } else if (std.mem.eql(u8, sub, "header")) {
+            const trimmed = std.mem.trim(u8, rest, " \t");
+            var hiter = std.mem.splitScalar(u8, trimmed, ' ');
+            const name = hiter.first();
+            const header_value = std.mem.trim(u8, hiter.rest(), " \t");
+            if (name.len == 0 or header_value.len == 0) {
+                return .{ .output = try allocator.dupe(u8, "usage: /remote header <name> <value>"), .is_error = true };
+            }
+            try replaceRemoteString(allocator, &cfg.remote.auth_token, "");
+            try replaceRemoteString(allocator, &cfg.remote.auth_header_name, name);
+            try replaceRemoteString(allocator, &cfg.remote.auth_header_value, header_value);
+        } else if (std.mem.eql(u8, sub, "off")) {
+            cfg.remote.enabled = false;
+        } else {
+            return .{ .output = try std.fmt.allocPrint(allocator, "unknown remote subcommand: {s}", .{sub}), .is_error = true };
+        }
+        try store.save(cfg);
+    }
+
+    return .{ .output = try formatRemoteStatus(allocator, cfg.remote) };
+}
+
+fn replaceRemoteString(allocator: std.mem.Allocator, field: *[]u8, value: []const u8) !void {
+    const next = try allocator.dupe(u8, value);
+    if (field.len > 0) allocator.free(field.*);
+    field.* = next;
+}
+
+fn validateUrlScheme(url: []const u8, schemes: []const []const u8) !void {
+    const scheme_end = std.mem.indexOf(u8, url, "://") orelse return error.InvalidUrl;
+    const scheme = url[0..scheme_end];
+    for (schemes) |allowed| {
+        if (std.mem.eql(u8, scheme, allowed)) return;
+    }
+    return error.InvalidUrl;
+}
+
+fn formatRemoteStatus(allocator: std.mem.Allocator, remote: tui_config.RemoteConfig) ![]u8 {
+    const status = if (remote.enabled) "enabled" else "disabled";
+    const auth = if (remote.auth_token.len > 0 or remote.auth_header_value.len > 0) "yes" else "no";
+    return try std.fmt.allocPrint(allocator, "remote {s}\ntransport: {s}\nendpoint: {s}\ncommand: {s}\nauth: {s}", .{
+        status,
+        remote.transport,
+        remote.endpoint,
+        remote.command,
+        auth,
+    });
 }
 
 fn currentModel(ctx: CommandContext) ?ai_types.Model {
@@ -889,3 +990,97 @@ const MockAbortSession = struct {
         if (self.events_initialized) self.events.deinit();
     }
 };
+
+test "remote command sets sse transport and persists" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const base = try std.fs.path.join(std.testing.allocator, &.{ ".zig-cache", "tmp", &tmp.sub_path, "makai" });
+    defer std.testing.allocator.free(base);
+    try compat.fs.createDir(compat.fs.getCwd(), base);
+
+    var store = try tui_config.Store.init(std.testing.allocator, base);
+    defer store.deinit();
+
+    var result = try applyRemoteCommand(std.testing.allocator, store, "sse http://localhost:8080");
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!result.is_error);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "transport: sse") != null);
+
+    var loaded = try store.load();
+    defer loaded.deinit(std.testing.allocator);
+    try std.testing.expect(loaded.remote.enabled);
+    try std.testing.expectEqualStrings("sse", loaded.remote.transport);
+    try std.testing.expectEqualStrings("http://localhost:8080", loaded.remote.endpoint);
+}
+
+test "remote command rejects invalid sse endpoint scheme" {
+    var state = tui_state.AppState.init(std.testing.allocator);
+    defer state.deinit();
+
+    var result = try dispatch(.{ .allocator = std.testing.allocator, .state = &state }, .{ .kind = .remote, .arg = "sse ftp://localhost:8080" });
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(result.is_error);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "SSE endpoint must use http or https scheme") != null);
+}
+
+test "remote command rejects unsupported websocket transport" {
+    var state = tui_state.AppState.init(std.testing.allocator);
+    defer state.deinit();
+
+    var result = try dispatch(.{ .allocator = std.testing.allocator, .state = &state }, .{ .kind = .remote, .arg = "ws ws://localhost:8080" });
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(result.is_error);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "WebSocket remote transport is not yet supported") != null);
+}
+
+test "remote command rejects invalid websocket endpoint scheme" {
+    var state = tui_state.AppState.init(std.testing.allocator);
+    defer state.deinit();
+
+    var result = try dispatch(.{ .allocator = std.testing.allocator, .state = &state }, .{ .kind = .remote, .arg = "ws http://localhost:8080" });
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(result.is_error);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "WebSocket endpoint must use ws or wss scheme") != null);
+}
+
+test "remote command sets auth token and persists" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const base = try std.fs.path.join(std.testing.allocator, &.{ ".zig-cache", "tmp", &tmp.sub_path, "makai" });
+    defer std.testing.allocator.free(base);
+    try compat.fs.createDir(compat.fs.getCwd(), base);
+
+    var store = try tui_config.Store.init(std.testing.allocator, base);
+    defer store.deinit();
+
+    var result = try applyRemoteCommand(std.testing.allocator, store, "auth secret-token");
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!result.is_error);
+
+    var loaded = try store.load();
+    defer loaded.deinit(std.testing.allocator);
+    try std.testing.expectEqualStrings("secret-token", loaded.remote.auth_token);
+}
+
+test "remote command shows current config" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const base = try std.fs.path.join(std.testing.allocator, &.{ ".zig-cache", "tmp", &tmp.sub_path, "makai" });
+    defer std.testing.allocator.free(base);
+    try compat.fs.createDir(compat.fs.getCwd(), base);
+
+    var store = try tui_config.Store.init(std.testing.allocator, base);
+    defer store.deinit();
+
+    var result = try applyRemoteCommand(std.testing.allocator, store, null);
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!result.is_error);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "remote") != null);
+}
+
+test "remote command parses as slash command" {
+    const command = try parse("/remote sse http://localhost:8080");
+    try std.testing.expectEqual(CommandKind.remote, command.kind);
+    try std.testing.expectEqualStrings("sse http://localhost:8080", command.arg.?);
+}
+

--- a/zig/src/tui/commands.zig
+++ b/zig/src/tui/commands.zig
@@ -104,7 +104,7 @@ pub const commands = [_]CommandInfo{
     .{ .name = "diff", .kind = .diff, .usage = "/diff", .description = "Show pending file changes", .handler = handleDiff },
     .{ .name = "abort", .kind = .abort, .usage = "/abort", .description = "Cancel the active streaming turn", .handler = handleAbort },
     .{ .name = "quit", .kind = .quit, .usage = "/quit", .description = "Exit TUI", .handler = handleQuit },
-    .{ .name = "remote", .kind = .remote, .usage = "/remote [stdio|sse|ws|auth|header|off]", .description = "Configure remote transport", .handler = handleRemote },
+    .{ .name = "remote", .kind = .remote, .usage = "/remote [stdio|sse <url>|ws <url>|auth <token>|header <name> <value>|off]", .description = "Configure remote transport", .handler = handleRemote },
 };
 
 pub fn parse(input: []const u8) ParseError!Command {
@@ -473,11 +473,11 @@ fn applyRemoteCommand(allocator: std.mem.Allocator, store: tui_config.Store, arg
 
         if (std.mem.eql(u8, sub, "stdio")) {
             if (rest.len > 0) {
-                return .{ .output = try allocator.dupe(u8, "stdio command spawn not yet supported"), .is_error = true };
+                return .{ .output = try allocator.dupe(u8, "stdio transport uses the current process; no command argument is supported"), .is_error = true };
             }
             cfg.remote.enabled = true;
             try replaceRemoteString(allocator, &cfg.remote.transport, "stdio");
-            try replaceRemoteString(allocator, &cfg.remote.command, rest);
+            try replaceRemoteString(allocator, &cfg.remote.command, "");
             try replaceRemoteString(allocator, &cfg.remote.endpoint, "");
         } else if (std.mem.eql(u8, sub, "sse")) {
             if (rest.len == 0) {
@@ -536,7 +536,11 @@ fn validateUrlScheme(url: []const u8, schemes: []const []const u8) !void {
     const scheme_end = std.mem.indexOf(u8, url, "://") orelse return error.InvalidUrl;
     const scheme = url[0..scheme_end];
     for (schemes) |allowed| {
-        if (std.mem.eql(u8, scheme, allowed)) return;
+        if (std.mem.eql(u8, scheme, allowed)) {
+            const host = std.mem.trim(u8, url[scheme_end + 3 ..], " \t\r\n/");
+            if (host.len == 0) return error.InvalidUrl;
+            return;
+        }
     }
     return error.InvalidUrl;
 }
@@ -1082,5 +1086,108 @@ test "remote command parses as slash command" {
     const command = try parse("/remote sse http://localhost:8080");
     try std.testing.expectEqual(CommandKind.remote, command.kind);
     try std.testing.expectEqualStrings("sse http://localhost:8080", command.arg.?);
+}
+
+test "remote command sets stdio transport and persists" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const base = try std.fs.path.join(std.testing.allocator, &.{ ".zig-cache", "tmp", &tmp.sub_path, "makai" });
+    defer std.testing.allocator.free(base);
+    try compat.fs.createDir(compat.fs.getCwd(), base);
+
+    var store = try tui_config.Store.init(std.testing.allocator, base);
+    defer store.deinit();
+
+    var result = try applyRemoteCommand(std.testing.allocator, store, "stdio");
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!result.is_error);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "transport: stdio") != null);
+
+    var loaded = try store.load();
+    defer loaded.deinit(std.testing.allocator);
+    try std.testing.expect(loaded.remote.enabled);
+    try std.testing.expectEqualStrings("stdio", loaded.remote.transport);
+    try std.testing.expectEqualStrings("", loaded.remote.command);
+    try std.testing.expectEqualStrings("", loaded.remote.endpoint);
+}
+
+test "remote command stdio rejects command argument" {
+    var state = tui_state.AppState.init(std.testing.allocator);
+    defer state.deinit();
+
+    var result = try dispatch(.{ .allocator = std.testing.allocator, .state = &state }, .{ .kind = .remote, .arg = "stdio /bin/foo" });
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(result.is_error);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "no command argument is supported") != null);
+}
+
+test "remote command off disables remote" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const base = try std.fs.path.join(std.testing.allocator, &.{ ".zig-cache", "tmp", &tmp.sub_path, "makai" });
+    defer std.testing.allocator.free(base);
+    try compat.fs.createDir(compat.fs.getCwd(), base);
+
+    var store = try tui_config.Store.init(std.testing.allocator, base);
+    defer store.deinit();
+
+    var sse_result = try applyRemoteCommand(std.testing.allocator, store, "sse http://localhost:8080");
+    defer sse_result.deinit(std.testing.allocator);
+    try std.testing.expect(!sse_result.is_error);
+
+    var off_result = try applyRemoteCommand(std.testing.allocator, store, "off");
+    defer off_result.deinit(std.testing.allocator);
+    try std.testing.expect(!off_result.is_error);
+    try std.testing.expect(std.mem.indexOf(u8, off_result.output, "disabled") != null);
+
+    var loaded = try store.load();
+    defer loaded.deinit(std.testing.allocator);
+    try std.testing.expect(!loaded.remote.enabled);
+    try std.testing.expectEqualStrings("sse", loaded.remote.transport);
+}
+
+test "remote command header sets header and clears auth token" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const base = try std.fs.path.join(std.testing.allocator, &.{ ".zig-cache", "tmp", &tmp.sub_path, "makai" });
+    defer std.testing.allocator.free(base);
+    try compat.fs.createDir(compat.fs.getCwd(), base);
+
+    var store = try tui_config.Store.init(std.testing.allocator, base);
+    defer store.deinit();
+
+    var auth_result = try applyRemoteCommand(std.testing.allocator, store, "auth secret-token");
+    defer auth_result.deinit(std.testing.allocator);
+    try std.testing.expect(!auth_result.is_error);
+
+    var header_result = try applyRemoteCommand(std.testing.allocator, store, "header X-Api-Key abc123");
+    defer header_result.deinit(std.testing.allocator);
+    try std.testing.expect(!header_result.is_error);
+
+    var loaded = try store.load();
+    defer loaded.deinit(std.testing.allocator);
+    try std.testing.expectEqualStrings("", loaded.remote.auth_token);
+    try std.testing.expectEqualStrings("X-Api-Key", loaded.remote.auth_header_name);
+    try std.testing.expectEqualStrings("abc123", loaded.remote.auth_header_value);
+}
+
+test "remote command rejects unknown subcommand" {
+    var state = tui_state.AppState.init(std.testing.allocator);
+    defer state.deinit();
+
+    var result = try dispatch(.{ .allocator = std.testing.allocator, .state = &state }, .{ .kind = .remote, .arg = "bogus" });
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(result.is_error);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "unknown remote subcommand: bogus") != null);
+}
+
+test "remote command rejects sse endpoint with empty host" {
+    var state = tui_state.AppState.init(std.testing.allocator);
+    defer state.deinit();
+
+    var result = try dispatch(.{ .allocator = std.testing.allocator, .state = &state }, .{ .kind = .remote, .arg = "sse http://" });
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(result.is_error);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "SSE endpoint must use http or https scheme") != null);
 }
 

--- a/zig/src/tui/commands.zig
+++ b/zig/src/tui/commands.zig
@@ -508,6 +508,10 @@ fn applyRemoteCommand(allocator: std.mem.Allocator, store: tui_config.Store, arg
             if (rest.len == 0) {
                 return .{ .output = try allocator.dupe(u8, "usage: /remote auth <token>"), .is_error = true };
             }
+            if (hasCrLf(rest)) {
+                return .{ .output = try allocator.dupe(u8, "remote auth token must not contain CR/LF"), .is_error = true };
+            }
+            restart_notice = true;
             try replaceRemoteString(allocator, &cfg.remote.auth_token, rest);
             try replaceRemoteString(allocator, &cfg.remote.auth_header_value, "");
         } else if (std.mem.eql(u8, sub, "header")) {
@@ -521,6 +525,7 @@ fn applyRemoteCommand(allocator: std.mem.Allocator, store: tui_config.Store, arg
             if (!isValidHeaderName(name) or hasCrLf(header_value)) {
                 return .{ .output = try allocator.dupe(u8, "remote header name/value must not contain CR/LF; name must be a valid HTTP token"), .is_error = true };
             }
+            restart_notice = true;
             try replaceRemoteString(allocator, &cfg.remote.auth_token, "");
             try replaceRemoteString(allocator, &cfg.remote.auth_header_name, name);
             try replaceRemoteString(allocator, &cfg.remote.auth_header_value, header_value);
@@ -549,6 +554,7 @@ fn replaceRemoteString(allocator: std.mem.Allocator, field: *[]u8, value: []cons
 }
 
 fn validateUrlScheme(url: []const u8, schemes: []const []const u8) !void {
+    if (hasWhitespaceOrControl(url)) return error.InvalidUrl;
     if (std.mem.indexOfScalar(u8, url, '#') != null) return error.InvalidUrl;
     const scheme_end = std.mem.indexOf(u8, url, "://") orelse return error.InvalidUrl;
     const scheme = url[0..scheme_end];
@@ -575,6 +581,13 @@ fn validateUrlScheme(url: []const u8, schemes: []const []const u8) !void {
     if (std.mem.lastIndexOfScalar(u8, authority, '@')) |at| host = authority[at + 1 ..];
     if (std.mem.indexOfScalar(u8, host, ':')) |colon| host = host[0..colon];
     if (host.len == 0) return error.InvalidUrl;
+}
+
+fn hasWhitespaceOrControl(value: []const u8) bool {
+    for (value) |ch| {
+        if (std.ascii.isWhitespace(ch) or ch < 0x20 or ch == 0x7f) return true;
+    }
+    return false;
 }
 
 fn hasCrLf(value: []const u8) bool {
@@ -1131,10 +1144,23 @@ test "remote command sets auth token and persists" {
     var result = try applyRemoteCommand(std.testing.allocator, store, "auth secret-token");
     defer result.deinit(std.testing.allocator);
     try std.testing.expect(!result.is_error);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "applies on next TUI start") != null);
 
     var loaded = try store.load();
     defer loaded.deinit(std.testing.allocator);
     try std.testing.expectEqualStrings("secret-token", loaded.remote.auth_token);
+}
+
+test "remote command rejects auth token injection" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var store = try remoteTestStore(std.testing.allocator, &tmp);
+    defer store.deinit();
+
+    var result = try applyRemoteCommand(std.testing.allocator, store, "auth secret\r\nInjected: yes");
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(result.is_error);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "must not contain CR/LF") != null);
 }
 
 test "remote command shows current config" {
@@ -1223,6 +1249,7 @@ test "remote command header sets header and clears auth token" {
     var header_result = try applyRemoteCommand(std.testing.allocator, store, "header X-Api-Key abc123");
     defer header_result.deinit(std.testing.allocator);
     try std.testing.expect(!header_result.is_error);
+    try std.testing.expect(std.mem.indexOf(u8, header_result.output, "applies on next TUI start") != null);
 
     var loaded = try store.load();
     defer loaded.deinit(std.testing.allocator);
@@ -1291,6 +1318,21 @@ test "remote command rejects sse endpoint with fragment" {
     defer store.deinit();
 
     var result = try applyRemoteCommand(std.testing.allocator, store, "sse http://localhost#events");
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(result.is_error);
+
+    var loaded = try store.load();
+    defer loaded.deinit(std.testing.allocator);
+    try std.testing.expect(!loaded.remote.enabled);
+}
+
+test "remote command rejects sse endpoint with whitespace" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var store = try remoteTestStore(std.testing.allocator, &tmp);
+    defer store.deinit();
+
+    var result = try applyRemoteCommand(std.testing.allocator, store, "sse http://localhost/events extra");
     defer result.deinit(std.testing.allocator);
     try std.testing.expect(result.is_error);
 

--- a/zig/src/tui/commands.zig
+++ b/zig/src/tui/commands.zig
@@ -568,6 +568,12 @@ fn validateUrlScheme(url: []const u8, schemes: []const []const u8) !void {
     }
     if (!matched) return error.InvalidUrl;
 
+    const after_scheme = url[scheme_end + 3 ..];
+    var authority_end: usize = 0;
+    while (authority_end < after_scheme.len and after_scheme[authority_end] != '/' and after_scheme[authority_end] != '?' and after_scheme[authority_end] != '#') : (authority_end += 1) {}
+    const authority = after_scheme[0..authority_end];
+    if (std.mem.indexOfScalar(u8, authority, '@') != null) return error.InvalidUrl;
+
     if (std.mem.eql(u8, scheme, "http") or std.mem.eql(u8, scheme, "https")) {
         _ = sse_transport.parseHttpUrl(url) catch return error.InvalidUrl;
         return;
@@ -576,10 +582,10 @@ fn validateUrlScheme(url: []const u8, schemes: []const []const u8) !void {
     const after = url[scheme_end + 3 ..];
     var auth_end: usize = 0;
     while (auth_end < after.len and after[auth_end] != '/' and after[auth_end] != '?' and after[auth_end] != '#') : (auth_end += 1) {}
-    const authority = after[0..auth_end];
-    if (authority.len == 0) return error.InvalidUrl;
-    var host = authority;
-    if (std.mem.lastIndexOfScalar(u8, authority, '@')) |at| host = authority[at + 1 ..];
+    const ws_authority = after[0..auth_end];
+    if (ws_authority.len == 0) return error.InvalidUrl;
+    var host = ws_authority;
+    if (std.mem.lastIndexOfScalar(u8, ws_authority, '@')) |at| host = ws_authority[at + 1 ..];
     if (std.mem.indexOfScalar(u8, host, ':')) |colon| host = host[0..colon];
     if (host.len == 0) return error.InvalidUrl;
 }
@@ -1320,6 +1326,21 @@ test "remote command rejects sse endpoint with fragment" {
     defer store.deinit();
 
     var result = try applyRemoteCommand(std.testing.allocator, store, "sse http://localhost#events");
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(result.is_error);
+
+    var loaded = try store.load();
+    defer loaded.deinit(std.testing.allocator);
+    try std.testing.expect(!loaded.remote.enabled);
+}
+
+test "remote command rejects sse endpoint with userinfo" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var store = try remoteTestStore(std.testing.allocator, &tmp);
+    defer store.deinit();
+
+    var result = try applyRemoteCommand(std.testing.allocator, store, "sse http://token@localhost:8080/events");
     defer result.deinit(std.testing.allocator);
     try std.testing.expect(result.is_error);
 

--- a/zig/src/tui/commands.zig
+++ b/zig/src/tui/commands.zig
@@ -538,14 +538,28 @@ fn replaceRemoteString(allocator: std.mem.Allocator, field: *[]u8, value: []cons
 fn validateUrlScheme(url: []const u8, schemes: []const []const u8) !void {
     const scheme_end = std.mem.indexOf(u8, url, "://") orelse return error.InvalidUrl;
     const scheme = url[0..scheme_end];
+    var matched = false;
     for (schemes) |allowed| {
         if (std.mem.eql(u8, scheme, allowed)) {
-            const host = std.mem.trim(u8, url[scheme_end + 3 ..], " \t\r\n/");
-            if (host.len == 0) return error.InvalidUrl;
-            return;
+            matched = true;
+            break;
         }
     }
-    return error.InvalidUrl;
+    if (!matched) return error.InvalidUrl;
+
+    // Authority runs from after "://" up to the first path/query/fragment.
+    const after = url[scheme_end + 3 ..];
+    var auth_end: usize = 0;
+    while (auth_end < after.len and after[auth_end] != '/' and after[auth_end] != '?' and after[auth_end] != '#') : (auth_end += 1) {}
+    const authority = after[0..auth_end];
+    if (authority.len == 0) return error.InvalidUrl;
+
+    // Strip userinfo (everything up to and including the last '@').
+    var host = authority;
+    if (std.mem.lastIndexOfScalar(u8, authority, '@')) |at| host = authority[at + 1 ..];
+    // Strip port.
+    if (std.mem.indexOfScalar(u8, host, ':')) |colon| host = host[0..colon];
+    if (host.len == 0) return error.InvalidUrl;
 }
 
 fn formatRemoteStatus(allocator: std.mem.Allocator, remote: tui_config.RemoteConfig) ![]u8 {
@@ -1205,5 +1219,35 @@ test "remote command rejects sse endpoint with empty host" {
     defer result.deinit(std.testing.allocator);
     try std.testing.expect(result.is_error);
     try std.testing.expect(std.mem.indexOf(u8, result.output, "SSE endpoint must use http scheme") != null);
+}
+
+test "remote command rejects sse endpoint with path-only authority" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var store = try remoteTestStore(std.testing.allocator, &tmp);
+    defer store.deinit();
+
+    var result = try applyRemoteCommand(std.testing.allocator, store, "sse http:///events");
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(result.is_error);
+
+    var loaded = try store.load();
+    defer loaded.deinit(std.testing.allocator);
+    try std.testing.expect(!loaded.remote.enabled);
+}
+
+test "remote command rejects sse endpoint with port-only authority" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var store = try remoteTestStore(std.testing.allocator, &tmp);
+    defer store.deinit();
+
+    var result = try applyRemoteCommand(std.testing.allocator, store, "sse http://:8080");
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(result.is_error);
+
+    var loaded = try store.load();
+    defer loaded.deinit(std.testing.allocator);
+    try std.testing.expect(!loaded.remote.enabled);
 }
 

--- a/zig/src/tui/commands.zig
+++ b/zig/src/tui/commands.zig
@@ -492,6 +492,7 @@ fn applyRemoteCommand(allocator: std.mem.Allocator, store: tui_config.Store, arg
                 return .{ .output = try allocator.dupe(u8, "SSE endpoint must use http scheme (TLS not yet supported)"), .is_error = true };
             };
             cfg.remote.enabled = true;
+            restart_notice = true;
             try replaceRemoteString(allocator, &cfg.remote.transport, "sse");
             try replaceRemoteString(allocator, &cfg.remote.endpoint, rest);
             try replaceRemoteString(allocator, &cfg.remote.command, "");
@@ -516,6 +517,9 @@ fn applyRemoteCommand(allocator: std.mem.Allocator, store: tui_config.Store, arg
             const header_value = std.mem.trim(u8, hiter.rest(), " \t");
             if (name.len == 0 or header_value.len == 0) {
                 return .{ .output = try allocator.dupe(u8, "usage: /remote header <name> <value>"), .is_error = true };
+            }
+            if (!isValidHeaderName(name) or hasCrLf(header_value)) {
+                return .{ .output = try allocator.dupe(u8, "remote header name/value must not contain CR/LF; name must be a valid HTTP token"), .is_error = true };
             }
             try replaceRemoteString(allocator, &cfg.remote.auth_token, "");
             try replaceRemoteString(allocator, &cfg.remote.auth_header_name, name);
@@ -545,6 +549,7 @@ fn replaceRemoteString(allocator: std.mem.Allocator, field: *[]u8, value: []cons
 }
 
 fn validateUrlScheme(url: []const u8, schemes: []const []const u8) !void {
+    if (std.mem.indexOfScalar(u8, url, '#') != null) return error.InvalidUrl;
     const scheme_end = std.mem.indexOf(u8, url, "://") orelse return error.InvalidUrl;
     const scheme = url[0..scheme_end];
     var matched = false;
@@ -570,6 +575,23 @@ fn validateUrlScheme(url: []const u8, schemes: []const []const u8) !void {
     if (std.mem.lastIndexOfScalar(u8, authority, '@')) |at| host = authority[at + 1 ..];
     if (std.mem.indexOfScalar(u8, host, ':')) |colon| host = host[0..colon];
     if (host.len == 0) return error.InvalidUrl;
+}
+
+fn hasCrLf(value: []const u8) bool {
+    return std.mem.indexOfAny(u8, value, "\r\n") != null;
+}
+
+fn isTchar(ch: u8) bool {
+    return std.ascii.isAlphanumeric(ch) or switch (ch) {
+        '!', '#', '$', '%', '&', '\'', '*', '+', '-', '.', '^', '_', '`', '|', '~' => true,
+        else => false,
+    };
+}
+
+fn isValidHeaderName(value: []const u8) bool {
+    if (value.len == 0) return false;
+    for (value) |ch| if (!isTchar(ch)) return false;
+    return true;
 }
 
 fn formatRemoteStatus(allocator: std.mem.Allocator, remote: tui_config.RemoteConfig) ![]u8 {
@@ -1039,6 +1061,7 @@ test "remote command sets sse transport and persists" {
     defer result.deinit(std.testing.allocator);
     try std.testing.expect(!result.is_error);
     try std.testing.expect(std.mem.indexOf(u8, result.output, "transport: sse") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "applies on next TUI start") != null);
 
     var loaded = try store.load();
     defer loaded.deinit(std.testing.allocator);
@@ -1208,6 +1231,35 @@ test "remote command header sets header and clears auth token" {
     try std.testing.expectEqualStrings("abc123", loaded.remote.auth_header_value);
 }
 
+test "remote command rejects header injection" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var store = try remoteTestStore(std.testing.allocator, &tmp);
+    defer store.deinit();
+
+    var bad_name = try applyRemoteCommand(std.testing.allocator, store, "header X-Bad\r\nInjected value");
+    defer bad_name.deinit(std.testing.allocator);
+    try std.testing.expect(bad_name.is_error);
+    try std.testing.expect(std.mem.indexOf(u8, bad_name.output, "must not contain CR/LF") != null);
+
+    var bad_value = try applyRemoteCommand(std.testing.allocator, store, "header X-Api-Key abc\r\nInjected: yes");
+    defer bad_value.deinit(std.testing.allocator);
+    try std.testing.expect(bad_value.is_error);
+    try std.testing.expect(std.mem.indexOf(u8, bad_value.output, "must not contain CR/LF") != null);
+}
+
+test "remote command rejects invalid header name" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var store = try remoteTestStore(std.testing.allocator, &tmp);
+    defer store.deinit();
+
+    var result = try applyRemoteCommand(std.testing.allocator, store, "header Bad:Name value");
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(result.is_error);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "valid HTTP token") != null);
+}
+
 test "remote command rejects unknown subcommand" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -1230,6 +1282,21 @@ test "remote command rejects sse endpoint with empty host" {
     defer result.deinit(std.testing.allocator);
     try std.testing.expect(result.is_error);
     try std.testing.expect(std.mem.indexOf(u8, result.output, "SSE endpoint must use http scheme") != null);
+}
+
+test "remote command rejects sse endpoint with fragment" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var store = try remoteTestStore(std.testing.allocator, &tmp);
+    defer store.deinit();
+
+    var result = try applyRemoteCommand(std.testing.allocator, store, "sse http://localhost#events");
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(result.is_error);
+
+    var loaded = try store.load();
+    defer loaded.deinit(std.testing.allocator);
+    try std.testing.expect(!loaded.remote.enabled);
 }
 
 test "remote command rejects sse endpoint with path-only authority" {

--- a/zig/src/tui/config.zig
+++ b/zig/src/tui/config.zig
@@ -37,6 +37,32 @@ pub const UiSettings = struct {
     }
 };
 
+pub const RemoteConfig = struct {
+    enabled: bool = false,
+    transport: []u8 = &.{},
+    endpoint: []u8 = &.{},
+    command: []u8 = &.{},
+    auth_token: []u8 = &.{},
+    auth_header_name: []u8 = &.{},
+    auth_header_value: []u8 = &.{},
+
+    pub fn defaults(allocator: std.mem.Allocator) !RemoteConfig {
+        return .{
+            .transport = try allocator.dupe(u8, "stdio"),
+        };
+    }
+
+    pub fn deinit(self: *RemoteConfig, allocator: std.mem.Allocator) void {
+        if (self.transport.len > 0) allocator.free(self.transport);
+        if (self.endpoint.len > 0) allocator.free(self.endpoint);
+        if (self.command.len > 0) allocator.free(self.command);
+        if (self.auth_token.len > 0) allocator.free(self.auth_token);
+        if (self.auth_header_name.len > 0) allocator.free(self.auth_header_name);
+        if (self.auth_header_value.len > 0) allocator.free(self.auth_header_value);
+        self.* = .{};
+    }
+};
+
 pub const Config = struct {
     model: []u8,
     provider: []u8,
@@ -45,6 +71,7 @@ pub const Config = struct {
     permissions: std.ArrayList(ToolPermission) = .empty,
     mode: ModeSettings = .{},
     ui: UiSettings = .{},
+    remote: RemoteConfig = .{},
 
     pub fn defaults(allocator: std.mem.Allocator) !Config {
         return .{
@@ -53,6 +80,7 @@ pub const Config = struct {
             .api = try allocator.dupe(u8, "anthropic-messages"),
             .workspace = try allocator.dupe(u8, "."),
             .ui = .{ .theme = try allocator.dupe(u8, "default") },
+            .remote = try RemoteConfig.defaults(allocator),
         };
     }
 
@@ -64,6 +92,7 @@ pub const Config = struct {
         for (self.permissions.items) |*permission| permission.deinit(allocator);
         self.permissions.deinit(allocator);
         self.ui.deinit(allocator);
+        self.remote.deinit(allocator);
         self.* = undefined;
     }
 };
@@ -146,6 +175,7 @@ fn parseConfig(allocator: std.mem.Allocator, data: []const u8) !Config {
         .api = try dupStringField(allocator, obj, "api", ""),
         .workspace = try dupStringField(allocator, obj, "workspace", ""),
         .ui = .{ .theme = try allocator.dupe(u8, "default") },
+        .remote = try RemoteConfig.defaults(allocator),
     };
     errdefer cfg.deinit(allocator);
 
@@ -188,6 +218,39 @@ fn parseConfig(allocator: std.mem.Allocator, data: []const u8) !Config {
         else => {},
     };
 
+    if (obj.get("remote")) |value| switch (value) {
+        .object => |remote_obj| {
+            cfg.remote.enabled = boolField(remote_obj, "enabled", cfg.remote.enabled);
+            if (stringField(remote_obj, "transport")) |transport| {
+                if (cfg.remote.transport.len > 0) allocator.free(cfg.remote.transport);
+                cfg.remote.transport = try allocator.dupe(u8, transport);
+            } else if (cfg.remote.transport.len == 0) {
+                cfg.remote.transport = try allocator.dupe(u8, "stdio");
+            }
+            if (stringField(remote_obj, "endpoint")) |endpoint| {
+                if (cfg.remote.endpoint.len > 0) allocator.free(cfg.remote.endpoint);
+                cfg.remote.endpoint = try allocator.dupe(u8, endpoint);
+            }
+            if (stringField(remote_obj, "command")) |command| {
+                if (cfg.remote.command.len > 0) allocator.free(cfg.remote.command);
+                cfg.remote.command = try allocator.dupe(u8, command);
+            }
+            if (stringField(remote_obj, "auth_token")) |auth_token| {
+                if (cfg.remote.auth_token.len > 0) allocator.free(cfg.remote.auth_token);
+                cfg.remote.auth_token = try allocator.dupe(u8, auth_token);
+            }
+            if (stringField(remote_obj, "auth_header_name")) |name| {
+                if (cfg.remote.auth_header_name.len > 0) allocator.free(cfg.remote.auth_header_name);
+                cfg.remote.auth_header_name = try allocator.dupe(u8, name);
+            }
+            if (stringField(remote_obj, "auth_header_value")) |val| {
+                if (cfg.remote.auth_header_value.len > 0) allocator.free(cfg.remote.auth_header_value);
+                cfg.remote.auth_header_value = try allocator.dupe(u8, val);
+            }
+        },
+        else => {},
+    };
+
     return cfg;
 }
 
@@ -217,6 +280,16 @@ fn serializeConfig(allocator: std.mem.Allocator, cfg: Config) ![]u8 {
     try w.beginObject();
     try w.writeStringField("theme", cfg.ui.theme);
     try w.writeBoolField("show_tool_panel", cfg.ui.show_tool_panel);
+    try w.endObject();
+    try w.writeKey("remote");
+    try w.beginObject();
+    try w.writeBoolField("enabled", cfg.remote.enabled);
+    try w.writeStringField("transport", cfg.remote.transport);
+    try w.writeStringField("endpoint", cfg.remote.endpoint);
+    try w.writeStringField("command", cfg.remote.command);
+    try w.writeStringField("auth_token", cfg.remote.auth_token);
+    try w.writeStringField("auth_header_name", cfg.remote.auth_header_name);
+    try w.writeStringField("auth_header_value", cfg.remote.auth_header_value);
     try w.endObject();
     try w.endObject();
     try buf.append(allocator, '\n');
@@ -297,7 +370,7 @@ test "missing config creates defaults" {
     try std.testing.expect(std.mem.indexOf(u8, data, "claude-sonnet-4-5") != null);
 }
 
-test "loadIfExists returns null without creating defaults" {
+test "save config preserves remote transport settings" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
     const base = try tmpBase(std.testing.allocator, &tmp);
@@ -306,6 +379,68 @@ test "loadIfExists returns null without creating defaults" {
     var store = try Store.init(std.testing.allocator, base);
     defer store.deinit();
 
+    var cfg = try Config.defaults(std.testing.allocator);
+    defer cfg.deinit(std.testing.allocator);
+    cfg.remote.deinit(std.testing.allocator);
+    cfg.remote.enabled = true;
+    cfg.remote.transport = try std.testing.allocator.dupe(u8, "sse");
+    cfg.remote.endpoint = try std.testing.allocator.dupe(u8, "http://localhost:8080");
+    cfg.remote.auth_token = try std.testing.allocator.dupe(u8, "secret");
+    cfg.remote.auth_header_name = try std.testing.allocator.dupe(u8, "Authorization");
+    cfg.remote.auth_header_value = try std.testing.allocator.dupe(u8, "Bearer secret");
+    try store.save(cfg);
+
+    var loaded = try store.load();
+    defer loaded.deinit(std.testing.allocator);
+    try std.testing.expect(loaded.remote.enabled);
+    try std.testing.expectEqualStrings("sse", loaded.remote.transport);
+    try std.testing.expectEqualStrings("http://localhost:8080", loaded.remote.endpoint);
+    try std.testing.expectEqualStrings("secret", loaded.remote.auth_token);
+    try std.testing.expectEqualStrings("Authorization", loaded.remote.auth_header_name);
+    try std.testing.expectEqualStrings("Bearer secret", loaded.remote.auth_header_value);
+}
+
+test "remote config defaults when missing from file" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const base = try tmpBase(std.testing.allocator, &tmp);
+    defer std.testing.allocator.free(base);
+
+    var store = try Store.init(std.testing.allocator, base);
+    defer store.deinit();
+
+    var cfg = try Config.defaults(std.testing.allocator);
+    defer cfg.deinit(std.testing.allocator);
+    try store.save(cfg);
+
+    var loaded = try store.load();
+    defer loaded.deinit(std.testing.allocator);
+    try std.testing.expectEqualStrings("stdio", loaded.remote.transport);
+    try std.testing.expectEqualStrings("", loaded.remote.endpoint);
+    try std.testing.expectEqualStrings("", loaded.remote.command);
+    try std.testing.expectEqualStrings("", loaded.remote.auth_token);
+}
+
+test "parse remote config from json" {
+    const data = "{\"model\":\"m\",\"provider\":\"p\",\"api\":\"a\",\"workspace\":\".\",\"remote\":{\"enabled\":true,\"transport\":\"sse\",\"endpoint\":\"http://x\",\"command\":\"\",\"auth_token\":\"t\",\"auth_header_name\":\"X-Auth\",\"auth_header_value\":\"v\"}}";
+    var cfg = try parseConfig(std.testing.allocator, data);
+    defer cfg.deinit(std.testing.allocator);
+    try std.testing.expect(cfg.remote.enabled);
+    try std.testing.expectEqualStrings("sse", cfg.remote.transport);
+    try std.testing.expectEqualStrings("http://x", cfg.remote.endpoint);
+    try std.testing.expectEqualStrings("t", cfg.remote.auth_token);
+    try std.testing.expectEqualStrings("X-Auth", cfg.remote.auth_header_name);
+    try std.testing.expectEqualStrings("v", cfg.remote.auth_header_value);
+}
+
+test "loadIfExists returns null without creating defaults" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const base = try tmpBase(std.testing.allocator, &tmp);
+    defer std.testing.allocator.free(base);
+
+    var store = try Store.init(std.testing.allocator, base);
+    defer store.deinit();
     const missing = try store.loadIfExists();
     try std.testing.expect(missing == null);
 

--- a/zig/src/tui/runtime.zig
+++ b/zig/src/tui/runtime.zig
@@ -127,6 +127,21 @@ pub fn parseRemoteTransport(value: []const u8) ?TuiRemoteTransport {
     return null;
 }
 
+fn hasWhitespaceOrControl(value: []const u8) bool {
+    for (value) |ch| {
+        if (std.ascii.isWhitespace(ch) or ch < 0x20 or ch == 0x7f) return true;
+    }
+    return false;
+}
+
+fn isValidSavedSseEndpoint(endpoint: []const u8) bool {
+    if (endpoint.len == 0) return false;
+    if (hasWhitespaceOrControl(endpoint)) return false;
+    if (std.mem.indexOfScalar(u8, endpoint, '#') != null) return false;
+    const parsed = sse_transport.parseHttpUrl(endpoint) catch return false;
+    return parsed.scheme == .http;
+}
+
 pub fn remoteConfigFromConfig(allocator: std.mem.Allocator, cfg: tui_config.Config) !TuiRemoteConfig {
     var result = TuiRemoteConfig{
         .mode = if (cfg.remote.enabled) .remote else .local,
@@ -154,6 +169,9 @@ pub fn remoteConfigFromConfig(allocator: std.mem.Allocator, cfg: tui_config.Conf
     // local mode so the TUI launches instead of binding protocol I/O to the
     // TUI's own stdio or aborting on an unsupported backend.
     if (result.transport == .stdio or result.transport == .websocket) {
+        result.mode = .local;
+    }
+    if (result.transport == .sse and !isValidSavedSseEndpoint(result.endpoint)) {
         result.mode = .local;
     }
 
@@ -4104,6 +4122,47 @@ test "remoteConfigFromConfig falls back to local for invalid transport" {
     var rc = try remoteConfigFromConfig(std.testing.allocator, cfg);
     defer rc.deinit(std.testing.allocator);
     try std.testing.expectEqual(TuiRemoteTransport.stdio, rc.transport);
+    try std.testing.expectEqual(TuiBackendMode.local, rc.mode);
+}
+
+test "remoteConfigFromConfig keeps valid saved sse remote" {
+    var cfg = try tui_config.Config.defaults(std.testing.allocator);
+    defer cfg.deinit(std.testing.allocator);
+    cfg.remote.deinit(std.testing.allocator);
+    cfg.remote.enabled = true;
+    cfg.remote.transport = try std.testing.allocator.dupe(u8, "sse");
+    cfg.remote.endpoint = try std.testing.allocator.dupe(u8, "http://localhost:8080/events");
+
+    var rc = try remoteConfigFromConfig(std.testing.allocator, cfg);
+    defer rc.deinit(std.testing.allocator);
+    try std.testing.expectEqual(TuiRemoteTransport.sse, rc.transport);
+    try std.testing.expectEqual(TuiBackendMode.remote, rc.mode);
+}
+
+test "remoteConfigFromConfig falls back to local for saved sse without endpoint" {
+    var cfg = try tui_config.Config.defaults(std.testing.allocator);
+    defer cfg.deinit(std.testing.allocator);
+    cfg.remote.deinit(std.testing.allocator);
+    cfg.remote.enabled = true;
+    cfg.remote.transport = try std.testing.allocator.dupe(u8, "sse");
+
+    var rc = try remoteConfigFromConfig(std.testing.allocator, cfg);
+    defer rc.deinit(std.testing.allocator);
+    try std.testing.expectEqual(TuiRemoteTransport.sse, rc.transport);
+    try std.testing.expectEqual(TuiBackendMode.local, rc.mode);
+}
+
+test "remoteConfigFromConfig falls back to local for invalid saved sse endpoint" {
+    var cfg = try tui_config.Config.defaults(std.testing.allocator);
+    defer cfg.deinit(std.testing.allocator);
+    cfg.remote.deinit(std.testing.allocator);
+    cfg.remote.enabled = true;
+    cfg.remote.transport = try std.testing.allocator.dupe(u8, "sse");
+    cfg.remote.endpoint = try std.testing.allocator.dupe(u8, "http://localhost/events extra");
+
+    var rc = try remoteConfigFromConfig(std.testing.allocator, cfg);
+    defer rc.deinit(std.testing.allocator);
+    try std.testing.expectEqual(TuiRemoteTransport.sse, rc.transport);
     try std.testing.expectEqual(TuiBackendMode.local, rc.mode);
 }
 

--- a/zig/src/tui/runtime.zig
+++ b/zig/src/tui/runtime.zig
@@ -139,7 +139,15 @@ pub fn remoteConfigFromConfig(allocator: std.mem.Allocator, cfg: tui_config.Conf
     errdefer result.deinit(allocator);
 
     const transport_name = if (cfg.remote.transport.len > 0) cfg.remote.transport else "stdio";
-    result.transport = parseRemoteTransport(transport_name) orelse .stdio;
+    if (parseRemoteTransport(transport_name)) |remote_transport| {
+        result.transport = remote_transport;
+    } else {
+        // Invalid hand-edited transport values must not fall back to stdio while
+        // remote remains enabled; that would bind the protocol to the TUI's own
+        // stdin/stdout. Fall back to local mode instead.
+        result.transport = .stdio;
+        result.mode = .local;
+    }
 
     // WebSocket backend is not wired up yet. If a hand-edited config requests
     // it, gracefully fall back to local mode so the TUI still launches.
@@ -4070,6 +4078,19 @@ test "remoteConfigFromConfig falls back to local for websocket" {
     var rc = try remoteConfigFromConfig(std.testing.allocator, cfg);
     defer rc.deinit(std.testing.allocator);
     try std.testing.expectEqual(TuiRemoteTransport.websocket, rc.transport);
+    try std.testing.expectEqual(TuiBackendMode.local, rc.mode);
+}
+
+test "remoteConfigFromConfig falls back to local for invalid transport" {
+    var cfg = try tui_config.Config.defaults(std.testing.allocator);
+    defer cfg.deinit(std.testing.allocator);
+    cfg.remote.deinit(std.testing.allocator);
+    cfg.remote.enabled = true;
+    cfg.remote.transport = try std.testing.allocator.dupe(u8, "stido");
+
+    var rc = try remoteConfigFromConfig(std.testing.allocator, cfg);
+    defer rc.deinit(std.testing.allocator);
+    try std.testing.expectEqual(TuiRemoteTransport.stdio, rc.transport);
     try std.testing.expectEqual(TuiBackendMode.local, rc.mode);
 }
 

--- a/zig/src/tui/runtime.zig
+++ b/zig/src/tui/runtime.zig
@@ -155,7 +155,11 @@ fn isValidSavedSseEndpoint(endpoint: []const u8) bool {
     if (endpoint.len == 0) return false;
     if (hasWhitespaceOrControl(endpoint)) return false;
     if (std.mem.indexOfScalar(u8, endpoint, '#') != null) return false;
-    if (std.mem.indexOfScalar(u8, endpoint, '@') != null) return false;
+    const scheme_end = std.mem.indexOf(u8, endpoint, "://") orelse return false;
+    const after_scheme = endpoint[scheme_end + 3 ..];
+    var authority_end: usize = 0;
+    while (authority_end < after_scheme.len and after_scheme[authority_end] != '/' and after_scheme[authority_end] != '?' and after_scheme[authority_end] != '#') : (authority_end += 1) {}
+    if (std.mem.indexOfScalar(u8, after_scheme[0..authority_end], '@') != null) return false;
     const parsed = sse_transport.parseHttpUrl(endpoint) catch return false;
     return parsed.scheme == .http;
 }
@@ -4157,6 +4161,34 @@ test "remoteConfigFromConfig keeps valid saved sse remote" {
     defer rc.deinit(std.testing.allocator);
     try std.testing.expectEqual(TuiRemoteTransport.sse, rc.transport);
     try std.testing.expectEqual(TuiBackendMode.remote, rc.mode);
+}
+
+test "remoteConfigFromConfig allows at-sign outside sse authority" {
+    var cfg = try tui_config.Config.defaults(std.testing.allocator);
+    defer cfg.deinit(std.testing.allocator);
+    cfg.remote.deinit(std.testing.allocator);
+    cfg.remote.enabled = true;
+    cfg.remote.transport = try std.testing.allocator.dupe(u8, "sse");
+    cfg.remote.endpoint = try std.testing.allocator.dupe(u8, "http://localhost:8080/events?user=a@b");
+
+    var rc = try remoteConfigFromConfig(std.testing.allocator, cfg);
+    defer rc.deinit(std.testing.allocator);
+    try std.testing.expectEqual(TuiRemoteTransport.sse, rc.transport);
+    try std.testing.expectEqual(TuiBackendMode.remote, rc.mode);
+}
+
+test "remoteConfigFromConfig rejects at-sign in saved sse authority" {
+    var cfg = try tui_config.Config.defaults(std.testing.allocator);
+    defer cfg.deinit(std.testing.allocator);
+    cfg.remote.deinit(std.testing.allocator);
+    cfg.remote.enabled = true;
+    cfg.remote.transport = try std.testing.allocator.dupe(u8, "sse");
+    cfg.remote.endpoint = try std.testing.allocator.dupe(u8, "http://token@localhost:8080/events");
+
+    var rc = try remoteConfigFromConfig(std.testing.allocator, cfg);
+    defer rc.deinit(std.testing.allocator);
+    try std.testing.expectEqual(TuiRemoteTransport.sse, rc.transport);
+    try std.testing.expectEqual(TuiBackendMode.local, rc.mode);
 }
 
 test "remoteConfigFromConfig falls back to local for saved sse without endpoint" {

--- a/zig/src/tui/runtime.zig
+++ b/zig/src/tui/runtime.zig
@@ -149,9 +149,11 @@ pub fn remoteConfigFromConfig(allocator: std.mem.Allocator, cfg: tui_config.Conf
         result.mode = .local;
     }
 
-    // WebSocket backend is not wired up yet. If a hand-edited config requests
-    // it, gracefully fall back to local mode so the TUI still launches.
-    if (result.transport == .websocket) {
+    // Stdio subprocess spawning and WebSocket are not wired up yet. If a
+    // hand-edited/legacy config enables either transport, gracefully fall back to
+    // local mode so the TUI launches instead of binding protocol I/O to the
+    // TUI's own stdio or aborting on an unsupported backend.
+    if (result.transport == .stdio or result.transport == .websocket) {
         result.mode = .local;
     }
 
@@ -4065,6 +4067,17 @@ test "remote config rejects unsupported endpoint" {
 
 test "remote config rejects unsupported transport" {
     try std.testing.expectError(error.UnsupportedRemoteTransport, TuiRuntime.init(std.testing.allocator, .{ .remote_config = .{ .mode = .remote, .transport = .websocket, .endpoint = "ws://localhost:1" } }));
+}
+
+test "remoteConfigFromConfig falls back to local for saved stdio" {
+    var cfg = try tui_config.Config.defaults(std.testing.allocator);
+    defer cfg.deinit(std.testing.allocator);
+    cfg.remote.enabled = true;
+
+    var rc = try remoteConfigFromConfig(std.testing.allocator, cfg);
+    defer rc.deinit(std.testing.allocator);
+    try std.testing.expectEqual(TuiRemoteTransport.stdio, rc.transport);
+    try std.testing.expectEqual(TuiBackendMode.local, rc.mode);
 }
 
 test "remoteConfigFromConfig falls back to local for websocket" {

--- a/zig/src/tui/runtime.zig
+++ b/zig/src/tui/runtime.zig
@@ -20,6 +20,7 @@ const local_tools = @import("tools/registry");
 const tool_local_runtime = @import("tool_local_runtime");
 const permission = @import("permission");
 const OwnedSlice = @import("owned_slice").OwnedSlice;
+const tui_config = @import("tui_config");
 
 pub const TuiSession = session.TuiSession;
 pub const TuiEvent = session.TuiEvent;
@@ -101,8 +102,61 @@ pub const TuiRemoteConfig = struct {
     mode: TuiBackendMode = .local,
     transport: TuiRemoteTransport = .stdio,
     endpoint: []const u8 = "",
+    command: []const u8 = "",
+    auth_token: []const u8 = "",
     auth_headers: []const ai_types.HeaderPair = &.{},
+
+    pub fn deinit(self: *TuiRemoteConfig, allocator: std.mem.Allocator) void {
+        allocator.free(self.endpoint);
+        allocator.free(self.command);
+        allocator.free(self.auth_token);
+        for (self.auth_headers) |header| {
+            var h = header;
+            h.deinit(allocator);
+        }
+        allocator.free(self.auth_headers);
+        self.* = .{};
+    }
 };
+
+pub fn parseRemoteTransport(value: []const u8) ?TuiRemoteTransport {
+    if (std.mem.eql(u8, value, "stdio")) return .stdio;
+    if (std.mem.eql(u8, value, "sse")) return .sse;
+    if (std.mem.eql(u8, value, "ws")) return .websocket;
+    if (std.mem.eql(u8, value, "websocket")) return .websocket;
+    return null;
+}
+
+pub fn remoteConfigFromConfig(allocator: std.mem.Allocator, cfg: tui_config.Config) !TuiRemoteConfig {
+    var result = TuiRemoteConfig{
+        .mode = if (cfg.remote.enabled) .remote else .local,
+        .transport = .stdio,
+        .endpoint = try allocator.dupe(u8, cfg.remote.endpoint),
+        .command = try allocator.dupe(u8, cfg.remote.command),
+        .auth_token = try allocator.dupe(u8, cfg.remote.auth_token),
+        .auth_headers = &.{},
+    };
+    errdefer result.deinit(allocator);
+
+    const transport_name = if (cfg.remote.transport.len > 0) cfg.remote.transport else "stdio";
+    result.transport = parseRemoteTransport(transport_name) orelse .stdio;
+
+    var headers: std.ArrayList(ai_types.HeaderPair) = .empty;
+    errdefer {
+        for (headers.items) |*header| header.deinit(allocator);
+        headers.deinit(allocator);
+    }
+    if (cfg.remote.auth_token.len > 0) {
+        const value = try std.fmt.allocPrint(allocator, "Bearer {s}", .{cfg.remote.auth_token});
+        errdefer allocator.free(value);
+        try headers.append(allocator, .{ .name = try allocator.dupe(u8, "Authorization"), .value = value });
+    } else if (cfg.remote.auth_header_value.len > 0) {
+        const name = if (cfg.remote.auth_header_name.len > 0) cfg.remote.auth_header_name else "Authorization";
+        try headers.append(allocator, .{ .name = try allocator.dupe(u8, name), .value = try allocator.dupe(u8, cfg.remote.auth_header_value) });
+    }
+    result.auth_headers = try headers.toOwnedSlice(allocator);
+    return result;
+}
 
 pub const TuiRuntimeOptions = struct {
     backend: TuiBackendMode = .local,

--- a/zig/src/tui/runtime.zig
+++ b/zig/src/tui/runtime.zig
@@ -134,10 +134,28 @@ fn hasWhitespaceOrControl(value: []const u8) bool {
     return false;
 }
 
+fn hasCrLf(value: []const u8) bool {
+    return std.mem.indexOfAny(u8, value, "\r\n") != null;
+}
+
+fn isTchar(ch: u8) bool {
+    return std.ascii.isAlphanumeric(ch) or switch (ch) {
+        '!', '#', '$', '%', '&', '\'', '*', '+', '-', '.', '^', '_', '`', '|', '~' => true,
+        else => false,
+    };
+}
+
+fn isValidHeaderName(value: []const u8) bool {
+    if (value.len == 0) return false;
+    for (value) |ch| if (!isTchar(ch)) return false;
+    return true;
+}
+
 fn isValidSavedSseEndpoint(endpoint: []const u8) bool {
     if (endpoint.len == 0) return false;
     if (hasWhitespaceOrControl(endpoint)) return false;
     if (std.mem.indexOfScalar(u8, endpoint, '#') != null) return false;
+    if (std.mem.indexOfScalar(u8, endpoint, '@') != null) return false;
     const parsed = sse_transport.parseHttpUrl(endpoint) catch return false;
     return parsed.scheme == .http;
 }
@@ -180,13 +198,15 @@ pub fn remoteConfigFromConfig(allocator: std.mem.Allocator, cfg: tui_config.Conf
         for (headers.items) |*header| header.deinit(allocator);
         headers.deinit(allocator);
     }
-    if (cfg.remote.auth_token.len > 0) {
+    if (cfg.remote.auth_token.len > 0 and !hasCrLf(cfg.remote.auth_token)) {
         const value = try std.fmt.allocPrint(allocator, "Bearer {s}", .{cfg.remote.auth_token});
         errdefer allocator.free(value);
         try headers.append(allocator, .{ .name = try allocator.dupe(u8, "Authorization"), .value = value });
-    } else if (cfg.remote.auth_header_value.len > 0) {
+    } else if (cfg.remote.auth_header_value.len > 0 and !hasCrLf(cfg.remote.auth_header_value)) {
         const name = if (cfg.remote.auth_header_name.len > 0) cfg.remote.auth_header_name else "Authorization";
-        try headers.append(allocator, .{ .name = try allocator.dupe(u8, name), .value = try allocator.dupe(u8, cfg.remote.auth_header_value) });
+        if (isValidHeaderName(name)) {
+            try headers.append(allocator, .{ .name = try allocator.dupe(u8, name), .value = try allocator.dupe(u8, cfg.remote.auth_header_value) });
+        }
     }
     if (headers.items.len > 0) {
         result.auth_headers = try headers.toOwnedSlice(allocator);
@@ -4164,6 +4184,50 @@ test "remoteConfigFromConfig falls back to local for invalid saved sse endpoint"
     defer rc.deinit(std.testing.allocator);
     try std.testing.expectEqual(TuiRemoteTransport.sse, rc.transport);
     try std.testing.expectEqual(TuiBackendMode.local, rc.mode);
+}
+
+test "remoteConfigFromConfig drops saved auth token with CRLF" {
+    var cfg = try tui_config.Config.defaults(std.testing.allocator);
+    defer cfg.deinit(std.testing.allocator);
+    cfg.remote.deinit(std.testing.allocator);
+    cfg.remote.enabled = true;
+    cfg.remote.transport = try std.testing.allocator.dupe(u8, "sse");
+    cfg.remote.endpoint = try std.testing.allocator.dupe(u8, "http://localhost:8080/events");
+    cfg.remote.auth_token = try std.testing.allocator.dupe(u8, "secret\r\nInjected: yes");
+
+    var rc = try remoteConfigFromConfig(std.testing.allocator, cfg);
+    defer rc.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 0), rc.auth_headers.len);
+}
+
+test "remoteConfigFromConfig drops invalid saved custom auth header" {
+    var cfg = try tui_config.Config.defaults(std.testing.allocator);
+    defer cfg.deinit(std.testing.allocator);
+    cfg.remote.deinit(std.testing.allocator);
+    cfg.remote.enabled = true;
+    cfg.remote.transport = try std.testing.allocator.dupe(u8, "sse");
+    cfg.remote.endpoint = try std.testing.allocator.dupe(u8, "http://localhost:8080/events");
+    cfg.remote.auth_header_name = try std.testing.allocator.dupe(u8, "Bad:Name");
+    cfg.remote.auth_header_value = try std.testing.allocator.dupe(u8, "value");
+
+    var rc = try remoteConfigFromConfig(std.testing.allocator, cfg);
+    defer rc.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 0), rc.auth_headers.len);
+}
+
+test "remoteConfigFromConfig drops saved custom auth header with CRLF" {
+    var cfg = try tui_config.Config.defaults(std.testing.allocator);
+    defer cfg.deinit(std.testing.allocator);
+    cfg.remote.deinit(std.testing.allocator);
+    cfg.remote.enabled = true;
+    cfg.remote.transport = try std.testing.allocator.dupe(u8, "sse");
+    cfg.remote.endpoint = try std.testing.allocator.dupe(u8, "http://localhost:8080/events");
+    cfg.remote.auth_header_name = try std.testing.allocator.dupe(u8, "X-Api-Key");
+    cfg.remote.auth_header_value = try std.testing.allocator.dupe(u8, "value\r\nInjected: yes");
+
+    var rc = try remoteConfigFromConfig(std.testing.allocator, cfg);
+    defer rc.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 0), rc.auth_headers.len);
 }
 
 test "remoteConfigFromConfig skips empty allocations" {

--- a/zig/src/tui/runtime.zig
+++ b/zig/src/tui/runtime.zig
@@ -107,14 +107,14 @@ pub const TuiRemoteConfig = struct {
     auth_headers: []const ai_types.HeaderPair = &.{},
 
     pub fn deinit(self: *TuiRemoteConfig, allocator: std.mem.Allocator) void {
-        allocator.free(self.endpoint);
-        allocator.free(self.command);
-        allocator.free(self.auth_token);
+        if (self.endpoint.len > 0) allocator.free(self.endpoint);
+        if (self.command.len > 0) allocator.free(self.command);
+        if (self.auth_token.len > 0) allocator.free(self.auth_token);
         for (self.auth_headers) |header| {
             var h = header;
             h.deinit(allocator);
         }
-        allocator.free(self.auth_headers);
+        if (self.auth_headers.len > 0) allocator.free(self.auth_headers);
         self.* = .{};
     }
 };
@@ -131,15 +131,21 @@ pub fn remoteConfigFromConfig(allocator: std.mem.Allocator, cfg: tui_config.Conf
     var result = TuiRemoteConfig{
         .mode = if (cfg.remote.enabled) .remote else .local,
         .transport = .stdio,
-        .endpoint = try allocator.dupe(u8, cfg.remote.endpoint),
-        .command = try allocator.dupe(u8, cfg.remote.command),
-        .auth_token = try allocator.dupe(u8, cfg.remote.auth_token),
+        .endpoint = if (cfg.remote.endpoint.len > 0) try allocator.dupe(u8, cfg.remote.endpoint) else &.{},
+        .command = if (cfg.remote.command.len > 0) try allocator.dupe(u8, cfg.remote.command) else &.{},
+        .auth_token = if (cfg.remote.auth_token.len > 0) try allocator.dupe(u8, cfg.remote.auth_token) else &.{},
         .auth_headers = &.{},
     };
     errdefer result.deinit(allocator);
 
     const transport_name = if (cfg.remote.transport.len > 0) cfg.remote.transport else "stdio";
     result.transport = parseRemoteTransport(transport_name) orelse .stdio;
+
+    // WebSocket backend is not wired up yet. If a hand-edited config requests
+    // it, gracefully fall back to local mode so the TUI still launches.
+    if (result.transport == .websocket) {
+        result.mode = .local;
+    }
 
     var headers: std.ArrayList(ai_types.HeaderPair) = .empty;
     errdefer {
@@ -154,7 +160,9 @@ pub fn remoteConfigFromConfig(allocator: std.mem.Allocator, cfg: tui_config.Conf
         const name = if (cfg.remote.auth_header_name.len > 0) cfg.remote.auth_header_name else "Authorization";
         try headers.append(allocator, .{ .name = try allocator.dupe(u8, name), .value = try allocator.dupe(u8, cfg.remote.auth_header_value) });
     }
-    result.auth_headers = try headers.toOwnedSlice(allocator);
+    if (headers.items.len > 0) {
+        result.auth_headers = try headers.toOwnedSlice(allocator);
+    }
     return result;
 }
 
@@ -4049,6 +4057,37 @@ test "remote config rejects unsupported endpoint" {
 
 test "remote config rejects unsupported transport" {
     try std.testing.expectError(error.UnsupportedRemoteTransport, TuiRuntime.init(std.testing.allocator, .{ .remote_config = .{ .mode = .remote, .transport = .websocket, .endpoint = "ws://localhost:1" } }));
+}
+
+test "remoteConfigFromConfig falls back to local for websocket" {
+    var cfg = try tui_config.Config.defaults(std.testing.allocator);
+    defer cfg.deinit(std.testing.allocator);
+    cfg.remote.deinit(std.testing.allocator);
+    cfg.remote.enabled = true;
+    cfg.remote.transport = try std.testing.allocator.dupe(u8, "websocket");
+    cfg.remote.endpoint = try std.testing.allocator.dupe(u8, "ws://localhost:1");
+
+    var rc = try remoteConfigFromConfig(std.testing.allocator, cfg);
+    defer rc.deinit(std.testing.allocator);
+    try std.testing.expectEqual(TuiRemoteTransport.websocket, rc.transport);
+    try std.testing.expectEqual(TuiBackendMode.local, rc.mode);
+}
+
+test "remoteConfigFromConfig skips empty allocations" {
+    var cfg = try tui_config.Config.defaults(std.testing.allocator);
+    defer cfg.deinit(std.testing.allocator);
+
+    var rc = try remoteConfigFromConfig(std.testing.allocator, cfg);
+    defer rc.deinit(std.testing.allocator);
+    try std.testing.expectEqualStrings("", rc.endpoint);
+    try std.testing.expectEqualStrings("", rc.command);
+    try std.testing.expectEqualStrings("", rc.auth_token);
+    try std.testing.expectEqual(@as(usize, 0), rc.auth_headers.len);
+}
+
+test "default TuiRemoteConfig deinit is safe" {
+    var rc: TuiRemoteConfig = .{};
+    rc.deinit(std.testing.allocator);
 }
 
 test "remote start resets state after pump error" {


### PR DESCRIPTION
## Summary
Adds slash-command-based configuration for the TUI remote transport, persistence to `~/.makai/config.json`, and startup loading.

- `tui/config.zig`: new `RemoteConfig` struct (transport, endpoint, command, auth token/header) with JSON round-trips.
- `tui/runtime.zig`: extends `TuiRemoteConfig` and adds `remoteConfigFromConfig` to convert saved config into runtime options.
- `tui/commands.zig`: new `/remote` command with subcommands:
  - `/remote stdio [command]`
  - `/remote sse <url>`
  - `/remote ws <url>` / `/remote websocket <url>`
  - `/remote auth <token>`
  - `/remote header <name> <value>`
  - `/remote off`
  Includes URL scheme validation and clear errors for unsupported transports.
- `tui/app.zig`: `ProductionRuntime.init` loads saved remote config and passes it to `TuiRuntimeOptions`.

## Test plan
- [x] `zig build test-unit-makai-cli`
- [x] `zig build test` (only pre-existing unrelated failure in `TuiModel remote streaming Enter falls back to submit and preserves composer`)
- [x] `./scripts/check-zig-patterns.sh`

Relates-to #128 #129