### PR TITLE
tui: render LaTeX math and Mermaid diagrams in transcript

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,7 +226,7 @@ jobs:
         run: zig build test-e2e-ollama
         env:
           OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
-          OLLAMA_MODEL: ministral-3:3b
+          OLLAMA_MODEL: minimax-m3
 
   e2e-github-copilot:
     name: E2E - GitHub Copilot
@@ -293,7 +293,7 @@ jobs:
         run: zig build test-e2e-provider-protocol-fullstack-ollama
         env:
           OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
-          OLLAMA_MODEL: ministral-3:3b
+          OLLAMA_MODEL: minimax-m3
 
   e2e-protocol-fullstack-github:
     name: E2E - Provider Protocol Fullstack (GitHub Copilot)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,7 +226,7 @@ jobs:
         run: zig build test-e2e-ollama
         env:
           OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
-          OLLAMA_MODEL: minimax-m3
+          OLLAMA_MODEL: gemma4:31b
 
   e2e-github-copilot:
     name: E2E - GitHub Copilot
@@ -293,7 +293,7 @@ jobs:
         run: zig build test-e2e-provider-protocol-fullstack-ollama
         env:
           OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
-          OLLAMA_MODEL: minimax-m3
+          OLLAMA_MODEL: gemma4:31b
 
   e2e-protocol-fullstack-github:
     name: E2E - Provider Protocol Fullstack (GitHub Copilot)

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ tmp/
 .env
 .env.*
 zig/.makai/
+zig/src/.makai/

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -972,8 +972,9 @@ pub fn build(b: *std.Build) void {
     const tui_theme_mod = b.createModule(.{ .root_source_file = b.path("src/tui/theme.zig"), .target = target, .optimize = optimize, .imports = &.{ .{ .name = "zigzag", .module = zigzag_mod }, .{ .name = "tui_state", .module = tui_state_mod } } });
     const tui_text_mod = b.createModule(.{ .root_source_file = b.path("src/tui/text.zig"), .target = target, .optimize = optimize, .imports = &.{.{ .name = "zigzag", .module = zigzag_mod }} });
     const tui_render_mod = b.createModule(.{ .root_source_file = b.path("src/tui/render.zig"), .target = target, .optimize = optimize, .imports = &.{.{ .name = "zigzag", .module = zigzag_mod }} });
+    const tui_markdown_mod = b.createModule(.{ .root_source_file = b.path("src/tui/markdown.zig"), .target = target, .optimize = optimize, .imports = &.{} });
 
-    const tui_view_transcript_mod = b.createModule(.{ .root_source_file = b.path("src/tui/views/transcript.zig"), .target = target, .optimize = optimize, .imports = &.{ .{ .name = "zigzag", .module = zigzag_mod }, .{ .name = "tui_state", .module = tui_state_mod }, .{ .name = "tui_theme", .module = tui_theme_mod }, .{ .name = "tui_text", .module = tui_text_mod }, .{ .name = "tui_render", .module = tui_render_mod } } });
+    const tui_view_transcript_mod = b.createModule(.{ .root_source_file = b.path("src/tui/views/transcript.zig"), .target = target, .optimize = optimize, .imports = &.{ .{ .name = "zigzag", .module = zigzag_mod }, .{ .name = "tui_state", .module = tui_state_mod }, .{ .name = "tui_theme", .module = tui_theme_mod }, .{ .name = "tui_text", .module = tui_text_mod }, .{ .name = "tui_markdown", .module = tui_markdown_mod }, .{ .name = "tui_render", .module = tui_render_mod } } });
     const tui_view_composer_mod = b.createModule(.{ .root_source_file = b.path("src/tui/views/composer.zig"), .target = target, .optimize = optimize, .imports = &.{ .{ .name = "zigzag", .module = zigzag_mod }, .{ .name = "tui_state", .module = tui_state_mod }, .{ .name = "tui_theme", .module = tui_theme_mod }, .{ .name = "tui_text", .module = tui_text_mod }, .{ .name = "tui_render", .module = tui_render_mod } } });
     const tui_view_status_bar_mod = b.createModule(.{ .root_source_file = b.path("src/tui/views/status_bar.zig"), .target = target, .optimize = optimize, .imports = &.{ .{ .name = "zigzag", .module = zigzag_mod }, .{ .name = "tui_state", .module = tui_state_mod }, .{ .name = "tui_theme", .module = tui_theme_mod }, .{ .name = "tui_text", .module = tui_text_mod }, .{ .name = "tui_render", .module = tui_render_mod } } });
     const tui_view_tool_panel_mod = b.createModule(.{ .root_source_file = b.path("src/tui/views/tool_panel.zig"), .target = target, .optimize = optimize, .imports = &.{ .{ .name = "zigzag", .module = zigzag_mod }, .{ .name = "ai_types", .module = ai_types_mod }, .{ .name = "agent", .module = agent_mod }, .{ .name = "tui_state", .module = tui_state_mod }, .{ .name = "tui_theme", .module = tui_theme_mod }, .{ .name = "tui_text", .module = tui_text_mod }, .{ .name = "tui_render", .module = tui_render_mod } } });
@@ -1462,6 +1463,7 @@ pub fn build(b: *std.Build) void {
     const tui_theme_test = b.addTest(.{ .root_module = tui_theme_mod });
     const tui_text_test = b.addTest(.{ .root_module = tui_text_mod });
     const tui_render_test = b.addTest(.{ .root_module = tui_render_mod });
+    const tui_markdown_test = b.addTest(.{ .root_module = tui_markdown_mod });
     const tui_view_transcript_test = b.addTest(.{ .root_module = tui_view_transcript_mod });
     const tui_view_composer_test = b.addTest(.{ .root_module = tui_view_composer_mod });
     const tui_view_status_bar_test = b.addTest(.{ .root_module = tui_view_status_bar_mod });
@@ -1678,6 +1680,7 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(&b.addRunArtifact(tui_theme_test).step);
     test_step.dependOn(&b.addRunArtifact(tui_text_test).step);
     test_step.dependOn(&b.addRunArtifact(tui_render_test).step);
+    test_step.dependOn(&b.addRunArtifact(tui_markdown_test).step);
     test_step.dependOn(&b.addRunArtifact(tui_view_transcript_test).step);
     test_step.dependOn(&b.addRunArtifact(tui_view_composer_test).step);
     test_step.dependOn(&b.addRunArtifact(tui_view_status_bar_test).step);
@@ -1850,6 +1853,7 @@ pub fn build(b: *std.Build) void {
     test_unit_tui_step.dependOn(&b.addRunArtifact(tui_theme_test).step);
     test_unit_tui_step.dependOn(&b.addRunArtifact(tui_text_test).step);
     test_unit_tui_step.dependOn(&b.addRunArtifact(tui_render_test).step);
+    test_unit_tui_step.dependOn(&b.addRunArtifact(tui_markdown_test).step);
     test_unit_tui_step.dependOn(&b.addRunArtifact(tui_view_transcript_test).step);
     test_unit_tui_step.dependOn(&b.addRunArtifact(tui_view_composer_test).step);
     test_unit_tui_step.dependOn(&b.addRunArtifact(tui_view_status_bar_test).step);

--- a/zig/src/agent/provider_protocol_bridge.zig
+++ b/zig/src/agent/provider_protocol_bridge.zig
@@ -272,10 +272,15 @@ test "InProcessProviderProtocolBridge smoke test" {
         ) anyerror!*event_stream.AssistantMessageEventStream {
             _ = model;
             _ = context;
-            _ = options;
 
             const s = try a.create(event_stream.AssistantMessageEventStream);
             s.* = event_stream.AssistantMessageEventStream.init(a);
+            if (options) |o| {
+                if (o.requires_owned_stream_events) {
+                    s.owns_events = true;
+                    s.clone_event_fn = ai_types.cloneAssistantMessageEvent;
+                }
+            }
 
             s.push(.{ .start = .{ .partial = .{
                 .content = &.{},

--- a/zig/src/agent/provider_protocol_bridge.zig
+++ b/zig/src/agent/provider_protocol_bridge.zig
@@ -60,6 +60,7 @@ fn streamViaProtocol(
     const out_stream = try allocator.create(event_stream.AssistantMessageEventStream);
     out_stream.* = event_stream.AssistantMessageEventStream.init(allocator);
     out_stream.owns_events = true;
+    out_stream.clone_event_fn = ai_types.cloneAssistantMessageEvent;
     out_stream.wait_for_thread_on_deinit = true;
 
     const thread_ctx = try allocator.create(StreamThreadContext);
@@ -82,20 +83,15 @@ fn streamViaProtocol(
     return out_stream;
 }
 
-fn pushEventBlocking(allocator: std.mem.Allocator, stream: *event_stream.AssistantMessageEventStream, ev: ai_types.AssistantMessageEvent) !void {
-    const cloned = try ai_types.cloneAssistantMessageEvent(allocator, ev);
-    errdefer {
-        var cleanup = cloned;
-        ai_types.deinitAssistantMessageEvent(allocator, &cleanup);
-    }
-
+fn pushEventBlocking(stream: *event_stream.AssistantMessageEventStream, ev: ai_types.AssistantMessageEvent) !void {
     while (true) {
-        stream.push(cloned) catch |err| switch (err) {
+        stream.push(ev) catch |err| switch (err) {
             error.QueueFull => {
                 compat.time.sleepNs(1 * std.time.ns_per_ms);
                 continue;
             },
             error.StreamCompleted => return error.StreamCompleted,
+            error.OutOfMemory => return error.OutOfMemory,
         };
         return;
     }
@@ -105,7 +101,7 @@ fn drainClientEvents(client: *ProtocolClient, out_stream: *event_stream.Assistan
     while (client.getEventStream().poll()) |ev| {
         var owned_ev = ev;
         defer ai_types.deinitAssistantMessageEvent(allocator, &owned_ev);
-        try pushEventBlocking(allocator, out_stream, ev);
+        try pushEventBlocking(out_stream, ev);
     }
 }
 
@@ -423,10 +419,14 @@ test "InProcessProviderProtocolBridge preserves streamed tool call terminal resu
             a: std.mem.Allocator,
         ) anyerror!*event_stream.AssistantMessageEventStream {
             _ = context;
-            _ = options;
+            const o = options orelse ai_types.StreamOptions{};
 
             const s = try a.create(event_stream.AssistantMessageEventStream);
             s.* = event_stream.AssistantMessageEventStream.init(a);
+            if (o.requires_owned_stream_events) {
+                s.owns_events = true;
+                s.clone_event_fn = ai_types.cloneAssistantMessageEvent;
+            }
             const p = partial(model);
 
             s.push(.{ .start = .{ .partial = p } }) catch {};

--- a/zig/src/ai_types.zig
+++ b/zig/src/ai_types.zig
@@ -129,6 +129,10 @@ pub const StreamOptions = struct {
     ping_interval_ms: ?u64 = null,
     /// Owned storage for headers when deserialized/cloned.
     owned_headers: ?OwnedSlice(HeaderPair) = null,
+    /// When true, the provider should configure its returned stream to own deep
+    /// copies of every event. The protocol server sets this because the consumer
+    /// may outlive the producer thread, so borrowed slices would dangle.
+    requires_owned_stream_events: bool = false,
 
     pub fn getApiKey(self: *const StreamOptions) ?[]const u8 {
         const key = self.api_key.slice();

--- a/zig/src/event_stream.zig
+++ b/zig/src/event_stream.zig
@@ -191,25 +191,36 @@ pub fn EventStream(comptime T: type, comptime R: type) type {
                     return error.QueueFull;
                 }
 
+                // If the stream owns events and has a clone function, deep-copy the event
+                // before claiming a slot. Doing this before the CAS ensures that an
+                // OutOfMemory error does not leave a reserved but unpublished slot,
+                // which would wedge consumers waiting at that tail position. The clone
+                // is reused on subsequent loop iterations if the CAS fails.
+                if (self.owns_events) {
+                    if (self.clone_event_fn) |clone_fn| {
+                        if (owned_event == null) {
+                            owned_event = try clone_fn(self.allocator, event);
+                        }
+                    }
+                }
+
                 // Try to claim this slot
                 if (self.head.cmpxchgWeak(current_head, next_head, .acquire, .acquire)) |_| {
                     continue;
                 }
 
                 // We claimed slot at current_head - now write the data.
-                // If the stream owns events and has a clone function, use a deep copy
-                // so the producer can free its temporary buffers.
                 var event_to_store = event;
                 if (self.owns_events) {
                     if (self.clone_event_fn) |clone_fn| {
-                        if (owned_event == null) {
-                            owned_event = try clone_fn(self.allocator, event);
+                        _ = clone_fn;
+                        if (owned_event) |*owned| {
+                            event_to_store = owned.*;
+                            owned_event = null; // ownership transferred to the ring buffer
                         }
-                        event_to_store = owned_event.?;
                     }
                 }
                 self.ring_buffer[current_head] = event_to_store;
-                owned_event = null; // ownership transferred to the ring buffer
 
                 // Mark the slot as published with release semantics
                 // This ensures the write above is visible before the flag

--- a/zig/src/event_stream.zig
+++ b/zig/src/event_stream.zig
@@ -23,10 +23,16 @@ pub fn EventStream(comptime T: type, comptime R: type) type {
         allocator: std.mem.Allocator,
         /// When true, deinit waits for markThreadDone() from a producer thread.
         wait_for_thread_on_deinit: bool = false,
-        /// When true, events in this stream were deep-copied via cloneAssistantMessageEvent()
-        /// and should be freed in deinit(). When false (default), events contain borrowed
-        /// string slices and must NOT be freed by the stream.
+        /// When true, events in this stream are (or will be) deep-copied before being
+        /// stored and should be freed in deinit(). When false (default), events contain
+        /// borrowed string slices and must NOT be freed by the stream.
         owns_events: bool = false,
+        /// Optional clone function used when owns_events is true. When set, push() will
+        /// deep-copy the event before storing it, so a producer thread may free its
+        /// temporary buffers immediately after pushing. This makes the stream safe for
+        /// protocol-server forwarding where the producer thread may exit before the
+        /// consumer has drained all events.
+        clone_event_fn: ?*const fn (std.mem.Allocator, T) error{OutOfMemory}!T = null,
 
         pub fn init(allocator: std.mem.Allocator) Self {
             var published: [RING_BUFFER_SIZE]std.atomic.Value(bool) = undefined;
@@ -43,6 +49,33 @@ pub fn EventStream(comptime T: type, comptime R: type) type {
                 .thread_done = std.atomic.Value(bool).init(false),
                 .allocator = allocator,
             };
+        }
+
+
+        /// Deinitialize a single generic event value. Used both for events that were
+        /// cloned but never stored in the ring buffer and for draining remaining events
+        /// during deinit().
+        fn deinitGenericEvent(self: *Self, event: *T) void {
+            const is_assistant_message_event = comptime blk: {
+                if (@hasDecl(ai_types, "AssistantMessageEvent")) {
+                    break :blk T == ai_types.AssistantMessageEvent;
+                }
+                break :blk false;
+            };
+            const event_has_deinit = comptime blk: {
+                const info = @typeInfo(T);
+                switch (info) {
+                    .@"struct", .@"union", .@"enum", .@"opaque" => break :blk @hasDecl(T, "deinit"),
+                    else => break :blk false,
+                }
+            };
+            if (comptime is_assistant_message_event) {
+                if (self.owns_events) {
+                    ai_types.deinitAssistantMessageEvent(self.allocator, event);
+                }
+            } else if (comptime event_has_deinit) {
+                event.deinit(self.allocator);
+            }
         }
 
         fn defaultIo() std.Io {
@@ -93,41 +126,14 @@ pub fn EventStream(comptime T: type, comptime R: type) type {
                 _ = self.waitForThread(120_000);
             }
 
-            // Drain any remaining events in the ring buffer.
-            // IMPORTANT: By default (owns_events=false), events contain BORROWED string slices
-            // that point into provider-managed temporary buffers (SSE parser buffers, JSON buffers).
-            // The stream does NOT own these strings, so freeing them would cause double-free panics.
-            //
-            // Memory ownership model:
-            // - Providers: Push events with borrowed strings; provider manages buffer lifetimes (owns_events=false)
-            // - ProtocolClient: Deep-copies via cloneAssistantMessageEvent() before push (owns_events=true)
-            //
-            // DO NOT change the default behavior - see CI failures from 2026-02-19.
-            const is_assistant_message_event = comptime blk: {
-                if (@hasDecl(ai_types, "AssistantMessageEvent")) {
-                    break :blk T == ai_types.AssistantMessageEvent;
-                }
-                break :blk false;
-            };
-
-            const event_has_deinit = comptime blk: {
-                const info = @typeInfo(T);
-                switch (info) {
-                    .@"struct", .@"union", .@"enum", .@"opaque" => break :blk @hasDecl(T, "deinit"),
-                    else => break :blk false,
-                }
-            };
-
+            // Drain any remaining events in the ring buffer. The helper respects
+            // the `owns_events` flag: borrowed events (default) are not freed,
+            // while owned events are deep-copied on push and freed here. This matches
+            // the protocol-server path where the producer thread may exit before the
+            // consumer has drained all events.
             while (self.poll()) |event| {
-                if (comptime is_assistant_message_event) {
-                    if (self.owns_events) {
-                        var ev = event;
-                        ai_types.deinitAssistantMessageEvent(self.allocator, &ev);
-                    }
-                } else if (comptime event_has_deinit) {
-                    var ev = event;
-                    ev.deinit(self.allocator);
-                }
+                var ev = event;
+                self.deinitGenericEvent(&ev);
             }
 
             if (self.result) |*result| {
@@ -158,15 +164,22 @@ pub fn EventStream(comptime T: type, comptime R: type) type {
 
         /// Push an event to the stream.
         ///
-        /// IMPORTANT: The event's string fields (delta, content, id, name, etc.) are
+        /// By default the event's string fields (delta, content, id, name, etc.) are
         /// treated as BORROWED references. The stream does NOT take ownership and will
         /// NOT free them in deinit(). The caller must ensure the backing memory outlives
         /// the event's consumption from the stream (typically by managing buffer lifetimes
         /// in the producer thread).
         ///
-        /// If you need the stream to own event memory, deep-copy via cloneAssistantMessageEvent()
-        /// before calling push(), and manage cleanup separately.
+        /// When `owns_events` is true and `clone_event_fn` is set, push() will deep-copy
+        /// the event before storing it. The copy is owned by the stream and freed in
+        /// deinit() (or by the consumer that polls it). This lets producer threads free
+        /// their temporary buffers immediately after pushing, which is required for
+        /// protocol-server forwarding where the producer may exit before the consumer
+        /// has drained all events.
         pub fn push(self: *Self, event: T) !void {
+            var owned_event: ?T = null;
+            defer if (owned_event) |*e| self.deinitGenericEvent(e);
+
             while (true) {
                 if (self.completed.load(.acquire)) return error.StreamCompleted;
                 const current_head = self.head.load(.acquire);
@@ -183,8 +196,20 @@ pub fn EventStream(comptime T: type, comptime R: type) type {
                     continue;
                 }
 
-                // We claimed slot at current_head - now write the data
-                self.ring_buffer[current_head] = event;
+                // We claimed slot at current_head - now write the data.
+                // If the stream owns events and has a clone function, use a deep copy
+                // so the producer can free its temporary buffers.
+                var event_to_store = event;
+                if (self.owns_events) {
+                    if (self.clone_event_fn) |clone_fn| {
+                        if (owned_event == null) {
+                            owned_event = try clone_fn(self.allocator, event);
+                        }
+                        event_to_store = owned_event.?;
+                    }
+                }
+                self.ring_buffer[current_head] = event_to_store;
+                owned_event = null; // ownership transferred to the ring buffer
 
                 // Mark the slot as published with release semantics
                 // This ensures the write above is visible before the flag
@@ -210,7 +235,7 @@ pub fn EventStream(comptime T: type, comptime R: type) type {
                         waitTimeoutMs(self, self.futex.load(.acquire), 1);
                         continue;
                     },
-                    error.StreamCompleted => return false,
+                    error.StreamCompleted, error.OutOfMemory => return false,
                 };
                 return true;
             }
@@ -788,7 +813,7 @@ const MultiProducerStressCtx = struct {
                         std.Thread.yield() catch {};
                         continue;
                     },
-                    error.StreamCompleted => return,
+                    error.StreamCompleted, error.OutOfMemory => return,
                 };
                 break;
             }

--- a/zig/src/protocol/provider/server.zig
+++ b/zig/src/protocol/provider/server.zig
@@ -1353,6 +1353,8 @@ fn mockStream(
     _ = options;
     const s = try allocator.create(event_stream.AssistantMessageEventStream);
     s.* = event_stream.AssistantMessageEventStream.init(allocator);
+    s.owns_events = true;
+    s.clone_event_fn = ai_types.cloneAssistantMessageEvent;
 
     // Complete immediately for tests
     const result = ai_types.AssistantMessage{
@@ -1381,6 +1383,8 @@ fn mockStreamSimple(
     _ = options;
     const s = try allocator.create(event_stream.AssistantMessageEventStream);
     s.* = event_stream.AssistantMessageEventStream.init(allocator);
+    s.owns_events = true;
+    s.clone_event_fn = ai_types.cloneAssistantMessageEvent;
 
     const result = ai_types.AssistantMessage{
         .content = &.{},
@@ -1484,6 +1488,8 @@ fn authTestStream(
     }
     const s = try allocator.create(event_stream.AssistantMessageEventStream);
     s.* = event_stream.AssistantMessageEventStream.init(allocator);
+    s.owns_events = true;
+    s.clone_event_fn = ai_types.cloneAssistantMessageEvent;
     if (state.auth_fail_all_calls or (state.auth_fail_first_call and state.stream_calls == 1)) {
         s.completeWithError("401 unauthorized");
     } else {
@@ -2691,6 +2697,8 @@ fn cancelCapturingStream(
 
     const s = try allocator.create(event_stream.AssistantMessageEventStream);
     s.* = event_stream.AssistantMessageEventStream.init(allocator);
+    s.owns_events = true;
+    s.clone_event_fn = ai_types.cloneAssistantMessageEvent;
 
     // Complete immediately for tests
     const result = ai_types.AssistantMessage{
@@ -2789,6 +2797,8 @@ fn cancelCapturingStreamSimple(
 
     const s = try allocator.create(event_stream.AssistantMessageEventStream);
     s.* = event_stream.AssistantMessageEventStream.init(allocator);
+    s.owns_events = true;
+    s.clone_event_fn = ai_types.cloneAssistantMessageEvent;
     s.complete(.{
         .content = &.{},
         .api = "test-api",
@@ -3097,6 +3107,8 @@ fn capturingStream(
 
     const s = try allocator.create(event_stream.AssistantMessageEventStream);
     s.* = event_stream.AssistantMessageEventStream.init(allocator);
+    s.owns_events = true;
+    s.clone_event_fn = ai_types.cloneAssistantMessageEvent;
     const result = ai_types.AssistantMessage{
         .content = &.{},
         .api = "test-api",

--- a/zig/src/protocol/provider/server.zig
+++ b/zig/src/protocol/provider/server.zig
@@ -555,14 +555,17 @@ fn deinitInjectedApiKey(allocator: std.mem.Allocator, injected: *ai_types.Stream
     injected.api_key = ai_types.OwnedSlice(u8).initBorrowed("");
 }
 
-/// Merge a server-side CancelToken into the caller's StreamOptions.
-/// Preserves any existing fields; only sets cancel_token.
-fn injectCancelToken(
+/// Merge server-side options into the caller's StreamOptions.
+/// Preserves all existing fields; only sets cancel_token and marks the stream
+/// as requiring owned events so the producer thread can exit while the protocol
+/// runtime is still forwarding unconsumed events.
+fn injectServerOptions(
     options: ?ai_types.StreamOptions,
     cancel_token: ai_types.CancelToken,
 ) ai_types.StreamOptions {
     var resolved = options orelse ai_types.StreamOptions{};
     resolved.cancel_token = cancel_token;
+    resolved.requires_owned_stream_events = true;
     return resolved;
 }
 
@@ -801,7 +804,7 @@ fn handleStreamRequest(server: *ProtocolServer, request: protocol_types.StreamRe
     const cancel_token = ai_types.CancelToken{ .cancelled = cancelled };
 
     // Inject cancel token into options so the provider can observe it.
-    const options_with_cancel = injectCancelToken(request.options, cancel_token);
+    const options_with_cancel = injectServerOptions(request.options, cancel_token);
 
     // Create new stream via provider.stream(), resolving and refreshing stored auth when configured.
     const stream = streamWithRefresh(server, provider, request.model, request.context, options_with_cancel) catch |err| {
@@ -816,6 +819,15 @@ fn handleStreamRequest(server: *ProtocolServer, request: protocol_types.StreamRe
     // Provider streams are produced by background threads; wait for producer completion
     // before deinit/destroy during abort and cleanup paths.
     stream.wait_for_thread_on_deinit = true;
+    // Providers that push borrowed slices (Ollama, Anthropic, Google, etc.) free their
+    // temporary buffers when the producer thread exits, but the protocol runtime may
+    // still serialize unconsumed events. Make such streams own deep copies. Providers
+    // that already push owned events (OpenAI completions/responses) set owns_events
+    // themselves; leave them unchanged to avoid double-cloning.
+    if (!stream.owns_events) {
+        stream.owns_events = true;
+        stream.clone_event_fn = ai_types.cloneAssistantMessageEvent;
+    }
 
     // Create ActiveStream entry
     const active_stream = ProtocolServer.ActiveStream{

--- a/zig/src/protocol/provider/server.zig
+++ b/zig/src/protocol/provider/server.zig
@@ -817,17 +817,11 @@ fn handleStreamRequest(server: *ProtocolServer, request: protocol_types.StreamRe
         );
     };
     // Provider streams are produced by background threads; wait for producer completion
-    // before deinit/destroy during abort and cleanup paths.
+    // before deinit/destroy during abort and cleanup paths. Providers must honor
+    // `requires_owned_stream_events` in their stream init by setting owns_events and
+    // clone_event_fn before spawning the producer, so no post-creation mutation is
+    // needed here.
     stream.wait_for_thread_on_deinit = true;
-    // Providers that push borrowed slices (Ollama, Anthropic, Google, etc.) free their
-    // temporary buffers when the producer thread exits, but the protocol runtime may
-    // still serialize unconsumed events. Make such streams own deep copies. Providers
-    // that already push owned events (OpenAI completions/responses) set owns_events
-    // themselves; leave them unchanged to avoid double-cloning.
-    if (!stream.owns_events) {
-        stream.owns_events = true;
-        stream.clone_event_fn = ai_types.cloneAssistantMessageEvent;
-    }
 
     // Create ActiveStream entry
     const active_stream = ProtocolServer.ActiveStream{

--- a/zig/src/protocol/provider/server.zig
+++ b/zig/src/protocol/provider/server.zig
@@ -820,7 +820,20 @@ fn handleStreamRequest(server: *ProtocolServer, request: protocol_types.StreamRe
     // before deinit/destroy during abort and cleanup paths. Providers must honor
     // `requires_owned_stream_events` in their stream init by setting owns_events and
     // clone_event_fn before spawning the producer, so no post-creation mutation is
-    // needed here.
+    // needed here. Extension providers are validated at the protocol boundary so
+    // borrowed events cannot outlive producer-owned temporary buffers while the
+    // server forwards queued events.
+    if (!stream.owns_events or stream.clone_event_fn == null) {
+        stream.deinit();
+        server.allocator.destroy(stream);
+        server.allocator.destroy(cancelled);
+        return try envelope.createNack(
+            nackTemplate(stream_id, in_reply_to),
+            "Provider returned borrowed events for protocol streaming",
+            .provider_error,
+            server.allocator,
+        );
+    }
     stream.wait_for_thread_on_deinit = true;
 
     // Create ActiveStream entry

--- a/zig/src/protocol/provider/server.zig
+++ b/zig/src/protocol/provider/server.zig
@@ -823,7 +823,13 @@ fn handleStreamRequest(server: *ProtocolServer, request: protocol_types.StreamRe
     // needed here. Extension providers are validated at the protocol boundary so
     // borrowed events cannot outlive producer-owned temporary buffers while the
     // server forwards queued events.
-    if (!stream.owns_events or stream.clone_event_fn == null) {
+    if (!stream.owns_events) {
+        // Extension providers must return owned events so the server can forward
+        // queued events after the producer thread exits. Cancel the in-flight
+        // producer and wait for it to finish before freeing the stream, otherwise
+        // a background thread could still be writing to the freed ring buffer.
+        cancelled.store(true, .release);
+        stream.wait_for_thread_on_deinit = true;
         stream.deinit();
         server.allocator.destroy(stream);
         server.allocator.destroy(cancelled);

--- a/zig/src/providers/anthropic_messages_api.zig
+++ b/zig/src/providers/anthropic_messages_api.zig
@@ -1822,6 +1822,10 @@ pub fn streamAnthropicMessages(
     errdefer allocator.destroy(s);
     s.* = event_stream.AssistantMessageEventStream.init(allocator);
     s.wait_for_thread_on_deinit = true;
+    if (o.requires_owned_stream_events) {
+        s.owns_events = true;
+        s.clone_event_fn = ai_types.cloneAssistantMessageEvent;
+    }
 
     const ctx = try allocator.create(ThreadCtx);
     errdefer allocator.destroy(ctx);

--- a/zig/src/providers/azure_openai_responses_api.zig
+++ b/zig/src/providers/azure_openai_responses_api.zig
@@ -443,6 +443,10 @@ pub fn streamAzureOpenAIResponses(model: ai_types.Model, context: ai_types.Conte
     errdefer allocator.destroy(s);
     s.* = event_stream.AssistantMessageEventStream.init(allocator);
     s.wait_for_thread_on_deinit = true;
+    if (o.requires_owned_stream_events) {
+        s.owns_events = true;
+        s.clone_event_fn = ai_types.cloneAssistantMessageEvent;
+    }
 
     const ctx = try allocator.create(ThreadCtx);
     errdefer allocator.destroy(ctx);

--- a/zig/src/providers/google_generative_api.zig
+++ b/zig/src/providers/google_generative_api.zig
@@ -1424,6 +1424,10 @@ pub fn streamGoogleGenerativeAI(model: ai_types.Model, context: ai_types.Context
     errdefer allocator.destroy(s);
     s.* = event_stream.AssistantMessageEventStream.init(allocator);
     s.wait_for_thread_on_deinit = true;
+    if (o.requires_owned_stream_events) {
+        s.owns_events = true;
+        s.clone_event_fn = ai_types.cloneAssistantMessageEvent;
+    }
 
     const ctx = try allocator.create(ThreadCtx);
     errdefer allocator.destroy(ctx);

--- a/zig/src/providers/google_vertex_api.zig
+++ b/zig/src/providers/google_vertex_api.zig
@@ -1376,6 +1376,10 @@ pub fn streamGoogleVertex(
     errdefer allocator.destroy(s);
     s.* = event_stream.AssistantMessageEventStream.init(allocator);
     s.wait_for_thread_on_deinit = true;
+    if (o.requires_owned_stream_events) {
+        s.owns_events = true;
+        s.clone_event_fn = ai_types.cloneAssistantMessageEvent;
+    }
 
     const ctx = allocator.create(ThreadCtx) catch return error.InvalidConfiguration;
     errdefer allocator.destroy(ctx);

--- a/zig/src/providers/ollama_api.zig
+++ b/zig/src/providers/ollama_api.zig
@@ -1241,6 +1241,10 @@ pub fn streamOllama(
     errdefer allocator.destroy(s);
     s.* = event_stream.AssistantMessageEventStream.init(allocator);
     s.wait_for_thread_on_deinit = true;
+    if (o.requires_owned_stream_events) {
+        s.owns_events = true;
+        s.clone_event_fn = ai_types.cloneAssistantMessageEvent;
+    }
 
     const ctx = try allocator.create(ThreadCtx);
     errdefer allocator.destroy(ctx);

--- a/zig/src/tools/makai.zig
+++ b/zig/src/tools/makai.zig
@@ -2419,6 +2419,8 @@ fn makeFixtureStream(
 ) !*event_stream.AssistantMessageEventStream {
     const s = try allocator.create(event_stream.AssistantMessageEventStream);
     s.* = event_stream.AssistantMessageEventStream.init(allocator);
+    s.owns_events = true;
+    s.clone_event_fn = ai_types.cloneAssistantMessageEvent;
 
     if (fail_with_error) {
         s.completeWithError("fixture stream failure");

--- a/zig/src/tui/app.zig
+++ b/zig/src/tui/app.zig
@@ -3440,10 +3440,15 @@ const MockProvider = struct {
     ) anyerror!*event_stream.AssistantMessageEventStream {
         _ = model;
         _ = context;
-        _ = options;
 
         const s = try a.create(event_stream.AssistantMessageEventStream);
         s.* = event_stream.AssistantMessageEventStream.init(a);
+        if (options) |opts| {
+            if (opts.requires_owned_stream_events) {
+                s.owns_events = true;
+                s.clone_event_fn = ai_types.cloneAssistantMessageEvent;
+            }
+        }
 
         s.push(.{ .start = .{ .partial = .{
             .content = &.{},

--- a/zig/src/tui/markdown.zig
+++ b/zig/src/tui/markdown.zig
@@ -98,8 +98,11 @@ fn isAtLineStart(source: []const u8, i: usize) bool {
 }
 
 /// Consume an inline code span verbatim. Returns false for fenced code block
-/// runs (handled by consumeFenceBlock) and unterminated spans so the default
-/// byte path preserves source.
+/// runs (handled by consumeFenceBlock) at line start. When the span has no
+/// closing backtick (e.g. streaming partial input like `` Run `echo $HOME$ ``),
+/// the rest of the line is copied verbatim so any `$` chars in the unfinished
+/// code are not rewritten as math — this prevents generated wrappers from
+/// pairing with the opening backtick and corrupting the displayed command.
 fn consumeInlineCode(writer: *std.Io.Writer, source: []const u8, i: *usize) anyerror!bool {
     const start = i.*;
     var tick_count: usize = 0;
@@ -121,7 +124,12 @@ fn consumeInlineCode(writer: *std.Io.Writer, source: []const u8, i: *usize) anye
         }
         scan += close_count - 1;
     }
-    return false;
+    // Unterminated inline code span — copy the rest of the line verbatim so
+    // any `$` / `*` / `_` chars in the unfinished code don't get rewritten.
+    const line_end = std.mem.indexOfScalarPos(u8, source, start, '\n') orelse source.len;
+    try writer.writeAll(source[start..line_end]);
+    i.* = line_end;
+    return true;
 }
 
 /// Consume a Markdown inline link `[text](url)`. Preprocesses the visible
@@ -183,8 +191,19 @@ fn consumeMarkdownLink(allocator: std.mem.Allocator, writer: *std.Io.Writer, sou
     const processed_label = try preprocessWithOptions(allocator, label_text, false);
     defer allocator.free(processed_label);
 
+    // If preprocessing introduced new `]` characters (e.g. from math commands
+    // like \rbrack or rendered [\text{...}]), ZigZag's link parser would stop
+    // at the first `]` and fail to recognize the link. Fall back to the raw
+    // label text so the link survives intact.
+    const raw_close_count = std.mem.count(u8, label_text, "]");
+    const processed_close_count = std.mem.count(u8, processed_label, "]");
+    const effective_label = if (processed_close_count > raw_close_count)
+        label_text
+    else
+        processed_label;
+
     try writer.writeByte('[');
-    try writer.writeAll(processed_label);
+    try writer.writeAll(effective_label);
     try writer.writeAll("](");
     try writer.writeAll(source[url_start + 1 .. url_end]);
     try writer.writeByte(')');
@@ -591,6 +610,11 @@ fn writeProtectedMathSpan(writer: *std.Io.Writer, text: []const u8) anyerror!voi
 /// currency (`$$$` or `$$<digit>`). In the false cases the caller emits the
 /// `$` byte by byte via the default path so prose like "cost $$5 total"
 /// survives unchanged.
+///
+/// When a `$$` opener is detected but no closing `$$` exists (e.g. streaming
+/// partial input like `$$x$`), the opening `$$` is written verbatim and `*i`
+/// advances past both dollars. This prevents the second `$` from being
+/// reinterpreted as inline math and corrupting the display.
 fn consumeBlockMath(allocator: std.mem.Allocator, writer: *std.Io.Writer, source: []const u8, i: *usize) !bool {
     const open = i.*;
     // Reject an escaped opener (`\$$...`) so the backslash survives verbatim.
@@ -599,9 +623,13 @@ fn consumeBlockMath(allocator: std.mem.Allocator, writer: *std.Io.Writer, source
     if (open + 2 < source.len and source[open + 2] == '$') return false;
     const body_start = open + 2;
     const close = findUnescapedDoubleDollar(source, body_start) orelse {
-        // Unterminated — let the caller emit `$$` verbatim via the default
-        // byte-by-byte path. We must NOT swallow the remainder.
-        return false;
+        // Unterminated — write the opening `$$` verbatim so the second `$`
+        // is not reinterpreted as inline math (which would corrupt streaming
+        // partials like `$$x$`). Advance past both dollars; the caller's
+        // main loop handles the remainder byte-by-byte.
+        try writer.writeAll("$$");
+        i.* = body_start;
+        return true;
     };
 
     // Force line boundaries so block math doesn't run into surrounding prose
@@ -1193,7 +1221,7 @@ fn lookupCommand(name: []const u8) ?[]const u8 {
             .{ .name = "beta", .sym = "β" },
             .{ .name = "gamma", .sym = "γ" },
             .{ .name = "delta", .sym = "δ" },
-            .{ .name = "epsilon", .sym = "ε" },
+            .{ .name = "epsilon", .sym = "ϵ" },
             .{ .name = "varepsilon", .sym = "ε" },
             .{ .name = "zeta", .sym = "ζ" },
             .{ .name = "eta", .sym = "η" },
@@ -2114,4 +2142,65 @@ test "styled text commands preserve literal operand" {
     try std.testing.expect(std.mem.indexOf(u8, out, "x_id") != null);
     try std.testing.expect(std.mem.indexOf(u8, out, "a^b") != null);
     try std.testing.expect(std.mem.indexOf(u8, out, "xᵢ") == null);
+}
+
+test "epsilon and varepsilon render distinctly" {
+    // \epsilon → ϵ (U+03F5), \varepsilon → ε (U+03B5). They are different
+    // symbols and authors use them to distinguish variables.
+    const src = "vars $\\epsilon$ vs $\\varepsilon$";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "ϵ") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "ε") != null);
+}
+
+test "link label with bracketed math falls back to raw" {
+    // Regression for P2: when preprocessing a link label would introduce new
+    // `]` chars (via \rbrack, [\text{...}], etc.), fall back to the raw label
+    // so ZigZag's link parser still recognizes the link.
+    const src = "[set $\\lbrack 0, 1 \\rbrack$](https://example.com)";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    // The link destination must survive — no corruption from introduced ].
+    try std.testing.expect(std.mem.indexOf(u8, out, "](https://example.com)") != null);
+}
+
+test "unterminated inline code preserves rest of line" {
+    // Regression for P2: while streaming, an inline code span may not yet
+    // have its closing backtick. Copy the rest of the line verbatim so `$`
+    // placeholders inside the unfinished code don't get rewritten as math.
+    const src = "Run `echo $HOME$";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expectEqualStrings(src, out);
+}
+
+test "unterminated inline code with newline preserves next line" {
+    // After the newline, processing resumes normally.
+    const src = "Run `echo $HOME$\nthen $x$ math";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    // First line verbatim, second line math rendered.
+    try std.testing.expect(std.mem.indexOf(u8, out, "`echo $HOME$") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "then x math") != null);
+}
+
+test "unterminated block math preserves opening dollars" {
+    // Regression for P2: `$$x$` (streaming partial) — the opening `$$` must
+    // be preserved verbatim, not split into individual `$` chars that get
+    // reinterpreted as inline math.
+    const src = "$$x$";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    // Source must survive unchanged — no `$$` swallowed, no inline math.
+    try std.testing.expectEqualStrings(src, out);
+}
+
+test "unterminated block math in prose preserves dollars" {
+    const src = "intro $$x$ trailing";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    // The `$$` must survive, not be eaten or reparsed.
+    try std.testing.expect(std.mem.indexOf(u8, out, "$$x$") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "`x`") == null);
 }

--- a/zig/src/tui/markdown.zig
+++ b/zig/src/tui/markdown.zig
@@ -357,9 +357,10 @@ fn consumeMarkdownLink(allocator: std.mem.Allocator, writer: *std.Io.Writer, sou
 }
 
 /// Return the end offset (exclusive) of a complete Markdown inline link
-/// `[text](url)` starting at `start`, or null when the bytes do not form a
-/// complete link. Used by the inline-math closer scan to skip protected link
-/// spans before `$` inside a label or destination can close an earlier dollar.
+/// `[text](url)` or reference-style link `[text][ref]` starting at `start`, or
+/// null when the bytes do not form a complete link. Used by the inline-math
+/// closer scan to skip protected link spans before `$` inside a label or
+/// destination/reference can close an earlier dollar.
 fn findMarkdownLinkEnd(source: []const u8, start: usize) ?usize {
     if (start >= source.len or source[start] != '[') return null;
 
@@ -380,26 +381,44 @@ fn findMarkdownLinkEnd(source: []const u8, start: usize) ?usize {
     }
     if (bracket_depth != 0 or text_end >= source.len) return null;
 
-    const url_start = text_end + 1;
-    if (url_start >= source.len or source[url_start] != '(') return null;
+    const dest_start = text_end + 1;
+    if (dest_start >= source.len) return null;
 
-    var url_end = url_start + 1;
-    var paren_depth: usize = 1;
-    while (url_end < source.len) {
-        const c = source[url_end];
-        if (c == '\\' and url_end + 1 < source.len) {
-            url_end += 2;
-            continue;
+    if (source[dest_start] == '(') {
+        var url_end = dest_start + 1;
+        var paren_depth: usize = 1;
+        while (url_end < source.len) {
+            const c = source[url_end];
+            if (c == '\\' and url_end + 1 < source.len) {
+                url_end += 2;
+                continue;
+            }
+            if (c == '(') paren_depth += 1;
+            if (c == ')') {
+                paren_depth -= 1;
+                if (paren_depth == 0) break;
+            }
+            url_end += 1;
         }
-        if (c == '(') paren_depth += 1;
-        if (c == ')') {
-            paren_depth -= 1;
-            if (paren_depth == 0) break;
-        }
-        url_end += 1;
+        if (paren_depth != 0 or url_end >= source.len) return null;
+        return url_end + 1;
     }
-    if (paren_depth != 0 or url_end >= source.len) return null;
-    return url_end + 1;
+
+    if (source[dest_start] == '[') {
+        var ref_end = dest_start + 1;
+        while (ref_end < source.len) {
+            const c = source[ref_end];
+            if (c == '\\' and ref_end + 1 < source.len) {
+                ref_end += 2;
+                continue;
+            }
+            if (c == ']') return ref_end + 1;
+            if (c == '\n' or c == '\r') return null;
+            ref_end += 1;
+        }
+    }
+
+    return null;
 }
 
 /// Returns true when `source[i..]` begins with a common bare URL scheme
@@ -811,10 +830,22 @@ fn writeProtectedMathSpan(writer: *std.Io.Writer, source: []const u8, open: usiz
 /// reinterpreted as inline math and corrupting the display.
 fn consumeBlockMath(allocator: std.mem.Allocator, writer: *std.Io.Writer, source: []const u8, i: *usize) !bool {
     const open = i.*;
-    // Reject an escaped opener (`\$$...`) so the backslash survives verbatim.
-    if (open > 0 and isEscaped(source, open)) return false;
-    // Reject `$$$` — ambiguous with inline math like `$$$x$$`.
-    if (open + 2 < source.len and source[open + 2] == '$') return false;
+    // Reject an escaped opener (`\$$...`) so the backslash survives verbatim,
+    // but consume the pair atomically so the second `$` is not reconsidered as
+    // a new overlapping opener.
+    if (open > 0 and isEscaped(source, open)) {
+        try writer.writeAll("$$");
+        i.* = open + 2;
+        return true;
+    }
+    // Reject `$$$` — ambiguous with inline math like `$$$x$$`. Consume the
+    // rejected pair verbatim so the trailing `$$x$$` cannot be reinterpreted as
+    // display math after the first `$` is emitted.
+    if (open + 2 < source.len and source[open + 2] == '$') {
+        try writer.writeAll("$$");
+        i.* = open + 2;
+        return true;
+    }
     const body_start = open + 2;
     const close = findUnescapedDoubleDollar(source, body_start) orelse {
         // Unterminated — write the opening `$$` verbatim so the second `$`
@@ -2502,6 +2533,29 @@ test "inline closer skips complete markdown links" {
     try std.testing.expect(std.mem.indexOf(u8, out, "Pay $5; see [x](https://example.com) now") != null);
     try std.testing.expect(std.mem.indexOf(u8, out, "`5; see [") == null);
     try std.testing.expect(std.mem.indexOf(u8, out, "x$](https://example.com)") == null);
+}
+
+
+test "inline closer skips reference markdown links" {
+    const src = "Pay $5; see [$x$][ref] now";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "Pay $5; see [x][ref] now") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "`5; see [") == null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "x$][ref]") == null);
+}
+
+
+test "rejected double dollar openers are consumed atomically" {
+    const escaped = "\\$$x$$";
+    const escaped_out = try preprocess(std.testing.allocator, escaped);
+    defer std.testing.allocator.free(escaped_out);
+    try std.testing.expectEqualStrings(escaped, escaped_out);
+
+    const triple = "$$$x$$";
+    const triple_out = try preprocess(std.testing.allocator, triple);
+    defer std.testing.allocator.free(triple_out);
+    try std.testing.expectEqualStrings(triple, triple_out);
 }
 
 

--- a/zig/src/tui/markdown.zig
+++ b/zig/src/tui/markdown.zig
@@ -44,10 +44,11 @@ fn preprocessWithOptions(allocator: std.mem.Allocator, source: []const u8, prote
         .line_start = 0,
         .line_end = 0,
         .in_style = false,
-        .star1_first = null,
-        .star1_last = null,
-        .star2_first = null,
-        .star2_last = null,
+        .star2_starts = undefined,
+        .star2_count = 0,
+        .star1_starts = undefined,
+        .star1_count = 0,
+        .overflow = false,
     };
 
     var i: usize = 0;
@@ -325,14 +326,21 @@ fn isListMarkerLine(trimmed: []const u8) bool {
     return i > 0 and i + 1 < trimmed.len and trimmed[i] == '.' and trimmed[i + 1] == ' ';
 }
 
+const MAX_STAR_RUNS = 32;
+
 const LineStyle = struct {
     line_start: usize,
     line_end: usize,
     in_style: bool,
-    star1_first: ?usize,
-    star1_last: ?usize,
-    star2_first: ?usize,
-    star2_last: ?usize,
+    /// Start offsets of `**` (bold) delimiter runs on the line (sorted ascending).
+    star2_starts: [MAX_STAR_RUNS]usize,
+    star2_count: usize,
+    /// Start offsets of single-`*` (italic) delimiter runs on the line.
+    star1_starts: [MAX_STAR_RUNS]usize,
+    star1_count: usize,
+    /// Set when the line has more emphasis runs than the fixed arrays can hold;
+    /// callers fall back to the safe "protect math" behavior.
+    overflow: bool,
 };
 
 fn computeLineStyle(source: []const u8, line_start: usize) LineStyle {
@@ -341,10 +349,11 @@ fn computeLineStyle(source: []const u8, line_start: usize) LineStyle {
     const trimmed_start = std.mem.indexOfNonePos(u8, line, 0, " ") orelse line.len;
     const trimmed = line[trimmed_start..];
 
-    var star1_first: ?usize = null;
-    var star1_last: ?usize = null;
-    var star2_first: ?usize = null;
-    var star2_last: ?usize = null;
+    var star2_starts: [MAX_STAR_RUNS]usize = undefined;
+    var star2_count: usize = 0;
+    var star1_starts: [MAX_STAR_RUNS]usize = undefined;
+    var star1_count: usize = 0;
+    var overflow = false;
 
     var pos: usize = 0;
     while (pos < line.len) {
@@ -355,11 +364,17 @@ fn computeLineStyle(source: []const u8, line_start: usize) LineStyle {
         const run_start = pos;
         while (pos < line.len and line[pos] == '*') pos += 1;
         const abs_start = line_start + run_start;
-        if (star1_first == null) star1_first = abs_start;
-        star1_last = abs_start;
-        if (pos - run_start >= 2) {
-            if (star2_first == null) star2_first = abs_start;
-            star2_last = abs_start;
+        const run_len = pos - run_start;
+        if (run_len >= 2) {
+            if (star2_count < MAX_STAR_RUNS) {
+                star2_starts[star2_count] = abs_start;
+                star2_count += 1;
+            } else overflow = true;
+        } else {
+            if (star1_count < MAX_STAR_RUNS) {
+                star1_starts[star1_count] = abs_start;
+                star1_count += 1;
+            } else overflow = true;
         }
     }
 
@@ -370,26 +385,51 @@ fn computeLineStyle(source: []const u8, line_start: usize) LineStyle {
             std.mem.startsWith(u8, trimmed, "## ") or
             std.mem.startsWith(u8, trimmed, "### ") or
             std.mem.startsWith(u8, trimmed, "> "),
-        .star1_first = star1_first,
-        .star1_last = star1_last,
-        .star2_first = star2_first,
-        .star2_last = star2_last,
+        .star2_starts = star2_starts,
+        .star2_count = star2_count,
+        .star1_starts = star1_starts,
+        .star1_count = star1_count,
+        .overflow = overflow,
     };
 }
 
-fn hasDelimiterBeforeAfter(open: usize, close: usize, first: ?usize, last: ?usize) bool {
-    const f = first orelse return false;
-    const l = last orelse return false;
-    return f < open and l > close;
+/// Returns true when `count` of the sorted run-starts in `starts[0..len]` are
+/// strictly less than `pos`, i.e. the number of delimiter runs preceding `pos`.
+fn runsBefore(starts: []const usize, len: usize, pos: usize) usize {
+    var n: usize = 0;
+    var i: usize = 0;
+    while (i < len) : (i += 1) {
+        if (starts[i] < pos) n += 1;
+    }
+    return n;
+}
+
+/// Returns true when any run-start in `starts[0..len]` is at or after `pos`.
+fn runAtOrAfter(starts: []const usize, len: usize, pos: usize) bool {
+    var i: usize = 0;
+    while (i < len) : (i += 1) {
+        if (starts[i] >= pos) return true;
+    }
+    return false;
 }
 
 /// ZigZag styles headings, blockquotes, bold, and italic directly without
 /// recursively invoking `renderInline`. Inside those contexts, an inline-code
 /// wrapper would be displayed literally, so protection must be skipped.
+///
+/// Emphasis enclosure is decided by matching delimiter pairs: a math span is
+/// inside an emphasis span only when an odd number of same-type delimiter runs
+/// precede it (an unmatched opener) and at least one matching run follows the
+/// closer. This avoids treating `**left** $a*b$ **right**` as enclosed (where
+/// the bold runs flank but do not enclose the math) while still recognizing a
+/// genuinely wrapped span like `**Energy: $E=mc^2$**`.
 fn isInsideNonRecursiveMarkdownStyle(open: usize, close: usize, style: LineStyle) bool {
     if (style.in_style) return true;
-    if (hasDelimiterBeforeAfter(open, close, style.star2_first, style.star2_last)) return true;
-    if (hasDelimiterBeforeAfter(open, close, style.star1_first, style.star1_last)) return true;
+    if (style.overflow) return false;
+    if (runsBefore(style.star2_starts[0..], style.star2_count, open) % 2 == 1 and
+        runAtOrAfter(style.star2_starts[0..], style.star2_count, close)) return true;
+    if (runsBefore(style.star1_starts[0..], style.star1_count, open) % 2 == 1 and
+        runAtOrAfter(style.star1_starts[0..], style.star1_count, close)) return true;
     return false;
 }
 
@@ -2848,3 +2888,48 @@ test "digit-prefixed algebraic coefficients render" {
     try std.testing.expect(std.mem.indexOf(u8, display_out, "> 10xy") != null);
     try std.testing.expect(std.mem.indexOf(u8, display_out, "$$10xy$$") == null);
 }
+
+test "emphasis-delimited math is protected only when truly enclosed" {
+    // Regression for P2: `**left** $a*b$ **right**` has bold runs flanking the
+    // math but not enclosing it. The math contains a `*`, so it MUST get the
+    // inline-code wrapper; otherwise ZigZag reinterprets the `*` as emphasis.
+    const flanking = "**left** $a*b$ **right**";
+    const flanking_out = try preprocess(std.testing.allocator, flanking);
+    defer std.testing.allocator.free(flanking_out);
+    try std.testing.expect(std.mem.indexOf(u8, flanking_out, "`a*b`") != null);
+    try std.testing.expect(std.mem.indexOf(u8, flanking_out, "$a*b$") == null);
+
+    // A genuinely enclosed span still skips the wrapper so no literal backticks
+    // leak inside the bold run.
+    const enclosed = "**Energy: $E=mc^2$**";
+    const enclosed_out = try preprocess(std.testing.allocator, enclosed);
+    defer std.testing.allocator.free(enclosed_out);
+    try std.testing.expect(std.mem.indexOf(u8, enclosed_out, "**Energy: E=mc²**") != null);
+    try std.testing.expect(std.mem.indexOf(u8, enclosed_out, "`E=mc²`") == null);
+
+    // Italic-delimited math follows the same matching rule.
+    const italic_flanking = "*left* $a*b$ *right*";
+    const italic_out = try preprocess(std.testing.allocator, italic_flanking);
+    defer std.testing.allocator.free(italic_out);
+    try std.testing.expect(std.mem.indexOf(u8, italic_out, "`a*b`") != null);
+}
+
+test "many inline formulas on one line do not rescans quadratically" {
+    // Regression for P2: emphasis/style enclosure is decided from precomputed
+    // per-line run positions, so a long line with many formulas stays linear.
+    var buf: [4096]u8 = undefined;
+    var len: usize = 0;
+    const part = "$a_i$ ";
+    var k: usize = 0;
+    while (k < 200) : (k += 1) {
+        std.mem.copyForwards(u8, buf[len..], part);
+        len += part.len;
+    }
+    const src = buf[0..len];
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    // Every formula rendered; none left raw.
+    try std.testing.expect(std.mem.indexOf(u8, out, "$a_i$") == null);
+    try std.testing.expect(std.mem.count(u8, out, "aᵢ") == 200);
+}
+

--- a/zig/src/tui/markdown.zig
+++ b/zig/src/tui/markdown.zig
@@ -43,12 +43,14 @@ fn preprocessWithOptions(allocator: std.mem.Allocator, source: []const u8, prote
     var i: usize = 0;
     while (i < source.len) {
         // 1. Fenced code block opener at line start. Consumed whole: mermaid
-        //    blocks are transformed in place, every other language is copied
-        //    verbatim (including any literal ```mermaid lines or `$` chars
-        //    inside). Emits directly to the writer so the math steps below
-        //    never re-process the interior.
+        //    (backtick) blocks are transformed in place, every other language
+        //    is copied verbatim (including any literal ```mermaid lines or `$`
+        //    chars inside). Tilde fences are also copied verbatim. Emits
+        //    directly to the writer so the math steps below never re-process
+        //    the interior.
         if (isAtLineStart(source, i)) {
             if (try consumeFenceBlock(allocator, writer, source, &i)) continue;
+            if (try consumeTildeFenceBlock(writer, source, &i)) continue;
         }
 
         // 2. Markdown inline links, bare URLs, and relative path/URL
@@ -218,9 +220,13 @@ fn consumeBareUrl(writer: *std.Io.Writer, source: []const u8, i: *usize) !bool {
 /// Consume a relative path or route span (`/users/$user_id$/orders`) verbatim
 /// so dollar placeholders inside it are not interpreted as inline math.
 /// Returns false when the bytes don't look like a path.
-fn consumeRelativePath(writer: *std.Io.Writer, source: []const u8, i: *usize) !bool {
+fn consumeRelativePath(writer: *std.Io.Writer, source: []const u8, i: *usize) anyerror!bool {
     if (source[i.*] != '/') return false;
     const start = i.*;
+    // Only treat this slash as the start of a route when it begins at a path
+    // boundary (start of source or after whitespace). This prevents ordinary
+    // prose such as `1/$n$` from having its math delimiter swallowed.
+    if (start > 0 and !std.ascii.isWhitespace(source[start - 1])) return false;
     var end = start;
     var slash_count: usize = 0;
     var has_dollar = false;
@@ -365,6 +371,62 @@ fn countLeadingBackticks(s: []const u8) usize {
     return n;
 }
 
+/// Consume a CommonMark tilde-fenced code block (`~~~ ... ~~~`) at line start.
+/// Unlike backtick fences, these are always copied verbatim because the
+/// downstream renderer displays them as plain text rather than bordered code.
+fn consumeTildeFenceBlock(writer: *std.Io.Writer, source: []const u8, i: *usize) anyerror!bool {
+    const start = i.*;
+    var indent_end = start;
+    while (indent_end < source.len and source[indent_end] == ' ') indent_end += 1;
+    if (indent_end >= source.len or source[indent_end] != '~') return false;
+
+    var fence_len: usize = 0;
+    while (indent_end + fence_len < source.len and source[indent_end + fence_len] == '~') fence_len += 1;
+    if (fence_len < 3) return false;
+
+    const fence_end = indent_end + fence_len;
+    const line_end = std.mem.indexOfScalarPos(u8, source, fence_end, '\n') orelse source.len;
+    const body_start = if (line_end < source.len) line_end + 1 else source.len;
+    const close_line_start = findTildeBlockCloseLine(source, body_start, fence_len);
+    const body_end = if (close_line_start) |cls| cls else source.len;
+
+    try writer.writeAll(source[start..body_end]);
+    if (close_line_start) |cls| {
+        const close_line_end = std.mem.indexOfScalarPos(u8, source, cls, '\n') orelse source.len;
+        const emit_end = if (close_line_end < source.len) close_line_end + 1 else source.len;
+        try writer.writeAll(source[cls..emit_end]);
+        i.* = emit_end;
+    } else {
+        i.* = body_end;
+        if (body_end < source.len and source[body_end] == '\n') {
+            try writer.writeByte('\n');
+            i.* = body_end + 1;
+        }
+    }
+    return true;
+}
+
+fn findTildeBlockCloseLine(source: []const u8, body_start: usize, fence_len: usize) ?usize {
+    var i = body_start;
+    while (i < source.len) {
+        const line_start = i;
+        const line_end = std.mem.indexOfScalarPos(u8, source, line_start, '\n') orelse source.len;
+        const line = source[line_start..line_end];
+        const trimmed = std.mem.trim(u8, line, " \t\r");
+        if (countLeadingTildes(trimmed) >= fence_len) {
+            if (std.mem.allEqual(u8, trimmed, '~')) return line_start;
+        }
+        i = if (line_end < source.len) line_end + 1 else source.len;
+    }
+    return null;
+}
+
+fn countLeadingTildes(s: []const u8) usize {
+    var n: usize = 0;
+    while (n < s.len and s[n] == '~') n += 1;
+    return n;
+}
+
 /// Inspect the first non-blank line of a Mermaid block to classify the
 /// diagram type (flowchart, sequenceDiagram, etc.). Returns an empty string
 /// when no recognized type is found.
@@ -373,6 +435,9 @@ fn detectMermaidType(body: []const u8) []const u8 {
     while (lines.next()) |raw_line| {
         const line = std.mem.trim(u8, raw_line, " \t\r");
         if (line.len == 0) continue;
+        // Skip Mermaid directive/comment lines (%%) so %%{init: ...}%% doesn't
+        // get misclassified as the diagram type.
+        if (std.mem.startsWith(u8, line, "%%")) continue;
         // Take the first whitespace-separated token. Mermaid's grammar uses
         // a fixed keyword (flowchart, graph, sequenceDiagram, ...) here.
         var tok_end: usize = 0;
@@ -540,12 +605,13 @@ fn writeBlockMath(allocator: std.mem.Allocator, writer: *std.Io.Writer, body: []
 /// open/close guards so they pass through verbatim:
 /// - `5$` — opening `$` preceded by a digit.
 /// - `$5-$10`, `$5/$10` — the closer is followed by a digit.
-/// - `$HOME/$PATH` — the closer is followed by an identifier char.
+/// - `$HOME/$PATH`, `$FOO-$BAR` — the body is an uppercase shell-variable
+///   path/dash fragment, or the closer is followed by an uppercase identifier.
 /// - `${HOME}/${XDG_CONFIG_HOME}` — the opener or closer is followed by `{`
 ///   (braced shell/config variables), so both dollar signs survive.
 /// - `\$FOO\$` — the opener/closer is escaped by a backslash.
-/// Digit-led formulas such as `$2^n$` still render because the closer is not
-/// identifier/digit-adjacent.
+/// Prose suffixes such as `$n$th` are allowed because they use lowercase
+/// identifiers and do not look like adjacent shell variables.
 fn consumeInlineMath(allocator: std.mem.Allocator, writer: *std.Io.Writer, source: []const u8, i: *usize, protect_math: bool) anyerror!bool {
     const open = i.*;
 
@@ -566,17 +632,29 @@ fn consumeInlineMath(allocator: std.mem.Allocator, writer: *std.Io.Writer, sourc
     const body_start = open + 1;
     const close = findUnescapedDollar(source, body_start) orelse return false;
 
+    const body = source[body_start..close];
+
     // Closing `$` must not be preceded by whitespace, followed by another
-    // `$`, followed by a digit (currency ranges), followed by an identifier
-    // char (adjacent shell vars like `$HOME/$PATH`), or followed by `{`
+    // `$`, followed by a digit (currency ranges), or followed by `{`
     // (braced shell variables like `${HOME}`).
+    // An identifier suffix is allowed for prose like `$n$th`, but uppercase
+    // identifiers are treated as adjacent shell variables/path components and
+    // rejected. Likewise, a body that is an uppercase identifier followed by a
+    // `/` or `-` path fragment (e.g. `$HOME/` in `$HOME/$PATH`) is rejected.
     if (source[close - 1] == ' ') return false;
     if (close + 1 < source.len) {
         const after = source[close + 1];
-        if (after == '$' or after == '{' or std.ascii.isDigit(after) or isIdentifierChar(after)) return false;
+        if (after == '$' or after == '{' or std.ascii.isDigit(after)) return false;
+        if (std.ascii.isAlphabetic(after) and std.ascii.isUpper(after)) {
+            return false;
+        }
+    }
+    if (body.len > 0 and std.ascii.isAlphabetic(body[0]) and std.ascii.isUpper(body[0])) {
+        for (body) |bc| {
+            if (bc == '/' or bc == '-') return false;
+        }
     }
 
-    const body = source[body_start..close];
     // Reject newlines — inline math is a single line.
     if (std.mem.indexOfScalar(u8, body, '\n') != null) return false;
 
@@ -624,7 +702,12 @@ fn renderMathBody(writer: *std.Io.Writer, body: []const u8) anyerror!void {
                     i = j + 1;
                     continue;
                 }
-                if (next == ';' or next == ':' or next == '!') {
+                if (next == ';' or next == ':') {
+                    try writer.writeAll(" ");
+                    i = j + 1;
+                    continue;
+                }
+                if (next == '!') {
                     i = j + 1;
                     continue;
                 }
@@ -1068,7 +1151,7 @@ fn lookupCommand(name: []const u8) ?[]const u8 {
             .{ .name = "approx", .sym = "≈" },
             .{ .name = "equiv", .sym = "≡" },
             .{ .name = "sim", .sym = "∼" },
-            .{ .name = "simeq", .sym = "≅" },
+            .{ .name = "simeq", .sym = "≃" },
             .{ .name = "cong", .sym = "≅" },
             .{ .name = "propto", .sym = "∝" },
             .{ .name = "in", .sym = "∈" },
@@ -1724,4 +1807,57 @@ test "relative path with dollar placeholders stays verbatim" {
     const out = try preprocess(std.testing.allocator, src);
     defer std.testing.allocator.free(out);
     try std.testing.expectEqualStrings(src, out);
+}
+
+test "inline math allows lowercase prose suffixes" {
+    const src = "the $n$th term";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "`n`th") != null);
+}
+
+test "division before inline math is not treated as a route" {
+    const src = "the rate is 1/$n$";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "1/`n`") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "1/$n$") == null);
+}
+
+test "tilde fenced code block is preserved verbatim" {
+    const src = "~~~sh\necho $x$\n~~~\n";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expectEqualStrings(src, out);
+}
+
+test "mermaid type detection skips directive lines" {
+    const src = "```mermaid\n%%{init: {'theme': 'dark'}}%%\nflowchart TD\n  A --> B\n```";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "**Mermaid diagram: flowchart**") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "Mermaid diagram: %%{init") == null);
+}
+
+test "simeq maps to the correct relation" {
+    const src = "$a \\simeq b$";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "≃") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "≅") == null);
+}
+
+test "positive latex spacing commands produce a space" {
+    const src = "$a\\;b$ and $x\\:y$";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "`a b`") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "`x y`") != null);
+}
+
+test "negative latex spacing command is dropped" {
+    const src = "$a\\!b$";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "`ab`") != null);
 }

--- a/zig/src/tui/markdown.zig
+++ b/zig/src/tui/markdown.zig
@@ -1361,6 +1361,9 @@ fn lookupCommand(name: []const u8) ?[]const u8 {
             .{ .name = "degree", .sym = "°" },
             .{ .name = "prime", .sym = "′" },
             .{ .name = "dprime", .sym = "″" },
+            // Bracket delimiters — standard LaTeX names for [ and ].
+            .{ .name = "lbrack", .sym = "[" },
+            .{ .name = "rbrack", .sym = "]" },
             // Style modifiers — silently dropped (no semantic loss in plain text).
             .{ .name = "mathrm", .sym = "" },
             .{ .name = "mathit", .sym = "" },
@@ -2156,13 +2159,17 @@ test "epsilon and varepsilon render distinctly" {
 
 test "link label with bracketed math falls back to raw" {
     // Regression for P2: when preprocessing a link label would introduce new
-    // `]` chars (via \rbrack, [\text{...}], etc.), fall back to the raw label
-    // so ZigZag's link parser still recognizes the link.
-    const src = "[set $\\lbrack 0, 1 \\rbrack$](https://example.com)";
+    // `]` chars (here \rbrack renders to ]), fall back to the raw label so
+    // ZigZag's link parser still recognizes the link. Without the fallback,
+    // the introduced ] would terminate the label prematurely.
+    const src = "[range $\\lbrack 0, 1 \\rbrack$](https://example.com)";
     const out = try preprocess(std.testing.allocator, src);
     defer std.testing.allocator.free(out);
-    // The link destination must survive — no corruption from introduced ].
-    try std.testing.expect(std.mem.indexOf(u8, out, "](https://example.com)") != null);
+    // The raw label is used, so \lbrack/\rbrack survive unrendered and the
+    // link destination stays attached: ](https://example.com) must appear.
+    try std.testing.expect(std.mem.indexOf(u8, out, "\\rbrack$](https://example.com)") != null);
+    // The rendered ] must NOT appear inside the label.
+    try std.testing.expect(std.mem.indexOf(u8, out, "[range [0, 1]]") == null);
 }
 
 test "unterminated inline code preserves rest of line" {

--- a/zig/src/tui/markdown.zig
+++ b/zig/src/tui/markdown.zig
@@ -47,10 +47,14 @@ pub fn preprocess(allocator: std.mem.Allocator, source: []const u8) ![]u8 {
             if (try consumeFenceBlock(allocator, writer, source, &i)) continue;
         }
 
-        // 2. Markdown inline links must stay raw. Protect their destinations
-        //    before math checks so URLs like `/users/$user_id$` survive.
+        // 2. Markdown inline links and bare URLs must stay raw. Protect their
+        //    destinations before math checks so URLs like
+        //    `/users/$user_id$` survive.
         if (source[i] == '[') {
             if (try consumeMarkdownLink(writer, source, &i)) continue;
+        }
+        if (isBareUrlPrefix(source, i)) {
+            if (try consumeBareUrl(writer, source, &i)) continue;
         }
 
         // 3. Inline code spans must stay raw. Protect them before math checks
@@ -160,6 +164,31 @@ fn consumeMarkdownLink(writer: *std.Io.Writer, source: []const u8, i: *usize) !b
 
     try writer.writeAll(source[start .. url_end + 1]);
     i.* = url_end + 1;
+    return true;
+}
+
+/// Returns true when `source[i..]` begins with a common bare URL scheme
+/// (`http://` or `https://`).
+fn isBareUrlPrefix(source: []const u8, i: usize) bool {
+    if (i + 7 <= source.len and std.mem.eql(u8, source[i .. i + 7], "http://")) return true;
+    if (i + 8 <= source.len and std.mem.eql(u8, source[i .. i + 8], "https://")) return true;
+    return false;
+}
+
+/// Consume a bare URL (`http://...` or `https://...`) verbatim. Returns false
+/// when `*i` is not at a URL prefix so the default path preserves the source.
+fn consumeBareUrl(writer: *std.Io.Writer, source: []const u8, i: *usize) !bool {
+    if (!isBareUrlPrefix(source, i.*)) return false;
+    const start = i.*;
+    var end = start;
+    while (end < source.len) {
+        const c = source[end];
+        // Stop at whitespace or common delimiters that terminate URLs in prose.
+        if (c == ' ' or c == '\t' or c == '\n' or c == '\r' or c == '<' or c == '>') break;
+        end += 1;
+    }
+    try writer.writeAll(source[start..end]);
+    i.* = end;
     return true;
 }
 
@@ -436,6 +465,7 @@ fn writeBlockMath(allocator: std.mem.Allocator, writer: *std.Io.Writer, body: []
 /// - `$HOME/$PATH` — the closer is followed by an identifier char.
 /// - `${HOME}/${XDG_CONFIG_HOME}` — the opener or closer is followed by `{`
 ///   (braced shell/config variables), so both dollar signs survive.
+/// - `\$FOO\$` — the opener/closer is escaped by a backslash.
 /// Digit-led formulas such as `$2^n$` still render because the closer is not
 /// identifier/digit-adjacent.
 fn consumeInlineMath(writer: *std.Io.Writer, source: []const u8, i: *usize) !bool {
@@ -443,9 +473,11 @@ fn consumeInlineMath(writer: *std.Io.Writer, source: []const u8, i: *usize) !boo
 
     // Opening `$` immediately after a digit is a price suffix, not math
     // (`5$`). A `$` followed by `{` is a braced shell/config variable, not
-    // math. Other punctuation/operators like `=` or `:` are allowed so
-    // common forms such as `f(x)=$x^2$` and `value:$v$` render.
+    // math. A `$` preceded by an unescaped backslash is an escaped literal
+    // dollar, not math. Other punctuation/operators like `=` or `:` are
+    // allowed so common forms such as `f(x)=$x^2$` and `value:$v$` render.
     if (open > 0 and std.ascii.isDigit(source[open - 1])) return false;
+    if (open > 0 and isEscaped(source, open)) return false;
     // Body must start with a non-space and non-`$` char.
     if (open + 1 >= source.len) return false;
     {
@@ -671,9 +703,11 @@ fn writeFrac(writer: *std.Io.Writer, body: []const u8, start: usize) anyerror!us
         try writer.writeByte(')');
         return i;
     }
-    // Fallback: emit literal so the user sees the source structure.
+    // Fallback: preserve the raw operand text so formulas like \frac{10}2 stay
+    // copyable instead of collapsing to \frac102.
     try writer.writeAll("\\frac");
-    return start;
+    try writer.writeAll(body[start..i]);
+    return i;
 }
 
 /// Render `\sqrt{X}` as `√X` (with braces stripped). If there's no brace
@@ -1181,6 +1215,20 @@ test "plain brackets still allow inline math" {
     try std.testing.expect(std.mem.indexOf(u8, out, "[x] = x ok") != null);
 }
 
+test "bare url with dollar variables stays verbatim" {
+    const src = "see https://api.example.com/users/$user_id$ here";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expectEqualStrings(src, out);
+}
+
+test "escaped dollar delimiters in prose stay verbatim" {
+    const src = "Use \\$FOO\\$ in docs and write \\$x\\$ to show the delimiter";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expectEqualStrings(src, out);
+}
+
 test "inline code span is not parsed as math" {
     const src = "Use `echo $x$` then $\\alpha$";
     const out = try preprocess(std.testing.allocator, src);
@@ -1376,6 +1424,16 @@ test "nested fraction renders fully" {
     const out = try preprocess(std.testing.allocator, src);
     defer std.testing.allocator.free(out);
     try std.testing.expect(std.mem.indexOf(u8, out, "((a)/(b))/(c)") != null);
+}
+
+test "fraction with non-braced operand preserves raw fallback" {
+    const src = "ratio $\\frac{10}2$ end";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    // When \frac doesn't have two brace groups, the raw operands must survive
+    // so the fallback stays copyable (NOT \frac102).
+    try std.testing.expect(std.mem.indexOf(u8, out, "\\frac{10}2") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "\\frac102") == null);
 }
 
 test "style modifiers are silently dropped" {

--- a/zig/src/tui/markdown.zig
+++ b/zig/src/tui/markdown.zig
@@ -220,17 +220,13 @@ fn updateListContext(source: []const u8, line_start: usize, in_list_item: *bool)
     const line_end = std.mem.indexOfScalarPos(u8, source, line_start, '\n') orelse source.len;
     const line = source[line_start..line_end];
     const trimmed = std.mem.trimStart(u8, line, " \t");
-    if (trimmed.len == 0) {
-        in_list_item.* = false;
-        return;
-    }
+    if (trimmed.len == 0) return;
     if (isListMarkerLine(trimmed)) {
         in_list_item.* = true;
         return;
     }
-    if (!isIndentedCodeLine(source, line_start)) {
-        in_list_item.* = false;
-    }
+    const indent = line.len - trimmed.len;
+    if (indent == 0) in_list_item.* = false;
 }
 
 fn isListMarkerLine(trimmed: []const u8) bool {
@@ -1221,10 +1217,19 @@ fn isShellVarSeparator(c: u8) bool {
 
 fn isCurrencyLikeMathBody(body: []const u8) bool {
     if (body.len == 0 or !std.ascii.isDigit(body[0])) return false;
+    var saw_space = false;
+    var saw_alpha = false;
     for (body[1..]) |c| {
-        if (std.ascii.isWhitespace(c) or c == ';' or c == ':' or c == ',') return true;
+        if (c == ';') return true;
+        if (c == '\\' or c == '^' or c == '_' or c == '+' or c == '-' or
+            c == '*' or c == '/' or c == '=' or c == '<' or c == '>')
+        {
+            return false;
+        }
+        if (std.ascii.isAlphabetic(c)) saw_alpha = true;
+        if (std.ascii.isWhitespace(c)) saw_space = true;
     }
-    return false;
+    return saw_alpha;
 }
 
 /// Returns true when the rendered math text contains a character that
@@ -2637,4 +2642,25 @@ test "long list continuations avoid quadratic backscan and render math" {
     try std.testing.expect(std.mem.indexOf(u8, out, "    a") != null);
     try std.testing.expect(std.mem.indexOf(u8, out, "    d") != null);
     try std.testing.expect(std.mem.indexOf(u8, out, "$d$") == null);
+}
+
+
+test "digit-prefixed formulas with math separators render" {
+    const src = "$2 + 3$ and $$10 \\times 4$$ and $2,000$ and $1:2$";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "2 + 3") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "> 10 × 4") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "2,000") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "1:2") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "$2 + 3$") == null);
+}
+
+
+test "list context survives ordinary continuation lines" {
+    const src = "- Formula:\n  explanation\n    $x^2$";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "    x²") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "    $x^2$") == null);
 }

--- a/zig/src/tui/markdown.zig
+++ b/zig/src/tui/markdown.zig
@@ -573,12 +573,20 @@ const BraceGroup = struct {
 
 /// Read a `{...}` group starting at `i`. Returns null if `i` doesn't point
 /// at a `{`. Handles nested braces via a depth counter so
-/// `\frac{\frac{a}{b}}{c}` renders as `((a)/(b))/(c)`.
+/// `\frac{\frac{a}{b}}{c}` renders as `((a)/(b))/(c)`. Skipped over escape
+/// pairs (`\{`, `\}`, etc.) so escaped LaTeX braces don't affect depth —
+/// otherwise unbalanced escapes like `\boxed{\{1,2}` corrupt grouping and
+/// drop content.
 fn readGroup(body: []const u8, i: usize) ?BraceGroup {
     if (i >= body.len or body[i] != '{') return null;
     var depth: usize = 1;
     var j = i + 1;
     while (j < body.len) : (j += 1) {
+        if (body[j] == '\\' and j + 1 < body.len) {
+            // Skip the escaped char so it can't affect brace depth.
+            j += 1;
+            continue;
+        }
         if (body[j] == '{') depth += 1;
         if (body[j] == '}') {
             depth -= 1;
@@ -994,6 +1002,20 @@ test "unknown LaTeX command with brace argument preserves group" {
     // the raw fallback stays copyable (NOT `\boxedx+1`).
     try std.testing.expect(std.mem.indexOf(u8, out, "\\boxed{x+1}") != null);
     try std.testing.expect(std.mem.indexOf(u8, out, "\\boxedx") == null);
+}
+
+test "escaped braces inside group do not corrupt depth" {
+    // `\{` and `\}` are literal brace chars in LaTeX math, not grouping
+    // braces. readGroup must skip the escaped pair so unbalanced escaped
+    // braces don't drop content. Repro from review: `\boxed{\{1,2}` should
+    // preserve the `\boxed{` opener.
+    const src = "set $\\boxed{\\{1,2}$ end";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    // The `\boxed{` opener must survive — without the escape-skip fix the
+    // depth counter matched `\}` against the inner `\boxed{` and lost it.
+    try std.testing.expect(std.mem.indexOf(u8, out, "\\boxed{\\{1,2}") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "\\boxed\\{1,2") == null);
 }
 
 test "mermaid block replaced with labeled summary" {

--- a/zig/src/tui/markdown.zig
+++ b/zig/src/tui/markdown.zig
@@ -170,8 +170,8 @@ fn consumeMarkdownLink(writer: *std.Io.Writer, source: []const u8, i: *usize) !b
 /// Returns true when `source[i..]` begins with a common bare URL scheme
 /// (`http://` or `https://`).
 fn isBareUrlPrefix(source: []const u8, i: usize) bool {
-    if (i + 7 <= source.len and std.mem.eql(u8, source[i .. i + 7], "http://")) return true;
-    if (i + 8 <= source.len and std.mem.eql(u8, source[i .. i + 8], "https://")) return true;
+    if (i + 7 <= source.len and std.ascii.eqlIgnoreCase(source[i .. i + 7], "http://")) return true;
+    if (i + 8 <= source.len and std.ascii.eqlIgnoreCase(source[i .. i + 8], "https://")) return true;
     return false;
 }
 
@@ -418,6 +418,8 @@ fn findUnescapedDoubleDollar(source: []const u8, start: usize) ?usize {
 /// survives unchanged.
 fn consumeBlockMath(allocator: std.mem.Allocator, writer: *std.Io.Writer, source: []const u8, i: *usize) !bool {
     const open = i.*;
+    // Reject an escaped opener (`\$$...`) so the backslash survives verbatim.
+    if (open > 0 and isEscaped(source, open)) return false;
     // Reject `$$$` — ambiguous with inline math like `$$$x$$`.
     if (open + 2 < source.len and source[open + 2] == '$') return false;
     const body_start = open + 2;
@@ -684,30 +686,59 @@ fn isIdentifierChar(c: u8) bool {
     return std.ascii.isAlphanumeric(c) or c == '_';
 }
 
-/// Render `\frac{A}{B}` as `(A)/(B)`. Returns the new cursor position past
-/// both groups. If the next non-whitespace tokens aren't brace groups, emit
-/// the operands inline as a graceful fallback.
-fn writeFrac(writer: *std.Io.Writer, body: []const u8, start: usize) anyerror!usize {
-    var i = skipSpace(body, start);
-    const a_group = readGroup(body, i);
-    if (a_group) |g| i = g.end;
-    i = skipSpace(body, i);
-    const b_group = readGroup(body, i);
-    if (b_group) |g| i = g.end;
+const FracOperand = struct {
+    raw: []const u8,
+    end: usize,
+};
 
-    if (a_group != null and b_group != null) {
+/// Read one fraction operand starting at `i`: either a `{...}` brace group,
+/// a command token (`\alpha`), or a single non-whitespace character. Returns
+/// the raw source span (including braces) and the cursor past the operand.
+fn readFracOperand(body: []const u8, i: usize) ?FracOperand {
+    const j = skipSpace(body, i);
+    if (j >= body.len) return null;
+    if (body[j] == '{') {
+        const g = readGroup(body, j) orelse return null;
+        return .{ .raw = body[j..g.end], .end = g.end };
+    }
+    if (body[j] == '\\' and j + 1 < body.len) {
+        var k = j + 2;
+        if (std.ascii.isAlphabetic(body[j + 1])) {
+            while (k < body.len and std.ascii.isAlphabetic(body[k])) k += 1;
+        }
+        return .{ .raw = body[j..k], .end = k };
+    }
+    return .{ .raw = body[j..j + 1], .end = j + 1 };
+}
+
+fn isBraceGroup(raw: []const u8) bool {
+    return raw.len >= 2 and raw[0] == '{' and raw[raw.len - 1] == '}';
+}
+
+/// Render `\frac{A}{B}` as `(A)/(B)`. Returns the new cursor position past
+/// both groups. If the operands aren't both brace groups, preserve the raw
+/// operand text as a graceful fallback so formulas stay copyable.
+fn writeFrac(writer: *std.Io.Writer, body: []const u8, start: usize) anyerror!usize {
+    const a = readFracOperand(body, start);
+    const b = if (a) |op| readFracOperand(body, op.end) else null;
+    if (a != null and b != null and isBraceGroup(a.?.raw) and isBraceGroup(b.?.raw)) {
         try writer.writeByte('(');
-        try renderMathBody(writer, a_group.?.inner);
+        try renderMathBody(writer, a.?.raw[1..a.?.raw.len - 1]);
         try writer.writeAll(")/(");
-        try renderMathBody(writer, b_group.?.inner);
+        try renderMathBody(writer, b.?.raw[1..b.?.raw.len - 1]);
         try writer.writeByte(')');
-        return i;
+        return b.?.end;
     }
     // Fallback: preserve the raw operand text so formulas like \frac{10}2 stay
-    // copyable instead of collapsing to \frac102.
+    // copyable instead of collapsing to \frac102. Include any leading
+    // whitespace so space-separated operands such as \frac a{b} survive.
     try writer.writeAll("\\frac");
-    try writer.writeAll(body[start..i]);
-    return i;
+    if (a) |op| {
+        const end = if (b) |op2| op2.end else op.end;
+        try writer.writeAll(body[start..end]);
+        return end;
+    }
+    return start;
 }
 
 /// Render `\sqrt{X}` as `√X` (with braces stripped). If there's no brace
@@ -727,7 +758,7 @@ fn writeSqrt(writer: *std.Io.Writer, body: []const u8, start: usize) anyerror!us
 
 fn skipSpace(body: []const u8, i: usize) usize {
     var j = i;
-    while (j < body.len and (body[j] == ' ' or body[j] == '\t')) j += 1;
+    while (j < body.len and (body[j] == ' ' or body[j] == '\t' or body[j] == '\n' or body[j] == '\r')) j += 1;
     return j;
 }
 
@@ -1180,6 +1211,14 @@ test "escaped dollar inside block math is not treated as closer" {
     try std.testing.expect(std.mem.indexOf(u8, out, "x = $5") != null);
 }
 
+test "escaped double dollar opener stays verbatim" {
+    const src = "\\$$x$$";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    // The leading \\$ must survive and the unescaped $$x$$ should not be eaten.
+    try std.testing.expect(std.mem.indexOf(u8, out, "\\$$x$$") != null);
+}
+
 test "adjacent shell variables are not parsed as math" {
     const src = "use $HOME/$PATH and $FOO-$BAR";
     const out = try preprocess(std.testing.allocator, src);
@@ -1217,6 +1256,13 @@ test "plain brackets still allow inline math" {
 
 test "bare url with dollar variables stays verbatim" {
     const src = "see https://api.example.com/users/$user_id$ here";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expectEqualStrings(src, out);
+}
+
+test "uppercase bare url scheme is protected from math parsing" {
+    const src = "see HTTPS://example.com/$x$ here";
     const out = try preprocess(std.testing.allocator, src);
     defer std.testing.allocator.free(out);
     try std.testing.expectEqualStrings(src, out);
@@ -1435,6 +1481,31 @@ test "fraction with non-braced operand preserves raw fallback" {
     try std.testing.expect(std.mem.indexOf(u8, out, "\\frac{10}2") != null);
     try std.testing.expect(std.mem.indexOf(u8, out, "\\frac102") == null);
 }
+test "fraction with space separated single token operands preserves braces" {
+    const src = "ratio $\\frac a{b}$ end";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    // The brace around the second operand must survive the fallback.
+    try std.testing.expect(std.mem.indexOf(u8, out, "\\frac a{b}") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "\\frac ab") == null);
+}
+
+test "fraction with space separated token operands preserves source" {
+    const src = "ratio $\\frac a b$ end";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "\\frac a b") != null);
+}
+
+test "fraction with newline separated brace operands renders" {
+    const src = "$$\\frac\n{a}\n{b}$$";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    // Newlines between \\frac and its brace groups should be treated as
+    // whitespace and the fraction should still render as (a)/(b).
+    try std.testing.expect(std.mem.indexOf(u8, out, "(a)/(b)") != null);
+}
+
 
 test "style modifiers are silently dropped" {
     const src = "math $\\mathrm{sin} + x$";

--- a/zig/src/tui/markdown.zig
+++ b/zig/src/tui/markdown.zig
@@ -47,14 +47,18 @@ pub fn preprocess(allocator: std.mem.Allocator, source: []const u8) ![]u8 {
             if (try consumeFenceBlock(allocator, writer, source, &i)) continue;
         }
 
-        // 2. Markdown inline links and bare URLs must stay raw. Protect their
-        //    destinations before math checks so URLs like
-        //    `/users/$user_id$` survive.
+        // 2. Markdown inline links, bare URLs, and relative path/URL
+        //    placeholders must stay raw. Protect their destinations before
+        //    math checks so URLs like `/users/$user_id$` and routes like
+        //    `/api/v1/$id` survive.
         if (source[i] == '[') {
-            if (try consumeMarkdownLink(writer, source, &i)) continue;
+            if (try consumeMarkdownLink(allocator, writer, source, &i)) continue;
         }
         if (isBareUrlPrefix(source, i)) {
             if (try consumeBareUrl(writer, source, &i)) continue;
+        }
+        if (source[i] == '/') {
+            if (try consumeRelativePath(writer, source, &i)) continue;
         }
 
         // 3. Inline code spans must stay raw. Protect them before math checks
@@ -71,7 +75,7 @@ pub fn preprocess(allocator: std.mem.Allocator, source: []const u8) ![]u8 {
 
         // 5. Inline math `$...$`.
         if (source[i] == '$') {
-            if (try consumeInlineMath(writer, source, &i)) continue;
+            if (try consumeInlineMath(allocator, writer, source, &i)) continue;
         }
 
         // 5. Plain byte.
@@ -111,11 +115,12 @@ fn consumeInlineCode(writer: *std.Io.Writer, source: []const u8, i: *usize) !boo
     return false;
 }
 
-/// Consume a Markdown inline link `[text](url)` verbatim. Returns false when
-/// the bytes at `*i` don't form a complete link so the default byte path
-/// preserves the source. Link destinations may contain `$` chars that must not
-/// be interpreted as inline math, so the whole link is copied unchanged.
-fn consumeMarkdownLink(writer: *std.Io.Writer, source: []const u8, i: *usize) !bool {
+/// Consume a Markdown inline link `[text](url)`. Preprocesses the visible
+/// label text so math like `[loss $L_2$](...)` renders, while copying the
+/// URL destination verbatim so any `$`variables in the URL stay copyable.
+/// Returns false when the bytes at `*i` don't form a complete link so the
+/// default byte path preserves the source.
+fn consumeMarkdownLink(allocator: std.mem.Allocator, writer: *std.Io.Writer, source: []const u8, i: *usize) anyerror!bool {
     const start = i.*;
     if (start >= source.len or source[start] != '[') return false;
 
@@ -162,7 +167,17 @@ fn consumeMarkdownLink(writer: *std.Io.Writer, source: []const u8, i: *usize) !b
     }
     if (paren_depth != 0 or url_end >= source.len) return false;
 
-    try writer.writeAll(source[start .. url_end + 1]);
+    // Preprocess the label so math inside link labels is rendered, while the
+    // URL stays verbatim.
+    const label_text = source[start + 1 .. text_end];
+    const processed_label = try preprocess(allocator, label_text);
+    defer allocator.free(processed_label);
+
+    try writer.writeByte('[');
+    try writer.writeAll(processed_label);
+    try writer.writeAll("](");
+    try writer.writeAll(source[url_start + 1 .. url_end]);
+    try writer.writeByte(')');
     i.* = url_end + 1;
     return true;
 }
@@ -187,6 +202,30 @@ fn consumeBareUrl(writer: *std.Io.Writer, source: []const u8, i: *usize) !bool {
         if (c == ' ' or c == '\t' or c == '\n' or c == '\r' or c == '<' or c == '>') break;
         end += 1;
     }
+    try writer.writeAll(source[start..end]);
+    i.* = end;
+    return true;
+}
+
+/// Consume a relative path or route span (`/users/$user_id$/orders`) verbatim
+/// so dollar placeholders inside it are not interpreted as inline math.
+/// Returns false when the bytes don't look like a path.
+fn consumeRelativePath(writer: *std.Io.Writer, source: []const u8, i: *usize) !bool {
+    if (source[i.*] != '/') return false;
+    const start = i.*;
+    var end = start;
+    var slash_count: usize = 0;
+    var has_dollar = false;
+    while (end < source.len) {
+        const c = source[end];
+        if (c == ' ' or c == '\t' or c == '\n' or c == '\r' or c == '<' or c == '>') break;
+        if (c == '/') slash_count += 1;
+        if (c == '$') has_dollar = true;
+        end += 1;
+    }
+    // Require at least two path segments (leading slash + another slash) or
+    // a dollar placeholder so we don't swallow ordinary `/` punctuation.
+    if (slash_count < 2 and !has_dollar) return false;
     try writer.writeAll(source[start..end]);
     i.* = end;
     return true;
@@ -409,6 +448,19 @@ fn findUnescapedDoubleDollar(source: []const u8, start: usize) ?usize {
     return null;
 }
 
+/// Write `text` to `writer` with Markdown inline metacharacters escaped so
+/// that rendered math (e.g. `a*b*c`) is not reinterpreted as emphasis, code,
+/// links, or escapes by the downstream Markdown pass.
+fn writeMarkdownEscaped(writer: *std.Io.Writer, text: []const u8) anyerror!void {
+    for (text) |c| {
+        switch (c) {
+            '*', '_', '`', '[', ']', '<', '>' => try writer.writeByte('\\'),
+            else => {},
+        }
+        try writer.writeByte(c);
+    }
+}
+
 /// Try to consume a `$$...$$` block math span at `*i`. Returns true and
 /// advances `*i` past the closing `$$` on success. Returns false (without
 /// modifying `*i`) when the bytes at `*i` aren't a real block-math opener —
@@ -429,9 +481,20 @@ fn consumeBlockMath(allocator: std.mem.Allocator, writer: *std.Io.Writer, source
         return false;
     };
 
+    // Force line boundaries so block math doesn't run into surrounding prose
+    // like `before $$x$$ after`.
+    if (open > 0 and source[open - 1] != '\n') try writer.writeByte('\n');
     const body = source[body_start..close];
     try writeBlockMath(allocator, writer, body);
-    i.* = close + 2;
+    const after_close = close + 2;
+    if (after_close < source.len and source[after_close] != '\n') {
+        try writer.writeByte('\n');
+        // Skip a single separating space so `$$x$$ after` becomes a clean line
+        // break rather than `> x\n after`.
+        i.* = if (source[after_close] == ' ') after_close + 1 else after_close;
+    } else {
+        i.* = after_close;
+    }
     return true;
 }
 
@@ -441,8 +504,8 @@ fn writeBlockMath(allocator: std.mem.Allocator, writer: *std.Io.Writer, body: []
     try renderMathBody(&rendered.writer, body);
 
     // Emit as a Markdown blockquote — one quote line per source line, with
-    // blank lines collapsed. This visually sets math apart from prose and
-    // survives the downstream markdown pass cleanly.
+    // blank lines collapsed. Escape Markdown metacharacters in the rendered
+    // math so stars/brackets/etc. are not reinterpreted by the downstream pass.
     var lines = std.mem.splitScalar(u8, rendered.written(), '\n');
     var wrote_any = false;
     while (lines.next()) |raw_line| {
@@ -450,7 +513,7 @@ fn writeBlockMath(allocator: std.mem.Allocator, writer: *std.Io.Writer, body: []
         if (line.len == 0) continue;
         if (wrote_any) try writer.writeByte('\n');
         try writer.writeAll("> ");
-        try writer.writeAll(line);
+        try writeMarkdownEscaped(writer, line);
         wrote_any = true;
     }
     if (!wrote_any) try writer.writeAll("> ");
@@ -470,7 +533,7 @@ fn writeBlockMath(allocator: std.mem.Allocator, writer: *std.Io.Writer, body: []
 /// - `\$FOO\$` — the opener/closer is escaped by a backslash.
 /// Digit-led formulas such as `$2^n$` still render because the closer is not
 /// identifier/digit-adjacent.
-fn consumeInlineMath(writer: *std.Io.Writer, source: []const u8, i: *usize) !bool {
+fn consumeInlineMath(allocator: std.mem.Allocator, writer: *std.Io.Writer, source: []const u8, i: *usize) !bool {
     const open = i.*;
 
     // Opening `$` immediately after a digit is a price suffix, not math
@@ -504,7 +567,12 @@ fn consumeInlineMath(writer: *std.Io.Writer, source: []const u8, i: *usize) !boo
     // Reject newlines — inline math is a single line.
     if (std.mem.indexOfScalar(u8, body, '\n') != null) return false;
 
-    try renderMathBody(writer, body);
+    // Render to a temporary buffer so we can escape Markdown metacharacters
+    // before inserting the result into the prose stream.
+    var rendered: std.Io.Writer.Allocating = .init(allocator);
+    defer rendered.deinit();
+    try renderMathBody(&rendered.writer, body);
+    try writeMarkdownEscaped(writer, rendered.written());
     i.* = close + 1;
     return true;
 }
@@ -581,12 +649,17 @@ fn renderMathBody(writer: *std.Io.Writer, body: []const u8) anyerror!void {
             // Preserve any immediate `{...}` argument verbatim so users can
             // still read / copy unsupported LaTeX like `\boxed{x+1}` instead
             // of having the brace-stripping pass run the operand into the
-            // command name (e.g. `\boxedx+1`).
+            // command name (e.g. `\boxedx+1`). If a brace group is incomplete,
+            // copy the rest of the body verbatim rather than leaving the `{`
+            // to be stripped by the main loop.
             try writer.writeByte('\\');
             try writer.writeAll(name);
             var after = j;
             while (after < body.len and body[after] == '{') {
-                const grp = readGroup(body, after) orelse break;
+                const grp = readGroup(body, after) orelse {
+                    try writer.writeAll(body[after..]);
+                    return;
+                };
                 try writer.writeAll(body[after..grp.end]);
                 after = grp.end;
             }
@@ -1566,4 +1639,60 @@ test "nested script braces preserve inner group" {
     // being truncated to `\frac{1}2`.
     try std.testing.expect(std.mem.indexOf(u8, out, "^{\\frac{1}{2}}") != null);
     try std.testing.expect(std.mem.indexOf(u8, out, "\\frac{1}2") == null);
+}
+
+test "inline math escapes markdown metacharacters" {
+    const src = "product $a*b*c$ and sum $x[y](z)$";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    // Stars and brackets inside rendered math must be escaped so they are not
+    // reinterpreted as emphasis or links by the downstream Markdown pass.
+    try std.testing.expect(std.mem.indexOf(u8, out, "a\\*b\\*c") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "x\\[y\\](z)") != null);
+}
+
+test "block math forces line boundaries around prose" {
+    const src = "before$$x$$after";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    // Block math must be on its own line, not embedded as `before > x after`.
+    try std.testing.expect(std.mem.indexOf(u8, out, "before\n> x\nafter") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "before > x after") == null);
+}
+
+test "block math with spaces around delimiters separates from prose" {
+    const src = "before $$x$$ after";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    // The inline-embedded block math should be separated onto its own quote line.
+    try std.testing.expect(std.mem.indexOf(u8, out, "> x") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "before > x after") == null);
+    // 'after' should land on its own line rather than being concatenated.
+    try std.testing.expect(std.mem.indexOf(u8, out, "\nafter") != null);
+}
+
+test "link label math is rendered while url stays verbatim" {
+    const src = "[loss $L_2$](https://example.com/$id)";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    // Label math should render (L_2 -> L with subscript 2), URL should stay raw.
+    try std.testing.expect(std.mem.indexOf(u8, out, "[loss L₂](https://example.com/$id)") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "$L_2$") == null);
+}
+
+test "incomplete unknown command group is preserved verbatim" {
+    const src = "set $\\boxed{\\{1,2$ end";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    // The unclosed brace group and escaped brace should survive the fallback
+    // instead of having the opening `{` stripped.
+    try std.testing.expect(std.mem.indexOf(u8, out, "\\boxed{\\{1,2") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "\\boxed\\{1,2") == null);
+}
+
+test "relative path with dollar placeholders stays verbatim" {
+    const src = "GET /users/$user_id$/orders";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expectEqualStrings(src, out);
 }

--- a/zig/src/tui/markdown.zig
+++ b/zig/src/tui/markdown.zig
@@ -46,8 +46,11 @@ const mermaid_fence = "```";
 const mermaid_lang = "mermaid";
 
 /// Replace each ```mermaid ... ``` block with a labeled summary plus the raw
-/// source as a Markdown blockquote. If the closing fence is missing we emit
-/// the label only and pass the remainder through verbatim.
+/// source as a Markdown blockquote. Fenced code blocks in other languages
+/// are passed through verbatim, including any literal ```mermaid lines they
+/// may contain — we walk the source line-by-line and track fence state so a
+/// mermaid syntax example embedded inside a `text`/`zig`/etc. block is not
+/// mis-transformed.
 fn replaceMermaidBlocks(allocator: std.mem.Allocator, source: []const u8) ![]u8 {
     var out: std.Io.Writer.Allocating = .init(allocator);
     errdefer out.deinit();
@@ -60,30 +63,43 @@ fn replaceMermaidBlocks(allocator: std.mem.Allocator, source: []const u8) ![]u8 
             break;
         };
 
+        // Only treat a fence that starts a line (optionally indented). A
+        // ``` buried inside a word is not a fence opener.
+        const line_start = lineStartBefore(source, fence_pos);
+        const indent = source[line_start..fence_pos];
+        if (!std.mem.allEqual(u8, indent, ' ') and indent.len != 0) {
+            // Not a real fence — emit one byte and keep scanning so we don't
+            // loop forever on the same position.
+            try writer.writeByte(source[cursor]);
+            cursor += 1;
+            continue;
+        }
+
         // Scan the language tag immediately after the fence.
         const tag_start = fence_pos + mermaid_fence.len;
         const line_end = std.mem.indexOfScalarPos(u8, source, tag_start, '\n') orelse source.len;
         const tag = std.mem.trim(u8, source[tag_start..line_end], " \t\r");
 
         if (!std.mem.eql(u8, tag, mermaid_lang)) {
-            // Not a mermaid block — copy through the fence line and keep
-            // scanning from after it so nested non-mermaid blocks are
-            // unaffected. Use min to stay in bounds when the fence runs to
-            // end-of-input without a trailing newline.
-            const advance = @min(line_end + 1, source.len);
+            // Non-mermaid fenced code block. Walk line-by-line until the
+            // matching closing fence, copying everything verbatim — any
+            // literal ```mermaid lines inside belong to the code block, not
+            // to us.
+            const block_end = findCodeBlockClose(source, line_end);
+            const advance = block_end;
             try writer.writeAll(source[cursor..advance]);
             cursor = advance;
             continue;
         }
 
-        // Find the closing fence.
+        // Mermaid block — find the closing fence.
         const body_start = if (line_end < source.len) line_end + 1 else source.len;
-        const close_pos = findMermaidClose(source, body_start);
+        const close_pos = findCodeBlockCloseLine(source, body_start);
 
         // Emit any plain text leading up to the fence verbatim.
         try writer.writeAll(source[cursor..fence_pos]);
 
-        const body_end = close_pos orelse source.len;
+        const body_end = if (close_pos) |cp| cp else source.len;
         const body = source[body_start..body_end];
         const diagram_type = detectMermaidType(body);
 
@@ -112,23 +128,39 @@ fn replaceMermaidBlocks(allocator: std.mem.Allocator, source: []const u8) ![]u8 
     return out.toOwnedSlice();
 }
 
-/// Locate the closing ``` for a mermaid block starting at `body_start`.
-/// Returns the absolute index of the closing fence or null if none is found.
-fn findMermaidClose(source: []const u8, body_start: usize) ?usize {
-    var i: usize = body_start;
+/// Find the start of the next line that is exactly a fenced-code-block
+/// closer (a line whose only non-newline content is ``` optionally preceded
+/// by spaces). Returns the index just past the closer's trailing newline
+/// (or `source.len` when none is found, in which case the rest of the source
+/// is treated as part of the unterminated code block).
+fn findCodeBlockClose(source: []const u8, after_open_line_end: usize) usize {
+    var i = after_open_line_end;
     while (i < source.len) {
-        if (source[i] == '`') {
-            // Only treat lines whose first non-space content is ``` as the
-            // closing fence — indented triple backticks inside a diagram are
-            // part of the diagram source.
-            const line_start = lineStartBefore(source, i);
-            const prefix = source[line_start..i];
-            const all_space = std.mem.allEqual(u8, prefix, ' ') or prefix.len == 0;
-            if (all_space and i + 3 <= source.len and std.mem.eql(u8, source[i .. i + 3], mermaid_fence)) {
-                return i;
-            }
+        const line_start = i;
+        const line_end = std.mem.indexOfScalarPos(u8, source, line_start, '\n') orelse source.len;
+        const line = source[line_start..line_end];
+        const trimmed = std.mem.trim(u8, line, " \t\r");
+        if (std.mem.eql(u8, trimmed, mermaid_fence)) {
+            // Position just past the newline that terminates the closer line.
+            return if (line_end < source.len) line_end + 1 else source.len;
         }
-        i += 1;
+        i = if (line_end < source.len) line_end + 1 else source.len;
+    }
+    return source.len;
+}
+
+/// Same as findCodeBlockClose but returns the index of the closer's first
+/// backtick (used by the mermaid path so the body excludes the closing
+/// fence). Returns null when no closer is found.
+fn findCodeBlockCloseLine(source: []const u8, body_start: usize) ?usize {
+    var i = body_start;
+    while (i < source.len) {
+        const line_start = i;
+        const line_end = std.mem.indexOfScalarPos(u8, source, line_start, '\n') orelse source.len;
+        const line = source[line_start..line_end];
+        const trimmed = std.mem.trim(u8, line, " \t\r");
+        if (std.mem.eql(u8, trimmed, mermaid_fence)) return line_start;
+        i = if (line_end < source.len) line_end + 1 else source.len;
     }
     return null;
 }
@@ -219,16 +251,18 @@ fn replaceBlockMath(allocator: std.mem.Allocator, source: []const u8) ![]u8 {
         const body_start = open + 2;
         const close = std.mem.indexOfPos(u8, source, body_start, "$$");
 
-        try writer.writeAll(source[cursor..open]);
-
         if (close) |cp| {
+            try writer.writeAll(source[cursor..open]);
             const body = source[body_start..cp];
             try writeBlockMath(allocator, writer, body);
             cursor = cp + 2;
         } else {
-            // Unterminated — render what's left as a block and stop.
-            const body = source[body_start..];
-            try writeBlockMath(allocator, writer, body);
+            // Unterminated `$$` — not actually a math block. Emit the rest
+            // of the source verbatim (including the literal `$$`) so prose
+            // like "cost $$5 total" survives unchanged. Mirrors the inline
+            // math path, which writes the bare `$` and moves on when no
+            // closer is found.
+            try writer.writeAll(source[cursor..]);
             cursor = source.len;
         }
     }
@@ -515,9 +549,8 @@ const BraceGroup = struct {
 };
 
 /// Read a `{...}` group starting at `i` (after skipping leading spaces).
-/// Returns null if `i` doesn't point at a `{`. Does not handle nested
-/// braces — math operands rarely nest, and raw fallback preserves the
-/// source when they do.
+/// Returns null if `i` doesn't point at a `{`. Handles nested braces via a
+/// depth counter so `\frac{\frac{a}{b}}{c}` renders as `((a)/(b))/(c)`.
 fn readGroup(body: []const u8, i: usize) ?BraceGroup {
     if (i >= body.len or body[i] != '{') return null;
     var depth: usize = 1;
@@ -781,6 +814,15 @@ fn lookupCommand(name: []const u8) ?[]const u8 {
             .{ .name = "mathtt", .sym = "" },
             .{ .name = "mathcal", .sym = "" },
             .{ .name = "mathbb", .sym = "" },
+            .{ .name = "textbf", .sym = "" },
+            .{ .name = "textit", .sym = "" },
+            .{ .name = "textrm", .sym = "" },
+            .{ .name = "texttt", .sym = "" },
+            .{ .name = "textsf", .sym = "" },
+            .{ .name = "emph", .sym = "" },
+            .{ .name = "underline", .sym = "" },
+            .{ .name = "boldsymbol", .sym = "" },
+            .{ .name = "pmb", .sym = "" },
             .{ .name = "displaystyle", .sym = "" },
             .{ .name = "textstyle", .sym = "" },
             .{ .name = "scriptstyle", .sym = "" },
@@ -881,12 +923,20 @@ test "inline math ignores dollar signs used as currency" {
     try std.testing.expectEqualStrings(src, out);
 }
 
-test "unterminated block math falls back gracefully" {
+test "unterminated block math passes through verbatim per doc" {
     const src = "text $$\\alpha no closer";
     const out = try preprocess(std.testing.allocator, src);
     defer std.testing.allocator.free(out);
-    try std.testing.expect(std.mem.indexOf(u8, out, "α") != null);
-    try std.testing.expect(std.mem.indexOf(u8, out, "$$") == null);
+    // Doc contract: unterminated `$$` is not a math block. Source must
+    // survive unchanged so prose like "cost $$5 total" doesn't lose data.
+    try std.testing.expectEqualStrings(src, out);
+}
+
+test "unterminated block math preserves currency-style double dollar" {
+    const src = "cost $$5 total";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expectEqualStrings(src, out);
 }
 
 test "unknown LaTeX command falls back to raw with backslash" {
@@ -915,6 +965,41 @@ test "mermaid sequenceDiagram type classified correctly" {
     const out = try preprocess(std.testing.allocator, src);
     defer std.testing.allocator.free(out);
     try std.testing.expect(std.mem.indexOf(u8, out, "**Mermaid diagram: sequence**") != null);
+}
+
+test "mermaid fence inside a non-mermaid code block is not transformed" {
+    // A code block that documents mermaid syntax must survive verbatim —
+    // we cannot eat its closing fence or rewrite its contents.
+    const src = "```text\n```mermaid\nflowchart TD\n  A --> B\n```\n```";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expectEqualStrings(src, out);
+}
+
+test "mermaid fence inside a zig code block is not transformed" {
+    const src = "```zig\nconst s = \"```mermaid\\nflowchart\\n```\";\n```";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expectEqualStrings(src, out);
+}
+
+test "unterminated non-mermaid code block passes through verbatim" {
+    // No closing fence at all — everything after the opener survives.
+    const src = "```text\nsome\nraw\nlines";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expectEqualStrings(src, out);
+}
+
+test "text style commands drop their wrapper" {
+    const src = "math $\\textbf{X} + \\textit{Y} + \\textrm{Z} + \\texttt{W}$";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "X + Y + Z + W") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "\\textbf") == null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "\\textit") == null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "\\textrm") == null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "\\texttt") == null);
 }
 
 test "mermaid block without closing fence still labels" {

--- a/zig/src/tui/markdown.zig
+++ b/zig/src/tui/markdown.zig
@@ -50,7 +50,7 @@ fn preprocessWithOptions(allocator: std.mem.Allocator, source: []const u8, prote
         //    the interior.
         if (isAtLineStart(source, i)) {
             if (try consumeFenceBlock(allocator, writer, source, &i)) continue;
-            if (try consumeTildeFenceBlock(writer, source, &i)) continue;
+            if (try consumeTildeFenceBlock(allocator, writer, source, &i)) continue;
         }
 
         // 2. Markdown inline links, bare URLs, and relative path/URL
@@ -224,9 +224,21 @@ fn consumeRelativePath(writer: *std.Io.Writer, source: []const u8, i: *usize) an
     if (source[i.*] != '/') return false;
     const start = i.*;
     // Only treat this slash as the start of a route when it begins at a path
-    // boundary (start of source or after whitespace). This prevents ordinary
-    // prose such as `1/$n$` from having its math delimiter swallowed.
-    if (start > 0 and !std.ascii.isWhitespace(source[start - 1])) return false;
+    // boundary (start of source, after whitespace, or after an opening
+    // delimiter such as `(`, `[`, `{`, `"`, `'`, or `<`). This prevents
+    // ordinary prose such as `1/$n$` from having its math delimiter swallowed.
+    // When the boundary is an opening delimiter we additionally require a dollar
+    // placeholder inside the token so that parenthesized math like `($A/B$)`
+    // is not misclassified as a route.
+    var requires_dollar_placeholder = false;
+    if (start > 0) {
+        const prev = source[start - 1];
+        const is_whitespace_boundary = std.ascii.isWhitespace(prev);
+        const is_opener_boundary = prev == '(' or prev == '[' or prev == '{' or
+            prev == '"' or prev == '\'' or prev == '<';
+        if (!is_whitespace_boundary and !is_opener_boundary) return false;
+        requires_dollar_placeholder = is_opener_boundary;
+    }
     var end = start;
     var slash_count: usize = 0;
     var has_dollar = false;
@@ -238,8 +250,11 @@ fn consumeRelativePath(writer: *std.Io.Writer, source: []const u8, i: *usize) an
         end += 1;
     }
     // Require at least two path segments (leading slash + another slash) or
-    // a dollar placeholder so we don't swallow ordinary `/` punctuation.
+    // a dollar placeholder. When the boundary was an opening delimiter we must
+    // see a dollar placeholder so parenthesized math like `($A/B$)` isn't
+    // swallowed as a route.
     if (slash_count < 2 and !has_dollar) return false;
+    if (requires_dollar_placeholder and !has_dollar) return false;
     try writer.writeAll(source[start..end]);
     i.* = end;
     return true;
@@ -251,46 +266,67 @@ fn consumeRelativePath(writer: *std.Io.Writer, source: []const u8, i: *usize) an
 
 const mermaid_lang = "mermaid";
 
-/// If `source[i..]` opens a fenced code block at line start (optionally
-/// indented), consume the whole block in place:
-///
-/// - mermaid blocks become the labeled summary + quoted source;
-/// - any other language is copied verbatim, including any literal
-///   ```` ```mermaid ```` lines or `$` chars inside.
-///
-/// Updates `*i` past the consumed block and returns true. Returns false
-/// (without modifying `*i`) if `i` is not at a fence opener.
-///
-/// Supports CommonMark-style long fences (4+ backticks) so a block opened
-/// with ```` ```` ```` is only closed by a line whose leading backtick run
-/// is at least as long — this lets users embed ``` ```` ``` fences inside
-/// without breaking the outer block.
+/// If `source[i..]` opens a backtick-fenced code block at line start
+/// (optionally indented), consume the whole block in place.
 fn consumeFenceBlock(allocator: std.mem.Allocator, writer: *std.Io.Writer, source: []const u8, i: *usize) !bool {
+    return try consumeFenceGeneric(allocator, writer, source, i, '`', true);
+}
+
+/// Consume a CommonMark tilde-fenced code block (`~~~ ... ~~~`) at line start.
+/// Unlike backtick fences, these are always copied verbatim because the
+/// downstream renderer displays them as plain text rather than bordered code.
+fn consumeTildeFenceBlock(allocator: std.mem.Allocator, writer: *std.Io.Writer, source: []const u8, i: *usize) anyerror!bool {
+    return try consumeFenceGeneric(allocator, writer, source, i, '~', false);
+}
+
+/// Generic fenced code block consumer.
+///
+/// - If `may_be_mermaid` is true and the language tag is `mermaid`, the block
+///   body is transformed into a labeled summary plus quoted source.
+/// - Otherwise the opener, body, and closer are copied verbatim so their
+///   contents (including literal ```` ```mermaid ```` lines and `$` shell
+///   variables) survive unchanged.
+///
+/// Supports CommonMark-style long fences (4+ chars) so a block opened with
+/// ```` ```` ```` is only closed by a line whose leading run is at least as
+/// long — this lets users embed ``` ```` ``` fences inside without breaking
+/// the outer block.
+fn consumeFenceGeneric(
+    allocator: std.mem.Allocator,
+    writer: *std.Io.Writer,
+    source: []const u8,
+    i: *usize,
+    fence_char: u8,
+    may_be_mermaid: bool,
+) !bool {
     const start = i.*;
-    // Allow leading space indentation (a line of spaces followed by ```).
+    // Allow leading space indentation (a line of spaces followed by the fence).
     var indent_end = start;
     while (indent_end < source.len and source[indent_end] == ' ') indent_end += 1;
-    if (indent_end >= source.len or source[indent_end] != '`') return false;
+    if (indent_end >= source.len or source[indent_end] != fence_char) return false;
 
-    // Count the opening backtick run. CommonMark requires >=3 to open a
-    // fence; we accept any length and require a closer with at least as
-    // many backticks so users can use ```` to wrap content containing ```.
+    // Count the opening fence run. CommonMark requires >=3 to open a fence;
+    // we accept any length and require a closer with at least as many chars.
     var fence_len: usize = 0;
-    while (indent_end + fence_len < source.len and source[indent_end + fence_len] == '`') fence_len += 1;
+    while (indent_end + fence_len < source.len and source[indent_end + fence_len] == fence_char) fence_len += 1;
     if (fence_len < 3) return false;
 
-    // Lang tag occupies the rest of the opener line.
+    // For backtick fences the rest of the opener line is the language tag;
+    // tilde fences have no meaningful tag.
     const fence_end = indent_end + fence_len;
     const line_end = std.mem.indexOfScalarPos(u8, source, fence_end, '\n') orelse source.len;
-    const tag = std.mem.trim(u8, source[fence_end..line_end], " \t\r");
+    const tag = if (may_be_mermaid)
+        std.mem.trim(u8, source[fence_end..line_end], " \t\r")
+    else
+        "";
 
     // Body starts on the line after the opener.
     const body_start = if (line_end < source.len) line_end + 1 else source.len;
-    const close_line_start = findCodeBlockCloseLine(source, body_start, fence_len);
+    const close_line_start = findFenceCloseLine(source, body_start, fence_len, fence_char);
     const body_end = if (close_line_start) |cls| cls else source.len;
     const body = source[body_start..body_end];
 
-    if (std.mem.eql(u8, tag, mermaid_lang)) {
+    if (may_be_mermaid and std.mem.eql(u8, tag, mermaid_lang)) {
         // Mermaid block — emit the label + quoted source directly to the
         // writer. The caller never sees these bytes again so a later math
         // step can't mutate the quoted diagram source.
@@ -307,7 +343,7 @@ fn consumeFenceBlock(allocator: std.mem.Allocator, writer: *std.Io.Writer, sourc
         try writer.writeByte('\n');
     } else {
         // Non-mermaid fenced code block — copy opener, body, and closer
-        // verbatim so any literal ```mermaid lines or `$` shell vars inside
+        // verbatim so any literal fence lines or `$` shell vars inside
         // survive unchanged.
         try writer.writeAll(source[start..body_end]);
         if (close_line_start) |cls| {
@@ -341,89 +377,33 @@ fn consumeFenceBlock(allocator: std.mem.Allocator, writer: *std.Io.Writer, sourc
 }
 
 /// Locate the first line at or after `body_start` that closes a fenced
-/// code block opened with `fence_len` backticks. A closing line is one
-/// whose leading backtick run (after optional whitespace) is at least
-/// `fence_len` ticks long and contains nothing else but whitespace.
+/// code block opened with `fence_len` `fence_char`s. A closing line is one
+/// whose leading run (after optional whitespace) is at least `fence_len`
+/// chars long and contains nothing else but whitespace.
 ///
 /// Returns the absolute index of that closer line's first byte, or null if
 /// none is found.
-fn findCodeBlockCloseLine(source: []const u8, body_start: usize, fence_len: usize) ?usize {
-    var i = body_start;
-    while (i < source.len) {
-        const line_start = i;
+fn findFenceCloseLine(source: []const u8, body_start: usize, fence_len: usize, fence_char: u8) ?usize {
+    var j = body_start;
+    while (j < source.len) {
+        const line_start = j;
         const line_end = std.mem.indexOfScalarPos(u8, source, line_start, '\n') orelse source.len;
         const line = source[line_start..line_end];
         const trimmed = std.mem.trim(u8, line, " \t\r");
-        if (countLeadingBackticks(trimmed) >= fence_len) {
-            // Reject lines that have non-tick content after the run, e.g.
-            // an opener ```text. A valid closer is all backticks (possibly
+        if (countLeadingChar(trimmed, fence_char) >= fence_len) {
+            // Reject lines that have non-fence content after the run, e.g.
+            // an opener ```text. A valid closer is all fence chars (possibly
             // followed by trailing whitespace, already trimmed off).
-            if (std.mem.allEqual(u8, trimmed, '`')) return line_start;
+            if (std.mem.allEqual(u8, trimmed, fence_char)) return line_start;
         }
-        i = if (line_end < source.len) line_end + 1 else source.len;
+        j = if (line_end < source.len) line_end + 1 else source.len;
     }
     return null;
 }
 
-fn countLeadingBackticks(s: []const u8) usize {
+fn countLeadingChar(s: []const u8, c: u8) usize {
     var n: usize = 0;
-    while (n < s.len and s[n] == '`') n += 1;
-    return n;
-}
-
-/// Consume a CommonMark tilde-fenced code block (`~~~ ... ~~~`) at line start.
-/// Unlike backtick fences, these are always copied verbatim because the
-/// downstream renderer displays them as plain text rather than bordered code.
-fn consumeTildeFenceBlock(writer: *std.Io.Writer, source: []const u8, i: *usize) anyerror!bool {
-    const start = i.*;
-    var indent_end = start;
-    while (indent_end < source.len and source[indent_end] == ' ') indent_end += 1;
-    if (indent_end >= source.len or source[indent_end] != '~') return false;
-
-    var fence_len: usize = 0;
-    while (indent_end + fence_len < source.len and source[indent_end + fence_len] == '~') fence_len += 1;
-    if (fence_len < 3) return false;
-
-    const fence_end = indent_end + fence_len;
-    const line_end = std.mem.indexOfScalarPos(u8, source, fence_end, '\n') orelse source.len;
-    const body_start = if (line_end < source.len) line_end + 1 else source.len;
-    const close_line_start = findTildeBlockCloseLine(source, body_start, fence_len);
-    const body_end = if (close_line_start) |cls| cls else source.len;
-
-    try writer.writeAll(source[start..body_end]);
-    if (close_line_start) |cls| {
-        const close_line_end = std.mem.indexOfScalarPos(u8, source, cls, '\n') orelse source.len;
-        const emit_end = if (close_line_end < source.len) close_line_end + 1 else source.len;
-        try writer.writeAll(source[cls..emit_end]);
-        i.* = emit_end;
-    } else {
-        i.* = body_end;
-        if (body_end < source.len and source[body_end] == '\n') {
-            try writer.writeByte('\n');
-            i.* = body_end + 1;
-        }
-    }
-    return true;
-}
-
-fn findTildeBlockCloseLine(source: []const u8, body_start: usize, fence_len: usize) ?usize {
-    var i = body_start;
-    while (i < source.len) {
-        const line_start = i;
-        const line_end = std.mem.indexOfScalarPos(u8, source, line_start, '\n') orelse source.len;
-        const line = source[line_start..line_end];
-        const trimmed = std.mem.trim(u8, line, " \t\r");
-        if (countLeadingTildes(trimmed) >= fence_len) {
-            if (std.mem.allEqual(u8, trimmed, '~')) return line_start;
-        }
-        i = if (line_end < source.len) line_end + 1 else source.len;
-    }
-    return null;
-}
-
-fn countLeadingTildes(s: []const u8) usize {
-    var n: usize = 0;
-    while (n < s.len and s[n] == '~') n += 1;
+    while (n < s.len and s[n] == c) n += 1;
     return n;
 }
 
@@ -605,8 +585,9 @@ fn writeBlockMath(allocator: std.mem.Allocator, writer: *std.Io.Writer, body: []
 /// open/close guards so they pass through verbatim:
 /// - `5$` — opening `$` preceded by a digit.
 /// - `$5-$10`, `$5/$10` — the closer is followed by a digit.
-/// - `$HOME/$PATH`, `$FOO-$BAR` — the body is an uppercase shell-variable
-///   path/dash fragment, or the closer is followed by an uppercase identifier.
+/// - `$HOME/$PATH`, `$FOO-$BAR`, `$HOME$var` — the body is an uppercase-only
+///   shell-variable name and the closer is followed by a path continuation
+///   (`/`, `-`) or another identifier.
 /// - `${HOME}/${XDG_CONFIG_HOME}` — the opener or closer is followed by `{`
 ///   (braced shell/config variables), so both dollar signs survive.
 /// - `\$FOO\$` — the opener/closer is escaped by a backslash.
@@ -637,21 +618,18 @@ fn consumeInlineMath(allocator: std.mem.Allocator, writer: *std.Io.Writer, sourc
     // Closing `$` must not be preceded by whitespace, followed by another
     // `$`, followed by a digit (currency ranges), or followed by `{`
     // (braced shell variables like `${HOME}`).
-    // An identifier suffix is allowed for prose like `$n$th`, but uppercase
-    // identifiers are treated as adjacent shell variables/path components and
-    // rejected. Likewise, a body that is an uppercase identifier followed by a
-    // `/` or `-` path fragment (e.g. `$HOME/` in `$HOME/$PATH`) is rejected.
+    // An identifier suffix is allowed for prose like `$n$th`. Uppercase-only
+    // bodies are treated as shell-variable names; reject them when the closer
+    // is followed by a path continuation (`/`, `-`) or another identifier.
     if (source[close - 1] == ' ') return false;
     if (close + 1 < source.len) {
         const after = source[close + 1];
         if (after == '$' or after == '{' or std.ascii.isDigit(after)) return false;
-        if (std.ascii.isAlphabetic(after) and std.ascii.isUpper(after)) {
+        if (isUppercaseShellName(body) and (after == '/' or after == '-' or isIdentifierChar(after))) {
             return false;
         }
-    }
-    if (body.len > 0 and std.ascii.isAlphabetic(body[0]) and std.ascii.isUpper(body[0])) {
-        for (body) |bc| {
-            if (bc == '/' or bc == '-') return false;
+        if (std.ascii.isAlphabetic(after) and std.ascii.isUpper(after)) {
+            return false;
         }
     }
 
@@ -860,6 +838,14 @@ fn isScriptTokenChar(c: u8) bool {
 
 fn isIdentifierChar(c: u8) bool {
     return std.ascii.isAlphanumeric(c) or c == '_';
+}
+
+fn isUppercaseShellName(s: []const u8) bool {
+    if (s.len == 0) return false;
+    for (s) |c| {
+        if (!(std.ascii.isUpper(c) or c == '_')) return false;
+    }
+    return true;
 }
 
 const FracOperand = struct {
@@ -1860,4 +1846,56 @@ test "negative latex spacing command is dropped" {
     const out = try preprocess(std.testing.allocator, src);
     defer std.testing.allocator.free(out);
     try std.testing.expect(std.mem.indexOf(u8, out, "`ab`") != null);
+}
+
+test "uppercase math with slash or minus renders" {
+    // Regression for P1: formulas like $A/B$ and $X - Y$ should not be
+    // rejected as shell-variable path fragments.
+    const src = "$A/B$ and $X - Y$";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "`A/B`") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "`X - Y`") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "$A/B$") == null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "$X - Y$") == null);
+}
+
+test "route after opening delimiter is protected when it has dollar placeholders" {
+    // Regression for P2: routes like `call (/api/v1/$id$) now` must keep
+    // the `$id$` placeholder verbatim, not render it as math.
+    const src = "call (/api/v1/$id$) now";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "/api/v1/$id$") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "`/api/v1/`)") == null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "`id`") == null);
+}
+
+test "parenthesized math is not swallowed as a route" {
+    // A slash token after `(` should only be treated as a route if it contains
+    // a dollar placeholder; otherwise inline math like `($A/B$)` must render.
+    const src = "value ($A/B$)";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "`A/B`") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "$/A/B$") == null);
+}
+
+test "uppercase shell variable suffix stays raw" {
+    // Uppercase-only bodies followed by an identifier are shell-variable
+    // adjacencies, not math suffixes.
+    const src = "path is $HOME$var today";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "$HOME$var") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "`HOME`var") == null);
+}
+
+test "lowercase prose suffix after math renders" {
+    // Document intended behavior: lowercase suffixes like `$x$_tmp` are
+    // treated as prose and render the math.
+    const src = "file $x$_tmp";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "`x`_tmp") != null);
 }

--- a/zig/src/tui/markdown.zig
+++ b/zig/src/tui/markdown.zig
@@ -492,6 +492,62 @@ fn findUnescapedDollar(source: []const u8, start: usize) ?usize {
     return null;
 }
 
+/// Find the closing `$` for an inline math span, skipping over structural
+/// spans that the outer walker protects: inline code (`` `...` ``) and bare
+/// URLs (`http://...`, `https://...`). Without this, a literal dollar in
+/// prose like `Pay $5; details: https://example.com/$id$` would pair with
+/// the URL's placeholder `$` and swallow the entire URL as a math body.
+fn findInlineMathClose(source: []const u8, start: usize) ?usize {
+    var i = start;
+    while (i < source.len) {
+        // Skip inline code spans — their `$` chars are not math delimiters.
+        if (source[i] == '`') {
+            const tick_count = countLeadingChar(source[i..], '`');
+            if (tick_count < 3) {
+                var scan = i + tick_count;
+                var found_close = false;
+                while (scan < source.len) {
+                    if (source[scan] == '`') {
+                        const close_count = countLeadingChar(source[scan..], '`');
+                        if (close_count == tick_count) {
+                            i = scan + close_count;
+                            found_close = true;
+                            break;
+                        }
+                        scan += close_count;
+                        continue;
+                    }
+                    scan += 1;
+                }
+                if (!found_close) return null;
+                continue;
+            }
+            // 3+ backticks — unusual inline; skip past the run and let the
+            // outer walker handle it.
+            i += tick_count;
+            continue;
+        }
+        // Skip bare URLs — their `$` placeholders are not math delimiters.
+        if (isBareUrlPrefix(source, i)) {
+            var url_end = i;
+            while (url_end < source.len) {
+                const c = source[url_end];
+                if (c == ' ' or c == '\t' or c == '\n' or c == '\r' or
+                    c == '<' or c == '>')
+                {
+                    break;
+                }
+                url_end += 1;
+            }
+            i = url_end;
+            continue;
+        }
+        if (source[i] == '$' and !isEscaped(source, i)) return i;
+        i += 1;
+    }
+    return null;
+}
+
 /// Find the next unescaped `$$` at or after `start`.
 fn findUnescapedDoubleDollar(source: []const u8, start: usize) ?usize {
     var i = start;
@@ -506,7 +562,17 @@ fn findUnescapedDoubleDollar(source: []const u8, start: usize) ?usize {
 /// `*`, `_`, `[`, `]`, or backticks as Markdown emphasis, links, or code spans.
 /// Backslash escapes are not honored by ZigZag's parser, so this inline-code
 /// boundary is the only protection it actually respects.
+///
+/// The wrapper is only emitted when the rendered math actually contains a
+/// Markdown metacharacter. This avoids leaking literal backticks inside styled
+/// contexts that ZigZag renders without recursing into `renderInline` (bold,
+/// italic, headings, blockquotes), where the wrapper would be displayed as a
+/// visible character rather than acting as a code-span boundary.
 fn writeProtectedMathSpan(writer: *std.Io.Writer, text: []const u8) anyerror!void {
+    if (!needsMathProtection(text)) {
+        try writer.writeAll(text);
+        return;
+    }
     if (std.mem.indexOfScalar(u8, text, '`') != null) {
         // ZigZag does not support multi-backtick code delimiters, so if the
         // rendered math somehow contains a backtick, fall back to the raw text.
@@ -611,23 +677,37 @@ fn consumeInlineMath(allocator: std.mem.Allocator, writer: *std.Io.Writer, sourc
     }
 
     const body_start = open + 1;
-    const close = findUnescapedDollar(source, body_start) orelse return false;
+    const close = findInlineMathClose(source, body_start) orelse return false;
 
     const body = source[body_start..close];
+
+    // Reject bodies that look like they swallowed a URL — a `$` before a
+    // bare URL can pair with a `$` inside the URL destination (e.g. a
+    // placeholder) even though the closer search skips URLs, because the
+    // URL may have already been consumed as part of the body when the
+    // opener was at a position where the URL check hadn't fired yet.
+    if (std.mem.indexOf(u8, body, "://") != null) return false;
 
     // Closing `$` must not be preceded by whitespace, followed by another
     // `$`, followed by a digit (currency ranges), or followed by `{`
     // (braced shell variables like `${HOME}`).
-    // An identifier suffix is allowed for prose like `$n$th`. Uppercase-only
-    // bodies are treated as shell-variable names; reject them when the closer
-    // is followed by a path continuation (`/`, `-`) or another identifier.
+    // An identifier suffix is allowed for prose like `$n$th`. Shell-variable
+    // adjacency is detected in two shapes:
+    //   - `$HOME/$PATH`, `$foo/$bar` — closer followed by `/` or `-` and body
+    //     is a shell-name token (alphanumeric + underscore).
+    //   - `$foo/$bar`, `$prefix-$suffix` — body ends with `/` or `-` and the
+    //     closer is followed by an identifier char (the next variable name).
+    // Uppercase-only bodies are additionally rejected when followed by any
+    // identifier (`$HOME$var`).
     if (source[close - 1] == ' ') return false;
+    if (body.len > 0 and (body[body.len - 1] == '/' or body[body.len - 1] == '-')) {
+        if (close + 1 < source.len and isIdentifierChar(source[close + 1])) return false;
+    }
     if (close + 1 < source.len) {
         const after = source[close + 1];
         if (after == '$' or after == '{' or std.ascii.isDigit(after)) return false;
-        if (isUppercaseShellName(body) and (after == '/' or after == '-' or isIdentifierChar(after))) {
-            return false;
-        }
+        if ((after == '/' or after == '-') and isShellNameLike(body)) return false;
+        if (isUppercaseShellName(body) and isIdentifierChar(after)) return false;
         if (std.ascii.isAlphabetic(after) and std.ascii.isUpper(after)) {
             return false;
         }
@@ -718,6 +798,19 @@ fn renderMathBody(writer: *std.Io.Writer, body: []const u8) anyerror!void {
             if (std.mem.eql(u8, name, "sqrt")) {
                 i = try writeSqrt(writer, body, j);
                 continue;
+            }
+
+            // Text-mode commands (\text, \textbf, \mathrm, ...) typeset their
+            // operand in literal text mode — the content must NOT be re-parsed
+            // as math. Emit the brace-group operand verbatim so characters
+            // like `_` and `^` stay literal (e.g. `\text{user_id}` becomes
+            // `user_id`, not `userᵢd`).
+            if (isTextModeCommand(name) and j < body.len and body[j] == '{') {
+                if (readGroup(body, j)) |grp| {
+                    try writer.writeAll(body[j + 1 .. grp.end - 1]);
+                    i = grp.end;
+                    continue;
+                }
             }
 
             if (lookupCommand(name)) |sym| {
@@ -846,6 +939,51 @@ fn isUppercaseShellName(s: []const u8) bool {
         if (!(std.ascii.isUpper(c) or c == '_')) return false;
     }
     return true;
+}
+
+/// Returns true when `s` is all ASCII alphanumeric or underscore — the shape
+/// of a shell variable name like `foo`, `HOME`, or `user_id`. Used to detect
+/// adjacent shell-variable path patterns like `$foo/$bar` without rejecting
+/// real math like `$a/b$` (which contains `/` inside the body).
+fn isShellNameLike(s: []const u8) bool {
+    if (s.len == 0) return false;
+    for (s) |c| {
+        if (!(std.ascii.isAlphanumeric(c) or c == '_')) return false;
+    }
+    return true;
+}
+
+/// Returns true when the rendered math text contains a character that
+/// ZigZag's `renderInline` would reinterpret (`*`, `_`, backtick, `[`, `]`,
+/// `<`, `>`). When false, the span needs no inline-code wrapper and can be
+/// emitted raw — this avoids leaking literal backticks inside styled contexts
+/// (bold, italic, headings, blockquotes) that bypass `renderInline`.
+fn needsMathProtection(text: []const u8) bool {
+    for (text) |c| {
+        if (c == '*' or c == '_' or c == '`' or c == '[' or c == ']' or
+            c == '<' or c == '>')
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
+/// Returns true for LaTeX commands that typeset their `{...}` operand in
+/// literal text mode, meaning the operand must be emitted verbatim without
+/// being re-parsed as math (so `_`, `^`, etc. inside the operand stay literal
+/// rather than being converted to sub/superscripts).
+fn isTextModeCommand(name: []const u8) bool {
+    const text_cmds = [_][]const u8{
+        "text",    "textbf",  "textit",  "textrm",  "texttt", "textsf",
+        "emph",    "underline", "mathrm", "mathit", "mathbf", "mathsf",
+        "mathtt",  "mathcal", "mathbb",  "boldsymbol", "pmb",
+        "operatorname",
+    };
+    for (text_cmds) |cmd| {
+        if (std.mem.eql(u8, name, cmd)) return true;
+    }
+    return false;
 }
 
 const FracOperand = struct {
@@ -1342,8 +1480,10 @@ test "inline math after operators renders" {
     const src = "f(x)=$x^2$ and value:$v$";
     const out = try preprocess(std.testing.allocator, src);
     defer std.testing.allocator.free(out);
-    try std.testing.expect(std.mem.indexOf(u8, out, "f(x)=`x²`") != null);
-    try std.testing.expect(std.mem.indexOf(u8, out, "value:`v`") != null);
+    // Rendered math contains no Markdown metacharacters, so no inline-code
+    // wrapper is emitted — the formulas integrate directly into prose.
+    try std.testing.expect(std.mem.indexOf(u8, out, "f(x)=x²") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "value:v") != null);
     try std.testing.expect(std.mem.indexOf(u8, out, "$x^2$") == null);
     try std.testing.expect(std.mem.indexOf(u8, out, "$v$") == null);
 }
@@ -1361,8 +1501,9 @@ test "escaped dollar inside inline math is not treated as closer" {
     const out = try preprocess(std.testing.allocator, src);
     defer std.testing.allocator.free(out);
     // The escaped \$ should render as a literal $ and the real closing $ should
-    // terminate the math span, so the whole formula renders as "`x = $5`".
-    try std.testing.expect(std.mem.indexOf(u8, out, "price `x = $5`") != null);
+    // terminate the math span. Rendered text "x = $5" has no Markdown
+    // metacharacters, so no inline-code wrapper is emitted.
+    try std.testing.expect(std.mem.indexOf(u8, out, "price x = $5") != null);
     try std.testing.expect(std.mem.indexOf(u8, out, "price $x = \\5") == null);
 }
 
@@ -1413,7 +1554,8 @@ test "plain brackets still allow inline math" {
     const src = "value is [x] = $x$ ok";
     const out = try preprocess(std.testing.allocator, src);
     defer std.testing.allocator.free(out);
-    try std.testing.expect(std.mem.indexOf(u8, out, "[x] = `x` ok") != null);
+    // Rendered "x" has no metacharacters — no wrapper needed.
+    try std.testing.expect(std.mem.indexOf(u8, out, "[x] = x ok") != null);
 }
 
 test "bare url with dollar variables stays verbatim" {
@@ -1799,14 +1941,16 @@ test "inline math allows lowercase prose suffixes" {
     const src = "the $n$th term";
     const out = try preprocess(std.testing.allocator, src);
     defer std.testing.allocator.free(out);
-    try std.testing.expect(std.mem.indexOf(u8, out, "`n`th") != null);
+    // Rendered "n" has no metacharacters — no wrapper, integrates with "th".
+    try std.testing.expect(std.mem.indexOf(u8, out, "the nth term") != null);
 }
 
 test "division before inline math is not treated as a route" {
     const src = "the rate is 1/$n$";
     const out = try preprocess(std.testing.allocator, src);
     defer std.testing.allocator.free(out);
-    try std.testing.expect(std.mem.indexOf(u8, out, "1/`n`") != null);
+    // Rendered "n" has no metacharacters — no wrapper.
+    try std.testing.expect(std.mem.indexOf(u8, out, "1/n") != null);
     try std.testing.expect(std.mem.indexOf(u8, out, "1/$n$") == null);
 }
 
@@ -1837,15 +1981,17 @@ test "positive latex spacing commands produce a space" {
     const src = "$a\\;b$ and $x\\:y$";
     const out = try preprocess(std.testing.allocator, src);
     defer std.testing.allocator.free(out);
-    try std.testing.expect(std.mem.indexOf(u8, out, "`a b`") != null);
-    try std.testing.expect(std.mem.indexOf(u8, out, "`x y`") != null);
+    // "a b" / "x y" have no metacharacters — no wrapper.
+    try std.testing.expect(std.mem.indexOf(u8, out, "a b") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "x y") != null);
 }
 
 test "negative latex spacing command is dropped" {
     const src = "$a\\!b$";
     const out = try preprocess(std.testing.allocator, src);
     defer std.testing.allocator.free(out);
-    try std.testing.expect(std.mem.indexOf(u8, out, "`ab`") != null);
+    // "ab" has no metacharacters — no wrapper.
+    try std.testing.expect(std.mem.indexOf(u8, out, "ab") != null);
 }
 
 test "uppercase math with slash or minus renders" {
@@ -1854,8 +2000,9 @@ test "uppercase math with slash or minus renders" {
     const src = "$A/B$ and $X - Y$";
     const out = try preprocess(std.testing.allocator, src);
     defer std.testing.allocator.free(out);
-    try std.testing.expect(std.mem.indexOf(u8, out, "`A/B`") != null);
-    try std.testing.expect(std.mem.indexOf(u8, out, "`X - Y`") != null);
+    // Rendered forms have no Markdown metacharacters — no wrapper.
+    try std.testing.expect(std.mem.indexOf(u8, out, "A/B") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "X - Y") != null);
     try std.testing.expect(std.mem.indexOf(u8, out, "$A/B$") == null);
     try std.testing.expect(std.mem.indexOf(u8, out, "$X - Y$") == null);
 }
@@ -1877,8 +2024,8 @@ test "parenthesized math is not swallowed as a route" {
     const src = "value ($A/B$)";
     const out = try preprocess(std.testing.allocator, src);
     defer std.testing.allocator.free(out);
-    try std.testing.expect(std.mem.indexOf(u8, out, "`A/B`") != null);
-    try std.testing.expect(std.mem.indexOf(u8, out, "$/A/B$") == null);
+    // "A/B" has no metacharacters — no wrapper.
+    try std.testing.expect(std.mem.indexOf(u8, out, "(A/B)") != null);
 }
 
 test "uppercase shell variable suffix stays raw" {
@@ -1893,9 +2040,78 @@ test "uppercase shell variable suffix stays raw" {
 
 test "lowercase prose suffix after math renders" {
     // Document intended behavior: lowercase suffixes like `$x$_tmp` are
-    // treated as prose and render the math.
+    // treated as prose and render the math. "x" has no metacharacters —
+    // no wrapper, integrates directly with "_tmp".
     const src = "file $x$_tmp";
     const out = try preprocess(std.testing.allocator, src);
     defer std.testing.allocator.free(out);
-    try std.testing.expect(std.mem.indexOf(u8, out, "`x`_tmp") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "file x_tmp") != null);
+}
+
+test "math wrapper omitted inside styled markdown contexts" {
+    // Regression for P2: when rendered math has no Markdown metacharacters,
+    // no inline-code wrapper is emitted — this prevents literal backticks
+    // from leaking inside **bold**, # headings, and > blockquotes (contexts
+    // ZigZag renders without recursing into renderInline).
+    const src = "**Energy: $E=mc^2$**";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    // "E=mc²" has no metacharacters: no wrapper, integrates cleanly into bold.
+    try std.testing.expect(std.mem.indexOf(u8, out, "**Energy: E=mc²**") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "`E=mc²`") == null);
+}
+
+test "math wrapper still applied when metacharacters present" {
+    // When rendered math DOES contain a Markdown metacharacter, the inline-code
+    // wrapper is still emitted so ZigZag's inline parser doesn't reinterpret it.
+    const src = "formula $a*b*c$ here";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "`a*b*c`") != null);
+}
+
+test "lowercase shell variables with path separators stay raw" {
+    // Regression for P2: $foo/$bar and $prefix-$suffix are shell-variable
+    // paths, not math formulas.
+    const src = "vars $foo/$bar and $prefix-$suffix";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "$foo/$bar") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "$prefix-$suffix") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "`foo`") == null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "`prefix`") == null);
+}
+
+test "inline math closer skips bare url placeholders" {
+    // Regression for P2: a literal dollar in prose must not pair with a
+    // dollar inside a later bare URL.
+    const src = "Pay $5; details: https://example.com/$id$ here";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    // The URL must survive verbatim with its $id$ placeholder intact.
+    try std.testing.expect(std.mem.indexOf(u8, out, "https://example.com/$id$") != null);
+    // The prose dollar must not swallow the URL as a math body.
+    try std.testing.expect(std.mem.indexOf(u8, out, "`5; details:") == null);
+}
+
+test "text command preserves literal operand" {
+    // Regression for P2: \text{...} must emit its operand verbatim so
+    // characters like _ and ^ stay literal (LaTeX text mode), not parsed
+    // as sub/superscripts.
+    const src = "label $\\text{user_id}$ end";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "user_id") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "userᵢd") == null);
+}
+
+test "styled text commands preserve literal operand" {
+    // \textbf, \textit, \mathrm, etc. also operate in text mode — their
+    // operands must not have _ or ^ reparsed as math.
+    const src = "vars $\\textbf{x_id}$ and $\\mathrm{a^b}$";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "x_id") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "a^b") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "xᵢ") == null);
 }

--- a/zig/src/tui/markdown.zig
+++ b/zig/src/tui/markdown.zig
@@ -139,6 +139,10 @@ fn consumeInlineCode(writer: *std.Io.Writer, source: []const u8, i: *usize) anye
 fn consumeIndentedCodeBlock(writer: *std.Io.Writer, source: []const u8, i: *usize) anyerror!bool {
     const start = i.*;
     if (!isIndentedCodeLine(source, start)) return false;
+    // Four-space indentation immediately under an open list item is a list
+    // continuation, not a top-level indented code block; allow normal math
+    // preprocessing there.
+    if (isInsideListContinuation(source, start)) return false;
 
     var end = start;
     while (end < source.len) {
@@ -156,6 +160,28 @@ fn isIndentedCodeLine(source: []const u8, line_start: usize) bool {
     if (line_start >= source.len) return false;
     if (source[line_start] == '\t') return true;
     return line_start + 4 <= source.len and std.mem.eql(u8, source[line_start .. line_start + 4], "    ");
+}
+
+fn isInsideListContinuation(source: []const u8, line_start: usize) bool {
+    if (line_start <= 1) return false;
+    var scan_end = line_start - 2; // skip the newline immediately before this line
+    while (true) {
+        var scan_start = scan_end;
+        while (scan_start > 0 and source[scan_start - 1] != '\n') scan_start -= 1;
+        const line = source[scan_start .. scan_end + 1];
+        const trimmed = std.mem.trimStart(u8, line, " \t");
+        if (trimmed.len == 0) return false;
+        if (isListMarkerLine(trimmed)) return true;
+        if (scan_start <= 1) return false;
+        scan_end = scan_start - 2;
+    }
+}
+
+fn isListMarkerLine(trimmed: []const u8) bool {
+    if (std.mem.startsWith(u8, trimmed, "- ") or std.mem.startsWith(u8, trimmed, "* ")) return true;
+    var i: usize = 0;
+    while (i < trimmed.len and std.ascii.isDigit(trimmed[i])) i += 1;
+    return i > 0 and i + 1 < trimmed.len and trimmed[i] == '.' and trimmed[i + 1] == ' ';
 }
 
 fn lineBounds(source: []const u8, pos: usize) struct { start: usize, end: usize } {
@@ -699,8 +725,8 @@ fn findUnescapedDoubleDollar(source: []const u8, start: usize) ?usize {
 /// contexts that ZigZag renders without recursing into `renderInline` (bold,
 /// italic, headings, blockquotes), where the wrapper would be displayed as a
 /// visible character rather than acting as a code-span boundary.
-fn writeProtectedMathSpan(writer: *std.Io.Writer, text: []const u8) anyerror!void {
-    if (!needsMathProtection(text)) {
+fn writeProtectedMathSpan(writer: *std.Io.Writer, source: []const u8, open: usize, text: []const u8) anyerror!void {
+    if (!needsMathProtection(source, open, text)) {
         try writer.writeAll(text);
         return;
     }
@@ -840,13 +866,13 @@ fn consumeInlineMath(allocator: std.mem.Allocator, writer: *std.Io.Writer, sourc
     // Uppercase-only bodies are additionally rejected when followed by any
     // identifier (`$HOME$var`).
     if (source[close - 1] == ' ') return false;
-    if (body.len > 0 and (body[body.len - 1] == '/' or body[body.len - 1] == '-')) {
-        if (close + 1 < source.len and isIdentifierChar(source[close + 1])) return false;
+    if (body.len > 0 and isShellVarSeparator(body[body.len - 1])) {
+        if (close + 1 < source.len and isIdentifierChar(source[close + 1]) and isShellNameLike(body[0 .. body.len - 1])) return false;
     }
     if (close + 1 < source.len) {
         const after = source[close + 1];
         if (after == '$' or after == '{' or std.ascii.isDigit(after)) return false;
-        if ((after == '/' or after == '-') and isShellNameLike(body)) return false;
+        if (isShellVarSeparator(after) and isShellNameLike(body)) return false;
         if (isUppercaseShellName(body) and isIdentifierChar(after)) return false;
         if (std.ascii.isAlphabetic(after) and std.ascii.isUpper(after)) {
             return false;
@@ -865,7 +891,7 @@ fn consumeInlineMath(allocator: std.mem.Allocator, writer: *std.Io.Writer, sourc
     defer rendered.deinit();
     try renderMathBody(&rendered.writer, body);
     if (protect_math and !isInsideNonRecursiveMarkdownStyle(source, open, close)) {
-        try writeProtectedMathSpan(writer, rendered.written());
+        try writeProtectedMathSpan(writer, source, open, rendered.written());
     } else {
         try writer.writeAll(rendered.written());
     }
@@ -1093,12 +1119,18 @@ fn isShellNameLike(s: []const u8) bool {
     return true;
 }
 
+fn isShellVarSeparator(c: u8) bool {
+    return c == '/' or c == '-' or c == ':' or c == '@' or c == '.';
+}
+
 /// Returns true when the rendered math text contains a character that
 /// ZigZag's `renderInline` would reinterpret (`*`, `_`, backtick, `[`, `]`,
-/// `<`, `>`). When false, the span needs no inline-code wrapper and can be
-/// emitted raw — this avoids leaking literal backticks inside styled contexts
-/// (bold, italic, headings, blockquotes) that bypass `renderInline`.
-fn needsMathProtection(text: []const u8) bool {
+/// `<`, `>`) or when emitting it at this source position would create a
+/// block-level Markdown construct. When false, the span needs no inline-code
+/// wrapper and can be emitted raw — this avoids leaking literal backticks
+/// inside styled contexts (bold, italic, headings, blockquotes) that bypass
+/// `renderInline`.
+fn needsMathProtection(source: []const u8, open: usize, text: []const u8) bool {
     for (text) |c| {
         if (c == '*' or c == '_' or c == '`' or c == '[' or c == ']' or
             c == '<' or c == '>')
@@ -1106,7 +1138,29 @@ fn needsMathProtection(text: []const u8) bool {
             return true;
         }
     }
-    return false;
+    return startsBlockMarkdownAtSourcePosition(source, open, text);
+}
+
+fn startsBlockMarkdownAtSourcePosition(source: []const u8, open: usize, text: []const u8) bool {
+    const bounds = lineBounds(source, open);
+    const before = source[bounds.start..open];
+    if (std.mem.indexOfNone(u8, before, " \t") != null) return false;
+
+    if (std.mem.startsWith(u8, text, "# ")) return true;
+    if (std.mem.startsWith(u8, text, "- ") or std.mem.startsWith(u8, text, "* ")) return true;
+    if (text.len >= 3 and isAllMarkdownRuleChar(text, '-')) return true;
+    if (text.len >= 3 and isAllMarkdownRuleChar(text, '*')) return true;
+
+    var i: usize = 0;
+    while (i < text.len and std.ascii.isDigit(text[i])) i += 1;
+    return i > 0 and i + 1 < text.len and text[i] == '.' and text[i + 1] == ' ';
+}
+
+fn isAllMarkdownRuleChar(text: []const u8, c: u8) bool {
+    for (text) |ch| {
+        if (ch != c and ch != ' ') return false;
+    }
+    return true;
 }
 
 /// Returns true for LaTeX commands that typeset their `{...}` operand in
@@ -2375,4 +2429,45 @@ test "inline closer skips complete markdown links" {
     try std.testing.expect(std.mem.indexOf(u8, out, "Pay $5; see [x](https://example.com) now") != null);
     try std.testing.expect(std.mem.indexOf(u8, out, "`5; see [") == null);
     try std.testing.expect(std.mem.indexOf(u8, out, "x$](https://example.com)") == null);
+}
+
+
+test "lowercase shell variables separated by punctuation stay raw" {
+    const src = "connect $host:$port as $user@$host via $name.$domain";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "$host:$port") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "$user@$host") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "$name.$domain") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "host:port") == null);
+}
+
+test "line-start inline math that renders block marker is protected" {
+    const heading_src = "$\\# S$";
+    const heading = try preprocess(std.testing.allocator, heading_src);
+    defer std.testing.allocator.free(heading);
+    try std.testing.expect(std.mem.indexOf(u8, heading, "`# S`") != null);
+
+    const rule_src = "$---$";
+    const rule = try preprocess(std.testing.allocator, rule_src);
+    defer std.testing.allocator.free(rule);
+    try std.testing.expect(std.mem.indexOf(u8, rule, "`---`") != null);
+
+    const list_src = "$- item$";
+    const list = try preprocess(std.testing.allocator, list_src);
+    defer std.testing.allocator.free(list);
+    try std.testing.expect(std.mem.indexOf(u8, list, "`- item`") != null);
+
+    const ordered_src = "$1. item$";
+    const ordered = try preprocess(std.testing.allocator, ordered_src);
+    defer std.testing.allocator.free(ordered);
+    try std.testing.expect(std.mem.indexOf(u8, ordered, "`1. item`") != null);
+}
+
+test "indented list continuation math is rendered" {
+    const src = "- Formula:\n    $x^2$";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "    x²") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "    $x^2$") == null);
 }

--- a/zig/src/tui/markdown.zig
+++ b/zig/src/tui/markdown.zig
@@ -51,6 +51,7 @@ fn preprocessWithOptions(allocator: std.mem.Allocator, source: []const u8, prote
         if (isAtLineStart(source, i)) {
             if (try consumeFenceBlock(allocator, writer, source, &i)) continue;
             if (try consumeTildeFenceBlock(allocator, writer, source, &i)) continue;
+            if (try consumeIndentedCodeBlock(writer, source, &i)) continue;
         }
 
         // 2. Markdown inline links, bare URLs, and relative path/URL
@@ -130,6 +131,68 @@ fn consumeInlineCode(writer: *std.Io.Writer, source: []const u8, i: *usize) anye
     try writer.writeAll(source[start..line_end]);
     i.* = line_end;
     return true;
+}
+
+/// Consume a contiguous Markdown indented code block (four spaces or one tab)
+/// verbatim. These blocks are not fenced, but their contents are still literal
+/// code and must not be preprocessed as math.
+fn consumeIndentedCodeBlock(writer: *std.Io.Writer, source: []const u8, i: *usize) anyerror!bool {
+    const start = i.*;
+    if (!isIndentedCodeLine(source, start)) return false;
+
+    var end = start;
+    while (end < source.len) {
+        if (!isAtLineStart(source, end) or !isIndentedCodeLine(source, end)) break;
+        const line_end = std.mem.indexOfScalarPos(u8, source, end, '\n') orelse source.len;
+        end = if (line_end < source.len) line_end + 1 else source.len;
+    }
+
+    try writer.writeAll(source[start..end]);
+    i.* = end;
+    return true;
+}
+
+fn isIndentedCodeLine(source: []const u8, line_start: usize) bool {
+    if (line_start >= source.len) return false;
+    if (source[line_start] == '\t') return true;
+    return line_start + 4 <= source.len and std.mem.eql(u8, source[line_start .. line_start + 4], "    ");
+}
+
+fn lineBounds(source: []const u8, pos: usize) struct { start: usize, end: usize } {
+    var start = pos;
+    while (start > 0 and source[start - 1] != '\n') start -= 1;
+    const end = std.mem.indexOfScalarPos(u8, source, pos, '\n') orelse source.len;
+    return .{ .start = start, .end = end };
+}
+
+/// ZigZag styles headings, blockquotes, bold, and italic directly without
+/// recursively invoking `renderInline`. Inside those contexts, an inline-code
+/// wrapper would be displayed literally, so protection must be skipped.
+fn isInsideNonRecursiveMarkdownStyle(source: []const u8, open: usize, close: usize) bool {
+    const bounds = lineBounds(source, open);
+    const line = source[bounds.start..bounds.end];
+    const rel_open = open - bounds.start;
+    const rel_close = close - bounds.start;
+    const trimmed_start = std.mem.indexOfNonePos(u8, line, 0, " ") orelse line.len;
+    const trimmed = line[trimmed_start..];
+
+    if (std.mem.startsWith(u8, trimmed, "# ") or
+        std.mem.startsWith(u8, trimmed, "## ") or
+        std.mem.startsWith(u8, trimmed, "### ") or
+        std.mem.startsWith(u8, trimmed, "> "))
+    {
+        return true;
+    }
+
+    if (isBetweenDelimiters(line, rel_open, rel_close, "**")) return true;
+    if (isBetweenDelimiters(line, rel_open, rel_close, "*")) return true;
+    return false;
+}
+
+fn isBetweenDelimiters(line: []const u8, rel_open: usize, rel_close: usize, delim: []const u8) bool {
+    const before = line[0..rel_open];
+    const after = line[rel_close + 1 ..];
+    return std.mem.lastIndexOf(u8, before, delim) != null and std.mem.indexOf(u8, after, delim) != null;
 }
 
 /// Consume a Markdown inline link `[text](url)`. Preprocesses the visible
@@ -522,28 +585,22 @@ fn findInlineMathClose(source: []const u8, start: usize) ?usize {
         // Skip inline code spans — their `$` chars are not math delimiters.
         if (source[i] == '`') {
             const tick_count = countLeadingChar(source[i..], '`');
-            if (tick_count < 3) {
-                var scan = i + tick_count;
-                var found_close = false;
-                while (scan < source.len) {
-                    if (source[scan] == '`') {
-                        const close_count = countLeadingChar(source[scan..], '`');
-                        if (close_count == tick_count) {
-                            i = scan + close_count;
-                            found_close = true;
-                            break;
-                        }
-                        scan += close_count;
-                        continue;
+            var scan = i + tick_count;
+            var found_close = false;
+            while (scan < source.len) {
+                if (source[scan] == '`') {
+                    const close_count = countLeadingChar(source[scan..], '`');
+                    if (close_count == tick_count) {
+                        i = scan + close_count;
+                        found_close = true;
+                        break;
                     }
-                    scan += 1;
+                    scan += close_count;
+                    continue;
                 }
-                if (!found_close) return null;
-                continue;
+                scan += 1;
             }
-            // 3+ backticks — unusual inline; skip past the run and let the
-            // outer walker handle it.
-            i += tick_count;
+            if (!found_close) return null;
             continue;
         }
         // Skip bare URLs — their `$` placeholders are not math delimiters.
@@ -752,7 +809,7 @@ fn consumeInlineMath(allocator: std.mem.Allocator, writer: *std.Io.Writer, sourc
     var rendered: std.Io.Writer.Allocating = .init(allocator);
     defer rendered.deinit();
     try renderMathBody(&rendered.writer, body);
-    if (protect_math) {
+    if (protect_math and !isInsideNonRecursiveMarkdownStyle(source, open, close)) {
         try writeProtectedMathSpan(writer, rendered.written());
     } else {
         try writer.writeAll(rendered.written());
@@ -2210,4 +2267,44 @@ test "unterminated block math in prose preserves dollars" {
     // The `$$` must survive, not be eaten or reparsed.
     try std.testing.expect(std.mem.indexOf(u8, out, "$$x$") != null);
     try std.testing.expect(std.mem.indexOf(u8, out, "`x`") == null);
+}
+
+
+test "inline closer skips triple-backtick code spans" {
+    // Regression for P2: a literal dollar before a mid-line triple-backtick
+    // span must not pair with dollars inside that protected code span.
+    const src = "Pay $5; run ```echo $x$``` now";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expectEqualStrings(src, out);
+}
+
+test "protection wrapper omitted in non-recursive markdown styles" {
+    // ZigZag styles bold/headings/blockquotes without recursively parsing
+    // inline spans. A backtick wrapper would therefore show literally there.
+    const bold_src = "**Index $x_j$**";
+    const bold = try preprocess(std.testing.allocator, bold_src);
+    defer std.testing.allocator.free(bold);
+    try std.testing.expect(std.mem.indexOf(u8, bold, "**Index x_j**") != null);
+    try std.testing.expect(std.mem.indexOf(u8, bold, "`x_j`") == null);
+
+    const heading_src = "# $x_j$";
+    const heading = try preprocess(std.testing.allocator, heading_src);
+    defer std.testing.allocator.free(heading);
+    try std.testing.expect(std.mem.indexOf(u8, heading, "# x_j") != null);
+    try std.testing.expect(std.mem.indexOf(u8, heading, "`x_j`") == null);
+
+    const quote_src = "> $x_j$";
+    const quote = try preprocess(std.testing.allocator, quote_src);
+    defer std.testing.allocator.free(quote);
+    try std.testing.expect(std.mem.indexOf(u8, quote, "> x_j") != null);
+    try std.testing.expect(std.mem.indexOf(u8, quote, "`x_j`") == null);
+}
+
+test "indented code block is preserved verbatim" {
+    const src = "intro\n\n    const formula = \"$x^2$\";\n\noutro $y$";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "    const formula = \"$x^2$\";") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "outro y") != null);
 }

--- a/zig/src/tui/markdown.zig
+++ b/zig/src/tui/markdown.zig
@@ -30,6 +30,10 @@ const std = @import("std");
 /// math spans and Mermaid blocks rewritten. The caller owns the returned
 /// slice.
 pub fn preprocess(allocator: std.mem.Allocator, source: []const u8) ![]u8 {
+    return preprocessWithOptions(allocator, source, true);
+}
+
+fn preprocessWithOptions(allocator: std.mem.Allocator, source: []const u8, protect_math: bool) anyerror![]u8 {
     if (source.len == 0) return allocator.dupe(u8, source);
 
     var out: std.Io.Writer.Allocating = .init(allocator);
@@ -75,7 +79,7 @@ pub fn preprocess(allocator: std.mem.Allocator, source: []const u8) ![]u8 {
 
         // 5. Inline math `$...$`.
         if (source[i] == '$') {
-            if (try consumeInlineMath(allocator, writer, source, &i)) continue;
+            if (try consumeInlineMath(allocator, writer, source, &i, protect_math)) continue;
         }
 
         // 5. Plain byte.
@@ -94,11 +98,14 @@ fn isAtLineStart(source: []const u8, i: usize) bool {
 /// Consume an inline code span verbatim. Returns false for fenced code block
 /// runs (handled by consumeFenceBlock) and unterminated spans so the default
 /// byte path preserves source.
-fn consumeInlineCode(writer: *std.Io.Writer, source: []const u8, i: *usize) !bool {
+fn consumeInlineCode(writer: *std.Io.Writer, source: []const u8, i: *usize) anyerror!bool {
     const start = i.*;
     var tick_count: usize = 0;
     while (start + tick_count < source.len and source[start + tick_count] == '`') tick_count += 1;
-    if (tick_count >= 3) return false;
+
+    // A run of three or more backticks at the start of a line is a fenced code
+    // block opener (handled by consumeFenceBlock), not an inline code span.
+    if (tick_count >= 3 and isAtLineStart(source, start)) return false;
 
     var scan = start + tick_count;
     while (scan < source.len) : (scan += 1) {
@@ -168,9 +175,10 @@ fn consumeMarkdownLink(allocator: std.mem.Allocator, writer: *std.Io.Writer, sou
     if (paren_depth != 0 or url_end >= source.len) return false;
 
     // Preprocess the label so math inside link labels is rendered, while the
-    // URL stays verbatim.
+    // URL stays verbatim. The label is already inside a link, so it does not
+    // need the inline-code protection we use for normal prose math.
     const label_text = source[start + 1 .. text_end];
-    const processed_label = try preprocess(allocator, label_text);
+    const processed_label = try preprocessWithOptions(allocator, label_text, false);
     defer allocator.free(processed_label);
 
     try writer.writeByte('[');
@@ -448,17 +456,21 @@ fn findUnescapedDoubleDollar(source: []const u8, start: usize) ?usize {
     return null;
 }
 
-/// Write `text` to `writer` with Markdown inline metacharacters escaped so
-/// that rendered math (e.g. `a*b*c`) is not reinterpreted as emphasis, code,
-/// links, or escapes by the downstream Markdown pass.
-fn writeMarkdownEscaped(writer: *std.Io.Writer, text: []const u8) anyerror!void {
-    for (text) |c| {
-        switch (c) {
-            '*', '_', '`', '[', ']', '<', '>' => try writer.writeByte('\\'),
-            else => {},
-        }
-        try writer.writeByte(c);
+/// Wrap a rendered math span in a single-backtick inline code span so that
+/// ZigZag's renderInline treats the content as verbatim and does not reinterpret
+/// `*`, `_`, `[`, `]`, or backticks as Markdown emphasis, links, or code spans.
+/// Backslash escapes are not honored by ZigZag's parser, so this inline-code
+/// boundary is the only protection it actually respects.
+fn writeProtectedMathSpan(writer: *std.Io.Writer, text: []const u8) anyerror!void {
+    if (std.mem.indexOfScalar(u8, text, '`') != null) {
+        // ZigZag does not support multi-backtick code delimiters, so if the
+        // rendered math somehow contains a backtick, fall back to the raw text.
+        try writer.writeAll(text);
+        return;
     }
+    try writer.writeByte('`');
+    try writer.writeAll(text);
+    try writer.writeByte('`');
 }
 
 /// Try to consume a `$$...$$` block math span at `*i`. Returns true and
@@ -504,8 +516,9 @@ fn writeBlockMath(allocator: std.mem.Allocator, writer: *std.Io.Writer, body: []
     try renderMathBody(&rendered.writer, body);
 
     // Emit as a Markdown blockquote — one quote line per source line, with
-    // blank lines collapsed. Escape Markdown metacharacters in the rendered
-    // math so stars/brackets/etc. are not reinterpreted by the downstream pass.
+    // blank lines collapsed. Blockquote content is rendered as a single styled
+    // span by ZigZag and is not run through its inline formatter, so Markdown
+    // metacharacters in the rendered math do not need additional escaping.
     var lines = std.mem.splitScalar(u8, rendered.written(), '\n');
     var wrote_any = false;
     while (lines.next()) |raw_line| {
@@ -513,7 +526,7 @@ fn writeBlockMath(allocator: std.mem.Allocator, writer: *std.Io.Writer, body: []
         if (line.len == 0) continue;
         if (wrote_any) try writer.writeByte('\n');
         try writer.writeAll("> ");
-        try writeMarkdownEscaped(writer, line);
+        try writer.writeAll(line);
         wrote_any = true;
     }
     if (!wrote_any) try writer.writeAll("> ");
@@ -533,7 +546,7 @@ fn writeBlockMath(allocator: std.mem.Allocator, writer: *std.Io.Writer, body: []
 /// - `\$FOO\$` — the opener/closer is escaped by a backslash.
 /// Digit-led formulas such as `$2^n$` still render because the closer is not
 /// identifier/digit-adjacent.
-fn consumeInlineMath(allocator: std.mem.Allocator, writer: *std.Io.Writer, source: []const u8, i: *usize) !bool {
+fn consumeInlineMath(allocator: std.mem.Allocator, writer: *std.Io.Writer, source: []const u8, i: *usize, protect_math: bool) anyerror!bool {
     const open = i.*;
 
     // Opening `$` immediately after a digit is a price suffix, not math
@@ -567,12 +580,19 @@ fn consumeInlineMath(allocator: std.mem.Allocator, writer: *std.Io.Writer, sourc
     // Reject newlines — inline math is a single line.
     if (std.mem.indexOfScalar(u8, body, '\n') != null) return false;
 
-    // Render to a temporary buffer so we can escape Markdown metacharacters
-    // before inserting the result into the prose stream.
+    // Render to a temporary buffer. When inserted into normal prose, wrap the
+    // result in inline-code backticks so ZigZag's renderInline treats the whole
+    // span as verbatim and does not reinterpret * / _ / [ ] / ` etc. Link labels
+    // and other contexts that are already protected by a structural delimiter
+    // skip the wrapper.
     var rendered: std.Io.Writer.Allocating = .init(allocator);
     defer rendered.deinit();
     try renderMathBody(&rendered.writer, body);
-    try writeMarkdownEscaped(writer, rendered.written());
+    if (protect_math) {
+        try writeProtectedMathSpan(writer, rendered.written());
+    } else {
+        try writer.writeAll(rendered.written());
+    }
     i.* = close + 1;
     return true;
 }
@@ -1253,8 +1273,8 @@ test "inline math after operators renders" {
     const src = "f(x)=$x^2$ and value:$v$";
     const out = try preprocess(std.testing.allocator, src);
     defer std.testing.allocator.free(out);
-    try std.testing.expect(std.mem.indexOf(u8, out, "f(x)=x²") != null);
-    try std.testing.expect(std.mem.indexOf(u8, out, "value:v") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "f(x)=`x²`") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "value:`v`") != null);
     try std.testing.expect(std.mem.indexOf(u8, out, "$x^2$") == null);
     try std.testing.expect(std.mem.indexOf(u8, out, "$v$") == null);
 }
@@ -1272,8 +1292,8 @@ test "escaped dollar inside inline math is not treated as closer" {
     const out = try preprocess(std.testing.allocator, src);
     defer std.testing.allocator.free(out);
     // The escaped \$ should render as a literal $ and the real closing $ should
-    // terminate the math span, so the whole formula renders as "x = $5".
-    try std.testing.expect(std.mem.indexOf(u8, out, "price x = $5") != null);
+    // terminate the math span, so the whole formula renders as "`x = $5`".
+    try std.testing.expect(std.mem.indexOf(u8, out, "price `x = $5`") != null);
     try std.testing.expect(std.mem.indexOf(u8, out, "price $x = \\5") == null);
 }
 
@@ -1324,7 +1344,7 @@ test "plain brackets still allow inline math" {
     const src = "value is [x] = $x$ ok";
     const out = try preprocess(std.testing.allocator, src);
     defer std.testing.allocator.free(out);
-    try std.testing.expect(std.mem.indexOf(u8, out, "[x] = x ok") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "[x] = `x` ok") != null);
 }
 
 test "bare url with dollar variables stays verbatim" {
@@ -1361,6 +1381,15 @@ test "multi-backtick inline code span is not parsed as math" {
     const out = try preprocess(std.testing.allocator, src);
     defer std.testing.allocator.free(out);
     try std.testing.expect(std.mem.indexOf(u8, out, "``echo $x$``") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "echo x") == null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "α") != null);
+}
+
+test "triple-backtick inline code span is not parsed as math" {
+    const src = "Use ```echo $x$``` then $\\alpha$";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "```echo $x$```") != null);
     try std.testing.expect(std.mem.indexOf(u8, out, "echo x") == null);
     try std.testing.expect(std.mem.indexOf(u8, out, "α") != null);
 }
@@ -1641,14 +1670,14 @@ test "nested script braces preserve inner group" {
     try std.testing.expect(std.mem.indexOf(u8, out, "\\frac{1}2") == null);
 }
 
-test "inline math escapes markdown metacharacters" {
+test "inline math protects markdown metacharacters with inline code" {
     const src = "product $a*b*c$ and sum $x[y](z)$";
     const out = try preprocess(std.testing.allocator, src);
     defer std.testing.allocator.free(out);
-    // Stars and brackets inside rendered math must be escaped so they are not
-    // reinterpreted as emphasis or links by the downstream Markdown pass.
-    try std.testing.expect(std.mem.indexOf(u8, out, "a\\*b\\*c") != null);
-    try std.testing.expect(std.mem.indexOf(u8, out, "x\\[y\\](z)") != null);
+    // Rendered math is wrapped in backticks so ZigZag's renderInline treats
+    // the span as verbatim and does not reinterpret * / _ / [ ] as Markdown.
+    try std.testing.expect(std.mem.indexOf(u8, out, "`a*b*c`") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "`x[y](z)`") != null);
 }
 
 test "block math forces line boundaries around prose" {

--- a/zig/src/tui/markdown.zig
+++ b/zig/src/tui/markdown.zig
@@ -47,19 +47,25 @@ pub fn preprocess(allocator: std.mem.Allocator, source: []const u8) ![]u8 {
             if (try consumeFenceBlock(allocator, writer, source, &i)) continue;
         }
 
-        // 2. Inline code spans must stay raw. Protect them before math checks
+        // 2. Markdown inline links must stay raw. Protect their destinations
+        //    before math checks so URLs like `/users/$user_id$` survive.
+        if (source[i] == '[') {
+            if (try consumeMarkdownLink(writer, source, &i)) continue;
+        }
+
+        // 3. Inline code spans must stay raw. Protect them before math checks
         //    so snippets like `echo $x$` remain copyable.
         if (source[i] == '`') {
             if (try consumeInlineCode(writer, source, &i)) continue;
         }
 
-        // 3. Block math `$$...$$`. Checked before inline `$` so the leading
+        // 4. Block math `$$...$$`. Checked before inline `$` so the leading
         //    `$$` isn't mis-parsed as two adjacent single-dollar spans.
         if (i + 1 < source.len and source[i] == '$' and source[i + 1] == '$') {
             if (try consumeBlockMath(allocator, writer, source, &i)) continue;
         }
 
-        // 4. Inline math `$...$`.
+        // 5. Inline math `$...$`.
         if (source[i] == '$') {
             if (try consumeInlineMath(writer, source, &i)) continue;
         }
@@ -99,6 +105,62 @@ fn consumeInlineCode(writer: *std.Io.Writer, source: []const u8, i: *usize) !boo
         scan += close_count - 1;
     }
     return false;
+}
+
+/// Consume a Markdown inline link `[text](url)` verbatim. Returns false when
+/// the bytes at `*i` don't form a complete link so the default byte path
+/// preserves the source. Link destinations may contain `$` chars that must not
+/// be interpreted as inline math, so the whole link is copied unchanged.
+fn consumeMarkdownLink(writer: *std.Io.Writer, source: []const u8, i: *usize) !bool {
+    const start = i.*;
+    if (start >= source.len or source[start] != '[') return false;
+
+    // Find the matching `]` for link text, respecting nested brackets and
+    // escaped brackets (e.g. `\]`).
+    var text_end = start + 1;
+    var bracket_depth: usize = 1;
+    while (text_end < source.len) {
+        const c = source[text_end];
+        if (c == '\\' and text_end + 1 < source.len) {
+            text_end += 2;
+            continue;
+        }
+        if (c == '[') bracket_depth += 1;
+        if (c == ']') {
+            bracket_depth -= 1;
+            if (bracket_depth == 0) break;
+        }
+        text_end += 1;
+    }
+    if (bracket_depth != 0 or text_end >= source.len) return false;
+
+    // Inline links are followed by `(`; reference-style `[text][ref]` is left
+    // for the default path (it has no URL destination to protect).
+    const url_start = text_end + 1;
+    if (url_start >= source.len or source[url_start] != '(') return false;
+
+    // Find the matching `)` for the URL, respecting balanced nested parens and
+    // escaped parens.
+    var url_end = url_start + 1;
+    var paren_depth: usize = 1;
+    while (url_end < source.len) {
+        const c = source[url_end];
+        if (c == '\\' and url_end + 1 < source.len) {
+            url_end += 2;
+            continue;
+        }
+        if (c == '(') paren_depth += 1;
+        if (c == ')') {
+            paren_depth -= 1;
+            if (paren_depth == 0) break;
+        }
+        url_end += 1;
+    }
+    if (paren_depth != 0 or url_end >= source.len) return false;
+
+    try writer.writeAll(source[start .. url_end + 1]);
+    i.* = url_end + 1;
+    return true;
 }
 
 // ---------------------------------------------------------------------------
@@ -341,32 +403,36 @@ fn writeBlockMath(allocator: std.mem.Allocator, writer: *std.Io.Writer, body: []
 /// - `5$` — opening `$` preceded by a digit.
 /// - `$5-$10`, `$5/$10` — the closer is followed by a digit.
 /// - `$HOME/$PATH` — the closer is followed by an identifier char.
+/// - `${HOME}/${XDG_CONFIG_HOME}` — the opener or closer is followed by `{`
+///   (braced shell/config variables), so both dollar signs survive.
 /// Digit-led formulas such as `$2^n$` still render because the closer is not
 /// identifier/digit-adjacent.
 fn consumeInlineMath(writer: *std.Io.Writer, source: []const u8, i: *usize) !bool {
     const open = i.*;
 
     // Opening `$` immediately after a digit is a price suffix, not math
-    // (`5$`). Other punctuation/operators like `=` or `:` are allowed so
+    // (`5$`). A `$` followed by `{` is a braced shell/config variable, not
+    // math. Other punctuation/operators like `=` or `:` are allowed so
     // common forms such as `f(x)=$x^2$` and `value:$v$` render.
     if (open > 0 and std.ascii.isDigit(source[open - 1])) return false;
     // Body must start with a non-space and non-`$` char.
     if (open + 1 >= source.len) return false;
     {
         const next = source[open + 1];
-        if (next == ' ' or next == '$') return false;
+        if (next == ' ' or next == '$' or next == '{') return false;
     }
 
     const body_start = open + 1;
     const close = std.mem.indexOfScalarPos(u8, source, body_start, '$') orelse return false;
 
     // Closing `$` must not be preceded by whitespace, followed by another
-    // `$`, followed by a digit (currency ranges), or followed by an
-    // identifier char (adjacent shell vars like `$HOME/$PATH`).
+    // `$`, followed by a digit (currency ranges), followed by an identifier
+    // char (adjacent shell vars like `$HOME/$PATH`), or followed by `{`
+    // (braced shell variables like `${HOME}`).
     if (source[close - 1] == ' ') return false;
     if (close + 1 < source.len) {
         const after = source[close + 1];
-        if (after == '$' or std.ascii.isDigit(after) or isIdentifierChar(after)) return false;
+        if (after == '$' or after == '{' or std.ascii.isDigit(after) or isIdentifierChar(after)) return false;
     }
 
     const body = source[body_start..close];
@@ -1031,6 +1097,34 @@ test "adjacent shell variables are not parsed as math" {
     const out = try preprocess(std.testing.allocator, src);
     defer std.testing.allocator.free(out);
     try std.testing.expectEqualStrings(src, out);
+}
+
+test "braced shell variables are not parsed as math" {
+    const src = "use ${HOME}/${XDG_CONFIG_HOME} here";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expectEqualStrings(src, out);
+}
+
+test "markdown link destination with dollar variables stays verbatim" {
+    const src = "[API](https://api.example.com/users/$user_id$)";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expectEqualStrings(src, out);
+}
+
+test "markdown link with nested parens in destination stays verbatim" {
+    const src = "[link](https://example.com/a(b)c)";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expectEqualStrings(src, out);
+}
+
+test "plain brackets still allow inline math" {
+    const src = "value is [x] = $x$ ok";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "[x] = x ok") != null);
 }
 
 test "inline code span is not parsed as math" {

--- a/zig/src/tui/markdown.zig
+++ b/zig/src/tui/markdown.zig
@@ -77,16 +77,28 @@ fn isAtLineStart(source: []const u8, i: usize) bool {
     return source[i - 1] == '\n';
 }
 
-/// Consume a single-backtick inline code span verbatim. Returns false for
-/// triple-backtick fences (handled by consumeFenceBlock) and unterminated
-/// spans so the default byte path preserves source.
+/// Consume an inline code span verbatim. Returns false for fenced code block
+/// runs (handled by consumeFenceBlock) and unterminated spans so the default
+/// byte path preserves source.
 fn consumeInlineCode(writer: *std.Io.Writer, source: []const u8, i: *usize) !bool {
     const start = i.*;
-    if (start + 2 < source.len and source[start + 1] == '`' and source[start + 2] == '`') return false;
-    const close = std.mem.indexOfScalarPos(u8, source, start + 1, '`') orelse return false;
-    try writer.writeAll(source[start .. close + 1]);
-    i.* = close + 1;
-    return true;
+    var tick_count: usize = 0;
+    while (start + tick_count < source.len and source[start + tick_count] == '`') tick_count += 1;
+    if (tick_count >= 3) return false;
+
+    var scan = start + tick_count;
+    while (scan < source.len) : (scan += 1) {
+        if (source[scan] != '`') continue;
+        var close_count: usize = 0;
+        while (scan + close_count < source.len and source[scan + close_count] == '`') close_count += 1;
+        if (close_count == tick_count) {
+            try writer.writeAll(source[start .. scan + close_count]);
+            i.* = scan + close_count;
+            return true;
+        }
+        scan += close_count - 1;
+    }
+    return false;
 }
 
 // ---------------------------------------------------------------------------
@@ -436,11 +448,10 @@ fn renderMathBody(writer: *std.Io.Writer, body: []const u8) anyerror!void {
             try writer.writeByte('\\');
             try writer.writeAll(name);
             var after = j;
-            if (after < body.len and body[after] == '{') {
-                if (readGroup(body, after)) |grp| {
-                    try writer.writeAll(body[after..grp.end]);
-                    after = grp.end;
-                }
+            while (after < body.len and body[after] == '{') {
+                const grp = readGroup(body, after) orelse break;
+                try writer.writeAll(body[after..grp.end]);
+                after = grp.end;
             }
             i = after;
             continue;
@@ -1030,6 +1041,15 @@ test "inline code span is not parsed as math" {
     try std.testing.expect(std.mem.indexOf(u8, out, "α") != null);
 }
 
+test "multi-backtick inline code span is not parsed as math" {
+    const src = "Use ``echo $x$`` then $\\alpha$";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "``echo $x$``") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "echo x") == null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "α") != null);
+}
+
 test "unterminated block math passes through verbatim per doc" {
     const src = "text $$\\alpha no closer";
     const out = try preprocess(std.testing.allocator, src);
@@ -1061,6 +1081,14 @@ test "unknown LaTeX command with brace argument preserves group" {
     // the raw fallback stays copyable (NOT `\boxedx+1`).
     try std.testing.expect(std.mem.indexOf(u8, out, "\\boxed{x+1}") != null);
     try std.testing.expect(std.mem.indexOf(u8, out, "\\boxedx") == null);
+}
+
+test "unknown LaTeX command with multiple brace arguments preserves groups" {
+    const src = "choose $\\binom{n}{k}$ end";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "\\binom{n}{k}") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "\\binom{n}k") == null);
 }
 
 test "escaped braces inside group do not corrupt depth" {

--- a/zig/src/tui/markdown.zig
+++ b/zig/src/tui/markdown.zig
@@ -274,6 +274,52 @@ fn consumeMarkdownLink(allocator: std.mem.Allocator, writer: *std.Io.Writer, sou
     return true;
 }
 
+/// Return the end offset (exclusive) of a complete Markdown inline link
+/// `[text](url)` starting at `start`, or null when the bytes do not form a
+/// complete link. Used by the inline-math closer scan to skip protected link
+/// spans before `$` inside a label or destination can close an earlier dollar.
+fn findMarkdownLinkEnd(source: []const u8, start: usize) ?usize {
+    if (start >= source.len or source[start] != '[') return null;
+
+    var text_end = start + 1;
+    var bracket_depth: usize = 1;
+    while (text_end < source.len) {
+        const c = source[text_end];
+        if (c == '\\' and text_end + 1 < source.len) {
+            text_end += 2;
+            continue;
+        }
+        if (c == '[') bracket_depth += 1;
+        if (c == ']') {
+            bracket_depth -= 1;
+            if (bracket_depth == 0) break;
+        }
+        text_end += 1;
+    }
+    if (bracket_depth != 0 or text_end >= source.len) return null;
+
+    const url_start = text_end + 1;
+    if (url_start >= source.len or source[url_start] != '(') return null;
+
+    var url_end = url_start + 1;
+    var paren_depth: usize = 1;
+    while (url_end < source.len) {
+        const c = source[url_end];
+        if (c == '\\' and url_end + 1 < source.len) {
+            url_end += 2;
+            continue;
+        }
+        if (c == '(') paren_depth += 1;
+        if (c == ')') {
+            paren_depth -= 1;
+            if (paren_depth == 0) break;
+        }
+        url_end += 1;
+    }
+    if (paren_depth != 0 or url_end >= source.len) return null;
+    return url_end + 1;
+}
+
 /// Returns true when `source[i..]` begins with a common bare URL scheme
 /// (`http://` or `https://`).
 fn isBareUrlPrefix(source: []const u8, i: usize) bool {
@@ -617,6 +663,15 @@ fn findInlineMathClose(source: []const u8, start: usize) ?usize {
             }
             i = url_end;
             continue;
+        }
+        // Skip complete Markdown links — their label and destination are
+        // protected by the outer walker, and `$` chars inside the label or URL
+        // must not close an earlier prose/currency dollar.
+        if (source[i] == '[') {
+            if (findMarkdownLinkEnd(source, i)) |link_end| {
+                i = link_end;
+                continue;
+            }
         }
         if (source[i] == '$' and !isEscaped(source, i)) return i;
         i += 1;
@@ -2307,4 +2362,17 @@ test "indented code block is preserved verbatim" {
     defer std.testing.allocator.free(out);
     try std.testing.expect(std.mem.indexOf(u8, out, "    const formula = \"$x^2$\";") != null);
     try std.testing.expect(std.mem.indexOf(u8, out, "outro y") != null);
+}
+
+
+test "inline closer skips complete markdown links" {
+    // Regression for P2: a literal/currency dollar before a Markdown link must
+    // not pair with `$` inside the link label before consumeMarkdownLink can
+    // protect the link.
+    const src = "Pay $5; see [$x$](https://example.com) now";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "Pay $5; see [x](https://example.com) now") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "`5; see [") == null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "x$](https://example.com)") == null);
 }

--- a/zig/src/tui/markdown.zig
+++ b/zig/src/tui/markdown.zig
@@ -12,9 +12,17 @@
 //!   summary line plus the raw diagram source as a blockquote.
 //!
 //! Unknown LaTeX commands fall back to their raw form (with the leading
-//! backslash preserved) so nothing is silently dropped. The conversion is
-//! intentionally lightweight — no external math engine, no unicode table
-//! beyond a curated symbol map.
+//! backslash preserved and any `{...}` argument left intact) so nothing is
+//! silently dropped. The conversion is intentionally lightweight — no
+//! external math engine, no unicode table beyond a curated symbol map.
+//!
+//! All three transformations run in a single source pass so that:
+//! - the interior of any non-mermaid fenced code block is left untouched
+//!   (including any literal ```` ```mermaid ```` lines it may contain, and
+//!   any `$` shell variables / currency prose inside); and
+//! - the blockquote emitted for a Mermaid block is not subsequently
+//!   re-processed by the math pass (which would otherwise eat `$` labels in
+//!   the diagram source).
 
 const std = @import("std");
 
@@ -24,134 +32,131 @@ const std = @import("std");
 pub fn preprocess(allocator: std.mem.Allocator, source: []const u8) ![]u8 {
     if (source.len == 0) return allocator.dupe(u8, source);
 
-    // Pass 1: replace ```mermaid ... ``` blocks. Doing this first avoids any
-    // accidental `$`/math interaction with diagram source.
-    const after_mermaid = try replaceMermaidBlocks(allocator, source);
-    defer allocator.free(after_mermaid);
-
-    // Pass 2: replace $$...$$ block math. Done before inline math so the `$$`
-    // sentinel doesn't get mis-parsed as two adjacent `$...$` spans.
-    const after_block = try replaceBlockMath(allocator, after_mermaid);
-    defer allocator.free(after_block);
-
-    // Pass 3: replace $...$ inline math.
-    return replaceInlineMath(allocator, after_block);
-}
-
-// ---------------------------------------------------------------------------
-// Mermaid
-// ---------------------------------------------------------------------------
-
-const mermaid_fence = "```";
-const mermaid_lang = "mermaid";
-
-/// Replace each ```mermaid ... ``` block with a labeled summary plus the raw
-/// source as a Markdown blockquote. Fenced code blocks in other languages
-/// are passed through verbatim, including any literal ```mermaid lines they
-/// may contain — we walk the source line-by-line and track fence state so a
-/// mermaid syntax example embedded inside a `text`/`zig`/etc. block is not
-/// mis-transformed.
-fn replaceMermaidBlocks(allocator: std.mem.Allocator, source: []const u8) ![]u8 {
     var out: std.Io.Writer.Allocating = .init(allocator);
     errdefer out.deinit();
     const writer = &out.writer;
 
-    var cursor: usize = 0;
-    while (cursor < source.len) {
-        const fence_pos = std.mem.indexOfPos(u8, source, cursor, mermaid_fence) orelse {
-            try writer.writeAll(source[cursor..]);
-            break;
-        };
-
-        // Only treat a fence that starts a line (optionally indented). A
-        // ``` buried inside a word is not a fence opener.
-        const line_start = lineStartBefore(source, fence_pos);
-        const indent = source[line_start..fence_pos];
-        if (!std.mem.allEqual(u8, indent, ' ') and indent.len != 0) {
-            // Not a real fence — emit one byte and keep scanning so we don't
-            // loop forever on the same position.
-            try writer.writeByte(source[cursor]);
-            cursor += 1;
-            continue;
+    var i: usize = 0;
+    while (i < source.len) {
+        // 1. Fenced code block opener at line start. Consumed whole: mermaid
+        //    blocks are transformed in place, every other language is copied
+        //    verbatim (including any literal ```mermaid lines or `$` chars
+        //    inside). Emits directly to the writer so the math steps below
+        //    never re-process the interior.
+        if (isAtLineStart(source, i)) {
+            if (try consumeFenceBlock(allocator, writer, source, &i)) continue;
         }
 
-        // Scan the language tag immediately after the fence.
-        const tag_start = fence_pos + mermaid_fence.len;
-        const line_end = std.mem.indexOfScalarPos(u8, source, tag_start, '\n') orelse source.len;
-        const tag = std.mem.trim(u8, source[tag_start..line_end], " \t\r");
-
-        if (!std.mem.eql(u8, tag, mermaid_lang)) {
-            // Non-mermaid fenced code block. Walk line-by-line until the
-            // matching closing fence, copying everything verbatim — any
-            // literal ```mermaid lines inside belong to the code block, not
-            // to us.
-            const block_end = findCodeBlockClose(source, line_end);
-            const advance = block_end;
-            try writer.writeAll(source[cursor..advance]);
-            cursor = advance;
-            continue;
+        // 2. Block math `$$...$$`. Checked before inline `$` so the leading
+        //    `$$` isn't mis-parsed as two adjacent single-dollar spans.
+        if (i + 1 < source.len and source[i] == '$' and source[i + 1] == '$') {
+            if (try consumeBlockMath(allocator, writer, source, &i)) continue;
         }
 
-        // Mermaid block — find the closing fence.
-        const body_start = if (line_end < source.len) line_end + 1 else source.len;
-        const close_pos = findCodeBlockCloseLine(source, body_start);
-
-        // Emit any plain text leading up to the fence verbatim.
-        try writer.writeAll(source[cursor..fence_pos]);
-
-        const body_end = if (close_pos) |cp| cp else source.len;
-        const body = source[body_start..body_end];
-        const diagram_type = detectMermaidType(body);
-
-        // Header line: bold "Mermaid diagram: <type>" — bold survives the
-        // downstream markdown pass and clearly delineates the diagram region.
-        if (diagram_type.len > 0) {
-            try writer.print("**Mermaid diagram: {s}**\n\n", .{diagram_type});
-        } else {
-            try writer.writeAll("**Mermaid diagram**\n\n");
+        // 3. Inline math `$...$`.
+        if (source[i] == '$') {
+            if (try consumeInlineMath(writer, source, &i)) continue;
         }
 
-        // Raw source as a blockquote so the markdown renderer offsets it from
-        // surrounding prose. Skip blank trailing lines to avoid empty quote
-        // lines.
-        try writeQuotedLines(writer, body);
-
-        if (close_pos) |cp| {
-            // Skip past the closing fence line.
-            const after_close = std.mem.indexOfScalarPos(u8, source, cp, '\n');
-            cursor = if (after_close) |ac| ac + 1 else source.len;
-        } else {
-            cursor = source.len;
-        }
+        // 4. Plain byte.
+        try writer.writeByte(source[i]);
+        i += 1;
     }
 
     return out.toOwnedSlice();
 }
 
-/// Find the start of the next line that is exactly a fenced-code-block
-/// closer (a line whose only non-newline content is ``` optionally preceded
-/// by spaces). Returns the index just past the closer's trailing newline
-/// (or `source.len` when none is found, in which case the rest of the source
-/// is treated as part of the unterminated code block).
-fn findCodeBlockClose(source: []const u8, after_open_line_end: usize) usize {
-    var i = after_open_line_end;
-    while (i < source.len) {
-        const line_start = i;
-        const line_end = std.mem.indexOfScalarPos(u8, source, line_start, '\n') orelse source.len;
-        const line = source[line_start..line_end];
-        const trimmed = std.mem.trim(u8, line, " \t\r");
-        if (std.mem.eql(u8, trimmed, mermaid_fence)) {
-            // Position just past the newline that terminates the closer line.
-            return if (line_end < source.len) line_end + 1 else source.len;
-        }
-        i = if (line_end < source.len) line_end + 1 else source.len;
-    }
-    return source.len;
+fn isAtLineStart(source: []const u8, i: usize) bool {
+    if (i == 0) return true;
+    return source[i - 1] == '\n';
 }
 
-/// Same as findCodeBlockClose but returns the index of the closer's first
-/// backtick (used by the mermaid path so the body excludes the closing
-/// fence). Returns null when no closer is found.
+// ---------------------------------------------------------------------------
+// Fence + mermaid
+// ---------------------------------------------------------------------------
+
+const mermaid_fence = "```";
+const mermaid_lang = "mermaid";
+
+/// If `source[i..]` opens a fenced code block at line start (optionally
+/// indented), consume the whole block in place:
+///
+/// - mermaid blocks become the labeled summary + quoted source;
+/// - any other language is copied verbatim, including any literal
+///   ```` ```mermaid ```` lines or `$` chars inside.
+///
+/// Updates `*i` past the consumed block and returns true. Returns false
+/// (without modifying `*i`) if `i` is not at a fence opener.
+fn consumeFenceBlock(allocator: std.mem.Allocator, writer: *std.Io.Writer, source: []const u8, i: *usize) !bool {
+    const start = i.*;
+    // Allow leading space indentation (a line of spaces followed by ```).
+    var indent_end = start;
+    while (indent_end < source.len and source[indent_end] == ' ') indent_end += 1;
+    if (indent_end + mermaid_fence.len > source.len) return false;
+    if (!std.mem.eql(u8, source[indent_end .. indent_end + mermaid_fence.len], mermaid_fence)) return false;
+    // The fence opener must sit at the start of the line — we've already
+    // returned false above if `i` is not at a line start.
+
+    // Lang tag occupies the rest of the opener line.
+    const fence_end = indent_end + mermaid_fence.len;
+    const line_end = std.mem.indexOfScalarPos(u8, source, fence_end, '\n') orelse source.len;
+    const tag = std.mem.trim(u8, source[fence_end..line_end], " \t\r");
+
+    // Body starts on the line after the opener.
+    const body_start = if (line_end < source.len) line_end + 1 else source.len;
+    const close_line_start = findCodeBlockCloseLine(source, body_start);
+    const body_end = if (close_line_start) |cls| cls else source.len;
+    const body = source[body_start..body_end];
+
+    if (std.mem.eql(u8, tag, mermaid_lang)) {
+        // Mermaid block — emit the label + quoted source directly to the
+        // writer. The caller never sees these bytes again so a later math
+        // step can't mutate the quoted diagram source.
+        const diagram_type = detectMermaidType(body);
+        if (diagram_type.len > 0) {
+            try writer.print("**Mermaid diagram: {s}**\n\n", .{diagram_type});
+        } else {
+            try writer.writeAll("**Mermaid diagram**\n\n");
+        }
+        try writeQuotedLines(writer, body);
+    } else {
+        // Non-mermaid fenced code block — copy opener, body, and closer
+        // verbatim so any literal ```mermaid lines or `$` shell vars inside
+        // survive unchanged.
+        try writer.writeAll(source[start..body_end]);
+        if (close_line_start) |cls| {
+            // Include the closer line together with its trailing newline so
+            // the verbatim copy stays byte-identical with the source.
+            const close_line_end = std.mem.indexOfScalarPos(u8, source, cls, '\n') orelse source.len;
+            const emit_end = if (close_line_end < source.len) close_line_end + 1 else source.len;
+            try writer.writeAll(source[cls..emit_end]);
+            i.* = emit_end;
+        } else {
+            // Unterminated fence — copy through the trailing newline if any.
+            i.* = body_end;
+            if (body_end < source.len and source[body_end] == '\n') {
+                try writer.writeByte('\n');
+                i.* = body_end + 1;
+            }
+        }
+        _ = allocator;
+        return true;
+    }
+
+    // Mermaid path: advance past the closing fence line (or end of source
+    // when unterminated).
+    if (close_line_start) |cls| {
+        const close_line_end = std.mem.indexOfScalarPos(u8, source, cls, '\n') orelse source.len;
+        i.* = if (close_line_end < source.len) close_line_end + 1 else source.len;
+    } else {
+        i.* = source.len;
+    }
+    return true;
+}
+
+/// Locate the first line at or after `body_start` whose content (after
+/// trimming whitespace) is exactly ```` ``` ````. Returns the absolute index
+/// of that closer line's first byte, or null if none is found.
 fn findCodeBlockCloseLine(source: []const u8, body_start: usize) ?usize {
     var i = body_start;
     while (i < source.len) {
@@ -163,12 +168,6 @@ fn findCodeBlockCloseLine(source: []const u8, body_start: usize) ?usize {
         i = if (line_end < source.len) line_end + 1 else source.len;
     }
     return null;
-}
-
-fn lineStartBefore(source: []const u8, pos: usize) usize {
-    var i: usize = pos;
-    while (i > 0 and source[i - 1] != '\n') i -= 1;
-    return i;
 }
 
 /// Inspect the first non-blank line of a Mermaid block to classify the
@@ -202,15 +201,21 @@ fn detectMermaidType(body: []const u8) []const u8 {
     return "";
 }
 
+/// Quote each line of `body` for the markdown renderer. Trailing whitespace
+/// and fully-blank lines are dropped, but **leading indentation is
+/// preserved** — mindmap, state diagrams, and several other Mermaid types
+/// rely on indentation as structural syntax, and the raw source must remain
+/// copyable from the transcript.
 fn writeQuotedLines(writer: *std.Io.Writer, body: []const u8) !void {
     var lines = std.mem.splitScalar(u8, body, '\n');
     var wrote_any = false;
     while (lines.next()) |raw_line| {
-        const line = std.mem.trim(u8, raw_line, " \t\r");
-        // Skip blank lines so the quote stays tight.
-        if (line.len == 0) continue;
+        const line = std.mem.trimEnd(u8, raw_line, " \t\r");
+        // Skip lines that are entirely whitespace so the quote stays tight.
+        if (std.mem.allEqual(u8, line, ' ') or line.len == 0) continue;
         if (wrote_any) try writer.writeByte('\n');
         try writer.writeAll("> ");
+        // Preserve any leading indentation (e.g. mindmap nesting).
         try writer.writeAll(line);
         wrote_any = true;
     }
@@ -225,49 +230,31 @@ fn writeQuotedLines(writer: *std.Io.Writer, body: []const u8) !void {
 // Math
 // ---------------------------------------------------------------------------
 
-/// Replace `$$...$$` blocks. The closing `$$` may appear on the same line
-/// or on a later line; both forms are supported. An unterminated `$$` is
-/// passed through verbatim.
-fn replaceBlockMath(allocator: std.mem.Allocator, source: []const u8) ![]u8 {
-    var out: std.Io.Writer.Allocating = .init(allocator);
-    errdefer out.deinit();
-    const writer = &out.writer;
+/// Try to consume a `$$...$$` block math span at `*i`. Returns true and
+/// advances `*i` past the closing `$$` on success. Returns false (without
+/// modifying `*i`) when the bytes at `*i` aren't a real block-math opener —
+/// either because there's no closing `$$`, or because the opening looks like
+/// currency (`$$$` or `$$<digit>`). In the false cases the caller emits the
+/// `$` byte by byte via the default path so prose like "cost $$5 total"
+/// survives unchanged.
+fn consumeBlockMath(allocator: std.mem.Allocator, writer: *std.Io.Writer, source: []const u8, i: *usize) !bool {
+    const open = i.*;
+    // Reject `$$$` — ambiguous with inline math like `$$$x$$`.
+    if (open + 2 < source.len and source[open + 2] == '$') return false;
+    // Reject `$$<digit>` — currency like "$$5" is not block math.
+    if (open + 2 < source.len and std.ascii.isDigit(source[open + 2])) return false;
 
-    var cursor: usize = 0;
-    while (cursor < source.len) {
-        const open = std.mem.indexOfPos(u8, source, cursor, "$$") orelse {
-            try writer.writeAll(source[cursor..]);
-            break;
-        };
-        // `$$$` is ambiguous — treat as not-a-block so we don't swallow the
-        // third `$` from inline math like `$$$x$$`. Require the char after
-        // the opening pair to not be another `$`.
-        if (open + 2 < source.len and source[open + 2] == '$') {
-            try writer.writeAll(source[cursor .. open + 1]);
-            cursor = open + 1;
-            continue;
-        }
+    const body_start = open + 2;
+    const close = std.mem.indexOfPos(u8, source, body_start, "$$") orelse {
+        // Unterminated — let the caller emit `$$` verbatim via the default
+        // byte-by-byte path. We must NOT swallow the remainder.
+        return false;
+    };
 
-        const body_start = open + 2;
-        const close = std.mem.indexOfPos(u8, source, body_start, "$$");
-
-        if (close) |cp| {
-            try writer.writeAll(source[cursor..open]);
-            const body = source[body_start..cp];
-            try writeBlockMath(allocator, writer, body);
-            cursor = cp + 2;
-        } else {
-            // Unterminated `$$` — not actually a math block. Emit the rest
-            // of the source verbatim (including the literal `$$`) so prose
-            // like "cost $$5 total" survives unchanged. Mirrors the inline
-            // math path, which writes the bare `$` and moves on when no
-            // closer is found.
-            try writer.writeAll(source[cursor..]);
-            cursor = source.len;
-        }
-    }
-
-    return out.toOwnedSlice();
+    const body = source[body_start..close];
+    try writeBlockMath(allocator, writer, body);
+    i.* = close + 2;
+    return true;
 }
 
 fn writeBlockMath(allocator: std.mem.Allocator, writer: *std.Io.Writer, body: []const u8) !void {
@@ -291,66 +278,52 @@ fn writeBlockMath(allocator: std.mem.Allocator, writer: *std.Io.Writer, body: []
     if (!wrote_any) try writer.writeAll("> ");
 }
 
-/// Replace inline `$...$` spans. Refuses to match if the opening `$` is
-/// preceded by a non-space char or if the body contains a newline — both
-/// are common false-positive sources (currency, "5$ for x" etc.).
-fn replaceInlineMath(allocator: std.mem.Allocator, source: []const u8) ![]u8 {
-    var out: std.Io.Writer.Allocating = .init(allocator);
-    errdefer out.deinit();
-    const writer = &out.writer;
+/// Try to consume an inline `$...$` math span at `*i`. Returns true and
+/// advances `*i` past the closing `$` on success. Returns false (leaving
+/// `*i` unmodified) when the bytes don't form a real inline-math span.
+///
+/// Common currency patterns are explicitly rejected by the open/close guards
+/// so they pass through verbatim:
+/// - `$5` — opening `$` followed by a digit.
+/// - `5$` — opening `$` preceded by a non-space char.
+/// - `$5-$10`, `$5/$10` — the second `$` is preceded or followed by a digit.
+fn consumeInlineMath(writer: *std.Io.Writer, source: []const u8, i: *usize) !bool {
+    const open = i.*;
 
-    var cursor: usize = 0;
-    while (cursor < source.len) {
-        if (source[cursor] != '$') {
-            try writer.writeByte(source[cursor]);
-            cursor += 1;
-            continue;
-        }
-        // Reject opening preceded by a non-space, non-start byte (e.g. "5$").
-        if (cursor > 0) {
-            const prev = source[cursor - 1];
-            if (prev != ' ' and prev != '\t' and prev != '\n' and prev != '(' and prev != '[') {
-                try writer.writeByte(source[cursor]);
-                cursor += 1;
-                continue;
-            }
-        }
-        // Reject opening with no body or body starting with space.
-        if (cursor + 1 >= source.len or source[cursor + 1] == ' ' or source[cursor + 1] == '$') {
-            try writer.writeByte(source[cursor]);
-            cursor += 1;
-            continue;
-        }
-
-        const body_start = cursor + 1;
-        const close = std.mem.indexOfScalarPos(u8, source, body_start, '$');
-        if (close == null) {
-            try writer.writeByte(source[cursor]);
-            cursor += 1;
-            continue;
-        }
-        const cp = close.?;
-        // Closing `$` must not be preceded by whitespace and must not be
-        // followed by another `$` (which would be a different block math
-        // boundary handled elsewhere).
-        if (source[cp - 1] == ' ' or (cp + 1 < source.len and source[cp + 1] == '$')) {
-            try writer.writeByte(source[cursor]);
-            cursor += 1;
-            continue;
-        }
-        const body = source[body_start..cp];
-        // Reject newlines — inline math is a single line.
-        if (std.mem.indexOfScalar(u8, body, '\n') != null) {
-            try writer.writeByte(source[cursor]);
-            cursor += 1;
-            continue;
-        }
-
-        try renderMathBody(writer, body);
-        cursor = cp + 1;
+    // Opening `$` must be preceded by whitespace, start-of-text, or an
+    // opening bracket — anything else (e.g. `5$`) is currency.
+    if (open > 0) {
+        const prev = source[open - 1];
+        if (prev != ' ' and prev != '\t' and prev != '\n' and prev != '(' and prev != '[') return false;
+    }
+    // Body must start with a non-space, non-`$`, non-digit char. Digit
+    // adjacency (`$5`) indicates currency, not math.
+    if (open + 1 >= source.len) return false;
+    {
+        const next = source[open + 1];
+        if (next == ' ' or next == '$' or std.ascii.isDigit(next)) return false;
     }
 
-    return out.toOwnedSlice();
+    const body_start = open + 1;
+    const close = std.mem.indexOfScalarPos(u8, source, body_start, '$') orelse return false;
+
+    // Closing `$` must not be preceded by whitespace, must not be followed
+    // by another `$`, and must not be followed by a digit (the second `$`
+    // in `$5-$10` is currency). Preceded-by-digit is fine — `$x^2$` is real
+    // math where the closer abuts a superscript digit.
+    if (source[close - 1] == ' ') return false;
+    if (close + 1 < source.len) {
+        const after = source[close + 1];
+        if (after == '$' or std.ascii.isDigit(after)) return false;
+    }
+
+    const body = source[body_start..close];
+    // Reject newlines — inline math is a single line.
+    if (std.mem.indexOfScalar(u8, body, '\n') != null) return false;
+
+    try renderMathBody(writer, body);
+    i.* = close + 1;
+    return true;
 }
 
 // ---------------------------------------------------------------------------
@@ -359,8 +332,9 @@ fn replaceInlineMath(allocator: std.mem.Allocator, source: []const u8) ![]u8 {
 
 /// Render a math body to `writer`. Walks the source, substituting recognized
 /// LaTeX commands and a small set of superscript/subscript forms. Anything
-/// unknown is emitted verbatim (with the backslash preserved) so the
-/// rendered output remains useful as a fallback.
+/// unknown is emitted verbatim (with the backslash preserved and any
+/// immediate `{...}` argument left intact) so the rendered output remains a
+/// useful fallback.
 fn renderMathBody(writer: *std.Io.Writer, body: []const u8) anyerror!void {
     var i: usize = 0;
     while (i < body.len) {
@@ -410,19 +384,32 @@ fn renderMathBody(writer: *std.Io.Writer, body: []const u8) anyerror!void {
 
             if (lookupCommand(name)) |sym| {
                 try writer.writeAll(sym);
-            } else {
-                // Unknown command — emit raw so it stays visible as a fallback.
-                try writer.writeByte('\\');
-                try writer.writeAll(name);
+                i = j;
+                continue;
             }
-            i = j;
+
+            // Unknown command — emit raw so it stays visible as a fallback.
+            // Preserve any immediate `{...}` argument verbatim so users can
+            // still read / copy unsupported LaTeX like `\boxed{x+1}` instead
+            // of having the brace-stripping pass run the operand into the
+            // command name (e.g. `\boxedx+1`).
+            try writer.writeByte('\\');
+            try writer.writeAll(name);
+            var after = j;
+            if (after < body.len and body[after] == '{') {
+                if (readGroup(body, after)) |grp| {
+                    try writer.writeAll(body[after..grp.end]);
+                    after = grp.end;
+                }
+            }
+            i = after;
             continue;
         }
 
         if (c == '^' or c == '_') {
             // Superscript / subscript. If the next char is `{`, read until
             // `}`; otherwise consume a single char. Render with Unicode
-            // superscripts when possible; otherwise emit `^x` / `_x` as
+            // superscripts when possible; otherwise emit `^x` / `^{x}` as
             // plain-text fallback (still readable, no semantic loss).
             try writeScript(writer, body, &i);
             continue;
@@ -455,7 +442,9 @@ fn writeScript(writer: *std.Io.Writer, body: []const u8, i: *usize) !void {
 
     var token_start = i.*;
     var token_end: usize = undefined;
+    var had_braces = false;
     if (body[i.*] == '{') {
+        had_braces = true;
         token_start = i.* + 1;
         const close = std.mem.indexOfScalarPos(u8, body, token_start, '}') orelse {
             // No closing brace — emit marker + rest verbatim.
@@ -487,10 +476,13 @@ fn writeScript(writer: *std.Io.Writer, body: []const u8, i: *usize) !void {
     const token = body[token_start..token_end];
     if (marker == '^') {
         if (writeSuperscript(writer, token)) return;
-        try writer.print("^{s}", .{token});
+        // Preserve the source brace grouping in the fallback so multi-char
+        // scripts like `^{abc}` render as `^{abc}` (not `^abc`); single-char
+        // fallbacks stay in the bare `^x` form for readability.
+        if (had_braces) try writer.print("^{{{s}}}", .{token}) else try writer.print("^{s}", .{token});
     } else {
         if (writeSubscript(writer, token)) return;
-        try writer.print("_{s}", .{token});
+        if (had_braces) try writer.print("_{{{s}}}", .{token}) else try writer.print("_{s}", .{token});
     }
 }
 
@@ -548,9 +540,9 @@ const BraceGroup = struct {
     end: usize,
 };
 
-/// Read a `{...}` group starting at `i` (after skipping leading spaces).
-/// Returns null if `i` doesn't point at a `{`. Handles nested braces via a
-/// depth counter so `\frac{\frac{a}{b}}{c}` renders as `((a)/(b))/(c)`.
+/// Read a `{...}` group starting at `i`. Returns null if `i` doesn't point
+/// at a `{`. Handles nested braces via a depth counter so
+/// `\frac{\frac{a}{b}}{c}` renders as `((a)/(b))/(c)`.
 fn readGroup(body: []const u8, i: usize) ?BraceGroup {
     if (i >= body.len or body[i] != '{') return null;
     var depth: usize = 1;
@@ -910,8 +902,9 @@ test "multi-line block math collapses to quoted lines" {
     defer std.testing.allocator.free(out);
     try std.testing.expect(std.mem.indexOf(u8, out, "> ∑") != null);
     // `^n` becomes Unicode superscript n; `_{i=1}` has no single-char form
-    // so it stays as the literal `_{i=1}` fallback.
+    // so the brace-preserving fallback emits `_{i=1}`.
     try std.testing.expect(std.mem.indexOf(u8, out, "ⁿ") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "_{i=1}") != null);
     try std.testing.expect(std.mem.indexOf(u8, out, "xᵢ") != null);
 }
 
@@ -920,6 +913,22 @@ test "inline math ignores dollar signs used as currency" {
     const out = try preprocess(std.testing.allocator, src);
     defer std.testing.allocator.free(out);
     // No transform should occur — currency stays as-is.
+    try std.testing.expectEqualStrings(src, out);
+}
+
+test "currency price range preserves both dollar signs" {
+    const src = "price $5-$10 today";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    // The second `$` in `$5-$10` is adjacent to digits on both sides and
+    // must NOT be treated as a math closer.
+    try std.testing.expectEqualStrings(src, out);
+}
+
+test "currency slash range preserves both dollar signs" {
+    const src = "split $5/$10 ratio";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
     try std.testing.expectEqualStrings(src, out);
 }
 
@@ -946,15 +955,25 @@ test "unknown LaTeX command falls back to raw with backslash" {
     try std.testing.expect(std.mem.indexOf(u8, out, "\\zzzx") != null);
 }
 
+test "unknown LaTeX command with brace argument preserves group" {
+    const src = "boxed $\\boxed{x+1}$ end";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    // Unknown `\boxed` must survive together with its `{x+1}` argument so
+    // the raw fallback stays copyable (NOT `\boxedx+1`).
+    try std.testing.expect(std.mem.indexOf(u8, out, "\\boxed{x+1}") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "\\boxedx") == null);
+}
+
 test "mermaid block replaced with labeled summary" {
     const src = "intro\n\n```mermaid\nflowchart TD\n  A --> B\n```\n\noutro";
     const out = try preprocess(std.testing.allocator, src);
     defer std.testing.allocator.free(out);
     try std.testing.expect(std.mem.indexOf(u8, out, "**Mermaid diagram: flowchart**") != null);
     try std.testing.expect(std.mem.indexOf(u8, out, "> flowchart TD") != null);
-    try std.testing.expect(std.mem.indexOf(u8, out, "> A --> B") != null);
-    // Raw fence must be gone — copy behavior relies on raw text being inside
-    // the quoted section, but the fence delimiters themselves are stripped.
+    // Indentation from the source is preserved ("> " + "  A --> B").
+    try std.testing.expect(std.mem.indexOf(u8, out, ">   A --> B") != null);
+    // Raw fence delimiters stripped.
     try std.testing.expect(std.mem.indexOf(u8, out, "```mermaid") == null);
     try std.testing.expect(std.mem.indexOf(u8, out, "intro") != null);
     try std.testing.expect(std.mem.indexOf(u8, out, "outro") != null);
@@ -991,6 +1010,44 @@ test "unterminated non-mermaid code block passes through verbatim" {
     try std.testing.expectEqualStrings(src, out);
 }
 
+test "math inside non-mermaid fenced code block is not transformed" {
+    // Shell-style `$$` (PID var) and `$x$` inside a bash block must survive
+    // unchanged — the math pass only runs outside fenced code.
+    const src = "```sh\necho $$ $HOME\nx=5\n```\nthen $\\alpha$ math";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    // Code block interior unchanged.
+    try std.testing.expect(std.mem.indexOf(u8, out, "echo $$ $HOME") != null);
+    // Outside-fence math still rendered.
+    try std.testing.expect(std.mem.indexOf(u8, out, "α") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "$\\alpha$") == null);
+}
+
+test "mermaid quoted source preserves indentation" {
+    // Indentation-sensitive diagram (mindmap shape) — leading spaces must
+    // survive so the raw spec stays copyable from the transcript.
+    const src = "```mermaid\nmindmap\n  root\n    child\n      grandchild\n```";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    // `> ` prefix + original indentation, so "  root" becomes ">   root".
+    try std.testing.expect(std.mem.indexOf(u8, out, ">   root") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, ">     child") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, ">       grandchild") != null);
+}
+
+test "mermaid source with dollar labels is not mutated by math pass" {
+    // Mermaid label `$x$` and `$5-$10` must reach the output unchanged —
+    // the quoted body is emitted directly by the fence consumer and never
+    // re-processed by the inline math step.
+    const src = "```mermaid\nflowchart TD\n  A[$x$] --> B[$5-$10]\n```";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "A[$x$]") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "B[$5-$10]") != null);
+    // Math pass did not eat the labels.
+    try std.testing.expect(std.mem.indexOf(u8, out, "A[x]") == null);
+}
+
 test "text style commands drop their wrapper" {
     const src = "math $\\textbf{X} + \\textit{Y} + \\textrm{Z} + \\texttt{W}$";
     const out = try preprocess(std.testing.allocator, src);
@@ -1024,6 +1081,13 @@ test "fraction command keeps operands visible" {
     // \frac{a}{b} renders as (a)/(b) so both operands and the slash survive.
     try std.testing.expect(std.mem.indexOf(u8, out, "(a)/(b)") != null);
     try std.testing.expect(std.mem.indexOf(u8, out, "\\frac") == null);
+}
+
+test "nested fraction renders fully" {
+    const src = "deep $\\frac{\\frac{a}{b}}{c}$ end";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "((a)/(b))/(c)") != null);
 }
 
 test "style modifiers are silently dropped" {

--- a/zig/src/tui/markdown.zig
+++ b/zig/src/tui/markdown.zig
@@ -1,0 +1,957 @@
+//! Preprocessor that adapts LaTeX math spans (`$...$`, `$$...$$`) and
+//! Mermaid fenced code blocks for terminal rendering by ZigZag's markdown
+//! renderer.
+//!
+//! The downstream renderer has no math or diagram support, so we rewrite the
+//! raw assistant text before it runs:
+//!
+//! - Block math (`$$...$$`) is replaced with a short Unicode rendering of the
+//!   math, wrapped as a Markdown blockquote so it gets visually offset.
+//! - Inline math (`$...$`) is replaced with the Unicode rendering inline.
+//! - Mermaid fenced blocks (```mermaid ... ```) are replaced with a labeled
+//!   summary line plus the raw diagram source as a blockquote.
+//!
+//! Unknown LaTeX commands fall back to their raw form (with the leading
+//! backslash preserved) so nothing is silently dropped. The conversion is
+//! intentionally lightweight — no external math engine, no unicode table
+//! beyond a curated symbol map.
+
+const std = @import("std");
+
+/// Public entry point. Returns an allocator-owned copy of `source` with
+/// math spans and Mermaid blocks rewritten. The caller owns the returned
+/// slice.
+pub fn preprocess(allocator: std.mem.Allocator, source: []const u8) ![]u8 {
+    if (source.len == 0) return allocator.dupe(u8, source);
+
+    // Pass 1: replace ```mermaid ... ``` blocks. Doing this first avoids any
+    // accidental `$`/math interaction with diagram source.
+    const after_mermaid = try replaceMermaidBlocks(allocator, source);
+    defer allocator.free(after_mermaid);
+
+    // Pass 2: replace $$...$$ block math. Done before inline math so the `$$`
+    // sentinel doesn't get mis-parsed as two adjacent `$...$` spans.
+    const after_block = try replaceBlockMath(allocator, after_mermaid);
+    defer allocator.free(after_block);
+
+    // Pass 3: replace $...$ inline math.
+    return replaceInlineMath(allocator, after_block);
+}
+
+// ---------------------------------------------------------------------------
+// Mermaid
+// ---------------------------------------------------------------------------
+
+const mermaid_fence = "```";
+const mermaid_lang = "mermaid";
+
+/// Replace each ```mermaid ... ``` block with a labeled summary plus the raw
+/// source as a Markdown blockquote. If the closing fence is missing we emit
+/// the label only and pass the remainder through verbatim.
+fn replaceMermaidBlocks(allocator: std.mem.Allocator, source: []const u8) ![]u8 {
+    var out: std.Io.Writer.Allocating = .init(allocator);
+    errdefer out.deinit();
+    const writer = &out.writer;
+
+    var cursor: usize = 0;
+    while (cursor < source.len) {
+        const fence_pos = std.mem.indexOfPos(u8, source, cursor, mermaid_fence) orelse {
+            try writer.writeAll(source[cursor..]);
+            break;
+        };
+
+        // Scan the language tag immediately after the fence.
+        const tag_start = fence_pos + mermaid_fence.len;
+        const line_end = std.mem.indexOfScalarPos(u8, source, tag_start, '\n') orelse source.len;
+        const tag = std.mem.trim(u8, source[tag_start..line_end], " \t\r");
+
+        if (!std.mem.eql(u8, tag, mermaid_lang)) {
+            // Not a mermaid block — copy through the fence line and keep
+            // scanning from after it so nested non-mermaid blocks are
+            // unaffected. Use min to stay in bounds when the fence runs to
+            // end-of-input without a trailing newline.
+            const advance = @min(line_end + 1, source.len);
+            try writer.writeAll(source[cursor..advance]);
+            cursor = advance;
+            continue;
+        }
+
+        // Find the closing fence.
+        const body_start = if (line_end < source.len) line_end + 1 else source.len;
+        const close_pos = findMermaidClose(source, body_start);
+
+        // Emit any plain text leading up to the fence verbatim.
+        try writer.writeAll(source[cursor..fence_pos]);
+
+        const body_end = close_pos orelse source.len;
+        const body = source[body_start..body_end];
+        const diagram_type = detectMermaidType(body);
+
+        // Header line: bold "Mermaid diagram: <type>" — bold survives the
+        // downstream markdown pass and clearly delineates the diagram region.
+        if (diagram_type.len > 0) {
+            try writer.print("**Mermaid diagram: {s}**\n\n", .{diagram_type});
+        } else {
+            try writer.writeAll("**Mermaid diagram**\n\n");
+        }
+
+        // Raw source as a blockquote so the markdown renderer offsets it from
+        // surrounding prose. Skip blank trailing lines to avoid empty quote
+        // lines.
+        try writeQuotedLines(writer, body);
+
+        if (close_pos) |cp| {
+            // Skip past the closing fence line.
+            const after_close = std.mem.indexOfScalarPos(u8, source, cp, '\n');
+            cursor = if (after_close) |ac| ac + 1 else source.len;
+        } else {
+            cursor = source.len;
+        }
+    }
+
+    return out.toOwnedSlice();
+}
+
+/// Locate the closing ``` for a mermaid block starting at `body_start`.
+/// Returns the absolute index of the closing fence or null if none is found.
+fn findMermaidClose(source: []const u8, body_start: usize) ?usize {
+    var i: usize = body_start;
+    while (i < source.len) {
+        if (source[i] == '`') {
+            // Only treat lines whose first non-space content is ``` as the
+            // closing fence — indented triple backticks inside a diagram are
+            // part of the diagram source.
+            const line_start = lineStartBefore(source, i);
+            const prefix = source[line_start..i];
+            const all_space = std.mem.allEqual(u8, prefix, ' ') or prefix.len == 0;
+            if (all_space and i + 3 <= source.len and std.mem.eql(u8, source[i .. i + 3], mermaid_fence)) {
+                return i;
+            }
+        }
+        i += 1;
+    }
+    return null;
+}
+
+fn lineStartBefore(source: []const u8, pos: usize) usize {
+    var i: usize = pos;
+    while (i > 0 and source[i - 1] != '\n') i -= 1;
+    return i;
+}
+
+/// Inspect the first non-blank line of a Mermaid block to classify the
+/// diagram type (flowchart, sequenceDiagram, etc.). Returns an empty string
+/// when no recognized type is found.
+fn detectMermaidType(body: []const u8) []const u8 {
+    var lines = std.mem.splitScalar(u8, body, '\n');
+    while (lines.next()) |raw_line| {
+        const line = std.mem.trim(u8, raw_line, " \t\r");
+        if (line.len == 0) continue;
+        // Take the first whitespace-separated token. Mermaid's grammar uses
+        // a fixed keyword (flowchart, graph, sequenceDiagram, ...) here.
+        var tok_end: usize = 0;
+        while (tok_end < line.len and !std.ascii.isWhitespace(line[tok_end])) tok_end += 1;
+        const tok = line[0..tok_end];
+        if (tok.len == 0) continue;
+
+        // Normalize graph vs flowchart — both render flowcharts; preserve
+        // the user's wording otherwise.
+        if (std.ascii.eqlIgnoreCase(tok, "graph") or std.ascii.eqlIgnoreCase(tok, "flowchart") or std.ascii.eqlIgnoreCase(tok, "flowChart")) return "flowchart";
+        if (std.ascii.eqlIgnoreCase(tok, "sequenceDiagram")) return "sequence";
+        if (std.ascii.eqlIgnoreCase(tok, "classDiagram")) return "class";
+        if (std.ascii.eqlIgnoreCase(tok, "stateDiagram") or std.ascii.eqlIgnoreCase(tok, "stateDiagram-v2")) return "state";
+        if (std.ascii.eqlIgnoreCase(tok, "erDiagram")) return "er";
+        if (std.ascii.eqlIgnoreCase(tok, "gantt")) return "gantt";
+        if (std.ascii.eqlIgnoreCase(tok, "pie")) return "pie";
+        if (std.ascii.eqlIgnoreCase(tok, "journey")) return "journey";
+        if (std.ascii.eqlIgnoreCase(tok, "gitGraph")) return "git";
+        return tok;
+    }
+    return "";
+}
+
+fn writeQuotedLines(writer: *std.Io.Writer, body: []const u8) !void {
+    var lines = std.mem.splitScalar(u8, body, '\n');
+    var wrote_any = false;
+    while (lines.next()) |raw_line| {
+        const line = std.mem.trim(u8, raw_line, " \t\r");
+        // Skip blank lines so the quote stays tight.
+        if (line.len == 0) continue;
+        if (wrote_any) try writer.writeByte('\n');
+        try writer.writeAll("> ");
+        try writer.writeAll(line);
+        wrote_any = true;
+    }
+    if (!wrote_any) {
+        // Empty body — emit a single placeholder line so the section still
+        // reads as a diagram block.
+        try writer.writeAll("> (empty)");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Math
+// ---------------------------------------------------------------------------
+
+/// Replace `$$...$$` blocks. The closing `$$` may appear on the same line
+/// or on a later line; both forms are supported. An unterminated `$$` is
+/// passed through verbatim.
+fn replaceBlockMath(allocator: std.mem.Allocator, source: []const u8) ![]u8 {
+    var out: std.Io.Writer.Allocating = .init(allocator);
+    errdefer out.deinit();
+    const writer = &out.writer;
+
+    var cursor: usize = 0;
+    while (cursor < source.len) {
+        const open = std.mem.indexOfPos(u8, source, cursor, "$$") orelse {
+            try writer.writeAll(source[cursor..]);
+            break;
+        };
+        // `$$$` is ambiguous — treat as not-a-block so we don't swallow the
+        // third `$` from inline math like `$$$x$$`. Require the char after
+        // the opening pair to not be another `$`.
+        if (open + 2 < source.len and source[open + 2] == '$') {
+            try writer.writeAll(source[cursor .. open + 1]);
+            cursor = open + 1;
+            continue;
+        }
+
+        const body_start = open + 2;
+        const close = std.mem.indexOfPos(u8, source, body_start, "$$");
+
+        try writer.writeAll(source[cursor..open]);
+
+        if (close) |cp| {
+            const body = source[body_start..cp];
+            try writeBlockMath(allocator, writer, body);
+            cursor = cp + 2;
+        } else {
+            // Unterminated — render what's left as a block and stop.
+            const body = source[body_start..];
+            try writeBlockMath(allocator, writer, body);
+            cursor = source.len;
+        }
+    }
+
+    return out.toOwnedSlice();
+}
+
+fn writeBlockMath(allocator: std.mem.Allocator, writer: *std.Io.Writer, body: []const u8) !void {
+    var rendered: std.Io.Writer.Allocating = .init(allocator);
+    defer rendered.deinit();
+    try renderMathBody(&rendered.writer, body);
+
+    // Emit as a Markdown blockquote — one quote line per source line, with
+    // blank lines collapsed. This visually sets math apart from prose and
+    // survives the downstream markdown pass cleanly.
+    var lines = std.mem.splitScalar(u8, rendered.written(), '\n');
+    var wrote_any = false;
+    while (lines.next()) |raw_line| {
+        const line = std.mem.trim(u8, raw_line, " \t\r");
+        if (line.len == 0) continue;
+        if (wrote_any) try writer.writeByte('\n');
+        try writer.writeAll("> ");
+        try writer.writeAll(line);
+        wrote_any = true;
+    }
+    if (!wrote_any) try writer.writeAll("> ");
+}
+
+/// Replace inline `$...$` spans. Refuses to match if the opening `$` is
+/// preceded by a non-space char or if the body contains a newline — both
+/// are common false-positive sources (currency, "5$ for x" etc.).
+fn replaceInlineMath(allocator: std.mem.Allocator, source: []const u8) ![]u8 {
+    var out: std.Io.Writer.Allocating = .init(allocator);
+    errdefer out.deinit();
+    const writer = &out.writer;
+
+    var cursor: usize = 0;
+    while (cursor < source.len) {
+        if (source[cursor] != '$') {
+            try writer.writeByte(source[cursor]);
+            cursor += 1;
+            continue;
+        }
+        // Reject opening preceded by a non-space, non-start byte (e.g. "5$").
+        if (cursor > 0) {
+            const prev = source[cursor - 1];
+            if (prev != ' ' and prev != '\t' and prev != '\n' and prev != '(' and prev != '[') {
+                try writer.writeByte(source[cursor]);
+                cursor += 1;
+                continue;
+            }
+        }
+        // Reject opening with no body or body starting with space.
+        if (cursor + 1 >= source.len or source[cursor + 1] == ' ' or source[cursor + 1] == '$') {
+            try writer.writeByte(source[cursor]);
+            cursor += 1;
+            continue;
+        }
+
+        const body_start = cursor + 1;
+        const close = std.mem.indexOfScalarPos(u8, source, body_start, '$');
+        if (close == null) {
+            try writer.writeByte(source[cursor]);
+            cursor += 1;
+            continue;
+        }
+        const cp = close.?;
+        // Closing `$` must not be preceded by whitespace and must not be
+        // followed by another `$` (which would be a different block math
+        // boundary handled elsewhere).
+        if (source[cp - 1] == ' ' or (cp + 1 < source.len and source[cp + 1] == '$')) {
+            try writer.writeByte(source[cursor]);
+            cursor += 1;
+            continue;
+        }
+        const body = source[body_start..cp];
+        // Reject newlines — inline math is a single line.
+        if (std.mem.indexOfScalar(u8, body, '\n') != null) {
+            try writer.writeByte(source[cursor]);
+            cursor += 1;
+            continue;
+        }
+
+        try renderMathBody(writer, body);
+        cursor = cp + 1;
+    }
+
+    return out.toOwnedSlice();
+}
+
+// ---------------------------------------------------------------------------
+// LaTeX → Unicode
+// ---------------------------------------------------------------------------
+
+/// Render a math body to `writer`. Walks the source, substituting recognized
+/// LaTeX commands and a small set of superscript/subscript forms. Anything
+/// unknown is emitted verbatim (with the backslash preserved) so the
+/// rendered output remains useful as a fallback.
+fn renderMathBody(writer: *std.Io.Writer, body: []const u8) anyerror!void {
+    var i: usize = 0;
+    while (i < body.len) {
+        const c = body[i];
+
+        if (c == '\\') {
+            // Read command name: letters, optionally followed by a single
+            // non-letter for one-char commands like `\,` `\;` etc.
+            var j = i + 1;
+            while (j < body.len and std.ascii.isAlphabetic(body[j])) j += 1;
+            if (j == i + 1 and j < body.len) {
+                // Single non-letter command — handle the common spacing ones.
+                const next = body[j];
+                if (next == ',') {
+                    try writer.writeAll(" ");
+                    i = j + 1;
+                    continue;
+                }
+                if (next == ';' or next == ':' or next == '!') {
+                    i = j + 1;
+                    continue;
+                }
+                if (next == '\\') {
+                    try writer.writeByte('\n');
+                    i = j + 1;
+                    continue;
+                }
+                // Unknown single-char command: emit backslash and the char.
+                try writer.writeByte('\\');
+                try writer.writeByte(next);
+                i = j + 1;
+                continue;
+            }
+
+            const name = body[i + 1 .. j];
+
+            // Multi-argument commands need special handling so their operands
+            // land in the right order.
+            if (std.mem.eql(u8, name, "frac")) {
+                i = try writeFrac(writer, body, j);
+                continue;
+            }
+            if (std.mem.eql(u8, name, "sqrt")) {
+                i = try writeSqrt(writer, body, j);
+                continue;
+            }
+
+            if (lookupCommand(name)) |sym| {
+                try writer.writeAll(sym);
+            } else {
+                // Unknown command — emit raw so it stays visible as a fallback.
+                try writer.writeByte('\\');
+                try writer.writeAll(name);
+            }
+            i = j;
+            continue;
+        }
+
+        if (c == '^' or c == '_') {
+            // Superscript / subscript. If the next char is `{`, read until
+            // `}`; otherwise consume a single char. Render with Unicode
+            // superscripts when possible; otherwise emit `^x` / `_x` as
+            // plain-text fallback (still readable, no semantic loss).
+            try writeScript(writer, body, &i);
+            continue;
+        }
+
+        if (c == '{' or c == '}') {
+            // Grouping braces have no visible meaning in plain Unicode math.
+            i += 1;
+            continue;
+        }
+
+        if (c == '\n') {
+            try writer.writeByte('\n');
+            i += 1;
+            continue;
+        }
+
+        try writer.writeByte(c);
+        i += 1;
+    }
+}
+
+fn writeScript(writer: *std.Io.Writer, body: []const u8, i: *usize) !void {
+    const marker = body[i.*];
+    i.* += 1;
+    if (i.* >= body.len) {
+        try writer.writeByte(marker);
+        return;
+    }
+
+    var token_start = i.*;
+    var token_end: usize = undefined;
+    if (body[i.*] == '{') {
+        token_start = i.* + 1;
+        const close = std.mem.indexOfScalarPos(u8, body, token_start, '}') orelse {
+            // No closing brace — emit marker + rest verbatim.
+            try writer.writeByte(marker);
+            try writer.writeAll(body[i.*..]);
+            i.* = body.len;
+            return;
+        };
+        token_end = close;
+        i.* = close + 1;
+    } else {
+        // Only consume a single ASCII alphanumeric or operator punctuation as
+        // the script token. Anything else (notably `\`, which starts a LaTeX
+        // command) is left in place for normal processing so `^\infty`
+        // becomes `^` + `∞` rather than swallowing the backslash.
+        const c = body[i.*];
+        if (isScriptTokenChar(c)) {
+            token_start = i.*;
+            token_end = i.* + 1;
+            i.* += 1;
+        } else {
+            // Bare marker with no consumable token — emit and let the
+            // following char process normally.
+            try writer.writeByte(marker);
+            return;
+        }
+    }
+
+    const token = body[token_start..token_end];
+    if (marker == '^') {
+        if (writeSuperscript(writer, token)) return;
+        try writer.print("^{s}", .{token});
+    } else {
+        if (writeSubscript(writer, token)) return;
+        try writer.print("_{s}", .{token});
+    }
+}
+
+fn isScriptTokenChar(c: u8) bool {
+    return std.ascii.isAlphanumeric(c) or c == '+' or c == '-' or c == '=' or c == '(' or c == ')';
+}
+
+/// Render `\frac{A}{B}` as `(A)/(B)`. Returns the new cursor position past
+/// both groups. If the next non-whitespace tokens aren't brace groups, emit
+/// the operands inline as a graceful fallback.
+fn writeFrac(writer: *std.Io.Writer, body: []const u8, start: usize) anyerror!usize {
+    var i = skipSpace(body, start);
+    const a_group = readGroup(body, i);
+    if (a_group) |g| i = g.end;
+    i = skipSpace(body, i);
+    const b_group = readGroup(body, i);
+    if (b_group) |g| i = g.end;
+
+    if (a_group != null and b_group != null) {
+        try writer.writeByte('(');
+        try renderMathBody(writer, a_group.?.inner);
+        try writer.writeAll(")/(");
+        try renderMathBody(writer, b_group.?.inner);
+        try writer.writeByte(')');
+        return i;
+    }
+    // Fallback: emit literal so the user sees the source structure.
+    try writer.writeAll("\\frac");
+    return start;
+}
+
+/// Render `\sqrt{X}` as `√X` (with braces stripped). If there's no brace
+/// group, emit `√` alone and let single-char scripts apply normally
+/// (e.g. `\sqrt2` → `√2` via the regular code path).
+fn writeSqrt(writer: *std.Io.Writer, body: []const u8, start: usize) anyerror!usize {
+    const i = skipSpace(body, start);
+    const g = readGroup(body, i);
+    if (g) |grp| {
+        try writer.writeAll("√");
+        try renderMathBody(writer, grp.inner);
+        return grp.end;
+    }
+    try writer.writeAll("√");
+    return start;
+}
+
+fn skipSpace(body: []const u8, i: usize) usize {
+    var j = i;
+    while (j < body.len and (body[j] == ' ' or body[j] == '\t')) j += 1;
+    return j;
+}
+
+const BraceGroup = struct {
+    inner: []const u8,
+    end: usize,
+};
+
+/// Read a `{...}` group starting at `i` (after skipping leading spaces).
+/// Returns null if `i` doesn't point at a `{`. Does not handle nested
+/// braces — math operands rarely nest, and raw fallback preserves the
+/// source when they do.
+fn readGroup(body: []const u8, i: usize) ?BraceGroup {
+    if (i >= body.len or body[i] != '{') return null;
+    var depth: usize = 1;
+    var j = i + 1;
+    while (j < body.len) : (j += 1) {
+        if (body[j] == '{') depth += 1;
+        if (body[j] == '}') {
+            depth -= 1;
+            if (depth == 0) return .{ .inner = body[i + 1 .. j], .end = j + 1 };
+        }
+    }
+    return null;
+}
+
+/// Emit a Unicode superscript for single-character tokens that have a
+/// dedicated superscript codepoint. Returns true if handled.
+fn writeSuperscript(writer: *std.Io.Writer, token: []const u8) bool {
+    const out: []const u8 = blk: {
+        if (token.len == 1) {
+            break :blk superscriptFor(token[0]) orelse "";
+        }
+        if (eqlCaseInsensitive(token, "th")) break :blk "ᵗʰ";
+        if (eqlCaseInsensitive(token, "nd")) break :blk "ⁿᵈ";
+        if (eqlCaseInsensitive(token, "rd")) break :blk "ʳᵈ";
+        if (eqlCaseInsensitive(token, "st")) break :blk "ˢᵗ";
+        break :blk "";
+    };
+    if (out.len == 0) return false;
+    writer.writeAll(out) catch return false;
+    return true;
+}
+
+fn writeSubscript(writer: *std.Io.Writer, token: []const u8) bool {
+    const out: []const u8 = blk: {
+        if (token.len == 1) {
+            break :blk subscriptFor(token[0]) orelse "";
+        }
+        break :blk "";
+    };
+    if (out.len == 0) return false;
+    writer.writeAll(out) catch return false;
+    return true;
+}
+
+fn superscriptFor(c: u8) ?[]const u8 {
+    return switch (c) {
+        '0' => "⁰",
+        '1' => "¹",
+        '2' => "²",
+        '3' => "³",
+        '4' => "⁴",
+        '5' => "⁵",
+        '6' => "⁶",
+        '7' => "⁷",
+        '8' => "⁸",
+        '9' => "⁹",
+        '+' => "⁺",
+        '-' => "⁻",
+        '=' => "⁼",
+        '(' => "⁽",
+        ')' => "⁾",
+        'n' => "ⁿ",
+        'i' => "ⁱ",
+        else => null,
+    };
+}
+
+fn subscriptFor(c: u8) ?[]const u8 {
+    return switch (c) {
+        '0' => "₀",
+        '1' => "₁",
+        '2' => "₂",
+        '3' => "₃",
+        '4' => "₄",
+        '5' => "₅",
+        '6' => "₆",
+        '7' => "₇",
+        '8' => "₈",
+        '9' => "₉",
+        '+' => "₊",
+        '-' => "₋",
+        '=' => "₌",
+        '(' => "₍",
+        ')' => "₎",
+        'a' => "ₐ",
+        'e' => "ₑ",
+        'i' => "ᵢ",
+        'o' => "ₒ",
+        'x' => "ₓ",
+        'h' => "ₕ",
+        'k' => "ₖ",
+        'l' => "ₗ",
+        'm' => "ₘ",
+        'n' => "ₙ",
+        'p' => "ₚ",
+        's' => "ₛ",
+        't' => "ₜ",
+        else => null,
+    };
+}
+
+fn eqlCaseInsensitive(a: []const u8, b: []const u8) bool {
+    return std.ascii.eqlIgnoreCase(a, b);
+}
+
+/// Curated LaTeX → Unicode symbol table. Covers common Greek letters and
+/// operators. Returns null for unknown commands so callers can fall back.
+fn lookupCommand(name: []const u8) ?[]const u8 {
+    const map = struct {
+        const entries = [_]struct { name: []const u8, sym: []const u8 }{
+            // Greek lowercase
+            .{ .name = "alpha", .sym = "α" },
+            .{ .name = "beta", .sym = "β" },
+            .{ .name = "gamma", .sym = "γ" },
+            .{ .name = "delta", .sym = "δ" },
+            .{ .name = "epsilon", .sym = "ε" },
+            .{ .name = "varepsilon", .sym = "ε" },
+            .{ .name = "zeta", .sym = "ζ" },
+            .{ .name = "eta", .sym = "η" },
+            .{ .name = "theta", .sym = "θ" },
+            .{ .name = "vartheta", .sym = "ϑ" },
+            .{ .name = "iota", .sym = "ι" },
+            .{ .name = "kappa", .sym = "κ" },
+            .{ .name = "lambda", .sym = "λ" },
+            .{ .name = "mu", .sym = "μ" },
+            .{ .name = "nu", .sym = "ν" },
+            .{ .name = "xi", .sym = "ξ" },
+            .{ .name = "omicron", .sym = "ο" },
+            .{ .name = "pi", .sym = "π" },
+            .{ .name = "varpi", .sym = "ϖ" },
+            .{ .name = "rho", .sym = "ρ" },
+            .{ .name = "varrho", .sym = "ϱ" },
+            .{ .name = "sigma", .sym = "σ" },
+            .{ .name = "varsigma", .sym = "ς" },
+            .{ .name = "tau", .sym = "τ" },
+            .{ .name = "upsilon", .sym = "υ" },
+            .{ .name = "phi", .sym = "φ" },
+            .{ .name = "varphi", .sym = "ϕ" },
+            .{ .name = "chi", .sym = "χ" },
+            .{ .name = "psi", .sym = "ψ" },
+            .{ .name = "omega", .sym = "ω" },
+            // Greek uppercase
+            .{ .name = "Alpha", .sym = "Α" },
+            .{ .name = "Beta", .sym = "Β" },
+            .{ .name = "Gamma", .sym = "Γ" },
+            .{ .name = "Delta", .sym = "Δ" },
+            .{ .name = "Epsilon", .sym = "Ε" },
+            .{ .name = "Zeta", .sym = "Ζ" },
+            .{ .name = "Eta", .sym = "Η" },
+            .{ .name = "Theta", .sym = "Θ" },
+            .{ .name = "Iota", .sym = "Ι" },
+            .{ .name = "Kappa", .sym = "Κ" },
+            .{ .name = "Lambda", .sym = "Λ" },
+            .{ .name = "Mu", .sym = "Μ" },
+            .{ .name = "Nu", .sym = "Ν" },
+            .{ .name = "Xi", .sym = "Ξ" },
+            .{ .name = "Omicron", .sym = "Ο" },
+            .{ .name = "Pi", .sym = "Π" },
+            .{ .name = "Rho", .sym = "Ρ" },
+            .{ .name = "Sigma", .sym = "Σ" },
+            .{ .name = "Tau", .sym = "Τ" },
+            .{ .name = "Upsilon", .sym = "Υ" },
+            .{ .name = "Phi", .sym = "Φ" },
+            .{ .name = "Chi", .sym = "Χ" },
+            .{ .name = "Psi", .sym = "Ψ" },
+            .{ .name = "Omega", .sym = "Ω" },
+            // Operators / relations
+            .{ .name = "sum", .sym = "∑" },
+            .{ .name = "prod", .sym = "∏" },
+            .{ .name = "coprod", .sym = "∐" },
+            .{ .name = "int", .sym = "∫" },
+            .{ .name = "oint", .sym = "∮" },
+            .{ .name = "iint", .sym = "∬" },
+            .{ .name = "iiint", .sym = "∭" },
+            .{ .name = "cbrt", .sym = "∛" },
+            .{ .name = "cdot", .sym = "·" },
+            .{ .name = "cdots", .sym = "⋯" },
+            .{ .name = "ldots", .sym = "…" },
+            .{ .name = "vdots", .sym = "⋮" },
+            .{ .name = "ddots", .sym = "⋱" },
+            .{ .name = "times", .sym = "×" },
+            .{ .name = "div", .sym = "÷" },
+            .{ .name = "pm", .sym = "±" },
+            .{ .name = "mp", .sym = "∓" },
+            .{ .name = "ast", .sym = "∗" },
+            .{ .name = "star", .sym = "⋆" },
+            .{ .name = "circ", .sym = "∘" },
+            .{ .name = "bullet", .sym = "•" },
+            .{ .name = "leq", .sym = "≤" },
+            .{ .name = "le", .sym = "≤" },
+            .{ .name = "geq", .sym = "≥" },
+            .{ .name = "ge", .sym = "≥" },
+            .{ .name = "neq", .sym = "≠" },
+            .{ .name = "ne", .sym = "≠" },
+            .{ .name = "approx", .sym = "≈" },
+            .{ .name = "equiv", .sym = "≡" },
+            .{ .name = "sim", .sym = "∼" },
+            .{ .name = "simeq", .sym = "≅" },
+            .{ .name = "cong", .sym = "≅" },
+            .{ .name = "propto", .sym = "∝" },
+            .{ .name = "in", .sym = "∈" },
+            .{ .name = "notin", .sym = "∉" },
+            .{ .name = "ni", .sym = "∋" },
+            .{ .name = "subset", .sym = "⊂" },
+            .{ .name = "supset", .sym = "⊃" },
+            .{ .name = "subseteq", .sym = "⊆" },
+            .{ .name = "supseteq", .sym = "⊇" },
+            .{ .name = "cup", .sym = "∪" },
+            .{ .name = "cap", .sym = "∩" },
+            .{ .name = "emptyset", .sym = "∅" },
+            .{ .name = "varnothing", .sym = "∅" },
+            .{ .name = "forall", .sym = "∀" },
+            .{ .name = "exists", .sym = "∃" },
+            .{ .name = "nexists", .sym = "∄" },
+            .{ .name = "neg", .sym = "¬" },
+            .{ .name = "lnot", .sym = "¬" },
+            .{ .name = "land", .sym = "∧" },
+            .{ .name = "lor", .sym = "∨" },
+            .{ .name = "Rightarrow", .sym = "⇒" },
+            .{ .name = "Leftarrow", .sym = "⇐" },
+            .{ .name = "Leftrightarrow", .sym = "⇔" },
+            .{ .name = "rightarrow", .sym = "→" },
+            .{ .name = "to", .sym = "→" },
+            .{ .name = "gets", .sym = "←" },
+            .{ .name = "leftarrow", .sym = "←" },
+            .{ .name = "leftrightarrow", .sym = "↔" },
+            .{ .name = "mapsto", .sym = "↦" },
+            .{ .name = "uparrow", .sym = "↑" },
+            .{ .name = "downarrow", .sym = "↓" },
+            .{ .name = "updownarrow", .sym = "↕" },
+            .{ .name = "infty", .sym = "∞" },
+            .{ .name = "partial", .sym = "∂" },
+            .{ .name = "nabla", .sym = "∇" },
+            .{ .name = "hbar", .sym = "ℏ" },
+            .{ .name = "ell", .sym = "ℓ" },
+            .{ .name = "Re", .sym = "ℜ" },
+            .{ .name = "Im", .sym = "ℑ" },
+            .{ .name = "aleph", .sym = "ℵ" },
+            .{ .name = "angle", .sym = "∠" },
+            .{ .name = "perp", .sym = "⊥" },
+            .{ .name = "parallel", .sym = "∥" },
+            .{ .name = "triangle", .sym = "△" },
+            .{ .name = "square", .sym = "□" },
+            .{ .name = "diamond", .sym = "◇" },
+            .{ .name = "oplus", .sym = "⊕" },
+            .{ .name = "ominus", .sym = "⊖" },
+            .{ .name = "otimes", .sym = "⊗" },
+            .{ .name = "oslash", .sym = "⊘" },
+            .{ .name = "odot", .sym = "⊙" },
+            .{ .name = "wr", .sym = "≀" },
+            .{ .name = "dagger", .sym = "†" },
+            .{ .name = "ddagger", .sym = "‡" },
+            .{ .name = "degree", .sym = "°" },
+            .{ .name = "prime", .sym = "′" },
+            .{ .name = "dprime", .sym = "″" },
+            // Style modifiers — silently dropped (no semantic loss in plain text).
+            .{ .name = "mathrm", .sym = "" },
+            .{ .name = "mathit", .sym = "" },
+            .{ .name = "mathbf", .sym = "" },
+            .{ .name = "mathsf", .sym = "" },
+            .{ .name = "mathtt", .sym = "" },
+            .{ .name = "mathcal", .sym = "" },
+            .{ .name = "mathbb", .sym = "" },
+            .{ .name = "displaystyle", .sym = "" },
+            .{ .name = "textstyle", .sym = "" },
+            .{ .name = "scriptstyle", .sym = "" },
+            .{ .name = "text", .sym = "" },
+            .{ .name = "operatorname", .sym = "" },
+            .{ .name = "left", .sym = "" },
+            .{ .name = "right", .sym = "" },
+            .{ .name = "big", .sym = "" },
+            .{ .name = "Big", .sym = "" },
+            .{ .name = "bigg", .sym = "" },
+            .{ .name = "Bigg", .sym = "" },
+            .{ .name = "bigl", .sym = "" },
+            .{ .name = "bigr", .sym = "" },
+            .{ .name = "Bigl", .sym = "" },
+            .{ .name = "Bigr", .sym = "" },
+        };
+    };
+
+    // Linear scan is fine: the table is small and lookup happens once per
+    // command occurrence in a chat message.
+    for (map.entries) |entry| {
+        if (std.mem.eql(u8, entry.name, name)) {
+            if (entry.sym.len == 0) return "";
+            return entry.sym;
+        }
+    }
+    return null;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test "preprocess returns input unchanged when no math or mermaid present" {
+    const src = "hello world\n# Heading";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expectEqualStrings(src, out);
+}
+
+test "preprocess handles empty input" {
+    const out = try preprocess(std.testing.allocator, "");
+    defer std.testing.allocator.free(out);
+    try std.testing.expectEqualStrings("", out);
+}
+
+test "inline math substitutes Greek letters" {
+    const src = "angle $\\alpha + \\beta$ equals gamma";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "α + β") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "\\alpha") == null);
+    // Surrounding prose survives.
+    try std.testing.expect(std.mem.indexOf(u8, out, "angle") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "equals gamma") != null);
+}
+
+test "inline math renders superscripts with Unicode" {
+    const src = "energy $E = mc^2$ is famous";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "E = mc²") != null);
+}
+
+test "inline math falls back to caret form for unsupported superscript" {
+    const src = "value $x^q$ here";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "x^q") != null);
+}
+
+test "block math on same line renders as blockquote" {
+    const src = "intro\n\n$$\\int_0^\\infty f(x)\\,dx$$\n\nafter";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "> ∫") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "₀") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "∞") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "$$") == null);
+}
+
+test "multi-line block math collapses to quoted lines" {
+    const src = "$$\n\\sum_{i=1}^n x_i\n$$";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "> ∑") != null);
+    // `^n` becomes Unicode superscript n; `_{i=1}` has no single-char form
+    // so it stays as the literal `_{i=1}` fallback.
+    try std.testing.expect(std.mem.indexOf(u8, out, "ⁿ") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "xᵢ") != null);
+}
+
+test "inline math ignores dollar signs used as currency" {
+    const src = "costs $5 and $10 each";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    // No transform should occur — currency stays as-is.
+    try std.testing.expectEqualStrings(src, out);
+}
+
+test "unterminated block math falls back gracefully" {
+    const src = "text $$\\alpha no closer";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "α") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "$$") == null);
+}
+
+test "unknown LaTeX command falls back to raw with backslash" {
+    const src = "weird $\\zzzx$ here";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "\\zzzx") != null);
+}
+
+test "mermaid block replaced with labeled summary" {
+    const src = "intro\n\n```mermaid\nflowchart TD\n  A --> B\n```\n\noutro";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "**Mermaid diagram: flowchart**") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "> flowchart TD") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "> A --> B") != null);
+    // Raw fence must be gone — copy behavior relies on raw text being inside
+    // the quoted section, but the fence delimiters themselves are stripped.
+    try std.testing.expect(std.mem.indexOf(u8, out, "```mermaid") == null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "intro") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "outro") != null);
+}
+
+test "mermaid sequenceDiagram type classified correctly" {
+    const src = "```mermaid\nsequenceDiagram\n  Alice->>Bob: Hi\n```";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "**Mermaid diagram: sequence**") != null);
+}
+
+test "mermaid block without closing fence still labels" {
+    const src = "```mermaid\nflowchart TD\n  A --> B";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "**Mermaid diagram: flowchart**") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "> flowchart TD") != null);
+}
+
+test "non-mermaid fenced code block is left untouched" {
+    const src = "```zig\nconst x = 1;\n```";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expectEqualStrings(src, out);
+}
+
+test "fraction command keeps operands visible" {
+    const src = "ratio $\\frac{a}{b}$ shows";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    // \frac{a}{b} renders as (a)/(b) so both operands and the slash survive.
+    try std.testing.expect(std.mem.indexOf(u8, out, "(a)/(b)") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "\\frac") == null);
+}
+
+test "style modifiers are silently dropped" {
+    const src = "math $\\mathrm{sin} + x$";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "sin") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "\\mathrm") == null);
+}
+
+test "sqrt emits radical sign" {
+    const src = "root $\\sqrt{x+1}$ end";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "√x+1") != null);
+}

--- a/zig/src/tui/markdown.zig
+++ b/zig/src/tui/markdown.zig
@@ -178,11 +178,11 @@ const BlockquoteFence = struct {
 };
 
 fn parseBlockquoteFenceLine(source: []const u8, line_start: usize) ?BlockquoteFence {
-    var pos = line_start;
-    while (pos < source.len and source[pos] == ' ') pos += 1;
-    if (pos >= source.len or source[pos] != '>') return null;
-    pos += 1;
-    if (pos < source.len and source[pos] == ' ') pos += 1;
+    // Consume the complete blockquote-marker prefix: nested quotes like
+    // `> > ```sh` repeat `>` markers separated by optional spaces.
+    const prefix = skipBlockquoteMarkers(source, line_start);
+    if (!prefix.has_marker) return null;
+    var pos = prefix.content_start;
     while (pos < source.len and source[pos] == ' ') pos += 1;
     if (pos >= source.len or (source[pos] != '`' and source[pos] != '~')) return null;
     const fence_char = source[pos];
@@ -201,24 +201,33 @@ fn parseBlockquoteFenceLine(source: []const u8, line_start: usize) ?BlockquoteFe
 
 /// Consume a contiguous Markdown indented code block (four spaces or one tab)
 /// verbatim. These blocks are not fenced, but their contents are still literal
-/// code and must not be preprocessed as math.
+/// code and must not be preprocessed as math. Also recognizes indented code
+/// nested inside blockquote markers (`>     code`), where the four-space
+/// indent follows the `>` prefix rather than the physical line start.
 fn consumeIndentedCodeBlock(writer: *std.Io.Writer, source: []const u8, i: *usize, list_ctx: ListContext) anyerror!bool {
     const start = i.*;
-    if (!isIndentedCodeLine(source, start)) return false;
+    const bq = skipBlockquoteMarkers(source, start);
+    if (!isIndentedCodeLine(source, bq.content_start)) return false;
 
     // In a list item, only lines indented at least four spaces past the
     // content column are nested indented code blocks. Lines indented fewer
     // than that are list continuations and should be processed normally
     // (e.g., so `$x^2$` on a four-space continuation still renders).
-    if (list_ctx.active) {
+    // Blockquote-nested code is always literal regardless of list context.
+    if (list_ctx.active and !bq.has_marker) {
         const indent = lineIndent(source, start);
         if (indent < list_ctx.content_indent + 4) return false;
     }
 
     var end = start;
     while (end < source.len) {
-        if (!isAtLineStart(source, end) or !isIndentedCodeLine(source, end)) break;
-        if (list_ctx.active) {
+        if (!isAtLineStart(source, end)) break;
+        const line_bq = skipBlockquoteMarkers(source, end);
+        // Require the same blockquote shape across the block (quoted code
+        // lines all carry the `>` prefix; unquoted blocks never gain one).
+        if (line_bq.has_marker != bq.has_marker) break;
+        if (!isIndentedCodeLine(source, line_bq.content_start)) break;
+        if (list_ctx.active and !line_bq.has_marker) {
             const indent = lineIndent(source, end);
             if (indent < list_ctx.content_indent + 4) break;
         }
@@ -229,6 +238,29 @@ fn consumeIndentedCodeBlock(writer: *std.Io.Writer, source: []const u8, i: *usiz
     try writer.writeAll(source[start..end]);
     i.* = end;
     return true;
+}
+
+const BlockquotePrefix = struct {
+    has_marker: bool,
+    content_start: usize,
+};
+
+/// Skip a blockquote-marker prefix (`>`, `> >`, …) at the start of a line,
+/// returning the offset where the quoted content begins. CommonMark allows up
+/// to three spaces before each `>` marker and one optional space after it.
+fn skipBlockquoteMarkers(source: []const u8, line_start: usize) BlockquotePrefix {
+    var pos = line_start;
+    var saw_marker = false;
+    while (true) {
+        var spaces: usize = 0;
+        while (pos + spaces < source.len and source[pos + spaces] == ' ' and spaces < 3) spaces += 1;
+        const after_spaces = pos + spaces;
+        if (after_spaces >= source.len or source[after_spaces] != '>') break;
+        saw_marker = true;
+        pos = after_spaces + 1;
+        if (pos < source.len and source[pos] == ' ') pos += 1;
+    }
+    return .{ .has_marker = saw_marker, .content_start = pos };
 }
 
 fn isIndentedCodeLine(source: []const u8, line_start: usize) bool {
@@ -586,10 +618,10 @@ fn consumeFenceBlock(allocator: std.mem.Allocator, writer: *std.Io.Writer, sourc
 }
 
 /// Consume a CommonMark tilde-fenced code block (`~~~ ... ~~~`) at line start.
-/// Unlike backtick fences, these are always copied verbatim because the
-/// downstream renderer displays them as plain text rather than bordered code.
+/// Mermaid blocks get the same labeled/quoted transformation as backtick
+/// fences; other tilde-fenced languages are copied verbatim.
 fn consumeTildeFenceBlock(allocator: std.mem.Allocator, writer: *std.Io.Writer, source: []const u8, i: *usize) anyerror!bool {
-    return try consumeFenceGeneric(allocator, writer, source, i, '~', false);
+    return try consumeFenceGeneric(allocator, writer, source, i, '~', true);
 }
 
 /// Generic fenced code block consumer.
@@ -624,8 +656,8 @@ fn consumeFenceGeneric(
     while (indent_end + fence_len < source.len and source[indent_end + fence_len] == fence_char) fence_len += 1;
     if (fence_len < 3) return false;
 
-    // For backtick fences the rest of the opener line is the language tag;
-    // tilde fences have no meaningful tag.
+    // Both backtick and tilde fences carry an optional language tag on the
+    // opener line.
     const fence_end = indent_end + fence_len;
     const line_end = std.mem.indexOfScalarPos(u8, source, fence_end, '\n') orelse source.len;
     const tag = if (may_be_mermaid)
@@ -1052,7 +1084,14 @@ fn consumeInlineMath(allocator: std.mem.Allocator, writer: *std.Io.Writer, sourc
     if (close + 1 < source.len) {
         const after = source[close + 1];
         if (after == '$' or after == '{' or std.ascii.isDigit(after)) return false;
-        if ((after == '/' or after == '-') and isShellNameLike(body)) return false;
+        // `$foo/$bar` / `$prefix-$suffix` look like adjacent shell-variable
+        // paths. Only reject when the separator actually leads into another
+        // `$` variable; hyphenated prose like `$x$-axis` must still render.
+        if ((after == '/' or after == '-') and isShellNameLike(body)) {
+            var scan = close + 2;
+            while (scan < source.len and (std.ascii.isAlphanumeric(source[scan]) or source[scan] == '_')) scan += 1;
+            if (scan < source.len and source[scan] == '$') return false;
+        }
         if (isUppercaseShellName(body) and isIdentifierChar(after)) return false;
         if (std.ascii.isAlphabetic(after) and std.ascii.isUpper(after)) {
             return false;
@@ -1317,7 +1356,7 @@ fn isCurrencyLikeMathBody(body: []const u8) bool {
         if (std.ascii.isAlphabetic(c)) saw_alpha = true;
         if (std.ascii.isWhitespace(c)) saw_space = true;
     }
-    return saw_alpha;
+    return saw_alpha and saw_space;
 }
 
 /// Returns true when the rendered math text contains a character that
@@ -2756,4 +2795,56 @@ test "list context survives ordinary continuation lines" {
     defer std.testing.allocator.free(out);
     try std.testing.expect(std.mem.indexOf(u8, out, "    x²") != null);
     try std.testing.expect(std.mem.indexOf(u8, out, "    $x^2$") == null);
+}
+
+
+test "nested blockquote code fence preserves quoted lines" {
+    const src = "> > ```sh\n> > echo $HOME$";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expectEqualStrings(src, out);
+}
+
+test "blockquote-indented code is preserved verbatim" {
+    const src = ">     const formula = \"$x^2$\";";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expectEqualStrings(src, out);
+}
+
+test "tilde-fenced mermaid block renders like backtick mermaid" {
+    const src = "~~~mermaid\nflowchart TD\n  A --> B\n~~~";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "**Mermaid diagram: flowchart**") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "> flowchart TD") != null);
+}
+
+test "tilde-fenced non-mermaid block stays verbatim" {
+    const src = "~~~sh\necho $x$\n~~~";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expectEqualStrings(src, out);
+}
+
+test "hyphenated prose after math renders" {
+    const src = "the $x$-axis";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "the x-axis") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "$x$") == null);
+}
+
+test "digit-prefixed algebraic coefficients render" {
+    const inline_src = "scale by $2x$";
+    const inline_out = try preprocess(std.testing.allocator, inline_src);
+    defer std.testing.allocator.free(inline_out);
+    try std.testing.expect(std.mem.indexOf(u8, inline_out, "scale by 2x") != null);
+    try std.testing.expect(std.mem.indexOf(u8, inline_out, "$2x$") == null);
+
+    const display_src = "$$10xy$$";
+    const display_out = try preprocess(std.testing.allocator, display_src);
+    defer std.testing.allocator.free(display_out);
+    try std.testing.expect(std.mem.indexOf(u8, display_out, "> 10xy") != null);
+    try std.testing.expect(std.mem.indexOf(u8, display_out, "$$10xy$$") == null);
 }

--- a/zig/src/tui/markdown.zig
+++ b/zig/src/tui/markdown.zig
@@ -75,7 +75,6 @@ fn isAtLineStart(source: []const u8, i: usize) bool {
 // Fence + mermaid
 // ---------------------------------------------------------------------------
 
-const mermaid_fence = "```";
 const mermaid_lang = "mermaid";
 
 /// If `source[i..]` opens a fenced code block at line start (optionally
@@ -87,24 +86,33 @@ const mermaid_lang = "mermaid";
 ///
 /// Updates `*i` past the consumed block and returns true. Returns false
 /// (without modifying `*i`) if `i` is not at a fence opener.
+///
+/// Supports CommonMark-style long fences (4+ backticks) so a block opened
+/// with ```` ```` ```` is only closed by a line whose leading backtick run
+/// is at least as long — this lets users embed ``` ```` ``` fences inside
+/// without breaking the outer block.
 fn consumeFenceBlock(allocator: std.mem.Allocator, writer: *std.Io.Writer, source: []const u8, i: *usize) !bool {
     const start = i.*;
     // Allow leading space indentation (a line of spaces followed by ```).
     var indent_end = start;
     while (indent_end < source.len and source[indent_end] == ' ') indent_end += 1;
-    if (indent_end + mermaid_fence.len > source.len) return false;
-    if (!std.mem.eql(u8, source[indent_end .. indent_end + mermaid_fence.len], mermaid_fence)) return false;
-    // The fence opener must sit at the start of the line — we've already
-    // returned false above if `i` is not at a line start.
+    if (indent_end >= source.len or source[indent_end] != '`') return false;
+
+    // Count the opening backtick run. CommonMark requires >=3 to open a
+    // fence; we accept any length and require a closer with at least as
+    // many backticks so users can use ```` to wrap content containing ```.
+    var fence_len: usize = 0;
+    while (indent_end + fence_len < source.len and source[indent_end + fence_len] == '`') fence_len += 1;
+    if (fence_len < 3) return false;
 
     // Lang tag occupies the rest of the opener line.
-    const fence_end = indent_end + mermaid_fence.len;
+    const fence_end = indent_end + fence_len;
     const line_end = std.mem.indexOfScalarPos(u8, source, fence_end, '\n') orelse source.len;
     const tag = std.mem.trim(u8, source[fence_end..line_end], " \t\r");
 
     // Body starts on the line after the opener.
     const body_start = if (line_end < source.len) line_end + 1 else source.len;
-    const close_line_start = findCodeBlockCloseLine(source, body_start);
+    const close_line_start = findCodeBlockCloseLine(source, body_start, fence_len);
     const body_end = if (close_line_start) |cls| cls else source.len;
     const body = source[body_start..body_end];
 
@@ -119,6 +127,10 @@ fn consumeFenceBlock(allocator: std.mem.Allocator, writer: *std.Io.Writer, sourc
             try writer.writeAll("**Mermaid diagram**\n\n");
         }
         try writeQuotedLines(writer, body);
+        // Trailing newline separates the mermaid region from whatever
+        // follows; without it the next paragraph would concatenate onto
+        // the last `> ...` line.
+        try writer.writeByte('\n');
     } else {
         // Non-mermaid fenced code block — copy opener, body, and closer
         // verbatim so any literal ```mermaid lines or `$` shell vars inside
@@ -154,20 +166,35 @@ fn consumeFenceBlock(allocator: std.mem.Allocator, writer: *std.Io.Writer, sourc
     return true;
 }
 
-/// Locate the first line at or after `body_start` whose content (after
-/// trimming whitespace) is exactly ```` ``` ````. Returns the absolute index
-/// of that closer line's first byte, or null if none is found.
-fn findCodeBlockCloseLine(source: []const u8, body_start: usize) ?usize {
+/// Locate the first line at or after `body_start` that closes a fenced
+/// code block opened with `fence_len` backticks. A closing line is one
+/// whose leading backtick run (after optional whitespace) is at least
+/// `fence_len` ticks long and contains nothing else but whitespace.
+///
+/// Returns the absolute index of that closer line's first byte, or null if
+/// none is found.
+fn findCodeBlockCloseLine(source: []const u8, body_start: usize, fence_len: usize) ?usize {
     var i = body_start;
     while (i < source.len) {
         const line_start = i;
         const line_end = std.mem.indexOfScalarPos(u8, source, line_start, '\n') orelse source.len;
         const line = source[line_start..line_end];
         const trimmed = std.mem.trim(u8, line, " \t\r");
-        if (std.mem.eql(u8, trimmed, mermaid_fence)) return line_start;
+        if (countLeadingBackticks(trimmed) >= fence_len) {
+            // Reject lines that have non-tick content after the run, e.g.
+            // an opener ```text. A valid closer is all backticks (possibly
+            // followed by trailing whitespace, already trimmed off).
+            if (std.mem.allEqual(u8, trimmed, '`')) return line_start;
+        }
         i = if (line_end < source.len) line_end + 1 else source.len;
     }
     return null;
+}
+
+fn countLeadingBackticks(s: []const u8) usize {
+    var n: usize = 0;
+    while (n < s.len and s[n] == '`') n += 1;
+    return n;
 }
 
 /// Inspect the first non-blank line of a Mermaid block to classify the
@@ -444,17 +471,21 @@ fn writeScript(writer: *std.Io.Writer, body: []const u8, i: *usize) !void {
     var token_end: usize = undefined;
     var had_braces = false;
     if (body[i.*] == '{') {
-        had_braces = true;
-        token_start = i.* + 1;
-        const close = std.mem.indexOfScalarPos(u8, body, token_start, '}') orelse {
-            // No closing brace — emit marker + rest verbatim.
+        // Use readGroup so nested braces like `^{\frac{1}{2}}` parse
+        // correctly — a scalar search for `}` would stop at the first
+        // inner closer and corrupt the rest.
+        if (readGroup(body, i.*)) |grp| {
+            had_braces = true;
+            token_start = i.* + 1;
+            token_end = grp.end - 1;
+            i.* = grp.end;
+        } else {
+            // Unterminated brace group — emit marker + rest verbatim.
             try writer.writeByte(marker);
             try writer.writeAll(body[i.*..]);
             i.* = body.len;
             return;
-        };
-        token_end = close;
-        i.* = close + 1;
+        }
     } else {
         // Only consume a single ASCII alphanumeric or operator punctuation as
         // the script token. Anything else (notably `\`, which starts a LaTeX
@@ -1103,4 +1134,50 @@ test "sqrt emits radical sign" {
     const out = try preprocess(std.testing.allocator, src);
     defer std.testing.allocator.free(out);
     try std.testing.expect(std.mem.indexOf(u8, out, "√x+1") != null);
+}
+
+test "mermaid block separates from following paragraph with newline" {
+    // Without a trailing newline after the quoted source, the next paragraph
+    // would concatenate onto the last `> ...` line.
+    const src = "```mermaid\nflowchart TD\n  A --> B\n```\noutro";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    // "outro" must land on its own line, not glued to the last quoted line.
+    try std.testing.expect(std.mem.indexOf(u8, out, "Boutro") == null);
+    try std.testing.expect(std.mem.indexOf(u8, out, ">   A --> B\n") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "\noutro") != null);
+}
+
+test "four-backtick fenced code block is recognized and closed" {
+    // CommonMark allows longer fences so users can wrap content containing
+    // triple backticks. A 4-tick fence must be matched by a 4+ tick closer
+    // and must protect its interior from math preprocessing.
+    const src = "````text\n$\\alpha$\n````\nthen $\\beta$";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    // Interior of the 4-tick block is untouched.
+    try std.testing.expect(std.mem.indexOf(u8, out, "$\\alpha$") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "α") == null);
+    // Math after the block still renders.
+    try std.testing.expect(std.mem.indexOf(u8, out, "β") != null);
+}
+
+test "four-backtick mermaid block is detected and labeled" {
+    const src = "````mermaid\nflowchart TD\n  A --> B\n````";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "**Mermaid diagram: flowchart**") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, ">   A --> B") != null);
+}
+
+test "nested script braces preserve inner group" {
+    // Grouped superscript with nested braces — the scalar `}` search used to
+    // truncate at the first inner closer. readGroup handles the nesting.
+    const src = "deep $x^{\\frac{1}{2}}$ end";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    // The full `\frac{1}{2}` survives inside the script fallback rather than
+    // being truncated to `\frac{1}2`.
+    try std.testing.expect(std.mem.indexOf(u8, out, "^{\\frac{1}{2}}") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "\\frac{1}2") == null);
 }

--- a/zig/src/tui/markdown.zig
+++ b/zig/src/tui/markdown.zig
@@ -47,18 +47,24 @@ pub fn preprocess(allocator: std.mem.Allocator, source: []const u8) ![]u8 {
             if (try consumeFenceBlock(allocator, writer, source, &i)) continue;
         }
 
-        // 2. Block math `$$...$$`. Checked before inline `$` so the leading
+        // 2. Inline code spans must stay raw. Protect them before math checks
+        //    so snippets like `echo $x$` remain copyable.
+        if (source[i] == '`') {
+            if (try consumeInlineCode(writer, source, &i)) continue;
+        }
+
+        // 3. Block math `$$...$$`. Checked before inline `$` so the leading
         //    `$$` isn't mis-parsed as two adjacent single-dollar spans.
         if (i + 1 < source.len and source[i] == '$' and source[i + 1] == '$') {
             if (try consumeBlockMath(allocator, writer, source, &i)) continue;
         }
 
-        // 3. Inline math `$...$`.
+        // 4. Inline math `$...$`.
         if (source[i] == '$') {
             if (try consumeInlineMath(writer, source, &i)) continue;
         }
 
-        // 4. Plain byte.
+        // 5. Plain byte.
         try writer.writeByte(source[i]);
         i += 1;
     }
@@ -69,6 +75,18 @@ pub fn preprocess(allocator: std.mem.Allocator, source: []const u8) ![]u8 {
 fn isAtLineStart(source: []const u8, i: usize) bool {
     if (i == 0) return true;
     return source[i - 1] == '\n';
+}
+
+/// Consume a single-backtick inline code span verbatim. Returns false for
+/// triple-backtick fences (handled by consumeFenceBlock) and unterminated
+/// spans so the default byte path preserves source.
+fn consumeInlineCode(writer: *std.Io.Writer, source: []const u8, i: *usize) !bool {
+    const start = i.*;
+    if (start + 2 < source.len and source[start + 1] == '`' and source[start + 2] == '`') return false;
+    const close = std.mem.indexOfScalarPos(u8, source, start + 1, '`') orelse return false;
+    try writer.writeAll(source[start .. close + 1]);
+    i.* = close + 1;
+    return true;
 }
 
 // ---------------------------------------------------------------------------
@@ -268,9 +286,6 @@ fn consumeBlockMath(allocator: std.mem.Allocator, writer: *std.Io.Writer, source
     const open = i.*;
     // Reject `$$$` — ambiguous with inline math like `$$$x$$`.
     if (open + 2 < source.len and source[open + 2] == '$') return false;
-    // Reject `$$<digit>` — currency like "$$5" is not block math.
-    if (open + 2 < source.len and std.ascii.isDigit(source[open + 2])) return false;
-
     const body_start = open + 2;
     const close = std.mem.indexOfPos(u8, source, body_start, "$$") orelse {
         // Unterminated — let the caller emit `$$` verbatim via the default
@@ -309,39 +324,37 @@ fn writeBlockMath(allocator: std.mem.Allocator, writer: *std.Io.Writer, body: []
 /// advances `*i` past the closing `$` on success. Returns false (leaving
 /// `*i` unmodified) when the bytes don't form a real inline-math span.
 ///
-/// Common currency patterns are explicitly rejected by the open/close guards
-/// so they pass through verbatim:
-/// - `$5` — opening `$` followed by a digit.
-/// - `5$` — opening `$` preceded by a non-space char.
-/// - `$5-$10`, `$5/$10` — the second `$` is preceded or followed by a digit.
+/// Common non-math dollar patterns are explicitly rejected by the
+/// open/close guards so they pass through verbatim:
+/// - `5$` — opening `$` preceded by a digit.
+/// - `$5-$10`, `$5/$10` — the closer is followed by a digit.
+/// - `$HOME/$PATH` — the closer is followed by an identifier char.
+/// Digit-led formulas such as `$2^n$` still render because the closer is not
+/// identifier/digit-adjacent.
 fn consumeInlineMath(writer: *std.Io.Writer, source: []const u8, i: *usize) !bool {
     const open = i.*;
 
-    // Opening `$` must be preceded by whitespace, start-of-text, or an
-    // opening bracket — anything else (e.g. `5$`) is currency.
-    if (open > 0) {
-        const prev = source[open - 1];
-        if (prev != ' ' and prev != '\t' and prev != '\n' and prev != '(' and prev != '[') return false;
-    }
-    // Body must start with a non-space, non-`$`, non-digit char. Digit
-    // adjacency (`$5`) indicates currency, not math.
+    // Opening `$` immediately after a digit is a price suffix, not math
+    // (`5$`). Other punctuation/operators like `=` or `:` are allowed so
+    // common forms such as `f(x)=$x^2$` and `value:$v$` render.
+    if (open > 0 and std.ascii.isDigit(source[open - 1])) return false;
+    // Body must start with a non-space and non-`$` char.
     if (open + 1 >= source.len) return false;
     {
         const next = source[open + 1];
-        if (next == ' ' or next == '$' or std.ascii.isDigit(next)) return false;
+        if (next == ' ' or next == '$') return false;
     }
 
     const body_start = open + 1;
     const close = std.mem.indexOfScalarPos(u8, source, body_start, '$') orelse return false;
 
-    // Closing `$` must not be preceded by whitespace, must not be followed
-    // by another `$`, and must not be followed by a digit (the second `$`
-    // in `$5-$10` is currency). Preceded-by-digit is fine — `$x^2$` is real
-    // math where the closer abuts a superscript digit.
+    // Closing `$` must not be preceded by whitespace, followed by another
+    // `$`, followed by a digit (currency ranges), or followed by an
+    // identifier char (adjacent shell vars like `$HOME/$PATH`).
     if (source[close - 1] == ' ') return false;
     if (close + 1 < source.len) {
         const after = source[close + 1];
-        if (after == '$' or std.ascii.isDigit(after)) return false;
+        if (after == '$' or std.ascii.isDigit(after) or isIdentifierChar(after)) return false;
     }
 
     const body = source[body_start..close];
@@ -519,6 +532,10 @@ fn writeScript(writer: *std.Io.Writer, body: []const u8, i: *usize) !void {
 
 fn isScriptTokenChar(c: u8) bool {
     return std.ascii.isAlphanumeric(c) or c == '+' or c == '-' or c == '=' or c == '(' or c == ')';
+}
+
+fn isIdentifierChar(c: u8) bool {
+    return std.ascii.isAlphanumeric(c) or c == '_';
 }
 
 /// Render `\frac{A}{B}` as `(A)/(B)`. Returns the new cursor position past
@@ -935,6 +952,15 @@ test "block math on same line renders as blockquote" {
     try std.testing.expect(std.mem.indexOf(u8, out, "$$") == null);
 }
 
+test "numeric display math renders as blockquote" {
+    const src = "$$2^n$$\n$$100\\%$$";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "> 2ⁿ") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "> 100\\%") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "$$") == null);
+}
+
 test "multi-line block math collapses to quoted lines" {
     const src = "$$\n\\sum_{i=1}^n x_i\n$$";
     const out = try preprocess(std.testing.allocator, src);
@@ -969,6 +995,39 @@ test "currency slash range preserves both dollar signs" {
     const out = try preprocess(std.testing.allocator, src);
     defer std.testing.allocator.free(out);
     try std.testing.expectEqualStrings(src, out);
+}
+
+test "inline math after operators renders" {
+    const src = "f(x)=$x^2$ and value:$v$";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "f(x)=x²") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "value:v") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "$x^2$") == null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "$v$") == null);
+}
+
+test "inline math starting with digits renders" {
+    const src = "count $2^n$ and percent $100\\%$";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "2ⁿ") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "100\\%") != null);
+}
+
+test "adjacent shell variables are not parsed as math" {
+    const src = "use $HOME/$PATH and $FOO-$BAR";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expectEqualStrings(src, out);
+}
+
+test "inline code span is not parsed as math" {
+    const src = "Use `echo $x$` then $\\alpha$";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "`echo $x$`") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "α") != null);
 }
 
 test "unterminated block math passes through verbatim per doc" {

--- a/zig/src/tui/markdown.zig
+++ b/zig/src/tui/markdown.zig
@@ -40,8 +40,18 @@ fn preprocessWithOptions(allocator: std.mem.Allocator, source: []const u8, prote
     errdefer out.deinit();
     const writer = &out.writer;
 
+    var line_style = LineStyle{
+        .line_start = 0,
+        .line_end = 0,
+        .in_style = false,
+        .star1_first = null,
+        .star1_last = null,
+        .star2_first = null,
+        .star2_last = null,
+    };
+
     var i: usize = 0;
-    var in_list_item = false;
+    var list_ctx = ListContext{};
     while (i < source.len) {
         // 1. Fenced code block opener at line start. Consumed whole: mermaid
         //    (backtick) blocks are transformed in place, every other language
@@ -50,11 +60,12 @@ fn preprocessWithOptions(allocator: std.mem.Allocator, source: []const u8, prote
         //    directly to the writer so the math steps below never re-process
         //    the interior.
         if (isAtLineStart(source, i)) {
-            updateListContext(source, i, &in_list_item);
+            line_style = computeLineStyle(source, i);
+            updateListContext(source, i, &list_ctx);
             if (try consumeFenceBlock(allocator, writer, source, &i)) continue;
             if (try consumeTildeFenceBlock(allocator, writer, source, &i)) continue;
             if (try consumeBlockquoteFenceBlock(writer, source, &i)) continue;
-            if (try consumeIndentedCodeBlock(writer, source, &i, in_list_item)) continue;
+            if (try consumeIndentedCodeBlock(writer, source, &i, list_ctx)) continue;
         }
 
         // 2. Markdown inline links, bare URLs, and relative path/URL
@@ -85,7 +96,7 @@ fn preprocessWithOptions(allocator: std.mem.Allocator, source: []const u8, prote
 
         // 5. Inline math `$...$`.
         if (source[i] == '$') {
-            if (try consumeInlineMath(allocator, writer, source, &i, protect_math)) continue;
+            if (try consumeInlineMath(allocator, writer, source, &i, protect_math, line_style)) continue;
         }
 
         // 5. Plain byte.
@@ -191,16 +202,26 @@ fn parseBlockquoteFenceLine(source: []const u8, line_start: usize) ?BlockquoteFe
 /// Consume a contiguous Markdown indented code block (four spaces or one tab)
 /// verbatim. These blocks are not fenced, but their contents are still literal
 /// code and must not be preprocessed as math.
-fn consumeIndentedCodeBlock(writer: *std.Io.Writer, source: []const u8, i: *usize, in_list_item: bool) anyerror!bool {
+fn consumeIndentedCodeBlock(writer: *std.Io.Writer, source: []const u8, i: *usize, list_ctx: ListContext) anyerror!bool {
     const start = i.*;
     if (!isIndentedCodeLine(source, start)) return false;
-    // Four-space indentation under an open list item is a list continuation,
-    // not a top-level indented code block; allow normal math preprocessing.
-    if (in_list_item) return false;
+
+    // In a list item, only lines indented at least four spaces past the
+    // content column are nested indented code blocks. Lines indented fewer
+    // than that are list continuations and should be processed normally
+    // (e.g., so `$x^2$` on a four-space continuation still renders).
+    if (list_ctx.active) {
+        const indent = lineIndent(source, start);
+        if (indent < list_ctx.content_indent + 4) return false;
+    }
 
     var end = start;
     while (end < source.len) {
         if (!isAtLineStart(source, end) or !isIndentedCodeLine(source, end)) break;
+        if (list_ctx.active) {
+            const indent = lineIndent(source, end);
+            if (indent < list_ctx.content_indent + 4) break;
+        }
         const line_end = std.mem.indexOfScalarPos(u8, source, end, '\n') orelse source.len;
         end = if (line_end < source.len) line_end + 1 else source.len;
     }
@@ -216,17 +237,53 @@ fn isIndentedCodeLine(source: []const u8, line_start: usize) bool {
     return line_start + 4 <= source.len and std.mem.eql(u8, source[line_start .. line_start + 4], "    ");
 }
 
-fn updateListContext(source: []const u8, line_start: usize, in_list_item: *bool) void {
+/// Tracks an open list item and the column where its content begins.
+/// Used to distinguish true indented code blocks nested inside a list from
+/// ordinary list continuation lines.
+const ListContext = struct {
+    active: bool = false,
+    content_indent: usize = 0,
+};
+
+fn updateListContext(source: []const u8, line_start: usize, ctx: *ListContext) void {
     const line_end = std.mem.indexOfScalarPos(u8, source, line_start, '\n') orelse source.len;
     const line = source[line_start..line_end];
     const trimmed = std.mem.trimStart(u8, line, " \t");
     if (trimmed.len == 0) return;
+    const indent = line.len - trimmed.len;
+
+    // A new list marker (possibly at column 0) opens a list item. A line at
+    // column 0 that is not a list marker closes any open list.
     if (isListMarkerLine(trimmed)) {
-        in_list_item.* = true;
+        ctx.active = true;
+        // Content starts after the marker and its required separating space.
+        if (trimmed[0] == '-' or trimmed[0] == '*') {
+            ctx.content_indent = indent + 2;
+        } else {
+            // Ordered marker: "1. ".
+            var marker_width: usize = 0;
+            while (marker_width < trimmed.len and std.ascii.isDigit(trimmed[marker_width])) marker_width += 1;
+            if (marker_width < trimmed.len and trimmed[marker_width] == '.') marker_width += 1;
+            if (marker_width < trimmed.len and trimmed[marker_width] == ' ') marker_width += 1;
+            ctx.content_indent = indent + marker_width;
+        }
         return;
     }
-    const indent = line.len - trimmed.len;
-    if (indent == 0) in_list_item.* = false;
+    if (indent == 0) ctx.active = false;
+}
+
+fn lineIndent(source: []const u8, line_start: usize) usize {
+    var width: usize = 0;
+    var i = line_start;
+    while (i < source.len) {
+        switch (source[i]) {
+            ' ' => width += 1,
+            '\t' => width += 4,
+            else => break,
+        }
+        i += 1;
+    }
+    return width;
 }
 
 fn isListMarkerLine(trimmed: []const u8) bool {
@@ -236,41 +293,72 @@ fn isListMarkerLine(trimmed: []const u8) bool {
     return i > 0 and i + 1 < trimmed.len and trimmed[i] == '.' and trimmed[i + 1] == ' ';
 }
 
-fn lineBounds(source: []const u8, pos: usize) struct { start: usize, end: usize } {
-    var start = pos;
-    while (start > 0 and source[start - 1] != '\n') start -= 1;
-    const end = std.mem.indexOfScalarPos(u8, source, pos, '\n') orelse source.len;
-    return .{ .start = start, .end = end };
+const LineStyle = struct {
+    line_start: usize,
+    line_end: usize,
+    in_style: bool,
+    star1_first: ?usize,
+    star1_last: ?usize,
+    star2_first: ?usize,
+    star2_last: ?usize,
+};
+
+fn computeLineStyle(source: []const u8, line_start: usize) LineStyle {
+    const line_end = std.mem.indexOfScalarPos(u8, source, line_start, '\n') orelse source.len;
+    const line = source[line_start..line_end];
+    const trimmed_start = std.mem.indexOfNonePos(u8, line, 0, " ") orelse line.len;
+    const trimmed = line[trimmed_start..];
+
+    var star1_first: ?usize = null;
+    var star1_last: ?usize = null;
+    var star2_first: ?usize = null;
+    var star2_last: ?usize = null;
+
+    var pos: usize = 0;
+    while (pos < line.len) {
+        if (line[pos] != '*') {
+            pos += 1;
+            continue;
+        }
+        const run_start = pos;
+        while (pos < line.len and line[pos] == '*') pos += 1;
+        const abs_start = line_start + run_start;
+        if (star1_first == null) star1_first = abs_start;
+        star1_last = abs_start;
+        if (pos - run_start >= 2) {
+            if (star2_first == null) star2_first = abs_start;
+            star2_last = abs_start;
+        }
+    }
+
+    return .{
+        .line_start = line_start,
+        .line_end = line_end,
+        .in_style = std.mem.startsWith(u8, trimmed, "# ") or
+            std.mem.startsWith(u8, trimmed, "## ") or
+            std.mem.startsWith(u8, trimmed, "### ") or
+            std.mem.startsWith(u8, trimmed, "> "),
+        .star1_first = star1_first,
+        .star1_last = star1_last,
+        .star2_first = star2_first,
+        .star2_last = star2_last,
+    };
+}
+
+fn hasDelimiterBeforeAfter(open: usize, close: usize, first: ?usize, last: ?usize) bool {
+    const f = first orelse return false;
+    const l = last orelse return false;
+    return f < open and l > close;
 }
 
 /// ZigZag styles headings, blockquotes, bold, and italic directly without
 /// recursively invoking `renderInline`. Inside those contexts, an inline-code
 /// wrapper would be displayed literally, so protection must be skipped.
-fn isInsideNonRecursiveMarkdownStyle(source: []const u8, open: usize, close: usize) bool {
-    const bounds = lineBounds(source, open);
-    const line = source[bounds.start..bounds.end];
-    const rel_open = open - bounds.start;
-    const rel_close = close - bounds.start;
-    const trimmed_start = std.mem.indexOfNonePos(u8, line, 0, " ") orelse line.len;
-    const trimmed = line[trimmed_start..];
-
-    if (std.mem.startsWith(u8, trimmed, "# ") or
-        std.mem.startsWith(u8, trimmed, "## ") or
-        std.mem.startsWith(u8, trimmed, "### ") or
-        std.mem.startsWith(u8, trimmed, "> "))
-    {
-        return true;
-    }
-
-    if (isBetweenDelimiters(line, rel_open, rel_close, "**")) return true;
-    if (isBetweenDelimiters(line, rel_open, rel_close, "*")) return true;
+fn isInsideNonRecursiveMarkdownStyle(open: usize, close: usize, style: LineStyle) bool {
+    if (style.in_style) return true;
+    if (hasDelimiterBeforeAfter(open, close, style.star2_first, style.star2_last)) return true;
+    if (hasDelimiterBeforeAfter(open, close, style.star1_first, style.star1_last)) return true;
     return false;
-}
-
-fn isBetweenDelimiters(line: []const u8, rel_open: usize, rel_close: usize, delim: []const u8) bool {
-    const before = line[0..rel_open];
-    const after = line[rel_close + 1 ..];
-    return std.mem.lastIndexOf(u8, before, delim) != null and std.mem.indexOf(u8, after, delim) != null;
 }
 
 /// Consume a Markdown inline link `[text](url)`. Preprocesses the visible
@@ -796,8 +884,8 @@ fn findUnescapedDoubleDollar(source: []const u8, start: usize) ?usize {
 /// contexts that ZigZag renders without recursing into `renderInline` (bold,
 /// italic, headings, blockquotes), where the wrapper would be displayed as a
 /// visible character rather than acting as a code-span boundary.
-fn writeProtectedMathSpan(writer: *std.Io.Writer, source: []const u8, open: usize, text: []const u8) anyerror!void {
-    if (!needsMathProtection(source, open, text)) {
+fn writeProtectedMathSpan(writer: *std.Io.Writer, source: []const u8, open: usize, text: []const u8, line_start: usize) anyerror!void {
+    if (!needsMathProtection(source, open, text, line_start)) {
         try writer.writeAll(text);
         return;
     }
@@ -912,7 +1000,7 @@ fn writeBlockMath(allocator: std.mem.Allocator, writer: *std.Io.Writer, body: []
 /// - `\$FOO\$` — the opener/closer is escaped by a backslash.
 /// Prose suffixes such as `$n$th` are allowed because they use lowercase
 /// identifiers and do not look like adjacent shell variables.
-fn consumeInlineMath(allocator: std.mem.Allocator, writer: *std.Io.Writer, source: []const u8, i: *usize, protect_math: bool) anyerror!bool {
+fn consumeInlineMath(allocator: std.mem.Allocator, writer: *std.Io.Writer, source: []const u8, i: *usize, protect_math: bool, line_style: LineStyle) anyerror!bool {
     const open = i.*;
 
     // Opening `$` immediately after a digit is a price suffix, not math
@@ -944,7 +1032,7 @@ fn consumeInlineMath(allocator: std.mem.Allocator, writer: *std.Io.Writer, sourc
     // like `$5; x=` are not and must not steal the next formula opener. A
     // digit-started body that would become a Markdown ordered-list marker at
     // line start is kept and protected instead.
-    if (isCurrencyLikeMathBody(body) and !startsBlockMarkdownAtSourcePosition(source, open, body)) return false;
+    if (isCurrencyLikeMathBody(body) and !startsBlockMarkdownAtSourcePosition(source, open, body, line_style.line_start)) return false;
 
     // Closing `$` must not be preceded by whitespace, followed by another
     // `$`, followed by a digit (currency ranges), or followed by `{`
@@ -982,8 +1070,8 @@ fn consumeInlineMath(allocator: std.mem.Allocator, writer: *std.Io.Writer, sourc
     var rendered: std.Io.Writer.Allocating = .init(allocator);
     defer rendered.deinit();
     try renderMathBody(&rendered.writer, body);
-    if (protect_math and !isInsideNonRecursiveMarkdownStyle(source, open, close)) {
-        try writeProtectedMathSpan(writer, source, open, rendered.written());
+    if (protect_math and !isInsideNonRecursiveMarkdownStyle(open, close, line_style)) {
+        try writeProtectedMathSpan(writer, source, open, rendered.written(), line_style.line_start);
     } else {
         try writer.writeAll(rendered.written());
     }
@@ -1239,7 +1327,7 @@ fn isCurrencyLikeMathBody(body: []const u8) bool {
 /// wrapper and can be emitted raw — this avoids leaking literal backticks
 /// inside styled contexts (bold, italic, headings, blockquotes) that bypass
 /// `renderInline`.
-fn needsMathProtection(source: []const u8, open: usize, text: []const u8) bool {
+fn needsMathProtection(source: []const u8, open: usize, text: []const u8, line_start: usize) bool {
     for (text) |c| {
         if (c == '*' or c == '_' or c == '`' or c == '[' or c == ']' or
             c == '<' or c == '>')
@@ -1247,12 +1335,11 @@ fn needsMathProtection(source: []const u8, open: usize, text: []const u8) bool {
             return true;
         }
     }
-    return startsBlockMarkdownAtSourcePosition(source, open, text);
+    return startsBlockMarkdownAtSourcePosition(source, open, text, line_start);
 }
 
-fn startsBlockMarkdownAtSourcePosition(source: []const u8, open: usize, text: []const u8) bool {
-    const bounds = lineBounds(source, open);
-    const before = source[bounds.start..open];
+fn startsBlockMarkdownAtSourcePosition(source: []const u8, open: usize, text: []const u8, line_start: usize) bool {
+    const before = source[line_start..open];
     if (std.mem.indexOfNone(u8, before, " \t") != null) return false;
 
     if (std.mem.startsWith(u8, text, "# ")) return true;
@@ -1278,10 +1365,9 @@ fn isAllMarkdownRuleChar(text: []const u8, c: u8) bool {
 /// rather than being converted to sub/superscripts).
 fn isTextModeCommand(name: []const u8) bool {
     const text_cmds = [_][]const u8{
-        "text",    "textbf",  "textit",  "textrm",  "texttt", "textsf",
-        "emph",    "underline", "mathrm", "mathit", "mathbf", "mathsf",
-        "mathtt",  "mathcal", "mathbb",  "boldsymbol", "pmb",
-        "operatorname",
+        "text",   "textbf",    "textit", "textrm",     "texttt", "textsf",
+        "emph",   "underline", "mathrm", "mathit",     "mathbf", "mathsf",
+        "mathtt", "mathcal",   "mathbb", "boldsymbol", "pmb",    "operatorname",
     };
     for (text_cmds) |cmd| {
         if (std.mem.eql(u8, name, cmd)) return true;
@@ -1311,7 +1397,7 @@ fn readFracOperand(body: []const u8, i: usize) ?FracOperand {
         }
         return .{ .raw = body[j..k], .end = k };
     }
-    return .{ .raw = body[j..j + 1], .end = j + 1 };
+    return .{ .raw = body[j .. j + 1], .end = j + 1 };
 }
 
 fn isBraceGroup(raw: []const u8) bool {
@@ -1326,9 +1412,9 @@ fn writeFrac(writer: *std.Io.Writer, body: []const u8, start: usize) anyerror!us
     const b = if (a) |op| readFracOperand(body, op.end) else null;
     if (a != null and b != null and isBraceGroup(a.?.raw) and isBraceGroup(b.?.raw)) {
         try writer.writeByte('(');
-        try renderMathBody(writer, a.?.raw[1..a.?.raw.len - 1]);
+        try renderMathBody(writer, a.?.raw[1 .. a.?.raw.len - 1]);
         try writer.writeAll(")/(");
-        try renderMathBody(writer, b.?.raw[1..b.?.raw.len - 1]);
+        try renderMathBody(writer, b.?.raw[1 .. b.?.raw.len - 1]);
         try writer.writeByte(')');
         return b.?.end;
     }
@@ -2125,7 +2211,6 @@ test "fraction with newline separated brace operands renders" {
     try std.testing.expect(std.mem.indexOf(u8, out, "(a)/(b)") != null);
 }
 
-
 test "style modifiers are silently dropped" {
     const src = "math $\\mathrm{sin} + x$";
     const out = try preprocess(std.testing.allocator, src);
@@ -2487,7 +2572,6 @@ test "unterminated block math in prose preserves dollars" {
     try std.testing.expect(std.mem.indexOf(u8, out, "`x`") == null);
 }
 
-
 test "inline closer skips triple-backtick code spans" {
     // Regression for P2: a literal dollar before a mid-line triple-backtick
     // span must not pair with dollars inside that protected code span.
@@ -2527,7 +2611,6 @@ test "indented code block is preserved verbatim" {
     try std.testing.expect(std.mem.indexOf(u8, out, "outro y") != null);
 }
 
-
 test "inline closer skips complete markdown links" {
     // Regression for P2: a literal/currency dollar before a Markdown link must
     // not pair with `$` inside the link label before consumeMarkdownLink can
@@ -2540,7 +2623,6 @@ test "inline closer skips complete markdown links" {
     try std.testing.expect(std.mem.indexOf(u8, out, "x$](https://example.com)") == null);
 }
 
-
 test "inline closer skips reference markdown links" {
     const src = "Pay $5; see [$x$][ref] now";
     const out = try preprocess(std.testing.allocator, src);
@@ -2549,7 +2631,6 @@ test "inline closer skips reference markdown links" {
     try std.testing.expect(std.mem.indexOf(u8, out, "`5; see [") == null);
     try std.testing.expect(std.mem.indexOf(u8, out, "x$][ref]") == null);
 }
-
 
 test "rejected double dollar openers are consumed atomically" {
     const escaped = "\\$$x$$";
@@ -2562,7 +2643,6 @@ test "rejected double dollar openers are consumed atomically" {
     defer std.testing.allocator.free(triple_out);
     try std.testing.expectEqualStrings(triple, triple_out);
 }
-
 
 test "lowercase shell variables separated by punctuation stay raw" {
     const src = "connect $host:$port as $user@$host via $name.$domain";
@@ -2596,6 +2676,22 @@ test "line-start inline math that renders block marker is protected" {
     try std.testing.expect(std.mem.indexOf(u8, ordered, "`1. item`") != null);
 }
 
+test "indented code nested inside unordered list item is preserved verbatim" {
+    const src = "- Example:\n\n        const formula = \"$x^2$\";";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "        const formula = \"$x^2$\";") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "x²") == null);
+}
+
+test "indented code nested inside ordered list item is preserved verbatim" {
+    const src = "1. Example:\n\n        const formula = \"$x^2$\";";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "        const formula = \"$x^2$\";") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "x²") == null);
+}
+
 test "indented list continuation math is rendered" {
     const src = "- Formula:\n    $x^2$";
     const out = try preprocess(std.testing.allocator, src);
@@ -2603,7 +2699,6 @@ test "indented list continuation math is rendered" {
     try std.testing.expect(std.mem.indexOf(u8, out, "    x²") != null);
     try std.testing.expect(std.mem.indexOf(u8, out, "    $x^2$") == null);
 }
-
 
 test "digit-prefixed double dollars stay prose" {
     const src = "cost $$5 total$$ today";
@@ -2644,7 +2739,6 @@ test "long list continuations avoid quadratic backscan and render math" {
     try std.testing.expect(std.mem.indexOf(u8, out, "$d$") == null);
 }
 
-
 test "digit-prefixed formulas with math separators render" {
     const src = "$2 + 3$ and $$10 \\times 4$$ and $2,000$ and $1:2$";
     const out = try preprocess(std.testing.allocator, src);
@@ -2655,7 +2749,6 @@ test "digit-prefixed formulas with math separators render" {
     try std.testing.expect(std.mem.indexOf(u8, out, "1:2") != null);
     try std.testing.expect(std.mem.indexOf(u8, out, "$2 + 3$") == null);
 }
-
 
 test "list context survives ordinary continuation lines" {
     const src = "- Formula:\n  explanation\n    $x^2$";

--- a/zig/src/tui/markdown.zig
+++ b/zig/src/tui/markdown.zig
@@ -1082,33 +1082,46 @@ fn consumeInlineMath(allocator: std.mem.Allocator, writer: *std.Io.Writer, sourc
     // allowed so common forms such as `f(x)=$x^2$` and `value:$v$` render.
     if (open > 0 and std.ascii.isDigit(source[open - 1])) return false;
     if (open > 0 and isEscaped(source, open)) return false;
-    // Body must start with a non-space and non-`$` char.
+    // Body must start with a non-`$`, non-`{` char. Leading inner whitespace
+    // (e.g. conventionally padded TeX like `$ x + y $`) is allowed and trimmed
+    // below before classification/rendering.
     if (open + 1 >= source.len) return false;
     {
         const next = source[open + 1];
-        if (next == ' ' or next == '$' or next == '{') return false;
+        if (next == '$' or next == '{') return false;
     }
 
     const body_start = open + 1;
     const close = findInlineMathClose(source, body_start) orelse return false;
 
     const body = source[body_start..close];
+    // Allow conventionally padded TeX (`$ x + y $`), but require the padding to
+    // be leading-anchored: a trailing space with no leading space is prose like
+    // `$bar and $baz`, where the second dollar is another shell variable's
+    // opener rather than a math closer. Symmetric padding is trimmed below.
+    const has_leading_ws = body.len > 0 and (body[0] == ' ' or body[0] == '\t');
+    const has_trailing_ws = body.len > 0 and (body[body.len - 1] == ' ' or body[body.len - 1] == '\t');
+    if (has_trailing_ws and !has_leading_ws) return false;
+    // Trim optional inner padding so `$ x + y $` renders like `$x + y$`. The
+    // trimmed body is used for all classification and rendering below.
+    const math_body = std.mem.trim(u8, body, " \t\r");
+    if (math_body.len == 0) return false; // `$ $` / `$  $` is not a formula
 
     // Reject bodies that look like they swallowed a URL — a `$` before a
     // bare URL can pair with a `$` inside the URL destination (e.g. a
     // placeholder) even though the closer search skips URLs, because the
     // URL may have already been consumed as part of the body when the
     // opener was at a position where the URL check hadn't fired yet.
-    if (std.mem.indexOf(u8, body, "://") != null) return false;
+    if (std.mem.indexOf(u8, math_body, "://") != null) return false;
     // Digit-started formulas like `$2^n$` are valid, but currency/prose bodies
     // like `$5; x=` are not and must not steal the next formula opener. A
     // digit-started body that would become a Markdown ordered-list marker at
     // line start is kept and protected instead.
-    if (isCurrencyLikeMathBody(body) and !startsBlockMarkdownAtSourcePosition(source, open, body, line_style.line_start)) return false;
+    if (isCurrencyLikeMathBody(math_body) and !startsBlockMarkdownAtSourcePosition(source, open, math_body, line_style.line_start)) return false;
 
-    // Closing `$` must not be preceded by whitespace, followed by another
-    // `$`, followed by a digit (currency ranges), or followed by `{`
-    // (braced shell variables like `${HOME}`).
+    // Closing `$` must not be followed by another `$`, a digit (currency
+    // ranges), or `{` (braced shell variables like `${HOME}`). Trailing inner
+    // whitespace is allowed (already trimmed into `math_body`).
     // An identifier suffix is allowed for prose like `$n$th`. Shell-variable
     // adjacency is detected in two shapes:
     //   - `$HOME/$PATH`, `$foo/$bar` — closer followed by `/` or `-` and body
@@ -1117,9 +1130,8 @@ fn consumeInlineMath(allocator: std.mem.Allocator, writer: *std.Io.Writer, sourc
     //     closer is followed by an identifier char (the next variable name).
     // Uppercase-only bodies are additionally rejected when followed by any
     // identifier (`$HOME$var`).
-    if (source[close - 1] == ' ') return false;
-    if (body.len > 0 and isShellVarSeparator(body[body.len - 1])) {
-        if (close + 1 < source.len and isIdentifierChar(source[close + 1]) and isShellNameLike(body[0 .. body.len - 1])) return false;
+    if (math_body.len > 0 and isShellVarSeparator(math_body[math_body.len - 1])) {
+        if (close + 1 < source.len and isIdentifierChar(source[close + 1]) and isShellNameLike(math_body[0 .. math_body.len - 1])) return false;
     }
     if (close + 1 < source.len) {
         const after = source[close + 1];
@@ -1127,19 +1139,19 @@ fn consumeInlineMath(allocator: std.mem.Allocator, writer: *std.Io.Writer, sourc
         // `$foo/$bar` / `$prefix-$suffix` look like adjacent shell-variable
         // paths. Only reject when the separator actually leads into another
         // `$` variable; hyphenated prose like `$x$-axis` must still render.
-        if ((after == '/' or after == '-') and isShellNameLike(body)) {
+        if ((after == '/' or after == '-') and isShellNameLike(math_body)) {
             var scan = close + 2;
             while (scan < source.len and (std.ascii.isAlphanumeric(source[scan]) or source[scan] == '_')) scan += 1;
             if (scan < source.len and source[scan] == '$') return false;
         }
-        if (isUppercaseShellName(body) and isIdentifierChar(after)) return false;
+        if (isUppercaseShellName(math_body) and isIdentifierChar(after)) return false;
         if (std.ascii.isAlphabetic(after) and std.ascii.isUpper(after)) {
             return false;
         }
     }
 
     // Reject newlines — inline math is a single line.
-    if (std.mem.indexOfScalar(u8, body, '\n') != null) return false;
+    if (std.mem.indexOfScalar(u8, math_body, '\n') != null) return false;
 
     // Render to a temporary buffer. When inserted into normal prose, wrap the
     // result in inline-code backticks so ZigZag's renderInline treats the whole
@@ -1148,7 +1160,7 @@ fn consumeInlineMath(allocator: std.mem.Allocator, writer: *std.Io.Writer, sourc
     // skip the wrapper.
     var rendered: std.Io.Writer.Allocating = .init(allocator);
     defer rendered.deinit();
-    try renderMathBody(&rendered.writer, body);
+    try renderMathBody(&rendered.writer, math_body);
     if (protect_math and !isInsideNonRecursiveMarkdownStyle(open, close, line_style)) {
         try writeProtectedMathSpan(writer, source, open, rendered.written(), line_style.line_start);
     } else {
@@ -1386,16 +1398,36 @@ fn isCurrencyLikeMathBody(body: []const u8) bool {
     if (body.len == 0 or !std.ascii.isDigit(body[0])) return false;
     var saw_space = false;
     var saw_alpha = false;
-    for (body[1..]) |c| {
+    var i: usize = 1;
+    while (i < body.len) : (i += 1) {
+        const c = body[i];
+        // A semicolon (e.g. `5; x=`) is a strong prose/currency indicator.
         if (c == ';') return true;
-        if (c == '\\' or c == '^' or c == '_' or c == '+' or c == '-' or
+        // A backslash introduces a LaTeX command (`\times`, `\cdot`, `\frac`);
+        // skip its command-name letters so they are not mistaken for prose
+        // alpha. This keeps real digit-prefixed math like `10 \times 4`
+        // rendering.
+        if (c == '\\') {
+            var j = i + 1;
+            while (j < body.len and std.ascii.isAlphabetic(body[j])) j += 1;
+            i = j - 1; // the loop's `i += 1` then advances past the name
+            continue;
+        }
+        // Math operators do not by themselves prove the body is math, but they
+        // do not prove it is currency either. Keep scanning so a later `;`,
+        // alphabetic word, or space can still classify currency/prose shapes
+        // like `5+tax; x=` without bailing on the `+`.
+        if (c == '^' or c == '_' or c == '+' or c == '-' or
             c == '*' or c == '/' or c == '=' or c == '<' or c == '>')
         {
-            return false;
+            continue;
         }
         if (std.ascii.isAlphabetic(c)) saw_alpha = true;
         if (std.ascii.isWhitespace(c)) saw_space = true;
     }
+    // Require both an alphabetic word and prose spacing so pure arithmetic
+    // (`2^n`, `5+3`, `2 + 3`, `10 \times 4`) still renders while prose/currency
+    // shapes (`5 total`, `5+tax; x=`) are rejected.
     return saw_alpha and saw_space;
 }
 
@@ -2731,6 +2763,59 @@ test "lowercase shell variables separated by punctuation stay raw" {
     try std.testing.expect(std.mem.indexOf(u8, out, "$user@$host") != null);
     try std.testing.expect(std.mem.indexOf(u8, out, "$name.$domain") != null);
     try std.testing.expect(std.mem.indexOf(u8, out, "host:port") == null);
+}
+
+test "currency dollar with operator does not steal formula opener" {
+    // Regression for P2: the `+` must not make isCurrencyLikeMathBody bail
+    // before seeing the `;` prose indicator. The price dollar stays literal
+    // and the real formula renders.
+    const src = "Costs $5+tax; x=$x$.";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "Costs $5+tax; x=x.") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "Costs 5+tax; x=x$.") == null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "$x$") == null);
+}
+
+test "pure digit-prefixed arithmetic still renders after currency widening" {
+    // After widening the currency scan to continue past operators, genuine
+    // arithmetic must still render.
+    const a = try preprocess(std.testing.allocator, "$5+3$");
+    defer std.testing.allocator.free(a);
+    try std.testing.expect(std.mem.indexOf(u8, a, "5+3") != null);
+    try std.testing.expect(std.mem.indexOf(u8, a, "$5+3$") == null);
+
+    const b = try preprocess(std.testing.allocator, "$2^n$");
+    defer std.testing.allocator.free(b);
+    try std.testing.expect(std.mem.indexOf(u8, b, "2ⁿ") != null);
+
+    const c = try preprocess(std.testing.allocator, "$$10 \\times 4$$");
+    defer std.testing.allocator.free(c);
+    try std.testing.expect(std.mem.indexOf(u8, c, "> 10 × 4") != null);
+}
+
+test "whitespace-padded inline math renders" {
+    // Regression for P2: conventionally padded TeX like `$ x + y $` must
+    // render, with the inner padding trimmed before the math renderer.
+    const src = "Sum $ x + y $ done";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "Sum x + y done") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "$ x + y $") == null);
+
+    // Tab padding is also accepted.
+    const tab_src = "Sum $\tx + y\t$ done";
+    const tab_out = try preprocess(std.testing.allocator, tab_src);
+    defer std.testing.allocator.free(tab_out);
+    try std.testing.expect(std.mem.indexOf(u8, tab_out, "Sum x + y done") != null);
+    try std.testing.expect(std.mem.indexOf(u8, tab_out, "$\tx + y\t$") == null);
+}
+
+test "empty padded dollars are not a formula" {
+    const src = "cost $ $ today";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expectEqualStrings(src, out);
 }
 
 test "line-start inline math that renders block marker is protected" {

--- a/zig/src/tui/markdown.zig
+++ b/zig/src/tui/markdown.zig
@@ -349,6 +349,37 @@ fn writeQuotedLines(writer: *std.Io.Writer, body: []const u8) !void {
 // Math
 // ---------------------------------------------------------------------------
 
+/// Returns true if `source[i]` is preceded by an odd number of consecutive
+/// backslashes, i.e. it is LaTeX-escaped.
+fn isEscaped(source: []const u8, i: usize) bool {
+    if (i == 0) return false;
+    var backslashes: usize = 0;
+    var j = i;
+    while (j > 0 and source[j - 1] == '\\') {
+        backslashes += 1;
+        j -= 1;
+    }
+    return backslashes % 2 == 1;
+}
+
+/// Find the next unescaped `$` at or after `start`.
+fn findUnescapedDollar(source: []const u8, start: usize) ?usize {
+    var i = start;
+    while (i < source.len) : (i += 1) {
+        if (source[i] == '$' and !isEscaped(source, i)) return i;
+    }
+    return null;
+}
+
+/// Find the next unescaped `$$` at or after `start`.
+fn findUnescapedDoubleDollar(source: []const u8, start: usize) ?usize {
+    var i = start;
+    while (i + 1 < source.len) : (i += 1) {
+        if (source[i] == '$' and source[i + 1] == '$' and !isEscaped(source, i)) return i;
+    }
+    return null;
+}
+
 /// Try to consume a `$$...$$` block math span at `*i`. Returns true and
 /// advances `*i` past the closing `$$` on success. Returns false (without
 /// modifying `*i`) when the bytes at `*i` aren't a real block-math opener —
@@ -361,7 +392,7 @@ fn consumeBlockMath(allocator: std.mem.Allocator, writer: *std.Io.Writer, source
     // Reject `$$$` — ambiguous with inline math like `$$$x$$`.
     if (open + 2 < source.len and source[open + 2] == '$') return false;
     const body_start = open + 2;
-    const close = std.mem.indexOfPos(u8, source, body_start, "$$") orelse {
+    const close = findUnescapedDoubleDollar(source, body_start) orelse {
         // Unterminated — let the caller emit `$$` verbatim via the default
         // byte-by-byte path. We must NOT swallow the remainder.
         return false;
@@ -423,7 +454,7 @@ fn consumeInlineMath(writer: *std.Io.Writer, source: []const u8, i: *usize) !boo
     }
 
     const body_start = open + 1;
-    const close = std.mem.indexOfScalarPos(u8, source, body_start, '$') orelse return false;
+    const close = findUnescapedDollar(source, body_start) orelse return false;
 
     // Closing `$` must not be preceded by whitespace, followed by another
     // `$`, followed by a digit (currency ranges), followed by an identifier
@@ -477,6 +508,12 @@ fn renderMathBody(writer: *std.Io.Writer, body: []const u8) anyerror!void {
                 }
                 if (next == '\\') {
                     try writer.writeByte('\n');
+                    i = j + 1;
+                    continue;
+                }
+                // Escaped literal characters render as themselves.
+                if (next == '$' or next == '%' or next == '&' or next == '#' or next == '_' or next == '{' or next == '}') {
+                    try writer.writeByte(next);
                     i = j + 1;
                     continue;
                 }
@@ -1034,7 +1071,7 @@ test "numeric display math renders as blockquote" {
     const out = try preprocess(std.testing.allocator, src);
     defer std.testing.allocator.free(out);
     try std.testing.expect(std.mem.indexOf(u8, out, "> 2ⁿ") != null);
-    try std.testing.expect(std.mem.indexOf(u8, out, "> 100\\%") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "> 100%") != null);
     try std.testing.expect(std.mem.indexOf(u8, out, "$$") == null);
 }
 
@@ -1089,7 +1126,24 @@ test "inline math starting with digits renders" {
     const out = try preprocess(std.testing.allocator, src);
     defer std.testing.allocator.free(out);
     try std.testing.expect(std.mem.indexOf(u8, out, "2ⁿ") != null);
-    try std.testing.expect(std.mem.indexOf(u8, out, "100\\%") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "100%") != null);
+}
+
+test "escaped dollar inside inline math is not treated as closer" {
+    const src = "price $x = \\$5$";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    // The escaped \$ should render as a literal $ and the real closing $ should
+    // terminate the math span, so the whole formula renders as "x = $5".
+    try std.testing.expect(std.mem.indexOf(u8, out, "price x = $5") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "price $x = \\5") == null);
+}
+
+test "escaped dollar inside block math is not treated as closer" {
+    const src = "$$x = \\$5$$";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "x = $5") != null);
 }
 
 test "adjacent shell variables are not parsed as math" {

--- a/zig/src/tui/markdown.zig
+++ b/zig/src/tui/markdown.zig
@@ -41,6 +41,7 @@ fn preprocessWithOptions(allocator: std.mem.Allocator, source: []const u8, prote
     const writer = &out.writer;
 
     var i: usize = 0;
+    var in_list_item = false;
     while (i < source.len) {
         // 1. Fenced code block opener at line start. Consumed whole: mermaid
         //    (backtick) blocks are transformed in place, every other language
@@ -49,9 +50,11 @@ fn preprocessWithOptions(allocator: std.mem.Allocator, source: []const u8, prote
         //    directly to the writer so the math steps below never re-process
         //    the interior.
         if (isAtLineStart(source, i)) {
+            updateListContext(source, i, &in_list_item);
             if (try consumeFenceBlock(allocator, writer, source, &i)) continue;
             if (try consumeTildeFenceBlock(allocator, writer, source, &i)) continue;
-            if (try consumeIndentedCodeBlock(writer, source, &i)) continue;
+            if (try consumeBlockquoteFenceBlock(writer, source, &i)) continue;
+            if (try consumeIndentedCodeBlock(writer, source, &i, in_list_item)) continue;
         }
 
         // 2. Markdown inline links, bare URLs, and relative path/URL
@@ -133,16 +136,67 @@ fn consumeInlineCode(writer: *std.Io.Writer, source: []const u8, i: *usize) anye
     return true;
 }
 
+/// Consume a fenced code block nested in Markdown blockquote markers (`> ```sh`).
+/// These fences are not at the physical line start, but their quoted contents
+/// are still literal code and must be copied verbatim, including unfinished
+/// streaming partials.
+fn consumeBlockquoteFenceBlock(writer: *std.Io.Writer, source: []const u8, i: *usize) anyerror!bool {
+    const start = i.*;
+    const opener = parseBlockquoteFenceLine(source, start) orelse return false;
+    var end = if (opener.line_end < source.len) opener.line_end + 1 else source.len;
+    while (end < source.len) {
+        if (parseBlockquoteFenceLine(source, end)) |candidate| {
+            if (candidate.fence_char == opener.fence_char and candidate.fence_len >= opener.fence_len and candidate.is_closer) {
+                end = if (candidate.line_end < source.len) candidate.line_end + 1 else source.len;
+                break;
+            }
+        }
+        const line_end = std.mem.indexOfScalarPos(u8, source, end, '\n') orelse source.len;
+        end = if (line_end < source.len) line_end + 1 else source.len;
+    }
+    try writer.writeAll(source[start..end]);
+    i.* = end;
+    return true;
+}
+
+const BlockquoteFence = struct {
+    fence_char: u8,
+    fence_len: usize,
+    line_end: usize,
+    is_closer: bool,
+};
+
+fn parseBlockquoteFenceLine(source: []const u8, line_start: usize) ?BlockquoteFence {
+    var pos = line_start;
+    while (pos < source.len and source[pos] == ' ') pos += 1;
+    if (pos >= source.len or source[pos] != '>') return null;
+    pos += 1;
+    if (pos < source.len and source[pos] == ' ') pos += 1;
+    while (pos < source.len and source[pos] == ' ') pos += 1;
+    if (pos >= source.len or (source[pos] != '`' and source[pos] != '~')) return null;
+    const fence_char = source[pos];
+    const fence_len = countLeadingChar(source[pos..], fence_char);
+    if (fence_len < 3) return null;
+    const after_fence = pos + fence_len;
+    const line_end = std.mem.indexOfScalarPos(u8, source, line_start, '\n') orelse source.len;
+    const rest = std.mem.trim(u8, source[after_fence..line_end], " \t\r");
+    return .{
+        .fence_char = fence_char,
+        .fence_len = fence_len,
+        .line_end = line_end,
+        .is_closer = rest.len == 0,
+    };
+}
+
 /// Consume a contiguous Markdown indented code block (four spaces or one tab)
 /// verbatim. These blocks are not fenced, but their contents are still literal
 /// code and must not be preprocessed as math.
-fn consumeIndentedCodeBlock(writer: *std.Io.Writer, source: []const u8, i: *usize) anyerror!bool {
+fn consumeIndentedCodeBlock(writer: *std.Io.Writer, source: []const u8, i: *usize, in_list_item: bool) anyerror!bool {
     const start = i.*;
     if (!isIndentedCodeLine(source, start)) return false;
-    // Four-space indentation immediately under an open list item is a list
-    // continuation, not a top-level indented code block; allow normal math
-    // preprocessing there.
-    if (isInsideListContinuation(source, start)) return false;
+    // Four-space indentation under an open list item is a list continuation,
+    // not a top-level indented code block; allow normal math preprocessing.
+    if (in_list_item) return false;
 
     var end = start;
     while (end < source.len) {
@@ -162,18 +216,20 @@ fn isIndentedCodeLine(source: []const u8, line_start: usize) bool {
     return line_start + 4 <= source.len and std.mem.eql(u8, source[line_start .. line_start + 4], "    ");
 }
 
-fn isInsideListContinuation(source: []const u8, line_start: usize) bool {
-    if (line_start <= 1) return false;
-    var scan_end = line_start - 2; // skip the newline immediately before this line
-    while (true) {
-        var scan_start = scan_end;
-        while (scan_start > 0 and source[scan_start - 1] != '\n') scan_start -= 1;
-        const line = source[scan_start .. scan_end + 1];
-        const trimmed = std.mem.trimStart(u8, line, " \t");
-        if (trimmed.len == 0) return false;
-        if (isListMarkerLine(trimmed)) return true;
-        if (scan_start <= 1) return false;
-        scan_end = scan_start - 2;
+fn updateListContext(source: []const u8, line_start: usize, in_list_item: *bool) void {
+    const line_end = std.mem.indexOfScalarPos(u8, source, line_start, '\n') orelse source.len;
+    const line = source[line_start..line_end];
+    const trimmed = std.mem.trimStart(u8, line, " \t");
+    if (trimmed.len == 0) {
+        in_list_item.* = false;
+        return;
+    }
+    if (isListMarkerLine(trimmed)) {
+        in_list_item.* = true;
+        return;
+    }
+    if (!isIndentedCodeLine(source, line_start)) {
+        in_list_item.* = false;
     }
 }
 
@@ -772,8 +828,12 @@ fn consumeBlockMath(allocator: std.mem.Allocator, writer: *std.Io.Writer, source
 
     // Force line boundaries so block math doesn't run into surrounding prose
     // like `before $$x$$ after`.
-    if (open > 0 and source[open - 1] != '\n') try writer.writeByte('\n');
     const body = source[body_start..close];
+    // Digit-prefixed display math like `$$2^n$$` is valid, but prose/currency
+    // tokens like `$$5 total$$` are not. Reject the latter before emitting any
+    // synthetic line boundary so the source remains byte-for-byte intact.
+    if (isCurrencyLikeMathBody(body)) return false;
+    if (open > 0 and source[open - 1] != '\n') try writer.writeByte('\n');
     try writeBlockMath(allocator, writer, body);
     const after_close = close + 2;
     if (after_close < source.len and source[after_close] != '\n') {
@@ -853,6 +913,11 @@ fn consumeInlineMath(allocator: std.mem.Allocator, writer: *std.Io.Writer, sourc
     // URL may have already been consumed as part of the body when the
     // opener was at a position where the URL check hadn't fired yet.
     if (std.mem.indexOf(u8, body, "://") != null) return false;
+    // Digit-started formulas like `$2^n$` are valid, but currency/prose bodies
+    // like `$5; x=` are not and must not steal the next formula opener. A
+    // digit-started body that would become a Markdown ordered-list marker at
+    // line start is kept and protected instead.
+    if (isCurrencyLikeMathBody(body) and !startsBlockMarkdownAtSourcePosition(source, open, body)) return false;
 
     // Closing `$` must not be preceded by whitespace, followed by another
     // `$`, followed by a digit (currency ranges), or followed by `{`
@@ -872,7 +937,7 @@ fn consumeInlineMath(allocator: std.mem.Allocator, writer: *std.Io.Writer, sourc
     if (close + 1 < source.len) {
         const after = source[close + 1];
         if (after == '$' or after == '{' or std.ascii.isDigit(after)) return false;
-        if (isShellVarSeparator(after) and isShellNameLike(body)) return false;
+        if ((after == '/' or after == '-') and isShellNameLike(body)) return false;
         if (isUppercaseShellName(body) and isIdentifierChar(after)) return false;
         if (std.ascii.isAlphabetic(after) and std.ascii.isUpper(after)) {
             return false;
@@ -1121,6 +1186,14 @@ fn isShellNameLike(s: []const u8) bool {
 
 fn isShellVarSeparator(c: u8) bool {
     return c == '/' or c == '-' or c == ':' or c == '@' or c == '.';
+}
+
+fn isCurrencyLikeMathBody(body: []const u8) bool {
+    if (body.len == 0 or !std.ascii.isDigit(body[0])) return false;
+    for (body[1..]) |c| {
+        if (std.ascii.isWhitespace(c) or c == ';' or c == ':' or c == ',') return true;
+    }
+    return false;
 }
 
 /// Returns true when the rendered math text contains a character that
@@ -2470,4 +2543,44 @@ test "indented list continuation math is rendered" {
     defer std.testing.allocator.free(out);
     try std.testing.expect(std.mem.indexOf(u8, out, "    x²") != null);
     try std.testing.expect(std.mem.indexOf(u8, out, "    $x^2$") == null);
+}
+
+
+test "digit-prefixed double dollars stay prose" {
+    const src = "cost $$5 total$$ today";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expectEqualStrings(src, out);
+}
+
+test "unfinished blockquoted code fence preserves quoted lines" {
+    const src = "> ```sh\n> echo $HOME$";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expectEqualStrings(src, out);
+}
+
+test "blockquoted code fence preserves quoted shell variables through close" {
+    const src = "> ```sh\n> echo $HOME$\n> ```\nthen $x$";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "> echo $HOME$") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "then x") != null);
+}
+
+test "currency dollar does not pair with following formula opener" {
+    const src = "Costs $5; x=$x$.";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "Costs $5; x=x.") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "Costs 5; x=x$.") == null);
+}
+
+test "long list continuations avoid quadratic backscan and render math" {
+    const src = "- Item:\n    $a$\n    $b$\n    $c$\n    $d$";
+    const out = try preprocess(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "    a") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "    d") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "$d$") == null);
 }

--- a/zig/src/tui/runtime.zig
+++ b/zig/src/tui/runtime.zig
@@ -1197,7 +1197,7 @@ pub const TuiRuntime = struct {
                 return;
             } else |err| switch (err) {
                 error.QueueFull => {},
-                error.StreamCompleted => {
+                error.StreamCompleted, error.OutOfMemory => {
                     self.backpressure_mutex.unlock();
                     var mutable = event;
                     mutable.deinit(self.allocator);
@@ -1224,7 +1224,7 @@ pub const TuiRuntime = struct {
         defer self.backpressure_mutex.unlock();
         self.event_stream.push(event) catch |err| switch (err) {
             error.QueueFull => return false,
-            error.StreamCompleted => {
+            error.StreamCompleted, error.OutOfMemory => {
                 var mutable = event;
                 mutable.deinit(self.allocator);
                 return true;

--- a/zig/src/tui/views/transcript.zig
+++ b/zig/src/tui/views/transcript.zig
@@ -3,6 +3,7 @@ const zz = @import("zigzag");
 const tui_state = @import("tui_state");
 const tui_theme = @import("tui_theme");
 const tui_text = @import("tui_text");
+const tui_markdown = @import("tui_markdown");
 
 const AppState = tui_state.AppState;
 const TranscriptKind = tui_state.TranscriptKind;
@@ -501,13 +502,14 @@ fn renderEntry(allocator: std.mem.Allocator, entry: *const DisplayEntry, width: 
         },
         .assistant => blk: {
             const budget = @max(body_layout.width -| 2, 8);
+            const prepared = try tui_markdown.preprocess(arena, entry.text);
             var markdown = zz.Markdown.init();
             markdown.width = @intCast(@min(budget, std.math.maxInt(u16)));
             markdown.text_style = (zz.Style{}).fg(assistant_fg).inline_style(true);
             markdown.code_style = (zz.Style{}).fg(zz.Color.fromRgb(255, 229, 120)).bg(assistant_code_bg).inline_style(true);
             markdown.code_block_style = (zz.Style{}).fg(zz.Color.fromRgb(96, 245, 150)).bg(assistant_code_bg).inline_style(true);
             markdown.code_block_border = (zz.Style{}).fg(zz.Color.fromRgb(124, 139, 160)).bg(assistant_code_bg).inline_style(true);
-            const md = try markdown.render(arena, entry.text);
+            const md = try markdown.render(arena, prepared);
             const wrapped = try tui_text.wrapTextPreservingPrefix(arena, md, budget);
             const open = try openSgr(arena, assistant_fg, assistant_bg);
             break :blk try renderBubble(arena, wrapped, open, false, body_layout.width);
@@ -1388,4 +1390,79 @@ test "transcript wraps assistant text within viewport width" {
     while (lines.next()) |line| {
         try std.testing.expect(tui_text.visibleWidth(line) <= 30);
     }
+}
+
+test "transcript renders inline LaTeX math as Unicode" {
+    var state = AppState.init(std.testing.allocator);
+    defer state.deinit();
+    try state.appendTranscript(.assistant, "energy is $E = mc^2$ here");
+
+    const text = try render(std.testing.allocator, &state, .{ .width = 80, .height = 10 });
+    defer std.testing.allocator.free(text);
+
+    // Greek/symbol substitution reaches the rendered bubble.
+    try std.testing.expect(std.mem.indexOf(u8, text, "E = mc²") != null);
+    // Raw LaTeX source markers must not leak through.
+    try std.testing.expect(std.mem.indexOf(u8, text, "$E") == null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "^2$") == null);
+}
+
+test "transcript renders block LaTeX math inside assistant bubble" {
+    var state = AppState.init(std.testing.allocator);
+    defer state.deinit();
+    try state.appendTranscript(.assistant, "Integral:\n\n$$\\int_0^\\infty f(x)\\,dx$$\n\ndone");
+
+    const text = try render(std.testing.allocator, &state, .{ .width = 80, .height = 12 });
+    defer std.testing.allocator.free(text);
+
+    try std.testing.expect(std.mem.indexOf(u8, text, "∫") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "∞") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "$$") == null);
+    // Surrounding prose survives.
+    try std.testing.expect(std.mem.indexOf(u8, text, "Integral") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "done") != null);
+}
+
+test "transcript labels Mermaid diagrams and quotes raw source" {
+    var state = AppState.init(std.testing.allocator);
+    defer state.deinit();
+    try state.appendTranscript(.assistant, "Diagram:\n\n```mermaid\nflowchart TD\n  A --> B\n```\n\nend");
+
+    const text = try render(std.testing.allocator, &state, .{ .width = 80, .height = 14 });
+    defer std.testing.allocator.free(text);
+
+    try std.testing.expect(std.mem.indexOf(u8, text, "Mermaid diagram: flowchart") != null);
+    // Raw diagram source remains available (in quoted form) so the user can
+    // still read/copy the original spec.
+    try std.testing.expect(std.mem.indexOf(u8, text, "A --> B") != null);
+    // Fenced fence markers themselves are stripped.
+    try std.testing.expect(std.mem.indexOf(u8, text, "```mermaid") == null);
+}
+
+test "transcript leaves non-mermaid fenced code blocks untouched by math pass" {
+    var state = AppState.init(std.testing.allocator);
+    defer state.deinit();
+    try state.appendTranscript(.assistant, "Code:\n\n```zig\nconst x = 1;\n```\n\nend");
+
+    const text = try render(std.testing.allocator, &state, .{ .width = 80, .height = 12 });
+    defer std.testing.allocator.free(text);
+
+    // Code block still renders with its border — the mermaid pass did not
+    // transform it.
+    try std.testing.expect(std.mem.indexOf(u8, text, "const x") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "Mermaid") == null);
+}
+
+test "transcript math falls back to raw for unknown LaTeX commands" {
+    var state = AppState.init(std.testing.allocator);
+    defer state.deinit();
+    try state.appendTranscript(.assistant, "weird $\\zztop$ end");
+
+    const text = try render(std.testing.allocator, &state, .{ .width = 80, .height = 10 });
+    defer std.testing.allocator.free(text);
+
+    // Unknown command preserved verbatim with backslash so user sees source.
+    try std.testing.expect(std.mem.indexOf(u8, text, "\\zztop") != null);
+    // Math delimiters consumed.
+    try std.testing.expect(std.mem.indexOf(u8, text, "$\\") == null);
 }

--- a/zig/test/e2e/distributed_fullstack.zig
+++ b/zig/test/e2e/distributed_fullstack.zig
@@ -84,12 +84,6 @@ fn distributedMockProviderStream(
     else
         try makeToolUseMessage(allocator);
 
-    try stream.push(.{
-        .done = .{
-            .reason = response.stop_reason,
-            .message = response,
-        },
-    });
     stream.complete(response);
     stream.markThreadDone();
     return stream;

--- a/zig/test/e2e/distributed_fullstack.zig
+++ b/zig/test/e2e/distributed_fullstack.zig
@@ -74,10 +74,15 @@ fn distributedMockProviderStream(
     allocator: std.mem.Allocator,
 ) !*event_stream.AssistantMessageEventStream {
     _ = model;
-    _ = options;
 
     const stream = try allocator.create(event_stream.AssistantMessageEventStream);
     stream.* = event_stream.AssistantMessageEventStream.init(allocator);
+    if (options) |o| {
+        if (o.requires_owned_stream_events) {
+            stream.owns_events = true;
+            stream.clone_event_fn = ai_types.cloneAssistantMessageEvent;
+        }
+    }
 
     const response = if (contextHasToolResult(context))
         try makeFinalMessage(allocator)

--- a/zig/test/e2e/ollama_api.zig
+++ b/zig/test/e2e/ollama_api.zig
@@ -52,8 +52,8 @@ test "ollama e2e: basic text generation (new api)" {
         }
     }
 
-    // Use minimax-m3 as default - a free model currently available on the Ollama cloud API
-    const model_id = getEnvOwned(testing.allocator, "OLLAMA_MODEL") orelse try testing.allocator.dupe(u8, "minimax-m3");
+    // Use gemma4:31b as default - a free model currently available on the Ollama cloud API
+    const model_id = getEnvOwned(testing.allocator, "OLLAMA_MODEL") orelse try testing.allocator.dupe(u8, "gemma4:31b");
     defer testing.allocator.free(model_id);
 
     const base_url = getEnvOwned(testing.allocator, "OLLAMA_BASE_URL") orelse try testing.allocator.dupe(u8, "");

--- a/zig/test/e2e/ollama_api.zig
+++ b/zig/test/e2e/ollama_api.zig
@@ -52,8 +52,8 @@ test "ollama e2e: basic text generation (new api)" {
         }
     }
 
-    // Use ministral-3:3b as default - it's the smallest Ollama cloud model (~4.67GB)
-    const model_id = getEnvOwned(testing.allocator, "OLLAMA_MODEL") orelse try testing.allocator.dupe(u8, "ministral-3:3b");
+    // Use minimax-m3 as default - a free model currently available on the Ollama cloud API
+    const model_id = getEnvOwned(testing.allocator, "OLLAMA_MODEL") orelse try testing.allocator.dupe(u8, "minimax-m3");
     defer testing.allocator.free(model_id);
 
     const base_url = getEnvOwned(testing.allocator, "OLLAMA_BASE_URL") orelse try testing.allocator.dupe(u8, "");

--- a/zig/test/unit/agent_protocol_chain.zig
+++ b/zig/test/unit/agent_protocol_chain.zig
@@ -24,10 +24,15 @@ fn mockProviderStream(
 ) !*event_stream.AssistantMessageEventStream {
     _ = model;
     _ = context;
-    _ = options;
 
     const s = try allocator.create(event_stream.AssistantMessageEventStream);
     s.* = event_stream.AssistantMessageEventStream.init(allocator);
+    if (options) |o| {
+        if (o.requires_owned_stream_events) {
+            s.owns_events = true;
+            s.clone_event_fn = ai_types.cloneAssistantMessageEvent;
+        }
+    }
 
     const final = ai_types.AssistantMessage{
         .content = &.{},

--- a/zig/vendor/zigzag/src/components/markdown.zig
+++ b/zig/vendor/zigzag/src/components/markdown.zig
@@ -138,16 +138,22 @@ pub const Markdown = struct {
 
         var lines_iter = std.mem.splitScalar(u8, source, '\n');
         var in_code_block = false;
+        var code_fence_len: usize = 0;
         var first_line = true;
 
         while (lines_iter.next()) |line| {
             if (!first_line) try writer.writeByte('\n');
             first_line = false;
 
-            // Code block toggle
-            if (std.mem.startsWith(u8, std.mem.trimStart(u8, line, " "), "```")) {
+            // Code block toggle. Track the opener length so a four-backtick
+            // block can safely contain literal triple-backtick examples without
+            // prematurely closing the displayed block.
+            const trimmed_for_fence = std.mem.trimStart(u8, line, " ");
+            const fence_len = countLeadingChar(trimmed_for_fence, '`');
+            if (fence_len >= 3 and (!in_code_block or isCodeFenceClose(trimmed_for_fence, code_fence_len))) {
                 in_code_block = !in_code_block;
                 if (in_code_block) {
+                    code_fence_len = fence_len;
                     // Opening fence
                     const bar = try self.code_block_border.render(tmp, "┌");
                     try writer.writeAll(bar);
@@ -159,6 +165,7 @@ pub const Markdown = struct {
                     const end = try self.code_block_border.render(tmp, "┐");
                     try writer.writeAll(end);
                 } else {
+                    code_fence_len = 0;
                     // Closing fence
                     const bar = try self.code_block_border.render(tmp, "└");
                     try writer.writeAll(bar);
@@ -359,4 +366,32 @@ pub const Markdown = struct {
         }
         return true;
     }
+
+    fn countLeadingChar(s: []const u8, c: u8) usize {
+        var n: usize = 0;
+        while (n < s.len and s[n] == c) n += 1;
+        return n;
+    }
+
+    fn isCodeFenceClose(trimmed: []const u8, opener_len: usize) bool {
+        if (countLeadingChar(trimmed, '`') < opener_len) return false;
+        for (trimmed) |c| {
+            if (c != '`' and c != ' ' and c != '\t' and c != '\r') return false;
+        }
+        return true;
+    }
 };
+
+
+test "markdown renderer respects long backtick fence length" {
+    const src = "````text\n```mermaid\nflowchart TD\n```\n````";
+    var md = Markdown.init();
+    const out = try md.render(std.testing.allocator, src);
+    defer std.testing.allocator.free(out);
+
+    // One outer opener and one outer closer; inner triple-backtick lines should
+    // render as code content, not toggle the code-block state.
+    try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, out, "┌"));
+    try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, out, "└"));
+    try std.testing.expect(std.mem.indexOf(u8, out, "```mermaid") != null);
+}


### PR DESCRIPTION
## Summary
- Add `zig/src/tui/markdown.zig` — a preprocessor that rewrites raw assistant text before ZigZag's markdown renderer runs.
- Inline `$...$` math converts to Unicode (α, β, ∑, ∫, ², ᵢ, etc.) in-place.
- Block `$$...$$` math renders to Unicode and emits as a Markdown blockquote so it visually offsets from surrounding prose.
- ` ```mermaid ... ``` ` fenced blocks become a labeled summary (\"Mermaid diagram: flowchart\") plus the raw diagram source as a blockquote, so the spec stays readable without an external renderer.
- Unknown LaTeX commands fall back to raw with the backslash preserved; currency-style dollar signs are left alone. No external runtime dependencies.

Wired into the assistant bubble path in `transcript.zig` so all four acceptance criteria (inline math, block math, mermaid label, raw fallback) are covered, plus copy semantics (raw source remains visible inside the quoted region).

## Test plan
- [x] `zig build test` — 1162/1163 pass (1 pre-existing skip)
- [x] `zig build test-unit-tui` — full TUI group green
- [x] `./scripts/check-zig-patterns.sh` — ok
- [x] New unit tests in `markdown.zig` (17 cases: Greek letters, superscripts, subscripts, fractions, sqrt, currency guard, mermaid type detection, fallback paths)
- [x] New transcript-level render tests (inline math, block math, mermaid label, non-mermaid code block passthrough, unknown-command fallback)

Closes #125
Relates-to #138