### PR TITLE
Add search to sessions picker

### DIFF
--- a/zig/src/tui/app.zig
+++ b/zig/src/tui/app.zig
@@ -435,7 +435,7 @@ pub const App = struct {
         for (metas.items) |meta| {
             const label = try formatSessionLabel(self.allocator, meta);
             defer self.allocator.free(label);
-            try self.state.addSession(meta.session_id, label);
+            try self.state.addSessionWithDetails(meta.session_id, label, meta.model, meta.provider);
         }
     }
 
@@ -443,11 +443,9 @@ pub const App = struct {
     pub fn resumeSelectedSession(self: *App) !void {
         const store = self.store orelse return error.NoStoreConfigured;
         const runtime = if (self.runtime) |r| r else return error.NoRuntimeConfigured;
-        const sessions = self.state.sessions.items;
-        if (sessions.len == 0) return;
-        const idx = self.state.session_index;
-        if (idx >= sessions.len) return;
-        const id = sessions[idx].id;
+        self.state.clampSessionSelectionToFilter();
+        const selected = self.state.sessionAtFilteredIndex(self.state.session_index) orelse return;
+        const id = selected.id;
         var loaded = try store.resumeSession(id, runtime);
         defer loaded.deinit(self.allocator);
         const new_session_id = try self.allocator.dupe(u8, loaded.metadata.session_id);
@@ -1122,6 +1120,7 @@ pub const App = struct {
                 try self.loadSessions();
                 self.state.session_index = 0;
                 self.state.session_scroll = 0;
+                self.state.session_filter.clear();
                 self.state.mode = .session_picker;
             },
             .open_model_picker => self.openModelPicker(),
@@ -1634,16 +1633,19 @@ pub const TuiModel = struct {
                         return .none;
                     }
                 }
-                // Session picker navigation (T10).
+                // Session picker navigation and filtering.
                 if (app.state.mode == .session_picker) {
                     switch (key.key) {
                         .up => moveSessionSelection(app, -1),
                         .down => moveSessionSelection(app, 1),
-                        .char => |c| switch (c) {
-                            'k' => moveSessionSelection(app, -1),
-                            'j' => moveSessionSelection(app, 1),
-                            else => {},
-                        },
+                        .backspace => updateSessionFilter(app, .backspace, null),
+                        .delete => updateSessionFilter(app, .delete, null),
+                        .char => |c| updateSessionFilter(app, .char, c),
+                        .space => updateSessionFilter(app, .char, ' '),
+                        .left => _ = app.state.session_filter.moveCursorPrev(),
+                        .right => _ = app.state.session_filter.moveCursorNext(),
+                        .home => app.state.session_filter.moveCursorHome(),
+                        .end => app.state.session_filter.moveCursorEnd(),
                         .enter => {
                             app.resumeSelectedSession() catch |err| app.recordError(@errorName(err)) catch {};
                         },
@@ -2104,6 +2106,34 @@ pub const TuiModel = struct {
         try term.flush();
     }
 
+    const SessionFilterEdit = enum { backspace, delete, char };
+
+    fn updateSessionFilter(app: *App, edit: SessionFilterEdit, c: ?u21) void {
+        const selected_raw_index = app.state.sessionRawIndexAtFilteredIndex(app.state.session_index);
+        switch (edit) {
+            .backspace => _ = app.state.session_filter.deleteBeforeCursor(),
+            .delete => _ = app.state.session_filter.deleteAfterCursor(),
+            .char => {
+                var buf: [4]u8 = undefined;
+                const len = std.unicode.utf8Encode(c.?, &buf) catch return;
+                app.state.session_filter.insertSlice(app.allocator, buf[0..len]) catch |err| {
+                    app.recordError(@errorName(err)) catch {};
+                    return;
+                };
+            },
+        }
+        if (selected_raw_index) |raw_index| {
+            if (app.state.sessionFilteredIndexForRawIndex(raw_index)) |filtered_index| {
+                app.state.session_index = filtered_index;
+            } else {
+                app.state.clampSessionSelectionToFilter();
+            }
+        } else {
+            app.state.clampSessionSelectionToFilter();
+        }
+        ensureSessionSelectionVisible(app);
+    }
+
     fn handleMouse(app: *App, mouse: zz.MouseEvent) void {
         if (mouse.event_type != .press) return;
         switch (mouse.button) {
@@ -2156,7 +2186,7 @@ pub const TuiModel = struct {
     }
 
     fn moveSessionSelection(app: *App, delta: isize) void {
-        const n = app.state.sessions.items.len;
+        const n = app.state.filteredSessionCount();
         if (n == 0) {
             app.state.session_index = 0;
             app.state.session_scroll = 0;
@@ -2171,6 +2201,7 @@ pub const TuiModel = struct {
     }
 
     fn ensureSessionSelectionVisible(app: *App) void {
+        app.state.clampSessionSelectionToFilter();
         const height = sessionPickerHeight(app);
         if (app.state.session_index < app.state.session_scroll) {
             app.state.session_scroll = app.state.session_index;
@@ -2180,7 +2211,7 @@ pub const TuiModel = struct {
     }
 
     fn visibleSessionCount(app: *const App) usize {
-        return @min(app.state.sessions.items.len -| app.state.session_scroll, sessionPickerHeight(app));
+        return @min(app.state.filteredSessionCount() -| app.state.session_scroll, sessionPickerHeight(app));
     }
 
     fn sessionPickerHeight(app: *const App) usize {
@@ -3270,6 +3301,43 @@ test "session picker navigation pages through hidden rows" {
     try std.testing.expectEqual(@as(usize, 4), app.state.session_index);
     try std.testing.expectEqual(@as(usize, 1), app.state.session_scroll);
     try std.testing.expectEqual(@as(usize, 4), TuiModel.visibleSessionCount(&app));
+}
+
+test "session picker typing filters without moving navigation" {
+    var model = TuiModel{ .app = App.initWithoutRuntime(std.testing.allocator) };
+    defer model.deinit();
+    model.app.?.state.mode = .session_picker;
+    try model.app.?.state.addSessionWithDetails("s1", "Alpha", "claude-sonnet", "anthropic");
+    try model.app.?.state.addSessionWithDetails("s2", "Beta", "gpt-4o", "openai");
+
+    _ = model.update(.{ .key = .{ .key = .{ .char = 'g' } } }, undefined);
+    _ = model.update(.{ .key = .{ .key = .{ .char = 'p' } } }, undefined);
+    _ = model.update(.{ .key = .{ .key = .{ .char = 't' } } }, undefined);
+
+    try std.testing.expectEqualStrings("gpt", model.app.?.state.sessionFilterText());
+    try std.testing.expectEqual(@as(usize, 1), model.app.?.state.filteredSessionCount());
+    try std.testing.expectEqual(@as(usize, 0), model.app.?.state.session_index);
+    try std.testing.expectEqual(@as(usize, 1), model.app.?.state.sessionRawIndexAtFilteredIndex(0).?);
+
+    _ = model.update(.{ .key = .{ .key = .backspace } }, undefined);
+    try std.testing.expectEqualStrings("gp", model.app.?.state.sessionFilterText());
+}
+
+test "session picker keeps selected session when still matched after filter" {
+    var app = App.initWithoutRuntime(std.testing.allocator);
+    defer app.deinit();
+    try app.state.addSessionWithDetails("s1", "Alpha", "claude-sonnet", "anthropic");
+    try app.state.addSessionWithDetails("s2", "Beta", "gpt-4o", "openai");
+    try app.state.addSessionWithDetails("s3", "Gamma", "gpt-4.1", "openai");
+    app.state.session_index = 2;
+
+    TuiModel.updateSessionFilter(&app, .char, 'g');
+    TuiModel.updateSessionFilter(&app, .char, 'p');
+    TuiModel.updateSessionFilter(&app, .char, 't');
+
+    try std.testing.expectEqual(@as(usize, 2), app.state.filteredSessionCount());
+    try std.testing.expectEqual(@as(usize, 1), app.state.session_index);
+    try std.testing.expectEqual(@as(usize, 2), app.state.sessionRawIndexAtFilteredIndex(app.state.session_index).?);
 }
 
 fn initRemoteRuntimeForTest(allocator: std.mem.Allocator) !*tui_runtime.TuiRuntime {

--- a/zig/src/tui/state.zig
+++ b/zig/src/tui/state.zig
@@ -315,17 +315,51 @@ pub const PreviewState = struct {
 pub const SessionEntry = struct {
     id: []u8,
     label: []u8,
+    model: []u8 = &.{},
+    provider: []u8 = &.{},
 
     pub fn init(allocator: std.mem.Allocator, id: []const u8, label: []const u8) !SessionEntry {
-        return .{ .id = try allocator.dupe(u8, id), .label = try allocator.dupe(u8, label) };
+        return initWithDetails(allocator, id, label, "", "");
+    }
+
+    pub fn initWithDetails(allocator: std.mem.Allocator, id: []const u8, label: []const u8, model: []const u8, provider: []const u8) !SessionEntry {
+        const owned_id = try allocator.dupe(u8, id);
+        errdefer allocator.free(owned_id);
+        const owned_label = try allocator.dupe(u8, label);
+        errdefer allocator.free(owned_label);
+        const owned_model = try dupOrEmpty(allocator, model);
+        errdefer if (owned_model.len > 0) allocator.free(owned_model);
+        const owned_provider = try dupOrEmpty(allocator, provider);
+        errdefer if (owned_provider.len > 0) allocator.free(owned_provider);
+        return .{
+            .id = owned_id,
+            .label = owned_label,
+            .model = owned_model,
+            .provider = owned_provider,
+        };
+    }
+
+    pub fn matchesQuery(self: SessionEntry, query: []const u8) bool {
+        if (query.len == 0) return true;
+        return std.ascii.indexOfIgnoreCase(self.label, query) != null or
+            std.ascii.indexOfIgnoreCase(self.id, query) != null or
+            std.ascii.indexOfIgnoreCase(self.model, query) != null or
+            std.ascii.indexOfIgnoreCase(self.provider, query) != null;
     }
 
     pub fn deinit(self: *SessionEntry, allocator: std.mem.Allocator) void {
         allocator.free(self.id);
         allocator.free(self.label);
+        if (self.model.len > 0) allocator.free(self.model);
+        if (self.provider.len > 0) allocator.free(self.provider);
         self.* = undefined;
     }
 };
+
+fn dupOrEmpty(allocator: std.mem.Allocator, value: []const u8) ![]u8 {
+    if (value.len == 0) return &.{};
+    return allocator.dupe(u8, value);
+}
 
 pub const ComposerState = struct {
     buffer: std.ArrayList(u8) = .empty,
@@ -371,6 +405,16 @@ pub const ComposerState = struct {
         std.mem.copyForwards(u8, self.buffer.items[start..], self.buffer.items[self.cursor..]);
         self.buffer.shrinkRetainingCapacity(self.buffer.items.len - removed);
         self.cursor = start;
+        return true;
+    }
+
+    pub fn deleteAfterCursor(self: *ComposerState) bool {
+        self.normalizeCursor();
+        if (self.cursor >= self.buffer.items.len) return false;
+        const end = nextCodepointEnd(self.buffer.items, self.cursor);
+        const removed = end - self.cursor;
+        std.mem.copyForwards(u8, self.buffer.items[self.cursor..], self.buffer.items[end..]);
+        self.buffer.shrinkRetainingCapacity(self.buffer.items.len - removed);
         return true;
     }
 
@@ -448,6 +492,7 @@ pub const AppState = struct {
     tool_scroll: usize = 0,
     session_index: usize = 0,
     session_scroll: usize = 0,
+    session_filter: ComposerState = .{},
     menu_index: usize = 0,
     menu_scroll: usize = 0,
     active_user_entry: ?usize = null,
@@ -473,6 +518,7 @@ pub const AppState = struct {
         self.tools.deinit(self.allocator);
         for (self.sessions.items) |*session| session.deinit(self.allocator);
         self.sessions.deinit(self.allocator);
+        self.session_filter.deinit(self.allocator);
         self.composer.deinit(self.allocator);
         self.approval.deinit(self.allocator);
         self.clearQueuedPreviews();
@@ -817,7 +863,62 @@ pub const AppState = struct {
     }
 
     pub fn addSession(self: *AppState, id: []const u8, label: []const u8) !void {
-        try self.sessions.append(self.allocator, try SessionEntry.init(self.allocator, id, label));
+        try self.addSessionWithDetails(id, label, "", "");
+    }
+
+    pub fn addSessionWithDetails(self: *AppState, id: []const u8, label: []const u8, model: []const u8, provider: []const u8) !void {
+        try self.sessions.append(self.allocator, try SessionEntry.initWithDetails(self.allocator, id, label, model, provider));
+    }
+
+    pub fn sessionFilterText(self: *const AppState) []const u8 {
+        return self.session_filter.text();
+    }
+
+    pub fn filteredSessionCount(self: *const AppState) usize {
+        const query = self.sessionFilterText();
+        var count: usize = 0;
+        for (self.sessions.items) |session| {
+            if (session.matchesQuery(query)) count += 1;
+        }
+        return count;
+    }
+
+    pub fn sessionRawIndexAtFilteredIndex(self: *const AppState, filtered_index: usize) ?usize {
+        const query = self.sessionFilterText();
+        var matched: usize = 0;
+        for (self.sessions.items, 0..) |session, raw_index| {
+            if (!session.matchesQuery(query)) continue;
+            if (matched == filtered_index) return raw_index;
+            matched += 1;
+        }
+        return null;
+    }
+
+    pub fn sessionFilteredIndexForRawIndex(self: *const AppState, target_raw_index: usize) ?usize {
+        const query = self.sessionFilterText();
+        var matched: usize = 0;
+        for (self.sessions.items, 0..) |session, raw_index| {
+            if (!session.matchesQuery(query)) continue;
+            if (raw_index == target_raw_index) return matched;
+            matched += 1;
+        }
+        return null;
+    }
+
+    pub fn sessionAtFilteredIndex(self: *const AppState, filtered_index: usize) ?*const SessionEntry {
+        const raw_index = self.sessionRawIndexAtFilteredIndex(filtered_index) orelse return null;
+        return &self.sessions.items[raw_index];
+    }
+
+    pub fn clampSessionSelectionToFilter(self: *AppState) void {
+        const count = self.filteredSessionCount();
+        if (count == 0) {
+            self.session_index = 0;
+            self.session_scroll = 0;
+            return;
+        }
+        if (self.session_index >= count) self.session_index = count - 1;
+        if (self.session_scroll > self.session_index) self.session_scroll = self.session_index;
     }
 
     fn setHashlinePreview(self: *AppState, args_json: []const u8) !void {

--- a/zig/src/tui/views/session_picker.zig
+++ b/zig/src/tui/views/session_picker.zig
@@ -15,17 +15,38 @@ pub fn render(allocator: std.mem.Allocator, state: *const tui_state.AppState, op
     const title = try tui_theme.panelTitle().render(allocator, "Sessions");
     defer allocator.free(title);
     try writer.writeAll(title);
+
+    const query = state.sessionFilterText();
+    const search_line = try std.fmt.allocPrint(allocator, "  Search: {s}", .{if (query.len > 0) query else "(type to filter)"});
+    defer allocator.free(search_line);
+    const styled_search = try tui_theme.muted().render(allocator, search_line);
+    defer allocator.free(styled_search);
+    try writer.writeByte('\n');
+    try writer.writeAll(styled_search);
+
     if (state.sessions.items.len == 0) {
         const none = try tui_theme.muted().render(allocator, "  no saved sessions");
         defer allocator.free(none);
         try writer.writeByte('\n');
         try writer.writeAll(none);
-        const body = try out.toOwnedSlice();
-        defer allocator.free(body);
-        return tui_theme.panel().width(@intCast(@min(options.width -| 4, std.math.maxInt(u16)))).render(allocator, body);
+        return renderPanel(allocator, &out, options.width);
     }
-    const end = @min(state.sessions.items.len, options.offset + options.height);
-    for (state.sessions.items[options.offset..end], options.offset..) |session, i| {
+
+    const filtered_count = state.filteredSessionCount();
+    if (filtered_count == 0) {
+        const empty = try std.fmt.allocPrint(allocator, "  No sessions match '{s}'", .{query});
+        defer allocator.free(empty);
+        const styled = try tui_theme.muted().render(allocator, empty);
+        defer allocator.free(styled);
+        try writer.writeByte('\n');
+        try writer.writeAll(styled);
+        return renderPanel(allocator, &out, options.width);
+    }
+
+    const end = @min(filtered_count, options.offset + options.height);
+    var i = options.offset;
+    while (i < end) : (i += 1) {
+        const session = state.sessionAtFilteredIndex(i) orelse continue;
         try writer.writeByte('\n');
         const marker = if (i == state.session_index) ">" else " ";
         const row = try std.fmt.allocPrint(allocator, "{s} {s} ({s})", .{ marker, session.label, session.id });
@@ -34,9 +55,13 @@ pub fn render(allocator: std.mem.Allocator, state: *const tui_state.AppState, op
         defer allocator.free(styled);
         try writer.writeAll(styled);
     }
+    return renderPanel(allocator, &out, options.width);
+}
+
+fn renderPanel(allocator: std.mem.Allocator, out: *std.Io.Writer.Allocating, width: usize) ![]const u8 {
     const body = try out.toOwnedSlice();
     defer allocator.free(body);
-    return tui_theme.panel().width(@intCast(@min(options.width -| 4, std.math.maxInt(u16)))).render(allocator, body);
+    return tui_theme.panel().width(@intCast(@min(width -| 4, std.math.maxInt(u16)))).render(allocator, body);
 }
 
 test "session picker renders selected session" {
@@ -69,4 +94,92 @@ test "session picker renders from offset" {
     try std.testing.expect(std.mem.indexOf(u8, text, "First (s1)") == null);
     try std.testing.expect(std.mem.indexOf(u8, text, "Second (s2)") != null);
     try std.testing.expect(std.mem.indexOf(u8, text, "> Third (s3)") != null);
+}
+
+fn setFilter(state: *tui_state.AppState, text: []const u8) !void {
+    state.session_filter.clear();
+    try state.session_filter.insertSlice(std.testing.allocator, text);
+    state.clampSessionSelectionToFilter();
+}
+
+test "session picker filters by title and id" {
+    var state = tui_state.AppState.init(std.testing.allocator);
+    defer state.deinit();
+    try state.addSessionWithDetails("session-alpha", "Alpha project", "claude-sonnet", "anthropic");
+    try state.addSessionWithDetails("session-beta", "Beta project", "gpt-4o", "openai");
+
+    try setFilter(&state, "beta");
+    const by_title = try render(std.testing.allocator, &state, .{ .height = 4 });
+    defer std.testing.allocator.free(by_title);
+    try std.testing.expect(std.mem.indexOf(u8, by_title, "Beta project (session-beta)") != null);
+    try std.testing.expect(std.mem.indexOf(u8, by_title, "Alpha project") == null);
+
+    try setFilter(&state, "alpha");
+    const by_id = try render(std.testing.allocator, &state, .{ .height = 4 });
+    defer std.testing.allocator.free(by_id);
+    try std.testing.expect(std.mem.indexOf(u8, by_id, "Alpha project (session-alpha)") != null);
+    try std.testing.expect(std.mem.indexOf(u8, by_id, "Beta project") == null);
+}
+
+test "session picker filters by model and provider" {
+    var state = tui_state.AppState.init(std.testing.allocator);
+    defer state.deinit();
+    try state.addSessionWithDetails("s1", "First", "claude-sonnet", "anthropic");
+    try state.addSessionWithDetails("s2", "Second", "gpt-4o", "openai");
+    try state.addSessionWithDetails("s3", "Third", "gemini", "google");
+
+    try setFilter(&state, "gpt");
+    const by_model = try render(std.testing.allocator, &state, .{ .height = 4 });
+    defer std.testing.allocator.free(by_model);
+    try std.testing.expect(std.mem.indexOf(u8, by_model, "Second (s2)") != null);
+    try std.testing.expect(std.mem.indexOf(u8, by_model, "First (s1)") == null);
+
+    try setFilter(&state, "google");
+    const by_provider = try render(std.testing.allocator, &state, .{ .height = 4 });
+    defer std.testing.allocator.free(by_provider);
+    try std.testing.expect(std.mem.indexOf(u8, by_provider, "Third (s3)") != null);
+    try std.testing.expect(std.mem.indexOf(u8, by_provider, "Second (s2)") == null);
+}
+
+test "session picker empty filter shows all sessions" {
+    var state = tui_state.AppState.init(std.testing.allocator);
+    defer state.deinit();
+    try state.addSession("s1", "First");
+    try state.addSession("s2", "Second");
+
+    const text = try render(std.testing.allocator, &state, .{ .height = 4 });
+    defer std.testing.allocator.free(text);
+
+    try std.testing.expect(std.mem.indexOf(u8, text, "First (s1)") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "Second (s2)") != null);
+}
+
+test "session picker empty result state names query" {
+    var state = tui_state.AppState.init(std.testing.allocator);
+    defer state.deinit();
+    try state.addSession("s1", "First");
+    try setFilter(&state, "missing");
+
+    const text = try render(std.testing.allocator, &state, .{ .height = 4 });
+    defer std.testing.allocator.free(text);
+
+    try std.testing.expect(std.mem.indexOf(u8, text, "No sessions match 'missing'") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "First (s1)") == null);
+}
+
+test "session picker clamps selection after filter changes" {
+    var state = tui_state.AppState.init(std.testing.allocator);
+    defer state.deinit();
+    try state.addSessionWithDetails("s1", "First", "claude", "anthropic");
+    try state.addSessionWithDetails("s2", "Second", "gpt", "openai");
+    try state.addSessionWithDetails("s3", "Third", "gemini", "google");
+    state.session_index = 2;
+    state.session_scroll = 2;
+
+    try setFilter(&state, "openai");
+
+    try std.testing.expectEqual(@as(usize, 1), state.filteredSessionCount());
+    try std.testing.expectEqual(@as(usize, 0), state.session_index);
+    try std.testing.expectEqual(@as(usize, 0), state.session_scroll);
+    try std.testing.expectEqual(@as(usize, 1), state.sessionRawIndexAtFilteredIndex(state.session_index).?);
 }


### PR DESCRIPTION
## Summary
- Add a live search field to the `/sessions` picker that filters by label/title, session id, model, or provider.
- Keep picker selection and scroll clamped/stable as filters change, and resume the selected filtered session.
- Render a clear empty state when no saved sessions match the query.

Closes #131

## Test plan
- [x] `cd zig && zig build test-unit-makai-cli`
- [x] `cd zig && zig build test`
- [x] `./scripts/check-zig-patterns.sh`