### PR TITLE
Add TUI transcript export command

### DIFF
--- a/zig/src/tui/app.zig
+++ b/zig/src/tui/app.zig
@@ -483,6 +483,13 @@ pub const App = struct {
 
     const thinking_levels = [_]ai_types.ThinkingLevel{ .off, .low, .medium, .high, .xhigh };
 
+    const export_methods = [_]ExportMethod{ .clipboard, .file };
+
+    const ExportMethod = enum {
+        clipboard,
+        file,
+    };
+
     fn loginProviderEnum(idx: usize) tui_login.Provider {
         return switch (idx) {
             0 => .anthropic,
@@ -558,6 +565,12 @@ pub const App = struct {
         self.enterMenu(.thinking_picker);
     }
 
+    fn openExportPicker(self: *App) void {
+        self.state.menu_scroll = 0;
+        self.state.menu_index = 0;
+        self.enterMenu(.export_picker);
+    }
+
     fn enterMenu(self: *App, mode: tui_state.AppMode) void {
         self.state.mode = mode;
         self.ensureMenuSelectionVisible();
@@ -570,6 +583,7 @@ pub const App = struct {
             .permission_picker => permission_modes.len,
             .view_picker => view_modes.len,
             .thinking_picker => thinking_levels.len,
+            .export_picker => export_methods.len,
             else => 0,
         };
     }
@@ -667,6 +681,16 @@ pub const App = struct {
         const msg = try std.fmt.allocPrint(self.allocator, "thinking level set to {s}", .{@tagName(level)});
         defer self.allocator.free(msg);
         try self.state.appendTranscript(.system, msg);
+    }
+
+    fn applySelectedExport(self: *App) !void {
+        const idx = @min(self.state.menu_index, export_methods.len - 1);
+        const method = export_methods[idx];
+        self.state.mode = .normal;
+        switch (method) {
+            .clipboard => self.exportTranscriptToClipboard(),
+            .file => try self.exportTranscriptToFile(null),
+        }
     }
 
     /// Drive the active login session forward. Called each tick; surfaces the
@@ -1144,10 +1168,12 @@ pub const App = struct {
             .open_permission_picker => self.openPermissionPicker(),
             .open_view_picker => self.openViewPicker(),
             .open_thinking_picker => self.openThinkingPicker(),
+            .open_export_picker => self.openExportPicker(),
             .start_login_provider => try self.startLoginProviderName(result.login_provider),
             .copy_last => self.copyLastAssistant(),
             .copy_all => self.copyTranscript(),
             .open_artifact_viewer => try self.openLatestArtifact(),
+            .export_file => try self.exportTranscriptToFile(if (result.export_path.len > 0) result.export_path else null),
             .none => {},
         }
         if ((command.kind == .model or command.kind == .provider) and command.arg != null) self.persistCurrentModel();
@@ -1278,6 +1304,56 @@ pub const App = struct {
             },
             else => {},
         }
+    }
+
+    fn exportTranscriptToClipboard(self: *App) void {
+        const text = self.state.transcriptToMarkdown(self.allocator) catch |err| {
+            self.recordExportError("clipboard", err) catch {};
+            return;
+        };
+        defer self.allocator.free(text);
+        if (text.len == 0) {
+            self.state.appendTranscript(.system, "nothing to export yet") catch {};
+            return;
+        }
+        self.stageClipboard(text);
+        self.state.appendTranscript(.system, "exported transcript to clipboard") catch {};
+    }
+
+    fn exportTranscriptToFile(self: *App, maybe_path: ?[]const u8) !void {
+        const text = self.state.transcriptToMarkdown(self.allocator) catch |err| {
+            try self.recordExportError("file", err);
+            return;
+        };
+        defer self.allocator.free(text);
+        if (text.len == 0) {
+            try self.state.appendTranscript(.system, "nothing to export yet");
+            return;
+        }
+
+        const owned_default = if (maybe_path == null) try defaultExportPath(self.allocator) else null;
+        defer if (owned_default) |path| self.allocator.free(path);
+        const path = maybe_path orelse owned_default.?;
+
+        var file = std.Io.Dir.createFile(.cwd(), defaultIo(), path, .{ .truncate = true }) catch |err| {
+            try self.recordExportError(path, err);
+            return;
+        };
+        defer file.close(defaultIo());
+        file.writeStreamingAll(defaultIo(), text) catch |err| {
+            try self.recordExportError(path, err);
+            return;
+        };
+
+        const msg = try std.fmt.allocPrint(self.allocator, "exported transcript to {s}", .{path});
+        defer self.allocator.free(msg);
+        try self.state.appendTranscript(.system, msg);
+    }
+
+    fn recordExportError(self: *App, target: []const u8, err: anyerror) !void {
+        const msg = try std.fmt.allocPrint(self.allocator, "export failed for {s}: {s}", .{ target, @errorName(err) });
+        defer self.allocator.free(msg);
+        try self.recordError(msg);
     }
 
     fn cycleThinkingLevel(self: *App) void {
@@ -1714,6 +1790,8 @@ pub const TuiModel = struct {
                                 app.applySelectedView() catch |err| app.recordError(@errorName(err)) catch {};
                             } else if (app.state.mode == .thinking_picker) {
                                 app.applySelectedThinking() catch |err| app.recordError(@errorName(err)) catch {};
+                            } else if (app.state.mode == .export_picker) {
+                                app.applySelectedExport() catch |err| app.recordError(@errorName(err)) catch {};
                             }
                         },
                         .escape => app.state.mode = .normal,
@@ -1923,6 +2001,22 @@ pub const TuiModel = struct {
                 }
                 break :blk menu_picker_view.render(ctx.allocator, .{
                     .title = "Thinking level",
+                    .items = &items,
+                    .selected = app.state.menu_index,
+                    .width = width,
+                    .height = sessionPickerHeight(app),
+                    .offset = app.state.menu_scroll,
+                }) catch "";
+            },
+            .export_picker => blk: {
+                var items: [App.export_methods.len]menu_picker_view.Item = undefined;
+                for (App.export_methods, 0..) |method, i| {
+                    items[i] = .{ .label = exportMethodLabel(method), .detail = exportMethodDetail(method) };
+                }
+                break :blk menu_picker_view.render(ctx.allocator, .{
+                    .title = "Export conversation",
+                    .subtitle = "Select export method",
+                    .footer = "Esc to cancel",
                     .items = &items,
                     .selected = app.state.menu_index,
                     .width = width,
@@ -2163,7 +2257,7 @@ pub const TuiModel = struct {
 
     fn isMenuMode(mode: tui_state.AppMode) bool {
         return switch (mode) {
-            .model_picker, .login_picker, .permission_picker, .view_picker, .thinking_picker => true,
+            .model_picker, .login_picker, .permission_picker, .view_picker, .thinking_picker, .export_picker => true,
             else => false,
         };
     }
@@ -2191,6 +2285,20 @@ pub const TuiModel = struct {
             .medium => "balanced reasoning",
             .high => "deeper reasoning",
             .xhigh => "maximum reasoning",
+        };
+    }
+
+    fn exportMethodLabel(method: App.ExportMethod) []const u8 {
+        return switch (method) {
+            .clipboard => "Copy to clipboard",
+            .file => "Save to file",
+        };
+    }
+
+    fn exportMethodDetail(method: App.ExportMethod) []const u8 {
+        return switch (method) {
+            .clipboard => "Copy the conversation to your system clipboard",
+            .file => "Save the conversation to a file in the current directory",
         };
     }
 
@@ -2256,6 +2364,28 @@ fn newerSessionFirst(_: void, a: session_store.SessionMetadata, b: session_store
 }
 
 /// Generate a collision-resistant session ID, e.g. "20260523-150405-123-a1b2c3d4e5f60708".
+fn defaultExportPath(allocator: std.mem.Allocator) ![]u8 {
+    const millis = compat.time.nowMillis();
+    const secs: i64 = @divFloor(millis, 1000);
+    const epoch = std.time.epoch.EpochSeconds{ .secs = @as(u64, @intCast(@max(secs, 0))) };
+    const day = epoch.getEpochDay();
+    const year_day = day.calculateYearDay();
+    const month_day = year_day.calculateMonthDay();
+    const day_secs = epoch.getDaySeconds();
+    return std.fmt.allocPrint(
+        allocator,
+        "transcript-{d:0>4}{d:0>2}{d:0>2}-{d:0>2}{d:0>2}{d:0>2}.md",
+        .{
+            year_day.year,
+            month_day.month.numeric(),
+            month_day.day_index + 1,
+            day_secs.getHoursIntoDay(),
+            day_secs.getMinutesIntoHour(),
+            day_secs.getSecondsIntoMinute(),
+        },
+    );
+}
+
 fn generateSessionId(allocator: std.mem.Allocator) ![]u8 {
     const millis = compat.time.nowMillis();
     const secs: i64 = @divFloor(millis, 1000);

--- a/zig/src/tui/app.zig
+++ b/zig/src/tui/app.zig
@@ -2363,10 +2363,11 @@ fn newerSessionFirst(_: void, a: session_store.SessionMetadata, b: session_store
     return a.last_active > b.last_active;
 }
 
-/// Build the default export filename, e.g. "transcript-20260615-120000.md".
+/// Build the default export filename, e.g. "transcript-20260615-120000-123.md".
 fn defaultExportPath(allocator: std.mem.Allocator) ![]u8 {
     const millis = compat.time.nowMillis();
     const secs: i64 = @divFloor(millis, 1000);
+    const ms: i64 = @mod(millis, 1000);
     const epoch = std.time.epoch.EpochSeconds{ .secs = @as(u64, @intCast(@max(secs, 0))) };
     const day = epoch.getEpochDay();
     const year_day = day.calculateYearDay();
@@ -2374,7 +2375,7 @@ fn defaultExportPath(allocator: std.mem.Allocator) ![]u8 {
     const day_secs = epoch.getDaySeconds();
     return std.fmt.allocPrint(
         allocator,
-        "transcript-{d:0>4}{d:0>2}{d:0>2}-{d:0>2}{d:0>2}{d:0>2}.md",
+        "transcript-{d:0>4}{d:0>2}{d:0>2}-{d:0>2}{d:0>2}{d:0>2}-{d:0>3}.md",
         .{
             year_day.year,
             month_day.month.numeric(),
@@ -2382,6 +2383,7 @@ fn defaultExportPath(allocator: std.mem.Allocator) ![]u8 {
             day_secs.getHoursIntoDay(),
             day_secs.getMinutesIntoHour(),
             day_secs.getSecondsIntoMinute(),
+            ms,
         },
     );
 }

--- a/zig/src/tui/app.zig
+++ b/zig/src/tui/app.zig
@@ -2363,7 +2363,7 @@ fn newerSessionFirst(_: void, a: session_store.SessionMetadata, b: session_store
     return a.last_active > b.last_active;
 }
 
-/// Generate a collision-resistant session ID, e.g. "20260523-150405-123-a1b2c3d4e5f60708".
+/// Build the default export filename, e.g. "transcript-20260615-120000.md".
 fn defaultExportPath(allocator: std.mem.Allocator) ![]u8 {
     const millis = compat.time.nowMillis();
     const secs: i64 = @divFloor(millis, 1000);

--- a/zig/src/tui/commands.zig
+++ b/zig/src/tui/commands.zig
@@ -19,6 +19,7 @@ pub const CommandKind = enum {
     clear,
     copy,
     artifact,
+    @"export",
     diff,
     abort,
     quit,
@@ -49,17 +50,21 @@ pub const CommandAction = enum {
     copy_last,
     copy_all,
     open_artifact_viewer,
+    open_export_picker,
+    export_file,
 };
 
 pub const CommandResult = struct {
     action: CommandAction = .none,
     output: []u8 = &.{},
     login_provider: []u8 = &.{},
+    export_path: []u8 = &.{},
     is_error: bool = false,
 
     pub fn deinit(self: *CommandResult, allocator: std.mem.Allocator) void {
         if (self.output.len > 0) allocator.free(self.output);
         if (self.login_provider.len > 0) allocator.free(self.login_provider);
+        if (self.export_path.len > 0) allocator.free(self.export_path);
         self.* = undefined;
     }
 };
@@ -98,6 +103,7 @@ pub const commands = [_]CommandInfo{
     .{ .name = "clear", .kind = .clear, .usage = "/clear", .description = "Clear transcript display", .handler = handleClear },
     .{ .name = "copy", .kind = .copy, .usage = "/copy [all]", .description = "Copy last reply (or whole transcript) to clipboard", .handler = handleCopy },
     .{ .name = "artifact", .kind = .artifact, .usage = "/artifact", .description = "Open the latest artifact in a local viewer", .handler = handleArtifact },
+    .{ .name = "export", .kind = .@"export", .usage = "/export [path.md]", .description = "Export transcript to clipboard or file", .handler = handleExport },
     .{ .name = "diff", .kind = .diff, .usage = "/diff", .description = "Show pending file changes", .handler = handleDiff },
     .{ .name = "abort", .kind = .abort, .usage = "/abort", .description = "Cancel the active streaming turn", .handler = handleAbort },
     .{ .name = "quit", .kind = .quit, .usage = "/quit", .description = "Exit TUI", .handler = handleQuit },
@@ -407,6 +413,13 @@ fn handleArtifact(ctx: CommandContext, command: Command) !CommandResult {
     return .{ .action = .open_artifact_viewer };
 }
 
+fn handleExport(ctx: CommandContext, command: Command) !CommandResult {
+    if (command.arg) |path| {
+        return .{ .action = .export_file, .export_path = try ctx.allocator.dupe(u8, path) };
+    }
+    return .{ .action = .open_export_picker };
+}
+
 fn handleDiff(ctx: CommandContext, command: Command) !CommandResult {
     _ = command;
     var out: std.Io.Writer.Allocating = .init(ctx.allocator);
@@ -494,7 +507,7 @@ test "dispatch reaches command handlers" {
     _ = try state.upsertToolForTest("t1", "file_write", "{}", .done);
 
     const ctx = CommandContext{ .allocator = std.testing.allocator, .state = &state };
-    const kinds = [_]CommandKind{ .help, .status, .sessions, .permissions, .think, .view, .clear, .diff, .abort, .quit };
+    const kinds = [_]CommandKind{ .help, .status, .sessions, .permissions, .think, .view, .clear, .@"export", .diff, .abort, .quit };
     for (kinds) |kind| {
         var result = try dispatch(ctx, .{ .kind = kind });
         defer result.deinit(std.testing.allocator);
@@ -510,6 +523,8 @@ test "dispatch reaches command handlers" {
             try std.testing.expectEqual(CommandAction.open_thinking_picker, result.action);
         } else if (kind == .view) {
             try std.testing.expectEqual(CommandAction.open_view_picker, result.action);
+        } else if (kind == .@"export") {
+            try std.testing.expectEqual(CommandAction.open_export_picker, result.action);
         } else {
             try std.testing.expect(result.output.len > 0);
         }
@@ -698,6 +713,28 @@ test "copy command selects last reply or whole transcript" {
     var all = try dispatch(ctx, .{ .kind = .copy, .arg = "all" });
     defer all.deinit(std.testing.allocator);
     try std.testing.expectEqual(CommandAction.copy_all, all.action);
+}
+
+test "export command opens picker or targets file" {
+    const picker_command = try parse("/export");
+    try std.testing.expectEqual(CommandKind.@"export", picker_command.kind);
+
+    const file_command = try parse("/export custom.md");
+    try std.testing.expectEqual(CommandKind.@"export", file_command.kind);
+    try std.testing.expectEqualStrings("custom.md", file_command.arg.?);
+
+    var state = tui_state.AppState.init(std.testing.allocator);
+    defer state.deinit();
+    const ctx = CommandContext{ .allocator = std.testing.allocator, .state = &state };
+
+    var picker = try dispatch(ctx, .{ .kind = .@"export" });
+    defer picker.deinit(std.testing.allocator);
+    try std.testing.expectEqual(CommandAction.open_export_picker, picker.action);
+
+    var file = try dispatch(ctx, .{ .kind = .@"export", .arg = "custom.md" });
+    defer file.deinit(std.testing.allocator);
+    try std.testing.expectEqual(CommandAction.export_file, file.action);
+    try std.testing.expectEqualStrings("custom.md", file.export_path);
 }
 
 test "abort when idle reports idle" {

--- a/zig/src/tui/state.zig
+++ b/zig/src/tui/state.zig
@@ -14,6 +14,7 @@ pub const AppMode = enum {
     permission_picker,
     view_picker,
     thinking_picker,
+    export_picker,
     login_input,
 };
 
@@ -618,6 +619,29 @@ pub const AppState = struct {
         return buf.toOwnedSlice(allocator);
     }
 
+    pub fn transcriptToMarkdown(self: *const AppState, allocator: std.mem.Allocator) ![]u8 {
+        var buf: std.ArrayList(u8) = .empty;
+        errdefer buf.deinit(allocator);
+        for (self.transcript.items, 0..) |entry, idx| {
+            if (idx > 0) try buf.appendSlice(allocator, "\n\n");
+            switch (entry.kind) {
+                .user => {
+                    try buf.appendSlice(allocator, "## User\n\n");
+                    try appendBlockquote(&buf, allocator, entry.text.items);
+                },
+                .assistant => {
+                    try buf.appendSlice(allocator, "## Assistant\n\n");
+                    try buf.appendSlice(allocator, entry.text.items);
+                },
+                .thinking => try appendFencedSection(&buf, allocator, "Thinking", entry.text.items),
+                .tool => try appendFencedSection(&buf, allocator, "Tool", entry.text.items),
+                .system => try appendFencedSection(&buf, allocator, "System", entry.text.items),
+                .@"error" => try appendFencedSection(&buf, allocator, "Error", entry.text.items),
+            }
+        }
+        return buf.toOwnedSlice(allocator);
+    }
+
     pub fn clearTools(self: *AppState) void {
         for (self.tools.items) |*tool| tool.deinit(self.allocator);
         self.tools.clearRetainingCapacity();
@@ -1194,6 +1218,30 @@ pub const AppState = struct {
     }
 };
 
+fn appendBlockquote(buf: *std.ArrayList(u8), allocator: std.mem.Allocator, text: []const u8) !void {
+    if (text.len == 0) {
+        try buf.appendSlice(allocator, "> ");
+        return;
+    }
+    var lines = std.mem.splitScalar(u8, text, '\n');
+    var first = true;
+    while (lines.next()) |line| {
+        if (!first) try buf.append(allocator, '\n');
+        first = false;
+        try buf.appendSlice(allocator, "> ");
+        try buf.appendSlice(allocator, line);
+    }
+}
+
+fn appendFencedSection(buf: *std.ArrayList(u8), allocator: std.mem.Allocator, title: []const u8, text: []const u8) !void {
+    try buf.appendSlice(allocator, "## ");
+    try buf.appendSlice(allocator, title);
+    try buf.appendSlice(allocator, "\n\n```text\n");
+    try buf.appendSlice(allocator, text);
+    if (text.len > 0 and text[text.len - 1] != '\n') try buf.append(allocator, '\n');
+    try buf.appendSlice(allocator, "```");
+}
+
 fn formatProtocolEvent(allocator: std.mem.Allocator, event: tui_runtime.TuiEvent) ![]u8 {
     var out: std.Io.Writer.Allocating = .init(allocator);
     errdefer out.deinit();
@@ -1553,6 +1601,33 @@ pub fn noopToolForTest(
     _ = on_update;
     _ = allocator;
     return error.NotImplemented;
+}
+
+test "AppState exports transcript as markdown" {
+    var state = AppState.init(std.testing.allocator);
+    defer state.deinit();
+    try state.appendUserMessage("hello\nworld");
+    try state.appendTranscript(.assistant, "# Answer\n- item");
+    try state.appendTranscript(.tool, "shell_execute {\"command\":\"pwd\"}");
+    try state.appendTranscript(.@"error", "failed");
+
+    const text = try state.transcriptToMarkdown(std.testing.allocator);
+    defer std.testing.allocator.free(text);
+
+    try std.testing.expect(std.mem.indexOf(u8, text, "## User\n\n> hello\n> world") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "## Assistant\n\n# Answer\n- item") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "## Tool\n\n```text\nshell_execute") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "## Error\n\n```text\nfailed\n```") != null);
+}
+
+test "AppState exports empty transcript as empty markdown" {
+    var state = AppState.init(std.testing.allocator);
+    defer state.deinit();
+
+    const text = try state.transcriptToMarkdown(std.testing.allocator);
+    defer std.testing.allocator.free(text);
+
+    try std.testing.expectEqualStrings("", text);
 }
 
 test "AppState protocol log captures every supported TUI event variant" {

--- a/zig/src/tui/state.zig
+++ b/zig/src/tui/state.zig
@@ -1234,12 +1234,33 @@ fn appendBlockquote(buf: *std.ArrayList(u8), allocator: std.mem.Allocator, text:
 }
 
 fn appendFencedSection(buf: *std.ArrayList(u8), allocator: std.mem.Allocator, title: []const u8, text: []const u8) !void {
+    const fence_len = markdownFenceLength(text);
     try buf.appendSlice(allocator, "## ");
     try buf.appendSlice(allocator, title);
-    try buf.appendSlice(allocator, "\n\n```text\n");
+    try buf.appendSlice(allocator, "\n\n");
+    try appendRepeated(buf, allocator, '`', fence_len);
+    try buf.appendSlice(allocator, "text\n");
     try buf.appendSlice(allocator, text);
     if (text.len > 0 and text[text.len - 1] != '\n') try buf.append(allocator, '\n');
-    try buf.appendSlice(allocator, "```");
+    try appendRepeated(buf, allocator, '`', fence_len);
+}
+
+fn markdownFenceLength(text: []const u8) usize {
+    var longest: usize = 0;
+    var current: usize = 0;
+    for (text) |c| {
+        if (c == '`') {
+            current += 1;
+            longest = @max(longest, current);
+        } else {
+            current = 0;
+        }
+    }
+    return @max(@as(usize, 3), longest + 1);
+}
+
+fn appendRepeated(buf: *std.ArrayList(u8), allocator: std.mem.Allocator, byte: u8, count: usize) !void {
+    for (0..count) |_| try buf.append(allocator, byte);
 }
 
 fn formatProtocolEvent(allocator: std.mem.Allocator, event: tui_runtime.TuiEvent) ![]u8 {
@@ -1608,7 +1629,9 @@ test "AppState exports transcript as markdown" {
     defer state.deinit();
     try state.appendUserMessage("hello\nworld");
     try state.appendTranscript(.assistant, "# Answer\n- item");
+    try state.appendTranscript(.thinking, "plan");
     try state.appendTranscript(.tool, "shell_execute {\"command\":\"pwd\"}");
+    try state.appendTranscript(.system, "notice");
     try state.appendTranscript(.@"error", "failed");
 
     const text = try state.transcriptToMarkdown(std.testing.allocator);
@@ -1616,8 +1639,21 @@ test "AppState exports transcript as markdown" {
 
     try std.testing.expect(std.mem.indexOf(u8, text, "## User\n\n> hello\n> world") != null);
     try std.testing.expect(std.mem.indexOf(u8, text, "## Assistant\n\n# Answer\n- item") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "## Thinking\n\n```text\nplan\n```") != null);
     try std.testing.expect(std.mem.indexOf(u8, text, "## Tool\n\n```text\nshell_execute") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "## System\n\n```text\nnotice\n```") != null);
     try std.testing.expect(std.mem.indexOf(u8, text, "## Error\n\n```text\nfailed\n```") != null);
+}
+
+test "AppState markdown export uses longer fences when content contains backticks" {
+    var state = AppState.init(std.testing.allocator);
+    defer state.deinit();
+    try state.appendTranscript(.tool, "before\n```\nafter");
+
+    const text = try state.transcriptToMarkdown(std.testing.allocator);
+    defer std.testing.allocator.free(text);
+
+    try std.testing.expect(std.mem.indexOf(u8, text, "## Tool\n\n````text\nbefore\n```\nafter\n````") != null);
 }
 
 test "AppState exports empty transcript as empty markdown" {

--- a/zig/src/tui/tests/e2e_tests.zig
+++ b/zig/src/tui/tests/e2e_tests.zig
@@ -471,6 +471,40 @@ test "e2e: /export opens picker and copies transcript" {
     try std.testing.expect(d.frameContains("exported transcript to clipboard"));
 }
 
+test "e2e: /export picker saves transcript to default file" {
+    const models = [_]ai_types.Model{mock_provider.test_model};
+    var provider = mock_provider.MockProvider.init(.{ .steps = &.{} });
+    var d = try Driver.init(std.testing.allocator, .{
+        .protocol = provider.protocolClient(),
+        .models = &models,
+        .run_async = false,
+    }, .{});
+    defer d.deinit();
+
+    try d.app().state.appendUserMessage("question");
+    try d.app().state.appendTranscript(.assistant, "answer");
+    d.typeText("/export");
+    d.pressEnter();
+    d.sendKey(.down);
+    d.sendKey(.enter);
+
+    try std.testing.expectEqual(tui_state.AppMode.normal, d.app().state.mode);
+    try std.testing.expect(d.frameContains("exported transcript to transcript-"));
+
+    var found = false;
+    var dir = try std.Io.Dir.openDir(.cwd(), std.testing.io, ".", .{ .iterate = true });
+    defer dir.close(std.testing.io);
+    var it = dir.iterate();
+    while (try it.next(std.testing.io)) |entry| {
+        if (entry.kind == .file and std.mem.startsWith(u8, entry.name, "transcript-") and std.mem.endsWith(u8, entry.name, ".md")) {
+            found = true;
+            try std.Io.Dir.deleteFile(.cwd(), std.testing.io, entry.name);
+            break;
+        }
+    }
+    try std.testing.expect(found);
+}
+
 test "e2e: /export writes explicit file and reports file errors" {
     const models = [_]ai_types.Model{mock_provider.test_model};
     var provider = mock_provider.MockProvider.init(.{ .steps = &.{} });

--- a/zig/src/tui/tests/e2e_tests.zig
+++ b/zig/src/tui/tests/e2e_tests.zig
@@ -491,18 +491,33 @@ test "e2e: /export picker saves transcript to default file" {
     try std.testing.expectEqual(tui_state.AppMode.normal, d.app().state.mode);
     try std.testing.expect(d.frameContains("exported transcript to transcript-"));
 
-    var found = false;
-    var dir = try std.Io.Dir.openDir(.cwd(), std.testing.io, ".", .{ .iterate = true });
-    defer dir.close(std.testing.io);
-    var it = dir.iterate();
-    while (try it.next(std.testing.io)) |entry| {
-        if (entry.kind == .file and std.mem.startsWith(u8, entry.name, "transcript-") and std.mem.endsWith(u8, entry.name, ".md")) {
-            found = true;
-            try std.Io.Dir.deleteFile(.cwd(), std.testing.io, entry.name);
-            break;
+    const path = exportedTranscriptPath(d.app()) orelse return error.MissingExportPath;
+    try std.testing.expect(std.mem.startsWith(u8, path, "transcript-"));
+    try std.testing.expect(std.mem.endsWith(u8, path, ".md"));
+
+    const content = try std.Io.Dir.readFileAlloc(.cwd(), std.testing.io, path, std.testing.allocator, .limited(1024 * 1024));
+    defer std.testing.allocator.free(content);
+    try std.testing.expect(std.mem.indexOf(u8, content, "## User\n\n> question") != null);
+    try std.testing.expect(std.mem.indexOf(u8, content, "## Assistant\n\nanswer") != null);
+
+    try std.Io.Dir.deleteFile(.cwd(), std.testing.io, path);
+}
+
+/// Returns the path from the most recent system transcript entry that reports a
+/// successful transcript export (e.g. "exported transcript to <path>").
+fn exportedTranscriptPath(app: *App) ?[]const u8 {
+    const prefix = "exported transcript to ";
+    var i = app.state.transcript.items.len;
+    while (i > 0) {
+        i -= 1;
+        const entry = app.state.transcript.items[i];
+        if (entry.kind != .system) continue;
+        const text = entry.text.items;
+        if (std.mem.startsWith(u8, text, prefix)) {
+            return text[prefix.len..];
         }
     }
-    try std.testing.expect(found);
+    return null;
 }
 
 test "e2e: /export writes explicit file and reports file errors" {

--- a/zig/src/tui/tests/e2e_tests.zig
+++ b/zig/src/tui/tests/e2e_tests.zig
@@ -446,6 +446,62 @@ test "e2e: /copy reports when there is a reply to copy" {
     try std.testing.expect(d.frameContains("copied last reply to clipboard"));
 }
 
+test "e2e: /export opens picker and copies transcript" {
+    const models = [_]ai_types.Model{mock_provider.test_model};
+    var provider = mock_provider.MockProvider.init(.{ .steps = &.{} });
+    var d = try Driver.init(std.testing.allocator, .{
+        .protocol = provider.protocolClient(),
+        .models = &models,
+        .run_async = false,
+    }, .{});
+    defer d.deinit();
+
+    try d.app().state.appendUserMessage("question");
+    try d.app().state.appendTranscript(.assistant, "answer");
+    d.typeText("/export");
+    d.pressEnter();
+
+    try std.testing.expectEqual(tui_state.AppMode.export_picker, d.app().state.mode);
+    try std.testing.expect(d.frameContains("Export conversation"));
+    try std.testing.expect(d.frameContains("Copy to clipboard"));
+    try std.testing.expect(d.frameContains("Save to file"));
+
+    d.sendKey(.enter);
+    try std.testing.expectEqual(tui_state.AppMode.normal, d.app().state.mode);
+    try std.testing.expect(d.frameContains("exported transcript to clipboard"));
+}
+
+test "e2e: /export writes explicit file and reports file errors" {
+    const models = [_]ai_types.Model{mock_provider.test_model};
+    var provider = mock_provider.MockProvider.init(.{ .steps = &.{} });
+    var d = try Driver.init(std.testing.allocator, .{
+        .protocol = provider.protocolClient(),
+        .models = &models,
+        .run_async = false,
+    }, .{});
+    defer d.deinit();
+
+    try d.app().state.appendUserMessage("question");
+    try d.app().state.appendTranscript(.assistant, "answer");
+
+    const export_path = try std.fmt.allocPrint(std.testing.allocator, ".zig-cache/tmp/{s}/explicit.md", .{d.tmp.sub_path[0..]});
+    defer std.testing.allocator.free(export_path);
+    const command = try std.fmt.allocPrint(std.testing.allocator, "/export {s}", .{export_path});
+    defer std.testing.allocator.free(command);
+    d.typeText(command);
+    d.pressEnter();
+    try std.testing.expect(d.frameContains("exported transcript to"));
+
+    const content = try std.Io.Dir.readFileAlloc(.cwd(), std.testing.io, export_path, std.testing.allocator, .limited(1024 * 1024));
+    defer std.testing.allocator.free(content);
+    try std.testing.expect(std.mem.indexOf(u8, content, "## User\n\n> question") != null);
+    try std.testing.expect(std.mem.indexOf(u8, content, "## Assistant\n\nanswer") != null);
+
+    d.typeText("/export missing-dir/export.md");
+    d.pressEnter();
+    try std.testing.expect(d.frameContains("export failed for missing-dir/export.md"));
+}
+
 test "e2e: /sessions opens the picker and resuming replays the saved transcript" {
     const models = [_]ai_types.Model{mock_provider.test_model};
     var provider = mock_provider.MockProvider.init(.{ .steps = &.{} });

--- a/zig/src/tui/views/menu_picker.zig
+++ b/zig/src/tui/views/menu_picker.zig
@@ -8,6 +8,8 @@ pub const Item = struct {
 
 pub const Options = struct {
     title: []const u8,
+    subtitle: ?[]const u8 = null,
+    footer: ?[]const u8 = null,
     items: []const Item,
     selected: usize = 0,
     width: usize = 80,
@@ -25,6 +27,12 @@ pub fn render(allocator: std.mem.Allocator, options: Options) ![]const u8 {
     const title = try tui_theme.panelTitle().render(allocator, options.title);
     defer allocator.free(title);
     try writer.writeAll(title);
+    if (options.subtitle) |subtitle| {
+        const styled = try tui_theme.muted().render(allocator, subtitle);
+        defer allocator.free(styled);
+        try writer.writeByte('\n');
+        try writer.writeAll(styled);
+    }
     if (options.items.len == 0) {
         const none = try tui_theme.muted().render(allocator, options.empty_message);
         defer allocator.free(none);
@@ -47,6 +55,13 @@ pub fn render(allocator: std.mem.Allocator, options: Options) ![]const u8 {
             defer allocator.free(styled);
             try writer.writeAll(styled);
         }
+    }
+    if (options.footer) |footer| {
+        const styled = try tui_theme.muted().render(allocator, footer);
+        defer allocator.free(styled);
+        try writer.writeByte('\n');
+        try writer.writeByte('\n');
+        try writer.writeAll(styled);
     }
     const body = try out.toOwnedSlice();
     defer allocator.free(body);
@@ -97,4 +112,19 @@ test "menu picker honors offset for scrolling" {
     try std.testing.expect(std.mem.indexOf(u8, text, " a") == null);
     try std.testing.expect(std.mem.indexOf(u8, text, " b") != null);
     try std.testing.expect(std.mem.indexOf(u8, text, "> c") != null);
+}
+
+test "menu picker renders subtitle and footer" {
+    const items = [_]Item{.{ .label = "Copy", .detail = "copy detail" }};
+    const text = try render(std.testing.allocator, .{
+        .title = "Export conversation",
+        .subtitle = "Select export method",
+        .footer = "Esc to cancel",
+        .items = &items,
+    });
+    defer std.testing.allocator.free(text);
+
+    try std.testing.expect(std.mem.indexOf(u8, text, "Export conversation") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "Select export method") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "Esc to cancel") != null);
 }


### PR DESCRIPTION
## Summary
- Add `/export` command with inline copy-or-file picker.
- Export transcript as markdown to clipboard or `transcript-<timestamp>.md` / explicit path.
- Render export failures in transcript and cover success/error paths.

Closes #134

## Test plan
- [x] `zig build test-unit-tui`
- [x] `./scripts/check-zig-patterns.sh`
- [x] Grouped unit suites run; `test-unit-utils` / full `zig build test` hit existing `Codex OAuth error: invalid_grant - bad code` output from OpenAI Codex OAuth test.