### PR TITLE
feat(tui): copy selected tool output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        group: [core, transport, protocol, providers, utils, makai-cli, agent-types, agent-loop, agent-mod, agent-bridge, agent-unit, agent-chain]
+        group: [core, transport, protocol, providers, utils, makai-cli, tui, agent-types, agent-loop, agent-mod, agent-bridge, agent-unit, agent-chain]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -1013,6 +1013,7 @@ pub fn build(b: *std.Build) void {
         .root_source_file = b.path("src/tui/app.zig"),
         .target = target,
         .optimize = optimize,
+        .link_libc = true,
         .imports = &.{
             .{ .name = "compat", .module = compat_mod },
             .{ .name = "zigzag", .module = zigzag_mod },

--- a/zig/src/tui/app.zig
+++ b/zig/src/tui/app.zig
@@ -1217,6 +1217,7 @@ pub const App = struct {
             .start_login_provider => try self.startLoginProviderName(result.login_provider),
             .copy_last => self.copyLastAssistant(),
             .copy_all => self.copyTranscript(),
+            .copy_tool => self.copySelectedToolOutput(),
             .open_artifact_viewer => try self.openLatestArtifact(),
             .export_file => try self.exportTranscriptToFile(if (result.export_path.len > 0) result.export_path else null),
             .none => {},
@@ -1274,7 +1275,11 @@ pub const App = struct {
         const text = self.pending_clipboard orelse return;
         self.pending_clipboard = null;
         defer self.allocator.free(text);
-        _ = ctx.setClipboard(text) catch {};
+        const copied = ctx.setClipboard(text) catch |err| {
+            self.recordError(@errorName(err)) catch {};
+            return;
+        };
+        if (!copied) self.recordError("clipboard unavailable") catch {};
     }
 
     /// Copy the most recent assistant reply to the system clipboard.
@@ -1309,6 +1314,19 @@ pub const App = struct {
         }
         self.stageClipboard(self.state.preview.content);
         self.state.appendTranscript(.system, "copied preview to clipboard") catch {};
+    }
+
+    fn copySelectedToolOutput(self: *App) void {
+        const text = self.state.selectedToolOutputText() orelse {
+            self.state.appendTranscript(.system, "selected tool has no output to copy") catch {};
+            return;
+        };
+        self.stageClipboard(text);
+        if (text.len > 256 * 1024) {
+            self.state.appendTranscript(.system, "copied tool output to clipboard (large output)") catch {};
+        } else {
+            self.state.appendTranscript(.system, "copied tool output to clipboard") catch {};
+        }
     }
 
     fn openLatestArtifact(self: *App) !void {
@@ -1742,6 +1760,11 @@ pub const TuiModel = struct {
                         },
                         'y' => {
                             if (app.state.mode == .preview) app.copyPreview() else app.copyLastAssistant();
+                            app.flushClipboard(ctx);
+                            return .none;
+                        },
+                        'x' => {
+                            app.copySelectedToolOutput();
                             app.flushClipboard(ctx);
                             return .none;
                         },
@@ -2802,6 +2825,54 @@ test "App submit routes help command to system transcript" {
     try std.testing.expectEqual(@as(usize, 1), app.state.transcript.items.len);
     try std.testing.expectEqual(tui_state.TranscriptKind.system, app.state.transcript.items[0].kind);
     try std.testing.expect(std.mem.indexOf(u8, app.state.transcript.items[0].text.items, "/model") != null);
+}
+
+test "App copies selected tool output" {
+    var app = App.initWithoutRuntime(std.testing.allocator);
+    defer app.deinit();
+    const tool = try app.state.upsertToolForTest("call-1", "shell_execute", "{}", .done);
+    try tool.output.appendSlice(std.testing.allocator, "tool stdout");
+
+    app.copySelectedToolOutput();
+
+    defer if (app.pending_clipboard) |text| {
+        std.testing.allocator.free(text);
+        app.pending_clipboard = null;
+    };
+    try std.testing.expect(app.pending_clipboard != null);
+    try std.testing.expectEqualStrings("tool stdout", app.pending_clipboard.?);
+    try std.testing.expectEqual(tui_state.TranscriptKind.system, app.state.transcript.items[0].kind);
+    try std.testing.expectEqualStrings("copied tool output to clipboard", app.state.transcript.items[0].text.items);
+}
+
+test "App reports empty selected tool output" {
+    var app = App.initWithoutRuntime(std.testing.allocator);
+    defer app.deinit();
+    _ = try app.state.upsertToolForTest("call-1", "shell_execute", "{}", .done);
+
+    app.copySelectedToolOutput();
+
+    try std.testing.expect(app.pending_clipboard == null);
+    try std.testing.expectEqual(tui_state.TranscriptKind.system, app.state.transcript.items[0].kind);
+    try std.testing.expectEqualStrings("selected tool has no output to copy", app.state.transcript.items[0].text.items);
+}
+
+test "App warns when copying large selected tool output" {
+    var app = App.initWithoutRuntime(std.testing.allocator);
+    defer app.deinit();
+    const tool = try app.state.upsertToolForTest("call-1", "shell_execute", "{}", .done);
+    try tool.output.resize(std.testing.allocator, 256 * 1024 + 1);
+    @memset(tool.output.items, 'x');
+
+    app.copySelectedToolOutput();
+
+    defer if (app.pending_clipboard) |text| {
+        std.testing.allocator.free(text);
+        app.pending_clipboard = null;
+    };
+    try std.testing.expect(app.pending_clipboard != null);
+    try std.testing.expectEqual(@as(usize, 256 * 1024 + 1), app.pending_clipboard.?.len);
+    try std.testing.expectEqualStrings("copied tool output to clipboard (large output)", app.state.transcript.items[0].text.items);
 }
 
 test "App submit starts direct OpenAI Codex login command" {

--- a/zig/src/tui/commands.zig
+++ b/zig/src/tui/commands.zig
@@ -53,6 +53,7 @@ pub const CommandAction = enum {
     start_login_provider,
     copy_last,
     copy_all,
+    copy_tool,
     open_artifact_viewer,
     open_export_picker,
     export_file,
@@ -105,7 +106,7 @@ pub const commands = [_]CommandInfo{
     .{ .name = "view", .kind = .view, .usage = "/view [everything|verbose|balanced|chat]", .description = "Show or set transcript detail level", .handler = handleView },
     .{ .name = "compact", .kind = .compact, .usage = "/compact", .description = "Compact conversation context", .handler = handleCompact },
     .{ .name = "clear", .kind = .clear, .usage = "/clear", .description = "Clear transcript display", .handler = handleClear },
-    .{ .name = "copy", .kind = .copy, .usage = "/copy [all]", .description = "Copy last reply (or whole transcript) to clipboard", .handler = handleCopy },
+    .{ .name = "copy", .kind = .copy, .usage = "/copy [all|tool]", .description = "Copy last reply, transcript, or selected tool output", .handler = handleCopy },
     .{ .name = "artifact", .kind = .artifact, .usage = "/artifact", .description = "Open the latest artifact in a local viewer", .handler = handleArtifact },
     .{ .name = "export", .kind = .@"export", .usage = "/export [path.md]", .description = "Export transcript to clipboard or file", .handler = handleExport },
     .{ .name = "diff", .kind = .diff, .usage = "/diff", .description = "Show pending file changes", .handler = handleDiff },
@@ -405,8 +406,12 @@ fn handleCopy(ctx: CommandContext, command: Command) !CommandResult {
     _ = ctx;
     // The app stages the clipboard write and reports status itself, so no output.
     if (command.arg) |arg| {
-        if (std.mem.eql(u8, std.mem.trim(u8, arg, " \t"), "all")) {
+        const trimmed = std.mem.trim(u8, arg, " \t");
+        if (std.mem.eql(u8, trimmed, "all")) {
             return .{ .action = .copy_all };
+        }
+        if (std.mem.eql(u8, trimmed, "tool")) {
+            return .{ .action = .copy_tool };
         }
     }
     return .{ .action = .copy_last };
@@ -887,6 +892,10 @@ test "copy command selects last reply or whole transcript" {
     var all = try dispatch(ctx, .{ .kind = .copy, .arg = "all" });
     defer all.deinit(std.testing.allocator);
     try std.testing.expectEqual(CommandAction.copy_all, all.action);
+
+    var tool = try dispatch(ctx, .{ .kind = .copy, .arg = "tool" });
+    defer tool.deinit(std.testing.allocator);
+    try std.testing.expectEqual(CommandAction.copy_tool, tool.action);
 }
 
 test "export command opens picker or targets file" {

--- a/zig/src/tui/state.zig
+++ b/zig/src/tui/state.zig
@@ -668,6 +668,20 @@ pub const AppState = struct {
         self.selected_tool_index = null;
     }
 
+    pub fn selectedTool(self: *const AppState) ?*const ToolEntry {
+        if (self.tools.items.len == 0) return null;
+        const index = self.selected_tool_index orelse self.tools.items.len - 1;
+        if (index >= self.tools.items.len) return null;
+        return &self.tools.items[index];
+    }
+
+    pub fn selectedToolOutputText(self: *const AppState) ?[]const u8 {
+        const tool = self.selectedTool() orelse return null;
+        if (tool.display_preview.len > 0) return tool.display_preview;
+        if (tool.output.items.len > 0) return tool.output.items;
+        return null;
+    }
+
     pub fn resetReplayState(self: *AppState) void {
         self.clearTranscript();
         self.clearTools();
@@ -2326,6 +2340,29 @@ test "AppState clones registered tool metadata" {
     try state.setRegisteredTools(&replacement);
     try std.testing.expectEqual(@as(usize, 1), state.registered_tools.items.len);
     try std.testing.expectEqualStrings("file_read", state.registered_tools.items[0].name);
+}
+
+test "AppState tracks selected tool output" {
+    var state = AppState.init(std.testing.allocator);
+    defer state.deinit();
+
+    const first = try state.upsertToolForTest("call-1", "shell_execute", "{}", .done);
+    try first.output.appendSlice(std.testing.allocator, "first output");
+    const second = try state.upsertToolForTest("call-2", "shell_execute", "{}", .done);
+    try second.output.appendSlice(std.testing.allocator, "second output");
+
+    try std.testing.expectEqual(@as(?usize, null), state.selected_tool_index);
+    try std.testing.expectEqualStrings("second output", state.selectedToolOutputText().?);
+    state.focus_pane = .tools;
+    state.selected_tool_index = 1;
+    state.moveSelection(-1);
+    try std.testing.expectEqualStrings("first output", state.selectedToolOutputText().?);
+    const third = try state.upsertToolForTest("call-3", "shell_execute", "{}", .done);
+    try third.output.appendSlice(std.testing.allocator, "third output");
+    try std.testing.expectEqual(@as(?usize, 0), state.selected_tool_index);
+    try std.testing.expectEqualStrings("first output", state.selectedToolOutputText().?);
+    state.clearTools();
+    try std.testing.expect(state.selectedToolOutputText() == null);
 }
 
 test "AppState tool_result message_end updates active tool entry only" {

--- a/zig/src/tui/views/tool_panel.zig
+++ b/zig/src/tui/views/tool_panel.zig
@@ -76,7 +76,7 @@ pub fn render(allocator: std.mem.Allocator, state: *tui_state.AppState, options:
         if (i < state.tool_scroll) continue;
         if (rows >= options.height) break;
         try writer.writeByte('\n');
-        const selected = state.focus_pane == .tools and state.selected_tool_index == i;
+        const selected = state.focus_pane == .tools and state.selected_tool_index != null and state.selected_tool_index.? == i;
         if (selected) {
             const line = try renderSelectedToolLine(allocator, &tool, inner_width);
             defer allocator.free(line);


### PR DESCRIPTION
Closes #133

## Summary
- Track and render the selected tool row in TUI state/tool panel
- Add selected tool output copying via Ctrl+X and `/copy tool`
- Render transcript success, empty-output, and large-output copy messages
- Add unit coverage for successful, empty, large, command, and selection/render states

## Tests
- `zig build test-unit-makai-cli`
- `zig build test-unit-core && zig build test-unit-transport && zig build test-unit-protocol && zig build test-unit-providers && zig build test-unit-makai-cli && zig build test-unit-agent`
- `../scripts/check-zig-patterns.sh`

## Known test issue
- `zig build test` currently fails in `test-unit-utils` with existing Codex OAuth mock output: `Codex OAuth error: invalid_grant - bad code`.